### PR TITLE
MINOR: Remove unused abstract function in test class

### DIFF
--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -44,9 +44,6 @@ class ProduceConsumeValidateTest(Test):
         self.consumer_init_timeout_sec = 0
         self.enable_idempotence = False
 
-    def setup_producer_and_consumer(self):
-        raise NotImplementedError("Subclasses should implement this")
-
     def start_producer_and_consumer(self):
         # Start background producer and consumer
         self.consumer.start()


### PR DESCRIPTION
The function `setup_producer_and_consumer` is unused in the
framework, which incorrectly suggests subclasses should implement
it. It is not required or even referenced by the framework, so
the requirement should be removed.