### PR TITLE
KAFKA-7560; PushHttpMetricsReporter should not convert metric value to double

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
@@ -174,8 +174,7 @@ public class PushHttpMetricsReporter implements MetricsReporter {
                 samples = new ArrayList<>(metrics.size());
                 for (KafkaMetric metric : metrics.values()) {
                     MetricName name = metric.metricName();
-                    double value = (Double) metric.metricValue();
-                    samples.add(new MetricValue(name.name(), name.group(), name.tags(), value));
+                    samples.add(new MetricValue(name.name(), name.group(), name.tags(), metric.metricValue()));
                 }
             }
 
@@ -212,9 +211,9 @@ public class PushHttpMetricsReporter implements MetricsReporter {
                 } else {
                     log.info("Finished reporting metrics with response code {}", responseCode);
                 }
-            } catch (Exception e) {
-                log.error("Error reporting metrics", e);
-                throw new KafkaException("Failed to report current metrics", e);
+            } catch (Throwable t) {
+                log.error("Error reporting metrics", t);
+                throw new KafkaException("Failed to report current metrics", t);
             } finally {
                 if (connection != null) {
                     connection.disconnect();


### PR DESCRIPTION
Currently PushHttpMetricsReporter will convert value from KafkaMetric.metricValue() to double. This will not work for non-numerical metrics such as version in AppInfoParser whose value can be string. This has caused issue for PushHttpMetricsReporter which in turn caused system test kafkatest.tests.client.quota_test.QuotaTest.test_quota to fail.  

Since we allow metric value to be object, PushHttpMetricsReporter should also read metric value as object and pass it to the http server.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
