### PR TITLE
refs KAFKA-7510, preventing data being leaked to logs by default

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -55,8 +55,9 @@ public class RecordCollectorImpl implements RecordCollector {
     private final Map<TopicPartition, Long> offsets;
     private final ProductionExceptionHandler productionExceptionHandler;
 
-    private final static String LOG_MESSAGE = "Error sending record (key {} value {} timestamp {}) to topic {} due to {}; " +
-        "No more records will be sent and no more offsets will be recorded for this task.";
+    private final static String LOG_MESSAGE = "Error sending record to topic {} due to {}; " +
+        "No more records will be sent and no more offsets will be recorded for this task. " +
+        "Enable TRACE logging to view failed record key and value.";
     private final static String EXCEPTION_MESSAGE = "%sAbort sending since %s with a previous record (key %s value %s timestamp %d) to topic %s due to %s";
     private final static String PARAMETER_HINT = "\nYou can increase producer parameter `retries` and `retry.backoff.ms` to avoid this error.";
     private volatile KafkaException sendException;
@@ -128,7 +129,11 @@ public class RecordCollectorImpl implements RecordCollector {
             errorLogMessage += PARAMETER_HINT;
             errorMessage += PARAMETER_HINT;
         }
-        log.error(errorLogMessage, key, value, timestamp, topic, exception.toString());
+        log.error(errorLogMessage, topic, exception.getMessage(), exception);
+
+        // KAFKA-7510 put message key and value in TRACE level log so we don't leak data by default
+        log.trace("Failed message: key {} value {} timestamp {}", key, value, timestamp);
+
         sendException = new StreamsException(
             String.format(
                 errorMessage,
@@ -172,7 +177,11 @@ public class RecordCollectorImpl implements RecordCollector {
                     } else {
                         if (sendException == null) {
                             if (exception instanceof ProducerFencedException) {
-                                log.warn(LOG_MESSAGE, key, value, timestamp, topic, exception.toString());
+                                log.warn(LOG_MESSAGE, topic, exception.getMessage(), exception);
+
+                                // KAFKA-7510 put message key and value in TRACE level log so we don't leak data by default
+                                log.trace("Failed message: (key {} value {} timestamp {}) topic=[{}] partition=[{}]", key, value, timestamp, topic, partition);
+
                                 sendException = new ProducerFencedException(
                                     String.format(
                                         EXCEPTION_MESSAGE,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -201,10 +201,15 @@ public class RecordCollectorImpl implements RecordCollector {
                                     recordSendError(key, value, timestamp, topic, exception);
                                 } else {
                                     log.warn(
-                                        "Error sending records (key=[{}] value=[{}] timestamp=[{}]) to topic=[{}] and partition=[{}]; " +
-                                            "The exception handler chose to CONTINUE processing in spite of this error.",
-                                        key, value, timestamp, topic, partition, exception
+                                        "Error sending records topic=[{}] and partition=[{}]; " +
+                                            "The exception handler chose to CONTINUE processing in spite of this error. " +
+                                            "Enable TRACE logging to view failed messages key and value.",
+                                        topic, partition, exception
                                     );
+
+                                    // KAFKA-7510 put message key and value in TRACE level log so we don't leak data by default
+                                    log.trace("Failed message: (key {} value {} timestamp {}) topic=[{}] partition=[{}]", key, value, timestamp, topic, partition);
+
                                     skippedRecordsSensor.record();
                                 }
                             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -230,7 +230,7 @@ public class RecordCollectorTest {
         });
         collector.send("topic1", "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
         assertEquals(1.0, metrics.metrics().get(metricName).metricValue());
-        assertTrue(logCaptureAppender.getMessages().contains("test Error sending records to topic=[topic1] and partition=[0]; The exception handler chose to CONTINUE processing in spite of this error. Enable TRACE logging to view failed messages key and value."));
+        assertTrue(logCaptureAppender.getMessages().contains("test Error sending records topic=[topic1] and partition=[0]; The exception handler chose to CONTINUE processing in spite of this error. Enable TRACE logging to view failed messages key and value."));
         LogCaptureAppender.unregister(logCaptureAppender);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -230,7 +230,7 @@ public class RecordCollectorTest {
         });
         collector.send("topic1", "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
         assertEquals(1.0, metrics.metrics().get(metricName).metricValue());
-        assertTrue(logCaptureAppender.getMessages().contains("test Error sending records (key=[3] value=[0] timestamp=[null]) to topic=[topic1] and partition=[0]; The exception handler chose to CONTINUE processing in spite of this error."));
+        assertTrue(logCaptureAppender.getMessages().contains("test Error sending records to topic=[topic1] and partition=[0]; The exception handler chose to CONTINUE processing in spite of this error. Enable TRACE logging to view failed messages key and value."));
         LogCaptureAppender.unregister(logCaptureAppender);
     }
 


### PR DESCRIPTION
Refs KAFKA-7510 (https://issues.apache.org/jira/browse/KAFKA-7510).

This is a bare minimum implementation to get data out of the logs by default as explained in the Jira ticket. I've tried to keep the formatting consistent with the existing formatting.

A further follow up PR as part of the wider KAFKA-7510 discussion can add unit tests asserting that data is not present at ERROR log level.

Note I do get flickering tests but they look to be unrelated and non deterministic due to the parallelism although they do appear to be mostly be from `RocksDBWindowsStoreTest` when I do get failures.

```
org.apache.kafka.streams.state.StoresTest > shouldCreateRocksDbWindowStore PASSED

org.apache.kafka.streams.state.StoresTest > shouldThrowIfILruMapStoreNameIsNull PASSED

org.apache.kafka.streams.state.StoresTest > shouldThrowIfIPersistentSessionStoreStoreNameIsNull PASSED

org.apache.kafka.streams.state.internals.RocksDBWindowStoreTest > testRestore SKIPPED

> Task :streams:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':streams:test'.
> Process 'Gradle Test Executor 103' finished with non-zero exit value 134
  This problem might be caused by incorrect test process configuration.
  Please refer to the test execution section in the user guide at https://docs.gradle.org/4.10.2/userguide/java_plugin.html#sec:test_execution
```

Note I've also yet to find out the `gradle` task to publish the artifact to my local maven repository to test in my app, `maven-publish` plugin doesn't look to be enabled and not been able to dig in to the build scripts enough to get it to work. Using `assembly` and manually adding the JAR to the classpath to test is non trivial with my build pipeline/app deployment.
