### PR TITLE
MINOR: Fix a few blocking calls in PlaintextConsumerTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -180,12 +180,12 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
                                      numRecords: Int,
                                      maxPollRecords: Int = Int.MaxValue): ArrayBuffer[ConsumerRecord[K, V]] = {
     val records = new ArrayBuffer[ConsumerRecord[K, V]]
-    def pollCondition(polledRecords: ConsumerRecords[K, V]): Boolean = {
+    def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
       assertTrue(polledRecords.asScala.size <= maxPollRecords)
       records ++= polledRecords.asScala
       records.size >= numRecords
     }
-    TestUtils.pollRecordsUntilTrue(consumer, pollCondition, waitTimeMs = 60000,
+    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = 60000,
       msg = s"Timed out before consuming expected $numRecords records. " +
         s"The number consumed was ${records.size}.")
     records

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -177,7 +177,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val listener = new TestConsumerReassignmentListener()
     consumer.subscribe(List(topic).asJava, listener)
 
-    // poll once to get the initial assignment
+    // rebalance to get the initial assignment
     awaitRebalance(consumer, listener)
     assertEquals(1, listener.callsToAssigned)
     assertEquals(1, listener.callsToRevoked)
@@ -218,7 +218,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     consumer.subscribe(List(topic).asJava, listener)
 
-    // poll once to join the group and get the initial assignment
+    // rebalance to get the initial assignment
     awaitRebalance(consumer, listener)
 
     // force a rebalance to trigger an invocation of the revocation callback while in the group
@@ -246,7 +246,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     }
     consumer.subscribe(List(topic).asJava, listener)
 
-    // poll once to join the group and get the initial assignment
+    // rebalance to get the initial assignment
     awaitRebalance(consumer, listener)
 
     // We should still be in the group after this invocation
@@ -1300,7 +1300,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val consumer = createConsumer()
     consumer.assign(List(tp, tp2).asJava)
 
-    // Need to poll to join the group
     val pos1 = consumer.position(tp)
     val pos2 = consumer.position(tp2)
     consumer.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp, new OffsetAndMetadata(3L))).asJava)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -12,6 +12,7 @@
   */
 package kafka.api
 
+import java.time.Duration
 import java.util
 import java.util.regex.Pattern
 import java.util.{Collections, Locale, Optional, Properties}
@@ -260,7 +261,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == assignment.asJava
     }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -288,7 +289,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == assignment.asJava
     }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -371,7 +372,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(topic1, 1))
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
@@ -385,7 +386,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(topic4, 1))
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
@@ -429,7 +430,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(fooTopic, 0))
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
@@ -439,7 +440,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val pattern2 = Pattern.compile("...") // only 'foo' and 'bar' match this
     consumer.subscribe(pattern2, new TestConsumerReassignmentListener)
-    consumer.poll(50)
+    consumer.poll(Duration.ofMillis(50))
 
     subscriptions --= Set(
       new TopicPartition(topic, 0),
@@ -449,7 +450,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(barTopic, 0))
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
@@ -480,7 +481,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(0, consumer.assignment().size)
 
     consumer.subscribe(Pattern.compile("t.*c"), new TestConsumerReassignmentListener)
-    consumer.poll(50)
+    consumer.poll(Duration.ofMillis(50))
 
     val subscriptions = Set(
       new TopicPartition(topic, 0),
@@ -489,7 +490,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(topic1, 1))
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
@@ -543,14 +544,14 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment}")
 
     createTopic(otherTopic, 2, serverCount)
     consumer.subscribe(List(topic, otherTopic).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment == expandedSubscriptions.asJava
     }, s"Expected partitions ${expandedSubscriptions.asJava} but actually got ${consumer.assignment}")
   }
@@ -564,13 +565,13 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val consumer = createConsumer()
     consumer.subscribe(List(topic, otherTopic).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment == subscriptions.asJava
     }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment}")
 
     consumer.subscribe(List(topic).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment == shrunkenSubscriptions.asJava
     }, s"Expected partitions ${shrunkenSubscriptions.asJava} but actually got ${consumer.assignment}")
   }
