### PR TITLE
KAFKA-7509: Logging unused configs as DEBUG rather than WARN

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -284,7 +284,7 @@ public class AbstractConfig {
      */
     public void logUnused() {
         for (String key : unused())
-            log.warn("The configuration '{}' was supplied but isn't a known config.", key);
+            log.debug("The configuration '{}' was supplied but isn't a known config.", key);
     }
 
     /**


### PR DESCRIPTION
The KafkaProducer, KafkaConsumer, and KafkaAdminClient all call `config.logUnused()` to log all of the unused configurations. These can be very misleading, because some conventional configuration properties for custom interceptors, key or value (de)serializers, metrics reporters, and partitioner are not actually defined by ConfigDefs and are thus all considered unused and logged as warnings.

Also, some client applications (such as Connect) do not determine the subset of properties that can be passed to one of these clients, since there are these custom extensions. This causes extra properties to be logged as warnings, which is concerning for new users.

These unused configurations should be logged at DEBUG level instead to reduce the number of unexpected warnings in many client application logs.

### Backporting
This is a usability improvement that affects only this particular log message. As such, it may or may not be something that should be backported. Advice from committers would be appreciated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
