### PR TITLE
MINOR: Optimization should only run with more than one repartition topic

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -310,7 +310,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
             final StreamsGraphNode keyChangingNode = entry.getKey();
 
-            if (entry.getValue().isEmpty()) {
+            if (entry.getValue().size() <= 1) {
                 continue;
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
@@ -93,8 +93,8 @@ public class StreamsGraphTest {
 
     @Test
     public void shouldNotOptimizeWithOnlyOneRepartitionTopic() {
-        final String notOptimized = getTopologyWithOnlyOneRepartionTopic(StreamsConfig.NO_OPTIMIZATION).describe().toString();
-        final String optimized = getTopologyWithOnlyOneRepartionTopic(StreamsConfig.OPTIMIZE).describe().toString();
+        final String notOptimized = getTopologyWithOnlyOneRepartitionTopic(StreamsConfig.NO_OPTIMIZATION).describe().toString();
+        final String optimized = getTopologyWithOnlyOneRepartitionTopic(StreamsConfig.OPTIMIZE).describe().toString();
 
         assertEquals(notOptimized, optimized);
     }
@@ -115,7 +115,7 @@ public class StreamsGraphTest {
 
     }
 
-    private Topology getTopologyWithOnlyOneRepartionTopic(final String optimizeConfig) {
+    private Topology getTopologyWithOnlyOneRepartitionTopic(final String optimizeConfig) {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizeConfig);


### PR DESCRIPTION
If there is only one repartition topic as the result of a key-change operation, then the optimization should not take place as the resulting sub-topology will have the same structure.  While not strictly an issue I'm very much in favor of not performing unnecessary operations. 

I've added a test which fails without the update to the optimization.  The existing test suite ensures all other code not impacted by the change. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage, and CI build status
- [ ] Verify documentation (including upgrade notes)
