### PR TITLE
KAFKA-5054 : synchronized all the methods

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
@@ -61,13 +61,13 @@ public class ChangeLoggingKeyValueBytesStore extends WrappedStateStore.AbstractS
     }
 
     @Override
-    public void put(final Bytes key, final byte[] value) {
+    public synchronized void put(final Bytes key, final byte[] value) {
         inner.put(key, value);
         changeLogger.logChange(key, value);
     }
 
     @Override
-    public byte[] putIfAbsent(final Bytes key, final byte[] value) {
+    public synchronized byte[] putIfAbsent(final Bytes key, final byte[] value) {
         final byte[] previous = get(key);
         if (previous == null) {
             put(key, value);
@@ -76,7 +76,7 @@ public class ChangeLoggingKeyValueBytesStore extends WrappedStateStore.AbstractS
     }
 
     @Override
-    public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+    public synchronized void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
         inner.putAll(entries);
         for (final KeyValue<Bytes, byte[]> entry : entries) {
             changeLogger.logChange(entry.key, entry.value);
@@ -84,24 +84,24 @@ public class ChangeLoggingKeyValueBytesStore extends WrappedStateStore.AbstractS
     }
 
     @Override
-    public byte[] delete(final Bytes key) {
+    public synchronized byte[] delete(final Bytes key) {
         final byte[] oldValue = inner.delete(key);
         changeLogger.logChange(key, null);
         return oldValue;
     }
 
     @Override
-    public byte[] get(final Bytes key) {
+    public synchronized byte[] get(final Bytes key) {
         return inner.get(key);
     }
 
     @Override
-    public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+    public synchronized KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
         return inner.range(from, to);
     }
 
     @Override
-    public KeyValueIterator<Bytes, byte[]> all() {
+    public synchronized KeyValueIterator<Bytes, byte[]> all() {
         return inner.all();
     }
 }


### PR DESCRIPTION
This avoids inconsistent results while querying or storing the underlying storage