### PR TITLE
KAFKA-7532: Fix controller log for list of shutting down brokers

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -411,7 +411,8 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     deadBrokers.foreach(controllerContext.replicasOnOfflineDirs.remove)
     val deadBrokersThatWereShuttingDown =
       deadBrokers.filter(id => controllerContext.shuttingDownBrokerIds.remove(id))
-    info(s"Removed $deadBrokersThatWereShuttingDown from list of shutting down brokers.")
+    if (deadBrokersThatWereShuttingDown.nonEmpty)
+      info(s"Removed ${deadBrokersThatWereShuttingDown.mkString(",")} from list of shutting down brokers.")
     val allReplicasOnDeadBrokers = controllerContext.replicasOnBrokers(deadBrokers.toSet)
     onReplicasBecomeOffline(allReplicasOnDeadBrokers)
 


### PR DESCRIPTION
As reported in [KAFKA-7532](https://issues.apache.org/jira/browse/KAFKA-7532) - this line prints out

```
[2018-10-23 12:19:59,977] INFO [Controller id=0] Removed ArrayBuffer() from list of shutting down brokers. (kafka.controller.KafkaController)
```

This change seems to be present in all versions even as back as `0.9.0`. I think it might be worth it to merge to `1.0` (pre-2.0 uses `"".format()`)