### PR TITLE
MINOR: Fix connect-0.11.0.x system-test service

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -265,7 +265,8 @@ class ConnectStandaloneService(ConnectServiceBase):
         return self.nodes[0]
 
     def start_cmd(self, node, connector_configs):
-        cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
+        cmd = "cd " + self.PERSISTENT_ROOT + " && "
+        cmd += "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:
             cmd += "export %s=%s; " % (envvar, str(self.environment[envvar]))
@@ -313,7 +314,8 @@ class ConnectDistributedService(ConnectServiceBase):
 
     # connector_configs argument is intentionally ignored in distributed service.
     def start_cmd(self, node, connector_configs):
-        cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
+        cmd = "cd " + self.PERSISTENT_ROOT + " && "
+        cmd += "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:
             cmd += "export %s=%s; " % (envvar, str(self.environment[envvar]))


### PR DESCRIPTION
For connect test services, changes directory before starting up.

If we don't change directory to persistent root, connect starts from the user home directory (`~/`). This is problematic only in connect version 0.11.0.x because of a known [classloader failure](https://github.com/apache/kafka/commit/17aaff3606393b42d4e8ef5299141b5bb21300b0#diff-b46eaec4e7101d2e92e71f3f871f3669). It tries to search through the current working directory and if it runs into broken symbolic links, causes connect to throw an exception and stop looking for plugins altogether. This is happening in a downstream `ducktape` test that is using this service running 0.11.0.x.

`kafkatest` connect tests (with change): PASSING

`ducktape` failing test (without change): FAILING
`ducktape` fixed test (with change): PASSING

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
