### PR TITLE
Kafka_7615

### DIFF
--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -73,7 +73,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
-    val producer = new MirrorMakerProducer(true, producerProps)
+    val producer = new MirrorMakerProducer(true, producerProps, collection.mutable.Map[String, String]())
     MirrorMaker.producer = producer
     MirrorMaker.producer.send(new ProducerRecord(topic, msg.getBytes()))
     MirrorMaker.producer.close()


### PR DESCRIPTION
KAFKA-7615

Currently mirrormaker only supports same topic name in source and destination broker. Support for different topic names in source and destination brokers is needed.

MirrorData from topicA to topicB
