### PR TITLE
HOTFIX: Fix compilation issue in streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
@@ -84,6 +84,21 @@ public abstract class Windows<W extends Window> {
     }
 
     /**
+     * Return the segment interval in milliseconds.
+     *
+     * @return the segment interval
+     * @deprecated since 2.1. Instead, directly configure the segment interval in a store supplier and use {@link Materialized#as(WindowBytesStoreSupplier)}.
+     */
+    @Deprecated
+    public long segmentInterval() {
+        // Pinned arbitrarily to a minimum of 60 seconds. Profiling may indicate a different value is more efficient.
+        final long minimumSegmentInterval = 60_000L;
+        // Scaled to the (possibly overridden) retention period
+        return Math.max(maintainMs() / (segments - 1), minimumSegmentInterval);
+    }
+
+
+    /**
      * Set the number of segments to be used for rolling the window store.
      * This function is not exposed to users but can be called by developers that extend this class.
      *

--- a/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
@@ -54,19 +54,15 @@ public class StoresTest {
     }
 
     @Test(expected = NullPointerException.class)
+    @SuppressWarnings("deprecation")
     public void shouldThrowIfIPersistentWindowStoreStoreNameIsNull() {
         Stores.persistentWindowStore(null, 0L, 0L, false, 0L);
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void shouldThrowIfIPersistentWindowStoreRetentionPeriodIsNegative() {
         Stores.persistentWindowStore("anyName", -1L, 0L, false, 0L);
-    }
-
-    @Deprecated
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIfIPersistentWindowStoreIfNumberOfSegmentsSmallerThanOne() {
-        Stores.persistentWindowStore("anyName", 0L, 1, 0L, false);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -75,6 +71,7 @@ public class StoresTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void shouldThrowIfIPersistentWindowStoreIfSegmentIntervalIsTooSmall() {
         Stores.persistentWindowStore("anyName", 1L, 1L, false, -1L);
     }


### PR DESCRIPTION
Fixed the compilation issue which raised when cleaning up overlapping KAFKA-7080 and KAFKA-7222 KIP changes.

- not sure whether to remove Windows#segments() method so kept it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
