### PR TITLE
KAFKA-7605; Retry async commit failures in integration test cases to fix flaky tests

### DIFF
--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -20,6 +20,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
+log4j.logger.kafka.coordinator.group=DEBUG
 
 # zkclient can be verbose, during debugging it is common to adjust it separately
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -20,7 +20,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
-log4j.logger.kafka.coordinator.group=DEBUG
 
 # zkclient can be verbose, during debugging it is common to adjust it separately
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -84,9 +84,7 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, startingOffset = 0)
 
     // check async commit callbacks
-    val commitCallback = new CountConsumerCommitCallback()
-    consumer.commitAsync(commitCallback)
-    awaitCommitCallback(consumer, commitCallback)
+    sendAndAwaitAsyncCommit(consumer)
   }
 
   @Test
@@ -191,14 +189,40 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     records
   }
 
-  protected def awaitCommitCallback[K, V](consumer: Consumer[K, V],
-                                          commitCallback: CountConsumerCommitCallback,
-                                          count: Int = 1): Unit = {
-    val numFailuresBeforePoll = commitCallback.failCount
-    TestUtils.pollUntilTrue(consumer, () => commitCallback.successCount >= count || commitCallback.failCount > numFailuresBeforePoll,
+  protected def sendAndAwaitAsyncCommit[K, V](consumer: Consumer[K, V],
+                                              offsetsOpt: Option[Map[TopicPartition, OffsetAndMetadata]] = None): Unit = {
+
+    def sendAsyncCommit(callback: OffsetCommitCallback) = {
+      offsetsOpt match {
+        case Some(offsets) => consumer.commitAsync(offsets.asJava, callback)
+        case None => consumer.commitAsync(callback)
+      }
+    }
+
+    class RetryCommitCallback extends OffsetCommitCallback {
+      var isComplete = false
+      var error: Option[Exception] = None
+
+      override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+        exception match {
+          case null =>
+            isComplete = true
+          case e: RetriableCommitFailedException =>
+            sendAsyncCommit(this)
+          case e =>
+            isComplete = true
+            error = Some(e)
+        }
+      }
+    }
+
+    val commitCallback = new RetryCommitCallback
+
+    sendAsyncCommit(commitCallback)
+    TestUtils.pollUntilTrue(consumer, () => commitCallback.isComplete,
       "Failed to observe commit callback before timeout", waitTimeMs = 10000)
-    assertEquals("Unexpected async commit failure", numFailuresBeforePoll, commitCallback.failCount)
-    assertEquals(count, commitCallback.successCount)
+
+    assertEquals(None, commitCallback.error)
   }
 
   protected def awaitRebalance(consumer: Consumer[_, _], rebalanceListener: TestConsumerReassignmentListener): Unit = {
@@ -211,22 +235,21 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     // The best way to verify that the current membership is still active is to commit offsets.
     // This would fail if the group had rebalanced.
     val initialRevokeCalls = rebalanceListener.callsToRevoked
-    val commitCallback = new CountConsumerCommitCallback
-    consumer.commitAsync(commitCallback)
-    awaitCommitCallback(consumer, commitCallback)
+    sendAndAwaitAsyncCommit(consumer)
     assertEquals(initialRevokeCalls, rebalanceListener.callsToRevoked)
   }
 
   protected class CountConsumerCommitCallback extends OffsetCommitCallback {
     var successCount = 0
     var failCount = 0
+    var lastError: Option[Exception] = None
 
     override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
-      if (exception == null)
+      if (exception == null) {
         successCount += 1
-      else {
-        error("Commit callback failed unexpectedly", exception)
+      } else {
         failCount += 1
+        lastError = Some(exception)
       }
     }
   }

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -205,13 +205,11 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
 
       override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
         exception match {
-          case null =>
-            isComplete = true
           case e: RetriableCommitFailedException =>
             sendAsyncCommit(this)
           case e =>
             isComplete = true
-            error = Some(e)
+            error = Option(e)
         }
       }
     }

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -224,8 +224,10 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
       if (exception == null)
         successCount += 1
-      else
+      else {
+        error("Commit callback failed unexpectedly", exception)
         failCount += 1
+      }
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -194,8 +194,10 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
   protected def awaitCommitCallback[K, V](consumer: Consumer[K, V],
                                           commitCallback: CountConsumerCommitCallback,
                                           count: Int = 1): Unit = {
-    TestUtils.pollUntilTrue(consumer, () => commitCallback.successCount >= count,
-      "Failed to observe commit callback before timeout", waitTimeMs = 20000)
+    val numFailuresBeforePoll = commitCallback.failCount
+    TestUtils.pollUntilTrue(consumer, () => commitCallback.successCount >= count || commitCallback.failCount > numFailuresBeforePoll,
+      "Failed to observe commit callback before timeout", waitTimeMs = 10000)
+    assertEquals("Unexpected async commit failure", numFailuresBeforePoll, commitCallback.failCount)
     assertEquals(count, commitCallback.successCount)
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -195,7 +195,7 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
                                           commitCallback: CountConsumerCommitCallback,
                                           count: Int = 1): Unit = {
     TestUtils.pollUntilTrue(consumer, () => commitCallback.successCount >= count,
-      "Failed to observe commit callback before timeout", waitTimeMs = 10000)
+      "Failed to observe commit callback before timeout", waitTimeMs = 20000)
     assertEquals(count, commitCallback.successCount)
   }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -478,14 +478,12 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // async commit
     val asyncMetadata = new OffsetAndMetadata(10, "bar")
