### PR TITLE
MINOR: Increase timeout and add more context to error message

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKTableJoinIntegrationTest.java
@@ -319,7 +319,7 @@ public class KStreamKTableJoinIntegrationTest {
             public boolean conditionMet() {
                 return remainingExpectedResult.isEmpty();
             }
-        }, "Never received expected result.");
+        }, 30000, "Never received all expected results.  Still waiting for " + remainingExpectedResult);
 
         final int expectedResultSize = expectedClicksPerRegion.size();
         final int expectedNumberOfOutputs = (cacheSizeBytes == 0)


### PR DESCRIPTION
Increasing timeout in the test, added more context to the error message to help diagnose future failures 

For testing, I ran the existing suite of streams tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
