### PR TITLE
KAFKA-7464: catch exceptions in "leaderEndpoint.close()" when shutting down ReplicaFetcherThread

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -115,11 +115,18 @@ class ReplicaFetcherThread(name: String,
   override def initiateShutdown(): Boolean = {
     val justShutdown = super.initiateShutdown()
     if (justShutdown) {
+      // leaderEndpoint.close can throw an exception when the replica fetcher thread is still
+      // actively fetching because the selector can close the channel while sending the request
+      // after we initiate leaderEndpoint.close and the leaderEndpoint.close itself may also close
+      // the channel again. When this race condition happens, an exception will be thrown.
+      // Throwing the exception to the caller may fail the ReplicaManager shutdown. It is safe to catch
+      // the exception without here causing correctness issue because we are going to shutdown the thread
+      // and will not re-use the leaderEndpoint anyway.
       try {
         leaderEndpoint.close()
       } catch {
         case t: Throwable =>
-          error(s"Fail to close leader endpoint $leaderEndpoint after initiating replica fetcher thread shutdown", t)
+          debug(s"Fail to close leader endpoint $leaderEndpoint after initiating replica fetcher thread shutdown", t)
       }
     }
     justShutdown

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -115,7 +115,12 @@ class ReplicaFetcherThread(name: String,
   override def initiateShutdown(): Boolean = {
     val justShutdown = super.initiateShutdown()
     if (justShutdown) {
-      leaderEndpoint.close()
+      try {
+        leaderEndpoint.close()
+      } catch {
+        case t: Throwable =>
+          error(s"Fail to close leader endpoint $leaderEndpoint after initiating replica fetcher thread shutdown", t)
+      }
     }
     justShutdown
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -16,6 +16,7 @@
   */
 package kafka.server
 
+import java.nio.channels.ClosedChannelException
 import java.util.Optional
 
 import kafka.cluster.{BrokerEndPoint, Replica}
@@ -24,16 +25,16 @@ import kafka.cluster.Partition
 import kafka.server.QuotaFactory.UnboundedQuota
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.server.epoch.util.ReplicaFetcherMockBlockingSend
-import kafka.utils.TestUtils
+import kafka.utils.{LogCaptureAppender, TestUtils}
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.internals.PartitionStates
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.protocol.Errors._
 import org.apache.kafka.common.requests.{EpochEndOffset, OffsetsForLeaderEpochRequest}
 import org.apache.kafka.common.requests.EpochEndOffset._
 import org.apache.kafka.common.utils.SystemTime
+import org.apache.log4j.Level
 import org.easymock.EasyMock._
 import org.easymock.{Capture, CaptureType, IAnswer}
 import org.junit.Assert._
@@ -791,6 +792,39 @@ class ReplicaFetcherThreadTest {
 
     //Then we should not have truncated the partition that became leader. Exactly one partition should be truncated.
     assertEquals(49, truncateToCapture.getValue)
+  }
+
+  @Test
+  def shouldCatchExceptionFromBlockingSendWhenShuttingDownReplicaFetcherThread(): Unit = {
+    val props = TestUtils.createBrokerConfig(1, "localhost:1234")
+    val config = KafkaConfig.fromProps(props)
+    val mockBlockingSend = createMock(classOf[BlockingSend])
+
+    expect(mockBlockingSend.close()).andThrow(new IllegalArgumentException()).once()
+    replay(mockBlockingSend)
+
+    val logCaptureAppender = LogCaptureAppender.createAndRegister()
+
+    val thread = new ReplicaFetcherThread(
+      name = "bob",
+      fetcherId = 0,
+      sourceBroker = brokerEndPoint,
+      brokerConfig = config,
+      replicaMgr = null,
+      metrics =  new Metrics(),
+      time = new SystemTime(),
+      quota = null,
+      leaderEndpointBlockingSend = Some(mockBlockingSend))
+
+    thread.initiateShutdown()
+
+    val event = logCaptureAppender.getMessages.find(e => e.getLevel == Level.ERROR
+      && e.getRenderedMessage.contains(s"Fail to close leader endpoint $mockBlockingSend after initiating replica fetcher thread shutdown")
+      && e.getThrowableInformation != null
+      && e.getThrowableInformation.getThrowable.getClass.getName.equals(new IllegalArgumentException().getClass.getName))
+    assertTrue(event.isDefined)
+
+    verify(mockBlockingSend)
   }
 
   def stub(replica: Replica, partition: Partition, replicaManager: ReplicaManager) = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -16,7 +16,6 @@
   */
 package kafka.server
 
-import java.nio.channels.ClosedChannelException
 import java.util.Optional
 
 import kafka.cluster.{BrokerEndPoint, Replica}

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -803,8 +803,6 @@ class ReplicaFetcherThreadTest {
     expect(mockBlockingSend.close()).andThrow(new IllegalArgumentException()).once()
     replay(mockBlockingSend)
 
-    val logCaptureAppender = LogCaptureAppender.createAndRegister()
-
     val thread = new ReplicaFetcherThread(
       name = "bob",
       fetcherId = 0,
@@ -816,9 +814,12 @@ class ReplicaFetcherThreadTest {
       quota = null,
       leaderEndpointBlockingSend = Some(mockBlockingSend))
 
+    LogCaptureAppender.setClassLoggerLevel(thread.getClass, Level.DEBUG)
+    val logCaptureAppender = LogCaptureAppender.createAndRegister()
+
     thread.initiateShutdown()
 
-    val event = logCaptureAppender.getMessages.find(e => e.getLevel == Level.ERROR
+    val event = logCaptureAppender.getMessages.find(e => e.getLevel == Level.DEBUG
       && e.getRenderedMessage.contains(s"Fail to close leader endpoint $mockBlockingSend after initiating replica fetcher thread shutdown")
       && e.getThrowableInformation != null
       && e.getThrowableInformation.getThrowable.getClass.getName.equals(new IllegalArgumentException().getClass.getName))


### PR DESCRIPTION
After KAFKA-6051, we close leaderEndPoint in replica fetcher thread initiateShutdown to try to preempt in-progress fetch request and accelerate repica fetcher thread shutdown. However, leaderEndpoint can throw an Exception when the replica fetcher thread is still actively fetching, which can cause ReplicaManager to fail to shutdown cleanly. This PR catches the exceptions thrown in "leaderEndpoint.close()" instead of letting it throw up in the call stack.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
