### PR TITLE
KAFKA-7514: Add threads to ConsumeBenchWorker

### DIFF
--- a/TROGDOR.md
+++ b/TROGDOR.md
@@ -38,16 +38,14 @@ Let's confirm that all of the daemons are running:
 Now, we can submit a test job to Trogdor.  Here's an example of a short bash script which makes it easier.
 
     > ./tests/bin/trogdor-run-produce-bench.sh
-    [2018-04-12 10:32:04,055] DEBUG Sending POST with input {"id":"produce_bench_22137","spec":{"class":"org.apache.kafka.trogdor.workload.ProduceBenchSpec","startMs":0,"durationMs":10000000,"producerNode":"node0","bootstrapServers":"localhost:9092","targetMessagesPerSec":10,"maxMessages":100,"keyGenerator":{"type":"sequential","size":4,"startOffset":0},"valueGenerator":{"type":"constant","size":512,"value":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"totalTopics":10,"activeTopics":5,"topicPrefix":"foo","replicationFactor":1,"classLoader":{},"numPartitions":1}} to http://localhost:8889/coordinator/task/create (org.apache.kafka.trogdor.coordinator.CoordinatorClient)
-    Created task.
-    $TASK_ID = produce_bench_20462
+    Sent CreateTaskRequest for task produce_bench_21634.$TASK_ID = produce_bench_21634
 
 To get the test results, we run --show-tasks:
 
     ./bin/trogdor.sh client --show-tasks localhost:8889
     Got coordinator tasks: {
       "tasks" : {
-        "produce_bench_20462" : {
+        "produce_bench_21634" : {
           "state" : "DONE",
           "spec" : {
             "class" : "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
@@ -55,8 +53,8 @@ To get the test results, we run --show-tasks:
             "durationMs" : 10000000,
             "producerNode" : "node0",
             "bootstrapServers" : "localhost:9092",
-            "targetMessagesPerSec" : 10,
-            "maxMessages" : 100,
+            "targetMessagesPerSec" : 10000,
+            "maxMessages" : 50000,
             "keyGenerator" : {
               "type" : "sequential",
               "size" : 4,
@@ -67,22 +65,28 @@ To get the test results, we run --show-tasks:
               "size" : 512,
               "value" : "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
             },
-            "totalTopics" : 10,
-            "activeTopics" : 5,
-            "topicPrefix" : "foo",
-            "replicationFactor" : 1,
-            "classLoader" : { },
-            "numPartitions" : 1
+            "activeTopics" : {
+              "foo[1-3]" : {
+                "numPartitions" : 10,
+                "replicationFactor" : 1
+              }
+            },
+            "inactiveTopics" : {
+              "foo[4-5]" : {
+                "numPartitions" : 10,
+                "replicationFactor" : 1
+              }
+            }
           },
-          "startedMs" : 1523552769850,
-          "doneMs" : 1523552780878,
+          "startedMs" : 1541435949784,
+          "doneMs" : 1541435955803,
           "cancelled" : false,
           "status" : {
-            "totalSent" : 500,
-            "averageLatencyMs" : 4.972,
-            "p50LatencyMs" : 4,
-            "p95LatencyMs" : 6,
-            "p99LatencyMs" : 12
+            "totalSent" : 50000,
+            "averageLatencyMs" : 11.0293,
+            "p50LatencyMs" : 9,
+            "p95LatencyMs" : 27,
+            "p99LatencyMs" : 39
           }
         }
       }

--- a/TROGDOR.md
+++ b/TROGDOR.md
@@ -145,7 +145,7 @@ ProduceBench starts a Kafka producer on a single agent node, producing to severa
 RoundTripWorkload tests both production and consumption.  The workload starts a Kafka producer and consumer on a single node.  The consumer will read back the messages that were produced by the producer.
 
 ### ConsumeBench
-ConsumeBench starts a Kafka consumer on a single agent node. Depending on the passed in configuration (see ConsumeBenchSpec), the consumer either subscribes to a set of topics (leveraging consumer group functionality) or manually assigns partitions to itself.
+ConsumeBench starts one or more Kafka consumers on a single agent node. Depending on the passed in configuration (see ConsumeBenchSpec), the consumers either subscribe to a set of topics (leveraging consumer group functionality and dynamic partition assignment) or manually assign partitions to themselves.
 The workload measures the average produce latency, as well as the median, 95th percentile, and 99th percentile latency.
 
 Faults

--- a/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.stream.IntStream.range;
+
 public final class CollectionUtils {
 
     private CollectionUtils() {}
@@ -35,6 +37,23 @@ public final class CollectionUtils {
         return minuend.entrySet().stream()
                 .filter(entry -> !subtrahend.containsKey(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Splits a #{@link List} into #{@code listsCount} #{@link List} instances,
+     * splitting the elements in a round-robin fashion.
+     *
+     * Example:
+     * splitListRoundRobin([1, 2, 3, 4, 5], 3)
+     *  -> [[1, 4], [2, 5], [3]]
+     *
+     */
+    public static <T> List<List<T>> splitListRoundRobin(List<T> collection, int listsCount) {
+        List<List<T>> splitLists = range(0, listsCount).mapToObj(i -> new ArrayList<T>()).collect(Collectors.toList());
+        for (int i = 0; i < collection.size(); i++) {
+            splitLists.get(i % listsCount).add(collection.get(i));
+        }
+        return splitLists;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.stream.IntStream.range;
-
 public final class CollectionUtils {
 
     private CollectionUtils() {}
@@ -37,23 +35,6 @@ public final class CollectionUtils {
         return minuend.entrySet().stream()
                 .filter(entry -> !subtrahend.containsKey(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    /**
-     * Splits a #{@link List} into #{@code listsCount} #{@link List} instances,
-     * splitting the elements in a round-robin fashion.
-     *
-     * Example:
-     * splitListRoundRobin([1, 2, 3, 4, 5], 3)
-     *  -> [[1, 4], [2, 5], [3]]
-     *
-     */
-    public static <T> List<List<T>> splitListRoundRobin(List<T> collection, int listsCount) {
-        List<List<T>> splitLists = range(0, listsCount).mapToObj(i -> new ArrayList<T>()).collect(Collectors.toList());
-        for (int i = 0; i < collection.size(); i++) {
-            splitLists.get(i % listsCount).add(collection.get(i));
-        }
-        return splitLists;
     }
 
     /**

--- a/tests/bin/trogdor-run-consume-bench.sh
+++ b/tests/bin/trogdor-run-consume-bench.sh
@@ -26,7 +26,7 @@ cat <<EOF
         "consumerNode": "node0",
         "bootstrapServers": "localhost:9092",
         "targetMessagesPerSec": 1000,
-        "threadCount": 5,
+        "threadsPerWorker": 5,
         "consumerGroup": "cg",
         "maxMessages": 10000,
         "activeTopics": ["foo[1-3]"]

--- a/tests/bin/trogdor-run-consume-bench.sh
+++ b/tests/bin/trogdor-run-consume-bench.sh
@@ -25,7 +25,10 @@ cat <<EOF
         "durationMs": 10000000,
         "consumerNode": "node0",
         "bootstrapServers": "localhost:9092",
-        "maxMessages": 100,
+        "targetMessagesPerSec": 1000,
+        "consumerCount": 5,
+        "consumerGroup": "cg",
+        "maxMessages": 10000,
         "activeTopics": ["foo[1-3]"]
     }
 }

--- a/tests/bin/trogdor-run-consume-bench.sh
+++ b/tests/bin/trogdor-run-consume-bench.sh
@@ -26,7 +26,7 @@ cat <<EOF
         "consumerNode": "node0",
         "bootstrapServers": "localhost:9092",
         "targetMessagesPerSec": 1000,
-        "consumerCount": 5,
+        "threadCount": 5,
         "consumerGroup": "cg",
         "maxMessages": 10000,
         "activeTopics": ["foo[1-3]"]

--- a/tests/bin/trogdor-run-produce-bench.sh
+++ b/tests/bin/trogdor-run-produce-bench.sh
@@ -25,17 +25,17 @@ cat <<EOF
         "durationMs": 10000000,
         "producerNode": "node0",
         "bootstrapServers": "localhost:9092",
-        "targetMessagesPerSec": 10,
-        "maxMessages": 100,
+        "targetMessagesPerSec": 10000,
+        "maxMessages": 50000,
         "activeTopics": {
             "foo[1-3]": {
-                "numPartitions": 3,
+                "numPartitions": 10,
                 "replicationFactor": 1
             }
         },
         "inactiveTopics": {
             "foo[4-5]": {
-                "numPartitions": 3,
+                "numPartitions": 10,
                 "replicationFactor": 1
             }
         }

--- a/tests/kafkatest/services/trogdor/consume_bench_workload.py
+++ b/tests/kafkatest/services/trogdor/consume_bench_workload.py
@@ -32,7 +32,7 @@ class ConsumeBenchWorkloadSpec(TaskSpec):
         self.message["adminClientConf"] = admin_client_conf
         self.message["commonClientConf"] = common_client_conf
         self.message["activeTopics"] = active_topics
-        self.message["consumerCount"] = consumer_count
+        self.message["threadCount"] = consumer_count
         if consumer_group is not None:
             self.message["consumerGroup"] = consumer_group
 

--- a/tests/kafkatest/services/trogdor/consume_bench_workload.py
+++ b/tests/kafkatest/services/trogdor/consume_bench_workload.py
@@ -21,7 +21,7 @@ from kafkatest.services.trogdor.task_spec import TaskSpec
 class ConsumeBenchWorkloadSpec(TaskSpec):
     def __init__(self, start_ms, duration_ms, consumer_node, bootstrap_servers,
                  target_messages_per_sec, max_messages, active_topics,
-                 consumer_conf, common_client_conf, admin_client_conf, consumer_group=None):
+                 consumer_conf, common_client_conf, admin_client_conf, consumer_group=None, consumer_count=1):
         super(ConsumeBenchWorkloadSpec, self).__init__(start_ms, duration_ms)
         self.message["class"] = "org.apache.kafka.trogdor.workload.ConsumeBenchSpec"
         self.message["consumerNode"] = consumer_node
@@ -32,6 +32,7 @@ class ConsumeBenchWorkloadSpec(TaskSpec):
         self.message["adminClientConf"] = admin_client_conf
         self.message["commonClientConf"] = common_client_conf
         self.message["activeTopics"] = active_topics
+        self.message["consumerCount"] = consumer_count
         if consumer_group is not None:
             self.message["consumerGroup"] = consumer_group
 

--- a/tests/kafkatest/services/trogdor/consume_bench_workload.py
+++ b/tests/kafkatest/services/trogdor/consume_bench_workload.py
@@ -21,7 +21,7 @@ from kafkatest.services.trogdor.task_spec import TaskSpec
 class ConsumeBenchWorkloadSpec(TaskSpec):
     def __init__(self, start_ms, duration_ms, consumer_node, bootstrap_servers,
                  target_messages_per_sec, max_messages, active_topics,
-                 consumer_conf, common_client_conf, admin_client_conf, consumer_group=None, consumer_count=1):
+                 consumer_conf, common_client_conf, admin_client_conf, consumer_group=None, threads_per_worker=1):
         super(ConsumeBenchWorkloadSpec, self).__init__(start_ms, duration_ms)
         self.message["class"] = "org.apache.kafka.trogdor.workload.ConsumeBenchSpec"
         self.message["consumerNode"] = consumer_node
@@ -32,7 +32,7 @@ class ConsumeBenchWorkloadSpec(TaskSpec):
         self.message["adminClientConf"] = admin_client_conf
         self.message["commonClientConf"] = common_client_conf
         self.message["activeTopics"] = active_topics
-        self.message["threadsPerWorker"] = consumer_count
+        self.message["threadsPerWorker"] = threads_per_worker
         if consumer_group is not None:
             self.message["consumerGroup"] = consumer_group
 

--- a/tests/kafkatest/services/trogdor/consume_bench_workload.py
+++ b/tests/kafkatest/services/trogdor/consume_bench_workload.py
@@ -32,7 +32,7 @@ class ConsumeBenchWorkloadSpec(TaskSpec):
         self.message["adminClientConf"] = admin_client_conf
         self.message["commonClientConf"] = common_client_conf
         self.message["activeTopics"] = active_topics
-        self.message["threadCount"] = consumer_count
+        self.message["threadsPerWorker"] = consumer_count
         if consumer_group is not None:
             self.message["consumerGroup"] = consumer_group
 

--- a/tests/kafkatest/tests/core/consume_bench_test.py
+++ b/tests/kafkatest/tests/core/consume_bench_test.py
@@ -86,7 +86,7 @@ class ConsumeBenchTest(Test):
         tasks = self.trogdor.tasks()
         self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
 
-    def test_consume_bench_single_partition(self):
+    def test_single_partition(self):
         """
         Run a ConsumeBench against a single partition
         """
@@ -107,9 +107,32 @@ class ConsumeBenchTest(Test):
         tasks = self.trogdor.tasks()
         self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
 
-    def test_consume_group_bench(self):
+    def test_multiple_consumers_random_group_topics(self):
         """
-        Runs two ConsumeBench workloads in the same consumer group to read messages from topics
+        Runs multiple consumers group to read messages from topics.
+        Since a consumerGroup isn't specified, each consumer should read from all topics independently
+        """
+        self.produce_messages(self.active_topics, max_messages=5000)
+        consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
+                                                self.consumer_workload_service.consumer_node,
+                                                self.consumer_workload_service.bootstrap_servers,
+                                                target_messages_per_sec=1000,
+                                                max_messages=5000, # all should read exactly 5k messages
+                                                consumer_conf={},
+                                                admin_client_conf={},
+                                                common_client_conf={},
+                                                consumer_count=5,
+                                                active_topics=["consume_bench_topic[0-5]"])
+        consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
+        consume_workload.wait_for_done(timeout_sec=360)
+        self.logger.debug("Consume workload finished")
+        tasks = self.trogdor.tasks()
+        self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
+
+    def test_two_consumers_specified_group_topics(self):
+        """
+        Runs two consumers in the same consumer group to read messages from topics.
+        Since a consumerGroup is specified, each consumer should dynamically get assigned a partition from group
         """
         self.produce_messages(self.active_topics)
         consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
@@ -120,13 +143,62 @@ class ConsumeBenchTest(Test):
                                                 consumer_conf={},
                                                 admin_client_conf={},
                                                 common_client_conf={},
+                                                consumer_count=2,
                                                 consumer_group="testGroup",
                                                 active_topics=["consume_bench_topic[0-5]"])
-        consume_workload_1 = self.trogdor.create_task("consume_workload_1", consume_spec)
-        consume_workload_2 = self.trogdor.create_task("consume_workload_2", consume_spec)
-        consume_workload_1.wait_for_done(timeout_sec=360)
-        self.logger.debug("Consume workload 1 finished")
-        consume_workload_2.wait_for_done(timeout_sec=360)
-        self.logger.debug("Consume workload 2 finished")
+        consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
+        consume_workload.wait_for_done(timeout_sec=360)
+        self.logger.debug("Consume workload finished")
         tasks = self.trogdor.tasks()
         self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
+
+    def test_multiple_consumers_random_group_partitions(self):
+        """
+        Runs multiple consumers in to read messages from specific partitions.
+        Since a consumerGroup isn't specified, each consumer will get assigned a random group
+        and consume from all partitions
+        """
+        self.produce_messages(self.active_topics, max_messages=20000)
+        consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
+                                                self.consumer_workload_service.consumer_node,
+                                                self.consumer_workload_service.bootstrap_servers,
+                                                target_messages_per_sec=1000,
+                                                max_messages=2000,
+                                                consumer_conf={},
+                                                admin_client_conf={},
+                                                common_client_conf={},
+                                                consumer_count=4,
+                                                active_topics=["consume_bench_topic1:[0-4]"])
+        consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
+        consume_workload.wait_for_done(timeout_sec=360)
+        self.logger.debug("Consume workload finished")
+        tasks = self.trogdor.tasks()
+        self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
+
+    def test_multiple_consumers_specified_group_partitions_should_raise(self):
+        """
+        Runs multiple consumers in to read messages from specific partitions.
+        Since a consumerGroup isn't specified, each consumer will get assigned a random group
+        and consume from all partitions
+        """
+        self.produce_messages(self.active_topics, max_messages=20000)
+        consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
+                                                self.consumer_workload_service.consumer_node,
+                                                self.consumer_workload_service.bootstrap_servers,
+                                                target_messages_per_sec=1000,
+                                                max_messages=2000,
+                                                consumer_conf={},
+                                                admin_client_conf={},
+                                                common_client_conf={},
+                                                consumer_count=4,
+                                                consumer_group="fail_group",
+                                                active_topics=["consume_bench_topic1:[0-4]"])
+        consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
+        try:
+            consume_workload.wait_for_done(timeout_sec=360)
+            raise Exception("Should have raised an exception due to an invalid configuration")
+        except RuntimeError as e:
+            if 'Will not split partitions' not in str(e):
+                raise RuntimeError("Unexpected Exception - " + str(e))
+            self.logger.info(e)
+

--- a/tests/kafkatest/tests/core/consume_bench_test.py
+++ b/tests/kafkatest/tests/core/consume_bench_test.py
@@ -121,7 +121,7 @@ class ConsumeBenchTest(Test):
                                                 consumer_conf={},
                                                 admin_client_conf={},
                                                 common_client_conf={},
-                                                consumer_count=5,
+                                                threads_per_worker=5,
                                                 active_topics=["consume_bench_topic[0-5]"])
         consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
         consume_workload.wait_for_done(timeout_sec=360)
@@ -143,7 +143,7 @@ class ConsumeBenchTest(Test):
                                                 consumer_conf={},
                                                 admin_client_conf={},
                                                 common_client_conf={},
-                                                consumer_count=2,
+                                                threads_per_worker=2,
                                                 consumer_group="testGroup",
                                                 active_topics=["consume_bench_topic[0-5]"])
         consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
@@ -167,7 +167,7 @@ class ConsumeBenchTest(Test):
                                                 consumer_conf={},
                                                 admin_client_conf={},
                                                 common_client_conf={},
-                                                consumer_count=4,
+                                                threads_per_worker=4,
                                                 active_topics=["consume_bench_topic1:[0-4]"])
         consume_workload = self.trogdor.create_task("consume_workload", consume_spec)
         consume_workload.wait_for_done(timeout_sec=360)
@@ -190,7 +190,7 @@ class ConsumeBenchTest(Test):
                                                 consumer_conf={},
                                                 admin_client_conf={},
                                                 common_client_conf={},
-                                                consumer_count=4,
+                                                threads_per_worker=4,
                                                 consumer_group="fail_group",
                                                 active_topics=["consume_bench_topic1:[0-4]"])
         consume_workload = self.trogdor.create_task("consume_workload", consume_spec)

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -63,8 +63,8 @@ import java.util.HashSet;
  * It will be assigned partitions dynamically from the consumer group.
  *
  * This specification supports the spawning of multiple consumers in the single Trogdor worker agent.
- * The "consumeCount" field denotes how many consumers should be spawned for this spec.
- * It is worth nothing that the "targetMessagesPerSec", "maxMessages" and "activeTopics" fields apply for every consumer individually.
+ * The "threadCount" field denotes how many consumers should be spawned for this spec.
+ * It is worth noting that the "targetMessagesPerSec", "maxMessages" and "activeTopics" fields apply for every consumer individually.
  * If a consumer group is not specified, every consumer is assigned a different, random group. When specified, all consumers use the same group.
  * Specifying partitions, a consumer group and multiple consumers will result in an #{@link ConfigException} and the task will abort.
  *
@@ -108,7 +108,7 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
-                            @JsonProperty("consumerCount") Integer consumerCount,
+                            @JsonProperty("threadCount") Integer threadCount,
                             @JsonProperty("activeTopics") List<String> activeTopics) {
         super(startMs, durationMs);
         this.consumerNode = (consumerNode == null) ? "" : consumerNode;
@@ -120,7 +120,7 @@ public class ConsumeBenchSpec extends TaskSpec {
         this.adminClientConf = configOrEmptyMap(adminClientConf);
         this.activeTopics = activeTopics == null ? new ArrayList<>() : activeTopics;
         this.consumerGroup = consumerGroup == null ? EMPTY_CONSUMER_GROUP : consumerGroup;
-        this.consumerCount = consumerCount == null ? 1 : consumerCount;
+        this.consumerCount = threadCount == null ? 1 : threadCount;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -63,8 +63,9 @@ import java.util.HashSet;
  *
  * This specification supports the spawning of multiple consumers in the single Trogdor worker agent.
  * The "consumeCount" field denotes how many consumers should be spawned for this spec.
- * It is worth nothing that the "targetMessagesPerSec" and "maxMessages" fields apply for every consumer individually,
- * whereas "activeTopics" will get assigned to every consumer in a round-robin fashion
+ * It is worth nothing that the "targetMessagesPerSec", "maxMessages" and "activeTopics" fields apply for every consumer individually.
+ * If a consumer group is not specified, every consumer is assigned a different, random group. When specified, all consumers use the same group.
+ * Specifying partitions, a consumer group and multiple consumers will result in an Exception
  *
  * An example JSON representation which will result in a consumer that is part of the consumer group "cg" and
  * subscribed to topics foo1, foo2, foo3 and bar.

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -61,6 +61,11 @@ import java.util.HashSet;
  * #{@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(Collection)}.
  * It will be assigned partitions dynamically from the consumer group.
  *
+ * This specification supports the spawning of multiple consumers in the single Trogdor worker agent.
+ * The "consumeCount" field denotes how many consumers should be spawned for this spec.
+ * It is worth nothing that the "targetMessagesPerSec" and "maxMessages" fields apply for every consumer individually,
+ * whereas "activeTopics" will get assigned to every consumer in a round-robin fashion
+ *
  * An example JSON representation which will result in a consumer that is part of the consumer group "cg" and
  * subscribed to topics foo1, foo2, foo3 and bar.
  * #{@code
@@ -88,6 +93,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final List<String> activeTopics;
     private final String consumerGroup;
+    private final int consumerCount;
 
     @JsonCreator
     public ConsumeBenchSpec(@JsonProperty("startMs") long startMs,
@@ -100,6 +106,7 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
+                            @JsonProperty("consumerCount") Integer consumerCount,
                             @JsonProperty("activeTopics") List<String> activeTopics) {
         super(startMs, durationMs);
         this.consumerNode = (consumerNode == null) ? "" : consumerNode;
@@ -111,6 +118,7 @@ public class ConsumeBenchSpec extends TaskSpec {
         this.adminClientConf = configOrEmptyMap(adminClientConf);
         this.activeTopics = activeTopics == null ? new ArrayList<>() : activeTopics;
         this.consumerGroup = consumerGroup == null ? EMPTY_CONSUMER_GROUP : consumerGroup;
+        this.consumerCount = consumerCount == null ? 1 : consumerCount;
     }
 
     @JsonProperty
@@ -136,6 +144,11 @@ public class ConsumeBenchSpec extends TaskSpec {
     @JsonProperty
     public int maxMessages() {
         return maxMessages;
+    }
+
+    @JsonProperty
+    public int consumerCount() {
+        return consumerCount;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.trogdor.common.StringExpander;
 import org.apache.kafka.trogdor.task.TaskController;
 import org.apache.kafka.trogdor.task.TaskSpec;
@@ -65,7 +66,7 @@ import java.util.HashSet;
  * The "consumeCount" field denotes how many consumers should be spawned for this spec.
  * It is worth nothing that the "targetMessagesPerSec", "maxMessages" and "activeTopics" fields apply for every consumer individually.
  * If a consumer group is not specified, every consumer is assigned a different, random group. When specified, all consumers use the same group.
- * Specifying partitions, a consumer group and multiple consumers will result in an Exception
+ * Specifying partitions, a consumer group and multiple consumers will result in an #{@link ConfigException} and the task will abort.
  *
  * An example JSON representation which will result in a consumer that is part of the consumer group "cg" and
  * subscribed to topics foo1, foo2, foo3 and bar.

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -63,10 +63,13 @@ import java.util.HashSet;
  * It will be assigned partitions dynamically from the consumer group.
  *
  * This specification supports the spawning of multiple consumers in the single Trogdor worker agent.
- * The "threadCount" field denotes how many consumers should be spawned for this spec.
+ * The "threadsPerWorker" field denotes how many consumers should be spawned for this spec.
  * It is worth noting that the "targetMessagesPerSec", "maxMessages" and "activeTopics" fields apply for every consumer individually.
+ *
  * If a consumer group is not specified, every consumer is assigned a different, random group. When specified, all consumers use the same group.
- * Specifying partitions, a consumer group and multiple consumers will result in an #{@link ConfigException} and the task will abort.
+ * Since no two consumers in the same group can be assigned the same partition,
+ * explicitly specifying partitions in "activeTopics" when there are multiple "threadsPerWorker"
+ * and a particular "consumerGroup" will result in an #{@link ConfigException}, aborting the task.
  *
  * An example JSON representation which will result in a consumer that is part of the consumer group "cg" and
  * subscribed to topics foo1, foo2, foo3 and bar.
@@ -84,7 +87,6 @@ import java.util.HashSet;
  */
 public class ConsumeBenchSpec extends TaskSpec {
 
-    static final String EMPTY_CONSUMER_GROUP = "";
     private static final String VALID_EXPANDED_TOPIC_NAME_PATTERN = "^[^:]+(:[\\d]+|[^:]*)$";
     private final String consumerNode;
     private final String bootstrapServers;
@@ -95,7 +97,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final List<String> activeTopics;
     private final String consumerGroup;
-    private final int consumerCount;
+    private final int threadsPerWorker;
 
     @JsonCreator
     public ConsumeBenchSpec(@JsonProperty("startMs") long startMs,
@@ -108,7 +110,7 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
-                            @JsonProperty("threadCount") Integer threadCount,
+                            @JsonProperty("threadsPerWorker") Integer threadsPerWorker,
                             @JsonProperty("activeTopics") List<String> activeTopics) {
         super(startMs, durationMs);
         this.consumerNode = (consumerNode == null) ? "" : consumerNode;
@@ -119,8 +121,8 @@ public class ConsumeBenchSpec extends TaskSpec {
         this.commonClientConf = configOrEmptyMap(commonClientConf);
         this.adminClientConf = configOrEmptyMap(adminClientConf);
         this.activeTopics = activeTopics == null ? new ArrayList<>() : activeTopics;
-        this.consumerGroup = consumerGroup == null ? EMPTY_CONSUMER_GROUP : consumerGroup;
-        this.consumerCount = threadCount == null ? 1 : threadCount;
+        this.consumerGroup = consumerGroup == null ? "" : consumerGroup;
+        this.threadsPerWorker = threadsPerWorker == null ? 1 : threadsPerWorker;
     }
 
     @JsonProperty
@@ -149,8 +151,8 @@ public class ConsumeBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public int consumerCount() {
-        return consumerCount;
+    public int threadsPerWorker() {
+        return threadsPerWorker;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -240,7 +240,6 @@ public class ConsumeBenchWorker implements TaskWorker {
             int maxMessages = spec.maxMessages();
             try {
                 while (messagesConsumed < maxMessages) {
-
                     ConsumerRecords<byte[], byte[]> records = consumer.poll();
                     if (records.isEmpty()) {
                         continue;
@@ -267,7 +266,6 @@ public class ConsumeBenchWorker implements TaskWorker {
                     startBatchMs = Time.SYSTEM.milliseconds();
                 }
             } catch (Exception e) {
-                // TODO: Should we close task on consumer failure?
                 WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -209,8 +209,12 @@ public class ConsumeBenchWorker implements TaskWorker {
             this.clientId = consumer.clientId();
             this.statusUpdaterFuture = executor.scheduleAtFixedRate(
                 new ConsumeStatusUpdater(latencyHistogram, messageSizeHistogram, consumer), 1, 1, TimeUnit.MINUTES);
-            int perPeriod = WorkerUtils.perSecToPerPeriod(
-                spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
+            int perPeriod;
+            if (spec.targetMessagesPerSec() == 0)
+                perPeriod = Integer.MAX_VALUE;
+            else
+                perPeriod = WorkerUtils.perSecToPerPeriod(spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
+
             this.throttle = new Throttle(perPeriod, THROTTLE_PERIOD_MS);
             this.consumer = consumer;
         }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
@@ -258,6 +259,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                     startBatchMs = Time.SYSTEM.milliseconds();
                 }
             } catch (Exception e) {
+                // TODO: Should we close task on consumer failure?
                 WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);
@@ -298,9 +300,11 @@ public class ConsumeBenchWorker implements TaskWorker {
 
     class StatusUpdater implements Runnable {
         final Map<String, JsonNode> statuses;
+        final Map<String, Boolean> statusesFailed;
 
         StatusUpdater() {
             statuses = new HashMap<>();
+            statusesFailed = new HashMap<>();
         }
 
         @Override
@@ -312,11 +316,26 @@ public class ConsumeBenchWorker implements TaskWorker {
             }
         }
 
+        /**
+         * Fails a single status updater. If all have failed, the worker is aborted
+         */
+        synchronized void failStatus(String clientId) throws KafkaException {
+            statusesFailed.put(clientId, true);
+            if (!statusesFailed.values().contains(false)) {
+                // all statuses have failed, abort the worker
+                WorkerUtils.abort(log, "StatusUpdater",
+                    new KafkaException("All consumer's status updaters have failed"), doneFuture);
+            }
+        }
+
         synchronized void update() {
             workerStatus.update(JsonUtil.JSON_SERDE.valueToTree(statuses));
         }
 
         synchronized void updateConsumeStatus(String clientId, StatusData status) {
+            if (!statusesFailed.containsKey(clientId))
+                statusesFailed.put(clientId, false);
+
             statuses.put(clientId, JsonUtil.JSON_SERDE.valueToTree(status));
         }
     }
@@ -340,8 +359,9 @@ public class ConsumeBenchWorker implements TaskWorker {
             try {
                 update();
             } catch (Exception e) {
-                // TODO: Shouldn't use doneFuture here :O
-                WorkerUtils.abort(log, "ConsumeStatusUpdater", e, doneFuture);
+                log.warn("ConsumeStatusUpdater caught an exception: ", e);
+                statusUpdater.failStatus(clientId);
+                throw new KafkaException(e);
             }
         }
 

--- a/tools/src/test/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpecTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpecTest.java
@@ -73,6 +73,6 @@ public class ConsumeBenchSpecTest {
     private ConsumeBenchSpec consumeBenchSpec(List<String> activeTopics) {
         return new ConsumeBenchSpec(0, 0, "node", "localhost",
             123, 1234, "cg-1",
-            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), activeTopics);
+            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), 1, activeTopics);
     }
 }


### PR DESCRIPTION
This PR adds a new ConsumeBenchSpec field - "consumerCount". "consumerCount" will be spawned over "consumerCount" threads in the ConsumeBenchWorker.
Since "consumerCount" will be 1 by default, these changes are backwards compatible

It's now questionable how existing fields such as "targetMessagesPerSec", "maxMessages", "consumerGroup" and "activeTopics" should work.

With "activeTopics", we need to decide whether they should be split over the consumers or not.
I see 4 cases which I believe we should address like this:

1. Random group, subscribe to topics - N unique groups all subscribed to all topics
2. Specifed group, subscribe to topics - 1 group subscribed to all topics. Consumers share workload.
3. Random groups, assign partitions - X groups all subscribed to all partitions
4. Specified group, assign partitions - Throw an exception. Only one consumer can read from a specific partition within the context of a consumer group. It is then unclear how and whether at all we should split the partitions across the consumers. At this phase, I believe it's best to not support this.


I believe "targetMessagesPerSec", "maxMessages" should account for each consumer individually. This would ease implementation by a ton, too.


I haven't written tests yet since I want to flesh out the design first. Any feedback is appreciated