### PR TITLE
KAFKA-7420: Global store surrounded by read only implementation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.internals.ApiUtils;
+import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
@@ -29,6 +30,9 @@ import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 
 import java.time.Duration;
@@ -75,65 +79,14 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         final StateStore global = stateManager.getGlobalStore(name);
         if (global != null) {
-            return new KeyValueStore() {
-                private final KeyValueStore underlying = (KeyValueStore) global;
+            if (global instanceof KeyValueStore)
+                return new KeyValueStoreReadOnlyDecorator((KeyValueStore) global);
+            else if (global instanceof WindowStore)
+                return new WindowStoreReadOnlyDecorator((WindowStore) global);
+            else if (global instanceof SessionStore)
+                return new SessionStoreReadOnlyDecorator((SessionStore) global);
 
-                @Override public Object get(final Object key) {
-                    return underlying.get(key);
-                }
-
-                @Override public KeyValueIterator range(final Object from, final Object to) {
-                    return underlying.range(from, to);
-                }
-
-                @Override public KeyValueIterator all() {
-                    return underlying.all();
-                }
-
-                @Override public long approximateNumEntries() {
-                    return underlying.approximateNumEntries();
-                }
-
-                @Override public String name() {
-                    return underlying.name();
-                }
-
-                @Override public void init(final ProcessorContext context, final StateStore root) {
-                    underlying.init(context, root);
-                }
-
-                @Override public void flush() {
-                    throw new UnsupportedOperationException("Global store is read only");
-                }
-
-                @Override public void close() {
-                    underlying.close();
-                }
-
-                @Override public boolean persistent() {
-                    return underlying.persistent();
-                }
-
-                @Override public boolean isOpen() {
-                    return underlying.isOpen();
-                }
-
-                @Override public void put(final Object key, final Object value) {
-                    throw new UnsupportedOperationException("Global store is read only");
-                }
-
-                @Override public Object putIfAbsent(final Object key, final Object value) {
-                    throw new UnsupportedOperationException("Global store is read only");
-                }
-
-                @Override public void putAll(final List entries) {
-                    throw new UnsupportedOperationException("Global store is read only");
-                }
-
-                @Override public Object delete(final Object key) {
-                    throw new UnsupportedOperationException("Global store is read only");
-                }
-            };
+            return global;
         }
 
         if (!currentNode().stateStores.contains(name)) {
@@ -239,4 +192,169 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         return streamTimeSupplier.get();
     }
 
