### PR TITLE
MINOR: Improve ReplicationQuotasTest#shouldThrottleOldSegments() test…

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -194,11 +194,12 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     //Add data
     addData(msgCount, msg)
 
-    val start = System.currentTimeMillis()
 
     //Start the new broker (and hence start replicating)
     debug("Starting new broker")
     brokers = brokers :+ createServer(fromProps(createBrokerConfig(101, zkConnect)))
+    val start = System.currentTimeMillis()
+
     waitForOffsetsToMatch(msgCount, 0, 101)
 
     val throttledTook = System.currentTimeMillis() - start

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -194,7 +194,6 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     //Add data
     addData(msgCount, msg)
 
-
     //Start the new broker (and hence start replicating)
     debug("Starting new broker")
     brokers = brokers :+ createServer(fromProps(createBrokerConfig(101, zkConnect)))


### PR DESCRIPTION
I've seen this test fail with
```
java.lang.AssertionError: Throttled replication of 6352ms should be < 6000ms
```

I think a possible cause to that might be that it starts counting the time it took for replication before the replication itself has started. `createServer()` initializes ZK and other systems before it starts up the replication thread.

I ran the test 25 times locally both ways.
Average `throttledTook` before the change: 5341.75
Mean `throttledTook` after the change: 5256.92

Note that those are the results from `./gradlew core:test --tests kafka.server.ReplicationQuotasTest.shouldThrottleOldSegments`. I've noticed that if I run the whole test class `ReplicationQuotasTest`, the `throttledTook` is close ~4100