@@ -831,7 +832,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.subscribe(List(topic1, topic2, topic3).asJava)
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == partitions.toSet.asJava
     }, s"Expected partitions ${partitions.asJava} but actually got ${consumer.assignment}")
 
@@ -869,7 +870,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // subscribe to two topics
     consumer.subscribe(List(topic1, topic2).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == expectedAssignment.asJava
     }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -880,14 +881,14 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val newExpectedAssignment = expectedAssignment ++ Set(new TopicPartition(topic3, 0), new TopicPartition(topic3, 1))
     consumer.subscribe(List(topic1, topic2, topic3).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == newExpectedAssignment.asJava
     }, s"Expected partitions ${newExpectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
     // remove the topic we just added
     consumer.subscribe(List(topic1, topic2).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == expectedAssignment.asJava
     }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -1321,8 +1322,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.subscribe(List(topic).asJava, listener)
 
     // the initial subscription should cause a callback execution
-    while (listener.callsToAssigned == 0)
-      consumer.poll(50)
+    TestUtils.waitUntilTrue(() => {
+      consumer.poll(Duration.ofMillis(50))
+      listener.callsToAssigned > 0
+    }, "Timed out waiting for initial assignment")
 
     consumer.subscribe(List[String]().asJava)
     assertEquals(0, consumer.assignment.size())
@@ -1404,7 +1407,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == assignment.asJava
     }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -1416,7 +1419,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val newAssignment = Set(tp, tp2, new TopicPartition(topic2, 0), new TopicPartition(topic2, 1))
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(50)
+      consumer.poll(Duration.ofMillis(50))
       consumer.assignment() == newAssignment.asJava
     }, s"Expected partitions ${newAssignment.asJava} but actually got ${consumer.assignment()}")
 
@@ -1442,7 +1445,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.subscribe(List(topic, topic2).asJava, listener0)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.records(tp).isEmpty
     }, "Consumer did not consume any message before timeout.")
     assertEquals("should be assigned once", 1, listener0.callsToAssigned)
@@ -1463,7 +1466,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Remove topic from subscription
     consumer.subscribe(List(topic2).asJava, listener0)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(100)
+      consumer.poll(Duration.ofMillis(100))
       listener0.callsToAssigned >= 2
     }, "Expected rebalance did not occur.")
     // Verify the metric has gone
@@ -1488,7 +1491,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.subscribe(List(topic, topic2).asJava, listener0)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.records(tp).isEmpty
     }, "Consumer did not consume any message before timeout.")
     assertEquals("should be assigned once", 1, listener0.callsToAssigned)
@@ -1510,7 +1513,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Remove topic from subscription
     consumer.subscribe(List(topic2).asJava, listener0)
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(100)
+      consumer.poll(Duration.ofMillis(100))
       listener0.callsToAssigned >= 2
     }, "Expected rebalance did not occur.")
     // Verify the metric has gone
@@ -1533,7 +1536,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.records(tp).isEmpty
     }, "Consumer did not consume any message before timeout.")
     // Verify the metric exist.
@@ -1547,7 +1550,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertTrue(s"The lead should be ${records.count}", records.count == fetchLead.metricValue())
 
     consumer.assign(List(tp2).asJava)
-    TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
+    TestUtils.waitUntilTrue(() => !consumer.poll(Duration.ofMillis(100)).isEmpty,
+      "Consumer did not consume any message before timeout.")
     assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags)))
   }
 
@@ -1566,7 +1570,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.records(tp).isEmpty
     }, "Consumer did not consume any message before timeout.")
     // Verify the metric exist.
@@ -1581,7 +1585,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(s"The lag should be $expectedLag", expectedLag, fetchLag.metricValue.asInstanceOf[Double], epsilon)
 
     consumer.assign(List(tp2).asJava)
-    TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
+    TestUtils.waitUntilTrue(() => !consumer.poll(Duration.ofMillis(100)).isEmpty,
+      "Consumer did not consume any message before timeout.")
     assertNull(consumer.metrics.get(new MetricName(tp + ".records-lag", "consumer-fetch-manager-metrics", "", tags)))
     assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags)))
   }
