### PR TITLE
KAFKA-7517: Add whitelist to Range config validator. Ensure retention bytes cannot be 0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -862,7 +862,7 @@ public class ConfigDef {
         }
 
         public static Range atLeast(Number min) {
-            return atLeast(min, new ArrayList<>());
+            return atLeast(min, Collections.emptyList());
         }
 
         /**
@@ -873,7 +873,7 @@ public class ConfigDef {
         }
 
         public static Range between(Number min, Number max) {
-            return between(min, max, new ArrayList<>());
+            return between(min, max, Collections.emptyList());
         }
 
         public void ensureValid(String name, Object o) {

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -141,6 +141,11 @@ public class ConfigDefTest {
         new ConfigDef().define("name", Type.INT, -1, Range.between(0, 10), Importance.HIGH, "docs");
     }
 
+    @Test
+    public void testInvalidDefaultRangeWhitelisted() {
+        new ConfigDef().define("name", Type.INT, -1, Range.between(0, 10, Collections.singletonList(-1)), Importance.HIGH, "docs");
+    }
+
     @Test(expected = ConfigException.class)
     public void testInvalidDefaultString() {
         new ConfigDef().define("name", Type.STRING, "bad", ValidString.in("valid", "values"), Importance.HIGH, "docs");

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -101,6 +101,21 @@ public class ConfigDefTest {
     }
 
     @Test
+    public void testRangeToString() {
+        assertEquals("[1,...,10] (whitelist: [])",
+            Range.between(1, 10).toString());
+
+        assertEquals("[1,...,10] (whitelist: [-1, -2])",
+            Range.between(1, 10, Arrays.asList(-1, -2)).toString());
+
+        assertEquals("[1,...] (whitelist: [])",
+            Range.atLeast(1).toString());
+
+        assertEquals("[1,...] (whitelist: [-1, -2])",
+            Range.atLeast(1, Arrays.asList(-1, -2)).toString());
+    }
+
+    @Test
     public void testParsingEmptyDefaultValueForStringFieldShouldSucceed() {
         new ConfigDef().define("a", Type.STRING, "", ConfigDef.Importance.HIGH, "docs")
                 .parse(new HashMap<String, Object>());
@@ -142,8 +157,10 @@ public class ConfigDefTest {
     }
 
     @Test
-    public void testInvalidDefaultRangeWhitelisted() {
-        new ConfigDef().define("name", Type.INT, -1, Range.between(0, 10, Collections.singletonList(-1)), Importance.HIGH, "docs");
+    public void testInvalidDefaultRangeWhitelistedWorks() {
+        Range whitelistRange = Range.between(0, 10, Collections.singletonList(-1));
+        ConfigDef def = new ConfigDef().define("name", Type.INT, -1, whitelistRange, Importance.HIGH, "docs");
+        assertEquals(-1, def.parse(new Properties()).get("name"));
     }
 
     @Test(expected = ConfigException.class)

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -229,8 +229,8 @@ object LogConfig {
       .define(FlushMsProp, LONG, Defaults.FlushMs, atLeast(0), MEDIUM, FlushMsDoc,
         KafkaConfig.LogFlushIntervalMsProp)
       // can be negative. See kafka.log.LogManager.cleanupSegmentsToMaintainSize
-      .define(RetentionBytesProp, LONG, Defaults.RetentionSize, MEDIUM, RetentionSizeDoc,
-        KafkaConfig.LogRetentionBytesProp)
+      .define(RetentionBytesProp, LONG, Defaults.RetentionSize, atLeast(LegacyRecord.RECORD_OVERHEAD_V0, Collections.singletonList(Defaults.RetentionSize)),
+        MEDIUM, RetentionSizeDoc, KafkaConfig.LogRetentionBytesProp)
       // can be negative. See kafka.log.LogManager.cleanupExpiredSegments
       .define(RetentionMsProp, LONG, Defaults.RetentionMs, MEDIUM, RetentionMsDoc,
         KafkaConfig.LogRetentionTimeMillisProp)


### PR DESCRIPTION
By adding a whitelist option to the `Range` config validator we can ensure that certain configs can still use their special value of -1 while not being less than a certain value