### PR TITLE
MINOR: Add DEBUG level logs for successful/failed authentications wit…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -532,21 +532,21 @@ public class Selector implements Selectable, AutoCloseable {
                     try {
                         channel.prepare();
                     } catch (AuthenticationException e) {
-                        boolean isReAuthentication = channel.successfulAuthentications() > 0;
-                        if (!isReAuthentication)
+                        boolean isReauthentication = channel.successfulAuthentications() > 0;
+                        if (!isReauthentication)
                             sensors.failedAuthentication.record();
                         else
                             sensors.failedReauthentication.record();
-                        log.debug("Address {} failed {}authentication ({})",
+                        log.info("Address {} failed {}authentication ({})",
                             channel.socketDescription(),
-                            isReAuthentication ? "re-" : "",
+                            isReauthentication ? "re-" : "",
                             e.getClass().getName());
                         throw e;
                     }
                     if (channel.ready()) {
                         long readyTimeMs = time.milliseconds();
-                        boolean isReAuthentication = channel.successfulAuthentications() > 1;
-                        if (!isReAuthentication) {
+                        boolean isReauthentication = channel.successfulAuthentications() > 1;
+                        if (!isReauthentication) {
                             sensors.successfulAuthentication.record(1.0, readyTimeMs);
                             if (!channel.connectedClientSupportsReauthentication())
                                 sensors.successfulAuthenticationNoReauth.record(1.0, readyTimeMs);
@@ -560,7 +560,7 @@ public class Selector implements Selectable, AutoCloseable {
                                         .record(channel.reauthenticationLatencyMs().doubleValue(), readyTimeMs);
                         }
                         log.debug("Address {} successfully {}authenticated",
-                            channel.socketDescription(), isReAuthentication ? "re-" : "");
+                            channel.socketDescription(), isReauthentication ? "re-" : "");
                     }
                     List<NetworkReceive> responsesReceivedDuringReauthentication = channel
                             .getAndClearResponsesReceivedDuringReauthentication();


### PR DESCRIPTION
I believe that it'll be useful for debugging purposes to know which IP addresses are consistently failing authentication.
Applications that consistently fail authentication can introduce CPU pressure to the broker and as such, I think it is useful for Ops teams to have the needed information to quickly block.

I've left these logs on `DEBUG` level since I presume that most common cases won't require to know this information. I'm sure we shouldn't log successful auths in `INFO` but I'm hesitant about unsuccessful auths

cc @rajinisivaram @ijuma @rondagostino 