@@ -1601,7 +1606,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.records(tp).isEmpty
     }, "Consumer did not consume any message before timeout.")
     // Verify the metric exist.
@@ -1627,7 +1632,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.isEmpty
     }, "Consumer did not consume any message before timeout.")
 
@@ -1653,7 +1658,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
     TestUtils.waitUntilTrue(() => {
-      records = consumer.poll(100)
+      records = consumer.poll(Duration.ofMillis(100))
       !records.isEmpty
     }, "Consumer did not consume any message before timeout.")
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -12,7 +12,6 @@
   */
 package kafka.api
 
-import java.time.Duration
 import java.util
 import java.util.regex.Pattern
 import java.util.{Collections, Locale, Optional, Properties}
@@ -353,7 +352,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val pattern = Pattern.compile("t.*c")
     consumer.subscribe(pattern, new TestConsumerReassignmentListener)
-    consumer.poll(50)
 
     var assignment = Set(
       new TopicPartition(topic, 0),
@@ -404,7 +402,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val pattern1 = Pattern.compile(".*o.*") // only 'topic' and 'foo' match this
     consumer.subscribe(pattern1, new TestConsumerReassignmentListener)
-    consumer.poll(50)
 
     var assignment = Set(
       new TopicPartition(topic, 0),
@@ -418,8 +415,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val pattern2 = Pattern.compile("...") // only 'foo' and 'bar' match this
     consumer.subscribe(pattern2, new TestConsumerReassignmentListener)
-    consumer.poll(Duration.ofMillis(50))
-
     assignment --= Set(
       new TopicPartition(topic, 0),
       new TopicPartition(topic, 1))
@@ -454,8 +449,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(0, consumer.assignment().size)
 
     consumer.subscribe(Pattern.compile("t.*c"), new TestConsumerReassignmentListener)
-    consumer.poll(Duration.ofMillis(50))
-
     val assignment = Set(
       new TopicPartition(topic, 0),
       new TopicPartition(topic, 1),
@@ -494,7 +487,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testAsyncCommit() {
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    consumer.poll(0)
 
     val callback = new CountConsumerCommitCallback
     val count = 5
@@ -1304,7 +1296,6 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp, tp2).asJava)
 
     // Need to poll to join the group
-    consumer.poll(50)
     val pos1 = consumer.position(tp)
     val pos2 = consumer.position(tp2)
     consumer.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp, new OffsetAndMetadata(3L))).asJava)

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -209,7 +209,7 @@ class TransactionsTest extends KafkaServerTestHarness {
     val readCommittedConsumer = createReadCommittedConsumer(props = consumerProps)
 
     readCommittedConsumer.assign(Set(new TopicPartition(topic1, 0)).asJava)
-    val records = consumeRecords(readCommittedConsumer, numMessages = 2)
+    val records = consumeRecords(readCommittedConsumer, numRecords = 2)
     assertEquals(2, records.size)
 
     val first = records.head

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -720,32 +720,51 @@ object TestUtils extends Logging {
     }
   }
 
+  def pollUntilTrue(consumer: Consumer[_, _],
+                    condition: () => Boolean,
+                    msg: => String,
+                    waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
+    waitUntilTrue(() => {
+      consumer.poll(Duration.ofMillis(50))
+      condition()
+    }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
+  }
+
+  def pollRecordsUntilTrue[K, V](consumer: Consumer[K, V],
+                                 condition: ConsumerRecords[K, V] => Boolean,
+                                 msg: => String,
+                                 waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
+    waitUntilTrue(() => {
+      val records = consumer.poll(Duration.ofMillis(50))
+      condition(records)
+    }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
+  }
+
   /**
     *  Wait until the given condition is true or throw an exception if the given wait time elapses.
     *
     * @param condition condition to check
     * @param msg error message
-    * @param waitTime maximum time to wait and retest the condition before failing the test
+    * @param waitTimeMs maximum time to wait and retest the condition before failing the test
     * @param pause delay between condition checks
     * @param maxRetries maximum number of retries to check the given condition if a retriable exception is thrown
     */
   def waitUntilTrue(condition: () => Boolean, msg: => String,
-                    waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L, maxRetries: Int = 0): Unit = {
+                    waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L, maxRetries: Int = 0): Unit = {
     val startTime = System.currentTimeMillis()
     var retry = 0
     while (true) {
       try {
         if (condition())
           return
-        if (System.currentTimeMillis() > startTime + waitTime)
+        if (System.currentTimeMillis() > startTime + waitTimeMs)
           fail(msg)
-        Thread.sleep(waitTime.min(pause))
+        Thread.sleep(waitTimeMs.min(pause))
       }
       catch {
-        case e: RetriableException if retry < maxRetries => {
+        case e: RetriableException if retry < maxRetries =>
           debug("Retrying after error", e)
           retry += 1
-        }
         case e : Throwable => throw e
       }
     }
@@ -840,7 +859,7 @@ object TestUtils extends Logging {
           }
       },
       "Partition [%s,%d] metadata not propagated after %d ms".format(topic, partition, timeout),
-      waitTime = timeout)
+      waitTimeMs = timeout)
 
     leader
   }
