### PR TITLE
MINOR: Reduce intermittent test failures for testMarksPartitionsAsOfflineAndPopulatesUncleanableMetrics and make log cleaner tests more efficient

### DIFF
--- a/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
@@ -42,7 +42,7 @@ abstract class AbstractLogCleanerIntegrationTest {
   private val defaultMinCleanableDirtyRatio = 0.0F
   private val defaultCompactionLag = 0L
   private val defaultDeleteDelay = 1000
-  private val defaultSegmentSize = 5120
+  private val defaultSegmentSize = 2048
 
   def time: MockTime
 

--- a/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
@@ -42,7 +42,7 @@ abstract class AbstractLogCleanerIntegrationTest {
   private val defaultMinCleanableDirtyRatio = 0.0F
   private val defaultCompactionLag = 0L
   private val defaultDeleteDelay = 1000
-  private val defaultSegmentSize = 256
+  private val defaultSegmentSize = 5120
 
   def time: MockTime
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -96,7 +96,7 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
     logProps.put(LogConfig.CleanupPolicyProp, "compact,delete")
 
     def runCleanerAndCheckCompacted(numKeys: Int): (Log, Seq[(Int, String, Long)]) = {
-      cleaner = makeCleaner(partitions = topicPartitions.take(1), propertyOverrides = logProps, backOffMs = 100L, segmentSize = 2560)
+      cleaner = makeCleaner(partitions = topicPartitions.take(1), propertyOverrides = logProps, backOffMs = 100L)
       val log = cleaner.logs.get(topicPartitions(0))
 
       val messages = writeDups(numKeys = numKeys, numDups = 3, log = log, codec = codec)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -96,7 +96,7 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
     logProps.put(LogConfig.CleanupPolicyProp, "compact,delete")
 
     def runCleanerAndCheckCompacted(numKeys: Int): (Log, Seq[(Int, String, Long)]) = {
-      cleaner = makeCleaner(partitions = topicPartitions.take(1), propertyOverrides = logProps, backOffMs = 100L)
+      cleaner = makeCleaner(partitions = topicPartitions.take(1), propertyOverrides = logProps, backOffMs = 100L, segmentSize = 2560)
       val log = cleaner.logs.get(topicPartitions(0))
 
       val messages = writeDups(numKeys = numKeys, numDups = 3, log = log, codec = codec)
@@ -190,10 +190,10 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
       return
 
     val maxMessageSize = 192
-    cleaner = makeCleaner(partitions = topicPartitions, maxMessageSize = maxMessageSize)
+    cleaner = makeCleaner(partitions = topicPartitions, maxMessageSize = maxMessageSize, segmentSize = 256)
 
     val log = cleaner.logs.get(topicPartitions(0))
-    val props = logConfigProperties(maxMessageSize = maxMessageSize)
+    val props = logConfigProperties(maxMessageSize = maxMessageSize, segmentSize = 256)
     props.put(LogConfig.MessageFormatVersionProp, KAFKA_0_9_0.version)
     log.config = new LogConfig(props)
 


### PR DESCRIPTION
As seen in https://builds.apache.org/job/kafka-pr-jdk11-scala2.12/239/testReport/junit/kafka.log/LogCleanerIntegrationTest/testMarksPartitionsAsOfflineAndPopulatesUncleanableMetrics/

This test sometimes fails because of passing the 15 second timeout. Inspecting the error message from the build failure, we see that this timeout happens in the `writeDups()` calls which call `roll()`.
```
[2018-10-23 15:18:51,018] ERROR Error while flushing log for log-1 in dir /tmp/kafka-8190355063195903574 with offset 74 (kafka.server.LogDirFailureChannel:76)
java.nio.channels.ClosedByInterruptException
...
	at kafka.log.Log.roll(Log.scala:1550)
...
	at kafka.log.AbstractLogCleanerIntegrationTest.writeDups(AbstractLogCleanerIntegrationTest.scala:132)
...
```

After investigating, I saw that this test would call `Log#roll()` around 60 times every run. Increasing the `segmentSize` config to `5120` reduces the `Log#roll()` calls to 4 per test.
I saw that most other LogCleaner tests also call `roll()` ~90 times, so I've changed the default to be `5120`. I've also made the one test which requires a smaller segmentSize to set it via the args