-    val callback = new CountConsumerCommitCallback
-    consumer.commitAsync(Map((tp, asyncMetadata)).asJava, callback)
-    awaitCommitCallback(consumer, callback)
+    sendAndAwaitAsyncCommit(consumer, Some(Map(tp -> asyncMetadata)))
     assertEquals(asyncMetadata, consumer.committed(tp))
 
     // handle null metadata
     val nullMetadata = new OffsetAndMetadata(5, null)
-    consumer.commitSync(Map((tp, nullMetadata)).asJava)
+    consumer.commitSync(Map(tp -> nullMetadata).asJava)
     assertEquals(nullMetadata, consumer.committed(tp))
   }
 
@@ -496,10 +494,15 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val callback = new CountConsumerCommitCallback
     val count = 5
+
     for (i <- 1 to count)
       consumer.commitAsync(Map(tp -> new OffsetAndMetadata(i)).asJava, callback)
 
-    awaitCommitCallback(consumer, callback, count=count)
+    TestUtils.pollUntilTrue(consumer, () => callback.successCount >= count || callback.lastError.isDefined,
+      "Failed to observe commit callback before timeout", waitTimeMs = 10000)
+
+    assertEquals(None, callback.lastError)
+    assertEquals(count, callback.successCount)
     assertEquals(new OffsetAndMetadata(count), consumer.committed(tp))
   }
 
@@ -1019,9 +1022,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(commitCountBefore + 1, MockConsumerInterceptor.ON_COMMIT_COUNT.intValue)
 
     // commit async and verify onCommit is called
-    val commitCallback = new CountConsumerCommitCallback()
-    testConsumer.commitAsync(Map[TopicPartition, OffsetAndMetadata]((tp, new OffsetAndMetadata(5L))).asJava, commitCallback)
-    awaitCommitCallback(testConsumer, commitCallback)
+    sendAndAwaitAsyncCommit(testConsumer, Some(Map(tp -> new OffsetAndMetadata(5L))))
     assertEquals(5, testConsumer.committed(tp).offset)
     assertEquals(commitCountBefore + 2, MockConsumerInterceptor.ON_COMMIT_COUNT.intValue)
 
@@ -1325,9 +1326,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(5, consumer.committed(tp2).offset)
 
     // Using async should pick up the committed changes after commit completes
-    val commitCallback = new CountConsumerCommitCallback()
-    consumer.commitAsync(Map[TopicPartition, OffsetAndMetadata]((tp2, new OffsetAndMetadata(7L))).asJava, commitCallback)
-    awaitCommitCallback(consumer, commitCallback)
+    sendAndAwaitAsyncCommit(consumer, Some(Map(tp2 -> new OffsetAndMetadata(7L))))
     assertEquals(7, consumer.committed(tp2).offset)
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -45,7 +45,6 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
 
   @Test
   def testMultipleBrokerMechanisms() {
-
     val plainSaslProducer = createProducer()
     val plainSaslConsumer = createConsumer()
 
@@ -60,9 +59,7 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
     plainSaslConsumer.assign(List(tp).asJava)
     plainSaslConsumer.seek(tp, 0)
     consumeAndVerifyRecords(consumer = plainSaslConsumer, numRecords = numRecords, startingOffset = startingOffset)
-    val plainCommitCallback = new CountConsumerCommitCallback()
-    plainSaslConsumer.commitAsync(plainCommitCallback)
-    awaitCommitCallback(plainSaslConsumer, plainCommitCallback)
+    sendAndAwaitAsyncCommit(plainSaslConsumer)
     startingOffset += numRecords
 
     // Test SASL/GSSAPI producer and consumer
@@ -70,9 +67,7 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
     gssapiSaslConsumer.assign(List(tp).asJava)
     gssapiSaslConsumer.seek(tp, startingOffset)
     consumeAndVerifyRecords(consumer = gssapiSaslConsumer, numRecords = numRecords, startingOffset = startingOffset)
-    val gssapiCommitCallback = new CountConsumerCommitCallback()
-    gssapiSaslConsumer.commitAsync(gssapiCommitCallback)
-    awaitCommitCallback(gssapiSaslConsumer, gssapiCommitCallback)
+    sendAndAwaitAsyncCommit(gssapiSaslConsumer)
     startingOffset += numRecords
 
     // Test SASL/PLAIN producer and SASL/GSSAPI consumer
@@ -87,6 +82,6 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
     plainSaslConsumer.assign(List(tp).asJava)
     plainSaslConsumer.seek(tp, startingOffset)
     consumeAndVerifyRecords(consumer = plainSaslConsumer, numRecords = numRecords, startingOffset = startingOffset)
-
   }
+
 }


### PR DESCRIPTION
We are seeing some timeouts in tests which depend on the `awaitCommitCallback` (e.g. `SaslMultiMechanismConsumerTest.testCoordinatorFailover`). After some investigation, we found that it is caused by a disconnect when attempting the async commit. To fix the problem, we have added simple retry logic to the test utility.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