+    private abstract static class StateStoreReadOnlyDecorator<T extends StateStore> implements StateStore {
+        static final String ERR_MSG = "Global store is read only";
+
+        protected final T underlying;
+
+        StateStoreReadOnlyDecorator(final T underlying) {
+            this.underlying = underlying;
+        }
+
+        @Override
+        public String name() {
+            return underlying.name();
+        }
+
+        @Override
+        public void init(final ProcessorContext context, final StateStore root) {
+            underlying.init(context, root);
+        }
+
+        @Override
+        public void flush() {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public void close() {
+            underlying.close();
+        }
+
+        @Override
+        public boolean persistent() {
+            return underlying.persistent();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return underlying.isOpen();
+        }
+    }
+
+    private static class KeyValueStoreReadOnlyDecorator<K, V> extends StateStoreReadOnlyDecorator<KeyValueStore<K, V>> implements KeyValueStore<K, V> {
+        KeyValueStoreReadOnlyDecorator(final KeyValueStore<K, V> underlying) {
+            super(underlying);
+        }
+
+        @Override
+        public V get(final K key) {
+            return underlying.get(key);
+        }
+
+        @Override
+        public KeyValueIterator<K, V> range(final K from, final K to) {
+            return underlying.range(from, to);
+        }
+
+        @Override
+        public KeyValueIterator<K, V> all() {
+            return underlying.all();
+        }
+
+        @Override
+        public long approximateNumEntries() {
+            return underlying.approximateNumEntries();
+        }
+
+        @Override
+        public void put(final K key, final V value) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public V putIfAbsent(final K key, final V value) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public void putAll(final List entries) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public V delete(final K key) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+    }
+
+    private static class WindowStoreReadOnlyDecorator<K, V> extends StateStoreReadOnlyDecorator<WindowStore<K, V>> implements WindowStore<K, V> {
+        WindowStoreReadOnlyDecorator(final WindowStore<K, V> underlying) {
+            super(underlying);
+        }
+
+        @Override
+        public void put(final K key, final V value) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public void put(final K key, final V value, final long windowStartTimestamp) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public V fetch(final K key, final long time) {
+            return underlying.fetch(key, time);
+        }
+
+        @Deprecated
+        @Override
+        public WindowStoreIterator<V> fetch(final K key, final long timeFrom, final long timeTo) {
+            return underlying.fetch(key, timeFrom, timeTo);
+        }
+
+        @Deprecated
+        @Override
+        public KeyValueIterator<Windowed<K>, V> fetch(final K from, final K to, final long timeFrom, final long timeTo) {
+            return underlying.fetch(from, to, timeFrom, timeTo);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, V> all() {
+            return underlying.all();
+        }
+
+        @Deprecated
+        @Override
+        public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom, final long timeTo) {
+            return underlying.fetchAll(timeFrom, timeTo);
+        }
+    }
+
+    private static class SessionStoreReadOnlyDecorator<K, AGG> extends StateStoreReadOnlyDecorator<SessionStore<K, AGG>> implements SessionStore<K, AGG> {
+        SessionStoreReadOnlyDecorator(final SessionStore<K, AGG> underlying) {
+            super(underlying);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, AGG> findSessions(final K key, final long earliestSessionEndTime, final long latestSessionStartTime) {
+            return underlying.findSessions(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, AGG> findSessions(final K keyFrom, final K keyTo, final long earliestSessionEndTime, final long latestSessionStartTime) {
+            return underlying.findSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public void remove(final Windowed sessionKey) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public void put(final Windowed<K> sessionKey, final AGG aggregate) {
+            throw new UnsupportedOperationException(ERR_MSG);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, AGG> fetch(final K key) {
+            return underlying.fetch(key);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, AGG> fetch(final K from, final K to) {
+            return underlying.fetch(from, to);
+        }
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -79,12 +79,13 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         final StateStore global = stateManager.getGlobalStore(name);
         if (global != null) {
-            if (global instanceof KeyValueStore)
+            if (global instanceof KeyValueStore) {
                 return new KeyValueStoreReadOnlyDecorator((KeyValueStore) global);
-            else if (global instanceof WindowStore)
+            } else if (global instanceof WindowStore) {
                 return new WindowStoreReadOnlyDecorator((WindowStore) global);
-            else if (global instanceof SessionStore)
+            } else if (global instanceof SessionStore) {
                 return new SessionStoreReadOnlyDecorator((SessionStore) global);
+            }
 
             return global;
         }
@@ -193,9 +194,9 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
     }
 
     private abstract static class StateStoreReadOnlyDecorator<T extends StateStore> implements StateStore {
-        static final String ERR_MSG = "Global store is read only";
+        static final String ERROR_MESSAGE = "Global store is read only";
 
-        protected final T underlying;
+        final T underlying;
 
         StateStoreReadOnlyDecorator(final T underlying) {
             this.underlying = underlying;
@@ -213,7 +214,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         @Override
         public void flush() {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
@@ -259,22 +260,22 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         @Override
         public void put(final K key, final V value) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
         public V putIfAbsent(final K key, final V value) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
         public void putAll(final List entries) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
         public V delete(final K key) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
     }
 
@@ -285,12 +286,12 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         @Override
         public void put(final K key, final V value) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
         public void put(final K key, final V value, final long windowStartTimestamp) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
@@ -339,12 +340,12 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         @Override
         public void remove(final Windowed sessionKey) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override
         public void put(final Windowed<K> sessionKey, final AGG aggregate) {
-            throw new UnsupportedOperationException(ERR_MSG);
+            throw new UnsupportedOperationException(ERROR_MESSAGE);
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -103,7 +103,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
                 }
 
                 @Override public void flush() {
-                    underlying.flush();
+                    throw new UnsupportedOperationException("Global store is read only");
                 }
 
                 @Override public void close() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -124,7 +124,7 @@ public class ProcessorContextImplTest {
 
                 checkThrowsUnsupportedOperation(store::flush, "flush");
 
-                assertEquals((Long)VAL, store.get(KEY));
+                assertEquals((Long) VAL, store.get(KEY));
                 assertEquals(rangeIter, store.range("one", "two"));
                 assertEquals(allIter, store.all());
                 assertEquals(VAL, store.approximateNumEntries());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -18,9 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apache.kafka.common.serialization.Serdes;
@@ -40,6 +38,7 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.util.Collections.emptySet;
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
@@ -71,8 +70,9 @@ public class ProcessorContextImplTest {
         allIter = mock(KeyValueIterator.class);
         windowStoreIter = mock(WindowStoreIterator.class);
 
-        for (int i = 0; i < 7; i++)
+        for (int i = 0; i < 7; i++) {
             iters.add(i, mock(KeyValueIterator.class));
+        }
 
         final StreamsConfig streamsConfig = mock(StreamsConfig.class);
         expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("add-id");
@@ -98,11 +98,7 @@ public class ProcessorContextImplTest {
             mock(ThreadCache.class)
         );
 
-        final Set<String> stateStores = new HashSet<>();
-
-        stateStores.add("KeyValueStore");
-
-        context.setCurrentNode(new ProcessorNode<String, Long>("fake", null, stateStores));
+        context.setCurrentNode(new ProcessorNode<String, Long>("fake", null, emptySet()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -89,7 +89,8 @@ public class ProcessorContextImplTest {
                 //No-op.
             }
 
-            @Override public void close() {
+            @Override
+            public void close() {
                 //No-op.
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -1,12 +1,12 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,96 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.processor.internals;
 
-/**
- */
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.fail;
+
 public class ProcessorContextImplTest {
+    private ProcessorContextImpl context;
+
+    @Before
+    public void setup() {
+        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("add-id");
+        expect(streamsConfig.defaultValueSerde()).andReturn(Serdes.ByteArray());
+        expect(streamsConfig.defaultKeySerde()).andReturn(Serdes.ByteArray());
+        replay(streamsConfig);
+
+        final ProcessorStateManager stateManager = mock(ProcessorStateManager.class);
+        expect(stateManager.getGlobalStore(anyString())).andReturn(mock(KeyValueStore.class));
+        replay(stateManager);
+
+        context = new ProcessorContextImpl(
+            mock(TaskId.class),
+            mock(StreamTask.class),
+            streamsConfig,
+            mock(RecordCollector.class),
+            stateManager,
+            mock(StreamsMetricsImpl.class),
+            mock(ThreadCache.class)
+        );
+
+        final Set<String> stateStores = new HashSet<>();
+
+        stateStores.add("Counts");
+
+        context.setCurrentNode(new ProcessorNode<String, Long>("fake", null, stateStores));
+    }
+
+    @Test
+    public void testStateStoreWriteMethodThrows() {
+        final Processor processor = new Processor<String, Long>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public void init(final ProcessorContext context) {
+                final KeyValueStore<String, Long> store = (KeyValueStore<String, Long>) context.getStateStore("Counts");
+
+                checkThrowsUnsupportedOperation(() -> store.put("1", 1L), "put");
+                checkThrowsUnsupportedOperation(() -> store.putIfAbsent("1", 1L), "putIfAbsent");
+                checkThrowsUnsupportedOperation(() -> store.putAll(Collections.emptyList()), "putAll");
+                checkThrowsUnsupportedOperation(() -> store.delete("1"), "delete");
+
+                checkThrowsUnsupportedOperation(store::flush, "flush");
+            }
+
+            @Override
+            public void process(final String k, final Long v) {
+                //No-op.
+            }
+
+            @Override public void close() {
+                //No-op.
+            }
+        };
+
+        processor.init(context);
+
+    }
+
+    private void checkThrowsUnsupportedOperation(final Runnable check, final String name) {
+        try {
+            check.run();
+            fail(name + " should throw exception");
+        } catch (final UnsupportedOperationException e) {
+            //ignore.
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -16,21 +16,31 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -52,45 +62,31 @@ public class ProcessorContextImplTest {
     private KeyValueIterator<String, Long> rangeIter;
     private KeyValueIterator<String, Long> allIter;
 
+    private List<KeyValueIterator<Windowed<String>, Long>> iters = new ArrayList<>(7);
+    private WindowStoreIterator<Long> windowStoreIter;
+
     @Before
     public void setup() {
+        rangeIter = mock(KeyValueIterator.class);
+        allIter = mock(KeyValueIterator.class);
+        windowStoreIter = mock(WindowStoreIterator.class);
+
+        for (int i = 0; i < 7; i++)
+            iters.add(i, mock(KeyValueIterator.class));
+
         final StreamsConfig streamsConfig = mock(StreamsConfig.class);
         expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("add-id");
         expect(streamsConfig.defaultValueSerde()).andReturn(Serdes.ByteArray());
         expect(streamsConfig.defaultKeySerde()).andReturn(Serdes.ByteArray());
         replay(streamsConfig);
 
-        rangeIter = mock(KeyValueIterator.class);
-        allIter = mock(KeyValueIterator.class);
-
-        final KeyValueStore<String, Long> globalStoreMock = mock(KeyValueStore.class);
-
-        expect(globalStoreMock.get(KEY)).andReturn(VAL);
-        expect(globalStoreMock.approximateNumEntries()).andReturn(VAL);
-        expect(globalStoreMock.name()).andReturn(STORE_NAME);
-        expect(globalStoreMock.persistent()).andReturn(true);
-        expect(globalStoreMock.isOpen()).andReturn(true);
-
-        expect(globalStoreMock.range("one", "two")).andReturn(rangeIter);
-        expect(globalStoreMock.all()).andReturn(allIter);
-
-        globalStoreMock.init(null, null);
-        expectLastCall().andAnswer(() -> {
-            initExecuted = true;
-            return null;
-        });
-
-        globalStoreMock.close();
-        expectLastCall().andAnswer(() -> {
-            closeExecuted = true;
-            return null;
-        });
-
         final ProcessorStateManager stateManager = mock(ProcessorStateManager.class);
 
-        expect(stateManager.getGlobalStore(anyString())).andReturn(globalStoreMock);
+        expect(stateManager.getGlobalStore("KeyValueStore")).andReturn(keyValueStoreMock());
+        expect(stateManager.getGlobalStore("WindowStore")).andReturn(windowStoreMock());
+        expect(stateManager.getGlobalStore("SessionStore")).andReturn(sessionStoreMock());
 
-        replay(globalStoreMock, stateManager);
+        replay(stateManager);
 
         context = new ProcessorContextImpl(
             mock(TaskId.class),
@@ -104,39 +100,129 @@ public class ProcessorContextImplTest {
 
         final Set<String> stateStores = new HashSet<>();
 
-        stateStores.add("Counts");
+        stateStores.add("KeyValueStore");
 
         context.setCurrentNode(new ProcessorNode<String, Long>("fake", null, stateStores));
     }
 
     @Test
-    public void testStateStoreWriteMethodThrows() {
+    public void testKeyValueStore() {
+        doTest("KeyValueStore", (Consumer<KeyValueStore<String, Long>>) store -> {
+            checkThrowsUnsupportedOperation(() -> store.put("1", 1L), "put");
+            checkThrowsUnsupportedOperation(() -> store.putIfAbsent("1", 1L), "putIfAbsent");
+            checkThrowsUnsupportedOperation(() -> store.putAll(Collections.emptyList()), "putAll");
+            checkThrowsUnsupportedOperation(() -> store.delete("1"), "delete");
+
+            assertEquals((Long) VAL, store.get(KEY));
+            assertEquals(rangeIter, store.range("one", "two"));
+            assertEquals(allIter, store.all());
+            assertEquals(VAL, store.approximateNumEntries());
+        });
+    }
+
+    @Test
+    public void testWindowStore() {
+        doTest("WindowStore", (Consumer<WindowStore<String, Long>>) store -> {
+            checkThrowsUnsupportedOperation(() -> store.put("1", 1L, 1L), "put");
+            checkThrowsUnsupportedOperation(() -> store.put("1", 1L), "put");
+
+            assertEquals(iters.get(0), store.fetchAll(0L, 0L));
+            assertEquals(windowStoreIter, store.fetch(KEY, 0L, 1L));
+            assertEquals(iters.get(1), store.fetch(KEY, KEY, 0L, 1L));
+            assertEquals((Long) VAL, store.fetch(KEY, 1L));
+            assertEquals(iters.get(2), store.all());
+        });
+    }
+
+    @Test
+    public void testSessionStore() {
+        doTest("SessionStore", (Consumer<SessionStore<String, Long>>) store -> {
+            checkThrowsUnsupportedOperation(() -> store.remove(null), "remove");
+            checkThrowsUnsupportedOperation(() -> store.put(null, null), "put");
+
+            assertEquals(iters.get(3), store.findSessions(KEY, 1L, 2L));
+            assertEquals(iters.get(4), store.findSessions(KEY, KEY, 1L, 2L));
+            assertEquals(iters.get(5), store.fetch(KEY));
+            assertEquals(iters.get(6), store.fetch(KEY, KEY));
+        });
+    }
+
+    private KeyValueStore<String, Long> keyValueStoreMock() {
+        final KeyValueStore<String, Long> keyValueStoreMock = mock(KeyValueStore.class);
+
+        initStateStoreMock(keyValueStoreMock);
+
+        expect(keyValueStoreMock.get(KEY)).andReturn(VAL);
+        expect(keyValueStoreMock.approximateNumEntries()).andReturn(VAL);
+
+        expect(keyValueStoreMock.range("one", "two")).andReturn(rangeIter);
+        expect(keyValueStoreMock.all()).andReturn(allIter);
+
+        replay(keyValueStoreMock);
+
+        return keyValueStoreMock;
+    }
+
+    private WindowStore<String, Long> windowStoreMock() {
+        final WindowStore<String, Long> windowStore = mock(WindowStore.class);
+
+        initStateStoreMock(windowStore);
+
+        expect(windowStore.fetchAll(anyLong(), anyLong())).andReturn(iters.get(0));
+        expect(windowStore.fetch(anyString(), anyString(), anyLong(), anyLong())).andReturn(iters.get(1));
+        expect(windowStore.fetch(anyString(), anyLong(), anyLong())).andReturn(windowStoreIter);
+        expect(windowStore.fetch(anyString(), anyLong())).andReturn(VAL);
+        expect(windowStore.all()).andReturn(iters.get(2));
+
+        replay(windowStore);
+
+        return windowStore;
+    }
+
+    private SessionStore<String, Long> sessionStoreMock() {
+        final SessionStore<String, Long> sessionStore = mock(SessionStore.class);
+
+        initStateStoreMock(sessionStore);
+
+        expect(sessionStore.findSessions(anyString(), anyLong(), anyLong())).andReturn(iters.get(3));
+        expect(sessionStore.findSessions(anyString(), anyString(), anyLong(), anyLong())).andReturn(iters.get(4));
+        expect(sessionStore.fetch(anyString())).andReturn(iters.get(5));
+        expect(sessionStore.fetch(anyString(), anyString())).andReturn(iters.get(6));
+
+        replay(sessionStore);
+
+        return sessionStore;
+    }
+
+    private void initStateStoreMock(final StateStore windowStore) {
+        expect(windowStore.name()).andReturn(STORE_NAME);
+        expect(windowStore.persistent()).andReturn(true);
+        expect(windowStore.isOpen()).andReturn(true);
+
+        windowStore.init(null, null);
+        expectLastCall().andAnswer(() -> {
+            initExecuted = true;
+            return null;
+        });
+
+        windowStore.close();
+        expectLastCall().andAnswer(() -> {
+            closeExecuted = true;
+            return null;
+        });
+    }
+
+    private <T extends StateStore> void doTest(final String name, final Consumer<T> checker) {
         final Processor processor = new Processor<String, Long>() {
             @Override
             @SuppressWarnings("unchecked")
             public void init(final ProcessorContext context) {
-                final KeyValueStore<String, Long> store = (KeyValueStore<String, Long>) context.getStateStore("Counts");
+                final T store = (T) context.getStateStore(name);
 
-                checkThrowsUnsupportedOperation(() -> store.put("1", 1L), "put");
-                checkThrowsUnsupportedOperation(() -> store.putIfAbsent("1", 1L), "putIfAbsent");
-                checkThrowsUnsupportedOperation(() -> store.putAll(Collections.emptyList()), "putAll");
-                checkThrowsUnsupportedOperation(() -> store.delete("1"), "delete");
+                checkStateStoreMethods(store);
 
-                checkThrowsUnsupportedOperation(store::flush, "flush");
+                checker.accept(store);
 
-                assertEquals((Long) VAL, store.get(KEY));
-                assertEquals(rangeIter, store.range("one", "two"));
-                assertEquals(allIter, store.all());
-                assertEquals(VAL, store.approximateNumEntries());
-                assertEquals(STORE_NAME, store.name());
-                assertTrue(store.persistent());
-                assertTrue(store.isOpen());
-
-                store.init(null, null);
-                assertTrue(initExecuted);
-
-                store.close();
-                assertTrue(closeExecuted);
             }
 
             @Override
@@ -151,7 +237,20 @@ public class ProcessorContextImplTest {
         };
 
         processor.init(context);
+    }
 
+    private void checkStateStoreMethods(final StateStore store) {
+        checkThrowsUnsupportedOperation(store::flush, "flush");
+
+        assertEquals(STORE_NAME, store.name());
+        assertTrue(store.persistent());
+        assertTrue(store.isOpen());
+
+        store.init(null, null);
+        assertTrue(initExecuted);
+
+        store.close();
+        assertTrue(closeExecuted);
     }
 
     private void checkThrowsUnsupportedOperation(final Runnable check, final String name) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+/**
+ */
+public class ProcessorContextImplTest {
+}


### PR DESCRIPTION
Global store surrounded by read-only `KeyValueStore` implementation.
All methods that try to write into Store will throw `UnsupportedOperationException`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