@@ -862,7 +881,7 @@ object TestUtils extends Logging {
     }
 
     TestUtils.waitUntilTrue(() => newLeaderExists.isDefined,
-      s"Did not observe leader change for partition $tp after $timeout ms", waitTime = timeout)
+      s"Did not observe leader change for partition $tp after $timeout ms", waitTimeMs = timeout)
 
     newLeaderExists.get
   }
@@ -877,7 +896,7 @@ object TestUtils extends Logging {
     }
 
     TestUtils.waitUntilTrue(() => leaderIfExists.isDefined,
-      s"Partition $tp leaders not made yet after $timeout ms", waitTime = timeout)
+      s"Partition $tp leaders not made yet after $timeout ms", waitTimeMs = timeout)
 
     leaderIfExists.get
   }
@@ -1086,7 +1105,7 @@ object TestUtils extends Logging {
 
     TestUtils.waitUntilTrue(() => authorizer.getAcls(resource) == expected,
       s"expected acls:${expected.mkString(newLine + "\t", newLine + "\t", newLine)}" +
-        s"but got:${authorizer.getAcls(resource).mkString(newLine + "\t", newLine + "\t", newLine)}", waitTime = JTestUtils.DEFAULT_MAX_WAIT_MS)
+        s"but got:${authorizer.getAcls(resource).mkString(newLine + "\t", newLine + "\t", newLine)}", waitTimeMs = JTestUtils.DEFAULT_MAX_WAIT_MS)
   }
 
   /**
@@ -1212,13 +1231,16 @@ object TestUtils extends Logging {
     } finally consumer.close()
   }
 
-  def consumeRecords[K, V](consumer: KafkaConsumer[K, V], numMessages: Int,
+  def consumeRecords[K, V](consumer: KafkaConsumer[K, V],
+                           numMessages: Int,
                            waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[K, V]] = {
     val records = new ArrayBuffer[ConsumerRecord[K, V]]()
-    waitUntilTrue(() => {
-      records ++= consumer.poll(Duration.ofMillis(50)).asScala
+    def pollCondition(polledRecords: ConsumerRecords[K, V]): Boolean = {
+      records ++= polledRecords.asScala
       records.size >= numMessages
-    }, s"Consumed ${records.size} records until timeout instead of the expected $numMessages records", waitTime)
+    }
+    pollRecordsUntilTrue(consumer, pollCondition,
+      s"Consumed ${records.size} records before timeout instead of the expected $numMessages records")
     assertEquals("Consumed more records than expected", numMessages, records.size)
     records
   }


### PR DESCRIPTION
We've been seeing some hanging builds recently (see KAFKA-7553). Consistently the culprit seems to be a test case in PlaintextConsumerTest. This patch doesn't fix the underlying issue, but it eliminates a few places where these test cases could block:

1. It replaces several calls to the deprecated `poll(long)` which can block indefinitely in the worst case with `poll(Duration)` which respects the timeout.
2. It also fixes a consume utility in `TestUtils` which can block for a long time depending on the number of records that are expected to be consumed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
