### PR TITLE
KAFKA-7481; Add upgrade/downgrade notes for 2.1.x

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -53,10 +53,9 @@
         protocol version, it will no longer be possible to downgrade the cluster to an older version.
     </li>
     <li> If you have overridden the message format version as instructed above, then you need to do one more rolling restart to
-        upgrade it to its latest version. To avoid message conversion costs, you can wait until most clients
-        (producers and consumers) have been upgraded to 0.11.0 or later before taking this step. Once they have,
-        change log.message.format.version to 2.1 on each broker and restart them one by one. Note that the older Scala clients
-        which are no longer maintained do not support the message format introduced in 0.11, so to avoid conversion costs 
+        upgrade it to its latest version. Once all (or most) consumers have been upgraded to 0.11.0 or later,
+        change log.message.format.version to 2.1 on each broker and restart them one by one. Note that the older Scala clients,
+        which are no longer maintained, do not support the message format introduced in 0.11, so to avoid conversion costs 
         (or to take advantage of <a href="#upgrade_11_exactly_once_semantics">exactly once semantics</a>),
         the newer Java clients must be used.
     </li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -20,6 +20,45 @@
 <script id="upgrade-template" type="text/x-handlebars-template">
 
 <h4><a id="upgrade_2_1_0" href="#upgrade_2_1_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, or 2.0.0 to 2.1.0</a></h4>
+
+<p><b>Note that 2.1.x contains an incompatible change to the internal schema used to store consumer offsets. Once the upgrade is
+  complete, it will not be possible to downgrade to previous versions. See the rolling upgrade notes below for more detail.</b></p>
+
+<p><b>For a rolling upgrade:</b></p>
+
+<ol>
+    <li> Update server.properties on all brokers and add the following properties. CURRENT_KAFKA_VERSION refers to the version you
+        are upgrading from. CURRENT_MESSAGE_FORMAT_VERSION refers to the message format version currently in use. If you have previously
+        overridden the message format version, you should keep its current value. Alternatively, if you are upgrading from a version prior
+        to 0.11.0.x, then CURRENT_MESSAGE_FORMAT_VERSION should be set to match CURRENT_KAFKA_VERSION.
+        <ul>
+            <li>inter.broker.protocol.version=CURRENT_KAFKA_VERSION (e.g. 0.8.2, 0.9.0, 0.10.0, 0.10.1, 0.10.2, 0.11.0, 1.0, 1.1).</li>
+            <li>log.message.format.version=CURRENT_MESSAGE_FORMAT_VERSION  (See <a href="#upgrade_10_performance_impact">potential performance impact
+                following the upgrade</a> for the details on what this configuration does.)</li>
+        </ul>
+        If you are upgrading from 0.11.0.x, 1.0.x, 1.1.x, or 2.0.x and you have not overridden the message format, then you only need to override
+        the inter-broker protocol version.
+        <ul>
+            <li>inter.broker.protocol.version=CURRENT_KAFKA_VERSION (0.11.0, 1.0, 1.1, 2.0).</li>
+        </ul>
+    </li>
+    <li> Upgrade the brokers one at a time: shut down the broker, update the code, and restart it. Once you have done so, the
+        brokers will be running the latest version and you can verify that the cluster's behavior and performance meets expectations.
+        It is still possible to downgrade at this point if there are any problems. 
+    </li>
+    <li> Once the entire cluster is upgraded, bump the protocol version by editing <code>inter.broker.protocol.version</code>
+        and setting it to 2.1.
+    </li>
+    <li> Restart the brokers one by one for the new protocol version to take effect. Once the brokers begin using the latest
+        protocol version, it will no longer be possible to downgrade the cluster to an older version.
+    </li>
+    <li> If you have overridden the message format version as instructed above, then you need to do one more rolling restart to
+        upgrade it to its latest version. Once all (or most) consumers have been upgraded to 0.11.0 or later,
+        change log.message.format.version to 2.1 on each broker and restart them one by one. Note that the older Scala consumer
+        does not support the new message format introduced in 0.11, so to avoid the performance cost of down-conversion (or to
+        take advantage of <a href="#upgrade_11_exactly_once_semantics">exactly once semantics</a>), the newer Java consumer must be used.</li>
+</ol>
+
 <p><b>Additional Upgrade Notes:</b></p>
 
 <ol>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -21,7 +21,7 @@
 
 <h4><a id="upgrade_2_1_0" href="#upgrade_2_1_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, or 2.0.0 to 2.1.0</a></h4>
 
-<p><b>Note that 2.1.x contains an incompatible change to the internal schema used to store consumer offsets. Once the upgrade is
+<p><b>Note that 2.1.x contains a change to the internal schema used to store consumer offsets. Once the upgrade is
   complete, it will not be possible to downgrade to previous versions. See the rolling upgrade notes below for more detail.</b></p>
 
 <p><b>For a rolling upgrade:</b></p>
@@ -46,17 +46,20 @@
         brokers will be running the latest version and you can verify that the cluster's behavior and performance meets expectations.
         It is still possible to downgrade at this point if there are any problems. 
     </li>
-    <li> Once the entire cluster is upgraded, bump the protocol version by editing <code>inter.broker.protocol.version</code>
-        and setting it to 2.1.
+    <li> Once the cluster's behavior and performance has been verified, bump the protocol version by editing
+        <code>inter.broker.protocol.version</code> and setting it to 2.1.
     </li>
     <li> Restart the brokers one by one for the new protocol version to take effect. Once the brokers begin using the latest
         protocol version, it will no longer be possible to downgrade the cluster to an older version.
     </li>
     <li> If you have overridden the message format version as instructed above, then you need to do one more rolling restart to
-        upgrade it to its latest version. Once all (or most) consumers have been upgraded to 0.11.0 or later,
-        change log.message.format.version to 2.1 on each broker and restart them one by one. Note that the older Scala consumer
-        does not support the new message format introduced in 0.11, so to avoid the performance cost of down-conversion (or to
-        take advantage of <a href="#upgrade_11_exactly_once_semantics">exactly once semantics</a>), the newer Java consumer must be used.</li>
+        upgrade it to its latest version. To avoid message conversion costs, you can wait until most clients
+        (producers and consumers) have been upgraded to 0.11.0 or later before taking this step. Once they have,
+        change log.message.format.version to 2.1 on each broker and restart them one by one. Note that the older Scala clients
+        which are no longer maintained do not support the message format introduced in 0.11, so to avoid conversion costs 
+        (or to take advantage of <a href="#upgrade_11_exactly_once_semantics">exactly once semantics</a>),
+        the newer Java clients must be used.
+    </li>
 </ol>
 
 <p><b>Additional Upgrade Notes:</b></p>


### PR DESCRIPTION
We seemed to be missing the usual rolling upgrade instructions so I've added them and emphasized the impact for downgrades after bumping the inter-broker protocol version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
