### PR TITLE
KAFKA-7534: Error in flush calling close may prevent underlying store  from closing

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -132,8 +132,11 @@ class CachingKeyValueStore<K, V> extends WrappedStateStore.AbstractStateStore im
         try {
             flush();
         } finally {
-            underlying.close();
-            cache.close(cacheName);
+            try {
+                underlying.close();
+            } finally {
+                cache.close(cacheName);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -129,9 +129,12 @@ class CachingKeyValueStore<K, V> extends WrappedStateStore.AbstractStateStore im
 
     @Override
     public void close() {
-        flush();
-        underlying.close();
-        cache.close(cacheName);
+        try {
+            flush();
+        } finally {
+            underlying.close();
+            cache.close(cacheName);
+        }
     }
 
     @Override


### PR DESCRIPTION
Calling the `CachingKeyValueStore#close()` method first calls `CachingKeyValueStore.flush()`.  If there is an exception thrown during the `flush` call, the underlying store is not closed.  Subsequently, another task can't open the RocksDB store and receives a `No locks available` exception.

I added a unit test that fails with the proposed fix.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
