### PR TITLE
Increase acceptable duration time for ReassignPartitionsClusterTest#shouldExecuteThrottledReassignment

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -51,12 +51,12 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   def startBrokers(brokerIds: Seq[Int]) {
-    servers = brokerIds.map(i => {
+    servers = brokerIds.map { i =>
       val props = createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3)
       // shorter backoff to reduce test durations when no active partitions are eligible for fetching due to throttling
       props.put(KafkaConfig.ReplicaFetchBackoffMsProp, "100")
       props
-    }).map(c => createServer(KafkaConfig.fromProps(c)))
+    }.map(c => createServer(KafkaConfig.fromProps(c)))
   }
 
   def createAdminClient(servers: Seq[KafkaServer]): JAdminClient = {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -53,6 +53,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   def startBrokers(brokerIds: Seq[Int]) {
     servers = brokerIds.map(i => {
       val props = createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3)
+      // shorter backoff to reduce test durations when no active partitions are eligible for fetching due to throttling
       props.put(KafkaConfig.ReplicaFetchBackoffMsProp, "100")
       props
     }).map(c => createServer(KafkaConfig.fromProps(c)))

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -51,9 +51,11 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   def startBrokers(brokerIds: Seq[Int]) {
-    servers = brokerIds.map(i => createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3,
-      replicaFetchBackoff = 100))
-      .map(c => createServer(KafkaConfig.fromProps(c)))
+    servers = brokerIds.map(i => {
+      val props = createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3)
+      props.put(KafkaConfig.ReplicaFetchBackoffMsProp, "100")
+      props
+    }).map(c => createServer(KafkaConfig.fromProps(c)))
   }
 
   def createAdminClient(servers: Seq[KafkaServer]): JAdminClient = {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -51,7 +51,8 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   def startBrokers(brokerIds: Seq[Int]) {
-    servers = brokerIds.map(i => createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3))
+    servers = brokerIds.map(i => createBrokerConfig(i, zkConnect, enableControlledShutdown = false, logDirCount = 3,
+      replicaFetchBackoff = 100))
       .map(c => createServer(KafkaConfig.fromProps(c)))
   }
 
@@ -300,7 +301,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     //Then command should have taken longer than the throttle rate
     assertTrue(s"Expected replication to be > ${expectedDurationSecs * 0.9 * 1000} but was $took",
       took > expectedDurationSecs * 0.9 * 1000)
-    assertTrue(s"Expected replication to be < ${expectedDurationSecs * 3 * 1000} but was $took",
+    assertTrue(s"Expected replication to be < ${expectedDurationSecs * 2 * 1000} but was $took",
       took < expectedDurationSecs * 2 * 1000)
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -300,7 +300,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     //Then command should have taken longer than the throttle rate
     assertTrue(s"Expected replication to be > ${expectedDurationSecs * 0.9 * 1000} but was $took",
       took > expectedDurationSecs * 0.9 * 1000)
-    assertTrue(s"Expected replication to be < ${expectedDurationSecs * 2 * 1000} but was $took",
+    assertTrue(s"Expected replication to be < ${expectedDurationSecs * 3 * 1000} but was $took",
       took < expectedDurationSecs * 2 * 1000)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -216,7 +216,6 @@ object TestUtils extends Logging {
                          saslSslPort: Int = RandomPort,
                          rack: Option[String] = None,
                          logDirCount: Int = 1,
-                         replicaFetchBackoff: Int = 1000,
                          enableToken: Boolean = false): Properties = {
     def shouldEnable(protocol: SecurityProtocol) = interBrokerSecurityProtocol.fold(false)(_ == protocol)
 
@@ -254,7 +253,6 @@ object TestUtils extends Logging {
     props.put(KafkaConfig.ControlledShutdownEnableProp, enableControlledShutdown.toString)
     props.put(KafkaConfig.DeleteTopicEnableProp, enableDeleteTopic.toString)
     props.put(KafkaConfig.LogDeleteDelayMsProp, "1000")
-    props.put(KafkaConfig.ReplicaFetchBackoffMsProp, replicaFetchBackoff.toString)
     props.put(KafkaConfig.ControlledShutdownRetryBackoffMsProp, "100")
     props.put(KafkaConfig.LogCleanerDedupeBufferSizeProp, "2097152")
     props.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, Long.MaxValue.toString)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -216,6 +216,7 @@ object TestUtils extends Logging {
                          saslSslPort: Int = RandomPort,
                          rack: Option[String] = None,
                          logDirCount: Int = 1,
+                         replicaFetchBackoff: Int = 1000,
                          enableToken: Boolean = false): Properties = {
     def shouldEnable(protocol: SecurityProtocol) = interBrokerSecurityProtocol.fold(false)(_ == protocol)
 
@@ -253,6 +254,7 @@ object TestUtils extends Logging {
     props.put(KafkaConfig.ControlledShutdownEnableProp, enableControlledShutdown.toString)
     props.put(KafkaConfig.DeleteTopicEnableProp, enableDeleteTopic.toString)
     props.put(KafkaConfig.LogDeleteDelayMsProp, "1000")
+    props.put(KafkaConfig.ReplicaFetchBackoffMsProp, replicaFetchBackoff.toString)
     props.put(KafkaConfig.ControlledShutdownRetryBackoffMsProp, "100")
     props.put(KafkaConfig.LogCleanerDedupeBufferSizeProp, "2097152")
     props.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, Long.MaxValue.toString)


### PR DESCRIPTION
We've seen this test fail in Jenkins (https://builds.apache.org/job/kafka-pr-jdk8-scala2.11/) with 10400ms.
Running locally 50 times, I had two instances where it took 8.2s and 9.3s. Since Jenkins is typically running on a slower machine, I think that it is reasonable to increase the acceptable duration here in order to reduce failed builds due to test flakiness.