### PR TITLE
Trogdor: Add Task State filter to /coordinator/tasks endpoint

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriBuilder;
 
+import java.util.Optional;
+
 import static net.sourceforge.argparse4j.impl.Arguments.store;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -244,7 +246,7 @@ public class CoordinatorClient {
         } else if (res.getBoolean("show_tasks")) {
             System.out.println("Got coordinator tasks: " +
                 JsonUtil.toPrettyJsonString(client.tasks(
-                    new TasksRequest(null, 0, 0, 0, 0, ""))));
+                    new TasksRequest(null, 0, 0, 0, 0, Optional.empty()))));
         } else if (res.getString("show_task") != null) {
             String taskId = res.getString("show_task");
             TaskRequest req = new TaskRequest(res.getString("show_task"));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -244,7 +244,7 @@ public class CoordinatorClient {
         } else if (res.getBoolean("show_tasks")) {
             System.out.println("Got coordinator tasks: " +
                 JsonUtil.toPrettyJsonString(client.tasks(
-                    new TasksRequest(null, 0, 0, 0, 0))));
+                    new TasksRequest(null, 0, 0, 0, 0, ""))));
         } else if (res.getString("show_task") != null) {
             String taskId = res.getString("show_task");
             TaskRequest req = new TaskRequest(res.getString("show_task"));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -107,10 +107,10 @@ public class CoordinatorRestResource {
             @DefaultValue("0") @QueryParam("lastEndMs") long lastEndMs,
             @DefaultValue("") @QueryParam("state") String state) throws Throwable {
         boolean isEmptyState = state.equals("");
-        if (!isEmptyState && !TaskStateType.Constants.values.contains(state)) {
+        if (!isEmptyState && !TaskStateType.Constants.VALUES.contains(state)) {
             return Response.status(400).entity(
                 String.format("State %s is invalid. Must be one of %s",
-                    state, TaskStateType.Constants.values)
+                    state, TaskStateType.Constants.VALUES)
             ).build();
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -23,15 +23,19 @@ import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
 import org.apache.kafka.trogdor.rest.StopTaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRequest;
+import org.apache.kafka.trogdor.rest.TaskStateType;
 import org.apache.kafka.trogdor.rest.TasksRequest;
 import org.apache.kafka.trogdor.rest.TaskState;
 import org.apache.kafka.trogdor.rest.TasksResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -40,10 +44,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.apache.kafka.trogdor.coordinator.TaskManager.MANAGED_TASK_STATE_NAMES;
 
 /**
  * The REST resource for the Coordinator. This describes the RPCs which the coordinator
@@ -97,27 +101,35 @@ public class CoordinatorRestResource {
         return Empty.INSTANCE;
     }
 
+    @GET
+    @Path("/tasks/")
     public Response tasks(@QueryParam("taskId") List<String> taskId,
             @DefaultValue("0") @QueryParam("firstStartMs") long firstStartMs,
             @DefaultValue("0") @QueryParam("lastStartMs") long lastStartMs,
             @DefaultValue("0") @QueryParam("firstEndMs") long firstEndMs,
             @DefaultValue("0") @QueryParam("lastEndMs") long lastEndMs,
             @DefaultValue("") @QueryParam("state") String state) throws Throwable {
-        if (!state.equals("") && !MANAGED_TASK_STATE_NAMES.contains(state))
-            return Response.status(400).entity(String.format("State %s is invalid. Must be one of %s", state, MANAGED_TASK_STATE_NAMES)).build();
+        boolean isEmptyState = state.equals("");
+        if (!isEmptyState && !TaskStateType.isValid(state))
+            return Response.status(400).entity(
+                String.format("State %s is invalid. Must be one of %s",
+                    state, Arrays.toString(TaskStateType.Constants.values))
+            ).build();
 
-        TasksResponse resp = coordinator().tasks(new TasksRequest(taskId, firstStartMs, lastStartMs, firstEndMs, lastEndMs, state));
+        Optional<TaskStateType> givenState = Optional.ofNullable(isEmptyState ? null : TaskStateType.valueOf(state));
+        TasksResponse resp = coordinator().tasks(new TasksRequest(taskId, firstStartMs, lastStartMs, firstEndMs, lastEndMs, givenState));
+
         return Response.status(200).entity(resp).build();
     }
 
     @GET
     @Path("/tasks/{taskId}")
-    public Response tasks(@PathParam("taskId") String taskId) throws Throwable {
+    public TaskState tasks(@PathParam("taskId") String taskId) throws Throwable {
         TaskState response = coordinator().task(new TaskRequest(taskId));
         if (response == null)
-            return Response.status(404).entity(String.format("No task with ID \"%s\" exists.", taskId)).build();
+            throw new NotFoundException(String.format("No task with ID \"%s\" exists.", taskId));
 
-        return Response.status(200).entity(response).build();
+        return response;
     }
 
     @PUT

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -110,11 +110,16 @@ public class CoordinatorRestResource {
             @DefaultValue("0") @QueryParam("lastEndMs") long lastEndMs,
             @DefaultValue("") @QueryParam("state") String state) throws Throwable {
         boolean isEmptyState = state.equals("");
-        if (!isEmptyState && !TaskStateType.isValid(state))
-            return Response.status(400).entity(
-                String.format("State %s is invalid. Must be one of %s",
-                    state, Arrays.toString(TaskStateType.Constants.values))
-            ).build();
+        if (!isEmptyState) {
+            try {
+                TaskStateType.valueOf(state);
+            } catch (IllegalArgumentException e) {
+                return Response.status(400).entity(
+                    String.format("State %s is invalid. Must be one of %s",
+                        state, Arrays.toString(TaskStateType.Constants.values))
+                ).build();
+            }
+        }
 
         Optional<TaskStateType> givenState = Optional.ofNullable(isEmptyState ? null : TaskStateType.valueOf(state));
         TasksResponse resp = coordinator().tasks(new TasksRequest(taskId, firstStartMs, lastStartMs, firstEndMs, lastEndMs, givenState));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -23,12 +23,10 @@ import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
 import org.apache.kafka.trogdor.rest.StopTaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRequest;
+import org.apache.kafka.trogdor.rest.TaskState;
 import org.apache.kafka.trogdor.rest.TaskStateType;
 import org.apache.kafka.trogdor.rest.TasksRequest;
-import org.apache.kafka.trogdor.rest.TaskState;
 import org.apache.kafka.trogdor.rest.TasksResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
@@ -39,12 +37,11 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -110,15 +107,11 @@ public class CoordinatorRestResource {
             @DefaultValue("0") @QueryParam("lastEndMs") long lastEndMs,
             @DefaultValue("") @QueryParam("state") String state) throws Throwable {
         boolean isEmptyState = state.equals("");
-        if (!isEmptyState) {
-            try {
-                TaskStateType.valueOf(state);
-            } catch (IllegalArgumentException e) {
-                return Response.status(400).entity(
-                    String.format("State %s is invalid. Must be one of %s",
-                        state, Arrays.toString(TaskStateType.Constants.values))
-                ).build();
-            }
+        if (!isEmptyState && !TaskStateType.Constants.values.contains(state)) {
+            return Response.status(400).entity(
+                String.format("State %s is invalid. Must be one of %s",
+                    state, TaskStateType.Constants.values)
+            ).build();
         }
 
         Optional<TaskStateType> givenState = Optional.ofNullable(isEmptyState ? null : TaskStateType.valueOf(state));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -32,12 +32,12 @@ import org.apache.kafka.trogdor.common.ThreadUtils;
 import org.apache.kafka.trogdor.rest.RequestConflictException;
 import org.apache.kafka.trogdor.rest.TaskDone;
 import org.apache.kafka.trogdor.rest.TaskPending;
+import org.apache.kafka.trogdor.rest.TaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRunning;
 import org.apache.kafka.trogdor.rest.TaskState;
 import org.apache.kafka.trogdor.rest.TaskStateType;
 import org.apache.kafka.trogdor.rest.TaskStopping;
 import org.apache.kafka.trogdor.rest.TasksRequest;
-import org.apache.kafka.trogdor.rest.TaskRequest;
 import org.apache.kafka.trogdor.rest.TasksResponse;
 import org.apache.kafka.trogdor.rest.WorkerDone;
 import org.apache.kafka.trogdor.rest.WorkerReceiving;
@@ -47,11 +47,8 @@ import org.apache.kafka.trogdor.task.TaskSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -62,7 +59,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 /**
  * The TaskManager is responsible for managing tasks inside the Trogdor coordinator.

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -46,7 +46,9 @@ import org.apache.kafka.trogdor.task.TaskSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -58,6 +60,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
  * The TaskManager is responsible for managing tasks inside the Trogdor coordinator.
@@ -142,12 +145,14 @@ public final class TaskManager {
             Utils.join(nodeManagers.keySet(), ", "));
     }
 
-    enum ManagedTaskState {
+    public enum ManagedTaskState {
         PENDING,
         RUNNING,
         STOPPING,
-        DONE;
+        DONE
     }
+
+    public static List<String> MANAGED_TASK_STATE_NAMES = Arrays.stream(TaskManager.ManagedTaskState.values()).map(Enum::name).collect(Collectors.toList());
 
     class ManagedTask {
         /**
@@ -621,7 +626,7 @@ public final class TaskManager {
         public TasksResponse call() throws Exception {
             TreeMap<String, TaskState> states = new TreeMap<>();
             for (ManagedTask task : tasks.values()) {
-                if (request.matches(task.id, task.startedMs, task.doneMs)) {
+                if (request.matches(task.id, task.startedMs, task.doneMs, task.state)) {
                     states.put(task.id, task.taskState());
                 }
             }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskState.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskState.java
@@ -31,10 +31,10 @@ import org.apache.kafka.trogdor.task.TaskSpec;
     include = JsonTypeInfo.As.PROPERTY,
     property = "state")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = TaskPending.class, name = "PENDING"),
-        @JsonSubTypes.Type(value = TaskRunning.class, name = "RUNNING"),
-        @JsonSubTypes.Type(value = TaskStopping.class, name = "STOPPING"),
-        @JsonSubTypes.Type(value = TaskDone.class, name = "DONE")
+        @JsonSubTypes.Type(value = TaskPending.class, name = TaskStateType.Constants.PENDING_VALUE),
+        @JsonSubTypes.Type(value = TaskRunning.class, name = TaskStateType.Constants.RUNNING_VALUE),
+        @JsonSubTypes.Type(value = TaskStopping.class, name = TaskStateType.Constants.STOPPING_VALUE),
+        @JsonSubTypes.Type(value = TaskDone.class, name = TaskStateType.Constants.DONE_VALUE)
     })
 public abstract class TaskState extends Message {
     private final TaskSpec spec;

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
@@ -38,8 +38,4 @@ public enum TaskStateType {
             PENDING_VALUE, RUNNING_VALUE, STOPPING_VALUE, DONE_VALUE
         };
     }
-
-    public static boolean isValid(String taskType) {
-        return Arrays.stream(Constants.values).anyMatch(taskType::equals);
-    }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
@@ -34,8 +34,5 @@ public enum TaskStateType {
         static final String RUNNING_VALUE = "RUNNING";
         static final String STOPPING_VALUE = "STOPPING";
         static final String DONE_VALUE = "DONE";
-        public static final String[] values = new String[]{
-            PENDING_VALUE, RUNNING_VALUE, STOPPING_VALUE, DONE_VALUE
-        };
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
@@ -36,7 +36,7 @@ public enum TaskStateType {
         static final String RUNNING_VALUE = "RUNNING";
         static final String STOPPING_VALUE = "STOPPING";
         static final String DONE_VALUE = "DONE";
-        public static final List<String> values = Collections.unmodifiableList(
+        public static final List<String> VALUES = Collections.unmodifiableList(
             Arrays.asList(PENDING_VALUE, RUNNING_VALUE, STOPPING_VALUE, DONE_VALUE));
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.trogdor.rest;
+
+import java.util.Arrays;
+
+/**
+ * The types of states a single Task can be in
+ */
+public enum TaskStateType {
+    PENDING(Constants.PENDING_VALUE),
+    RUNNING(Constants.RUNNING_VALUE),
+    STOPPING(Constants.STOPPING_VALUE),
+    DONE(Constants.DONE_VALUE);
+
+    TaskStateType(String stateType) {}
+
+    public static class Constants {
+        static final String PENDING_VALUE = "PENDING";
+        static final String RUNNING_VALUE = "RUNNING";
+        static final String STOPPING_VALUE = "STOPPING";
+        static final String DONE_VALUE = "DONE";
+        public static final String[] values = new String[]{
+            PENDING_VALUE, RUNNING_VALUE, STOPPING_VALUE, DONE_VALUE
+        };
+    }
+
+    public static boolean isValid(String taskType) {
+        return Arrays.stream(Constants.values).anyMatch(taskType::equals);
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TaskStateType.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.trogdor.rest;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The types of states a single Task can be in
@@ -34,5 +36,7 @@ public enum TaskStateType {
         static final String RUNNING_VALUE = "RUNNING";
         static final String STOPPING_VALUE = "STOPPING";
         static final String DONE_VALUE = "DONE";
+        public static final List<String> values = Collections.unmodifiableList(
+            Arrays.asList(PENDING_VALUE, RUNNING_VALUE, STOPPING_VALUE, DONE_VALUE));
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.trogdor.coordinator.TaskManager;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -60,7 +61,7 @@ public class TasksRequest extends Message {
      * The desired state of the tasks.
      * An empty string will match all states.
      */
-    private final String state;
+    private final Optional<TaskStateType> state;
 
     @JsonCreator
     public TasksRequest(@JsonProperty("taskIds") Collection<String> taskIds,
@@ -68,7 +69,7 @@ public class TasksRequest extends Message {
             @JsonProperty("lastStartMs") long lastStartMs,
             @JsonProperty("firstEndMs") long firstEndMs,
             @JsonProperty("lastEndMs") long lastEndMs,
-            @JsonProperty("state") String state) {
+            @JsonProperty("state") Optional<TaskStateType> state) {
         this.taskIds = Collections.unmodifiableSet((taskIds == null) ?
             new HashSet<String>() : new HashSet<>(taskIds));
         this.firstStartMs = Math.max(0, firstStartMs);
@@ -104,7 +105,7 @@ public class TasksRequest extends Message {
     }
 
     @JsonProperty
-    public String state() {
+    public Optional<TaskStateType> state() {
         return state;
     }
 
@@ -116,7 +117,7 @@ public class TasksRequest extends Message {
      * @param endMs     The task end time, or -1 if the task hasn't ended.
      * @return          True if information about the task should be returned.
      */
-    public boolean matches(String taskId, long startMs, long endMs, TaskManager.ManagedTaskState state) {
+    public boolean matches(String taskId, long startMs, long endMs, TaskStateType state) {
         if ((!taskIds.isEmpty()) && (!taskIds.contains(taskId))) {
             return false;
         }
@@ -133,7 +134,7 @@ public class TasksRequest extends Message {
             return false;
         }
 
-        if (!this.state.equals("") && TaskManager.ManagedTaskState.valueOf(this.state) != state) {
+        if (this.state.isPresent() && !this.state.get().equals(state)) {
             return false;
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.trogdor.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.trogdor.coordinator.TaskManager;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/TasksRequest.java
@@ -76,7 +76,7 @@ public class TasksRequest extends Message {
         this.lastStartMs = Math.max(0, lastStartMs);
         this.firstEndMs = Math.max(0, firstEndMs);
         this.lastEndMs = Math.max(0, lastEndMs);
-        this.state = state;
+        this.state = state == null ? Optional.empty() : state;
     }
 
     @JsonProperty

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
@@ -146,7 +146,7 @@ public class ExpectedTasks {
             public boolean conditionMet() {
                 TasksResponse tasks = null;
                 try {
-                    tasks = client.tasks(new TasksRequest(null, 0, 0, 0, 0));
+                    tasks = client.tasks(new TasksRequest(null, 0, 0, 0, 0, ""));
                 } catch (Exception e) {
                     log.info("Unable to get coordinator tasks", e);
                     throw new RuntimeException(e);

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 public class ExpectedTasks {
@@ -146,7 +147,7 @@ public class ExpectedTasks {
             public boolean conditionMet() {
                 TasksResponse tasks = null;
                 try {
-                    tasks = client.tasks(new TasksRequest(null, 0, 0, 0, 0, ""));
+                    tasks = client.tasks(new TasksRequest(null, 0, 0, 0, 0, Optional.empty()));
                 } catch (Exception e) {
                     log.info("Unable to get coordinator tasks", e);
                     throw new RuntimeException(e);

--- a/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.trogdor.rest.TaskDone;
 import org.apache.kafka.trogdor.rest.TaskPending;
 import org.apache.kafka.trogdor.rest.TaskRunning;
 import org.apache.kafka.trogdor.rest.TaskRequest;
+import org.apache.kafka.trogdor.rest.TaskStateType;
 import org.apache.kafka.trogdor.rest.TasksRequest;
 import org.apache.kafka.trogdor.rest.TaskState;
 import org.apache.kafka.trogdor.rest.TasksResponse;
@@ -60,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -407,40 +409,40 @@ public class CoordinatorTest {
 
     @Test
     public void testTasksRequestMatches() throws Exception {
-        TasksRequest req1 = new TasksRequest(null, 0, 0, 0, 0, "");
-        assertTrue(req1.matches("foo1", -1, -1, TaskManager.ManagedTaskState.PENDING));
-        assertTrue(req1.matches("bar1", 100, 200, TaskManager.ManagedTaskState.DONE));
-        assertTrue(req1.matches("baz1", 100, -1, TaskManager.ManagedTaskState.RUNNING));
+        TasksRequest req1 = new TasksRequest(null, 0, 0, 0, 0, Optional.empty());
+        assertTrue(req1.matches("foo1", -1, -1, TaskStateType.PENDING));
+        assertTrue(req1.matches("bar1", 100, 200, TaskStateType.DONE));
+        assertTrue(req1.matches("baz1", 100, -1, TaskStateType.RUNNING));
 
-        TasksRequest req2 = new TasksRequest(null, 100, 0, 0, 0, "");
-        assertFalse(req2.matches("foo1", -1, -1, TaskManager.ManagedTaskState.PENDING));
-        assertTrue(req2.matches("bar1", 100, 200, TaskManager.ManagedTaskState.DONE));
-        assertFalse(req2.matches("bar1", 99, 200, TaskManager.ManagedTaskState.DONE));
-        assertFalse(req2.matches("baz1", 99, -1, TaskManager.ManagedTaskState.RUNNING));
+        TasksRequest req2 = new TasksRequest(null, 100, 0, 0, 0, Optional.empty());
+        assertFalse(req2.matches("foo1", -1, -1, TaskStateType.PENDING));
+        assertTrue(req2.matches("bar1", 100, 200, TaskStateType.DONE));
+        assertFalse(req2.matches("bar1", 99, 200, TaskStateType.DONE));
+        assertFalse(req2.matches("baz1", 99, -1, TaskStateType.RUNNING));
 
-        TasksRequest req3 = new TasksRequest(null, 200, 900, 200, 900, "");
-        assertFalse(req3.matches("foo1", -1, -1, TaskManager.ManagedTaskState.PENDING));
-        assertFalse(req3.matches("bar1", 100, 200, TaskManager.ManagedTaskState.DONE));
-        assertFalse(req3.matches("bar1", 200, 1000, TaskManager.ManagedTaskState.DONE));
-        assertTrue(req3.matches("bar1", 200, 700, TaskManager.ManagedTaskState.DONE));
-        assertFalse(req3.matches("baz1", 101, -1, TaskManager.ManagedTaskState.RUNNING));
+        TasksRequest req3 = new TasksRequest(null, 200, 900, 200, 900, Optional.empty());
+        assertFalse(req3.matches("foo1", -1, -1, TaskStateType.PENDING));
+        assertFalse(req3.matches("bar1", 100, 200, TaskStateType.DONE));
+        assertFalse(req3.matches("bar1", 200, 1000, TaskStateType.DONE));
+        assertTrue(req3.matches("bar1", 200, 700, TaskStateType.DONE));
+        assertFalse(req3.matches("baz1", 101, -1, TaskStateType.RUNNING));
 
         List<String> taskIds = new ArrayList<>();
         taskIds.add("foo1");
         taskIds.add("bar1");
         taskIds.add("baz1");
-        TasksRequest req4 = new TasksRequest(taskIds, 1000, -1, -1, -1, "");
-        assertFalse(req4.matches("foo1", -1, -1, TaskManager.ManagedTaskState.PENDING));
-        assertTrue(req4.matches("foo1", 1000, -1, TaskManager.ManagedTaskState.RUNNING));
-        assertFalse(req4.matches("foo1", 900, -1, TaskManager.ManagedTaskState.RUNNING));
-        assertFalse(req4.matches("baz2", 2000, -1, TaskManager.ManagedTaskState.RUNNING));
-        assertFalse(req4.matches("baz2", -1, -1, TaskManager.ManagedTaskState.PENDING));
+        TasksRequest req4 = new TasksRequest(taskIds, 1000, -1, -1, -1, Optional.empty());
+        assertFalse(req4.matches("foo1", -1, -1, TaskStateType.PENDING));
+        assertTrue(req4.matches("foo1", 1000, -1, TaskStateType.RUNNING));
+        assertFalse(req4.matches("foo1", 900, -1, TaskStateType.RUNNING));
+        assertFalse(req4.matches("baz2", 2000, -1, TaskStateType.RUNNING));
+        assertFalse(req4.matches("baz2", -1, -1, TaskStateType.PENDING));
 
-        TasksRequest req5 = new TasksRequest(null, 0, 0, 0, 0, TaskManager.ManagedTaskState.RUNNING.name());
-        assertTrue(req5.matches("foo1", -1, -1, TaskManager.ManagedTaskState.RUNNING));
-        assertFalse(req5.matches("bar1", -1, -1, TaskManager.ManagedTaskState.DONE));
-        assertFalse(req5.matches("baz1", -1, -1, TaskManager.ManagedTaskState.STOPPING));
-        assertFalse(req5.matches("baz1", -1, -1, TaskManager.ManagedTaskState.PENDING));
+        TasksRequest req5 = new TasksRequest(null, 0, 0, 0, 0, Optional.of(TaskStateType.RUNNING));
+        assertTrue(req5.matches("foo1", -1, -1, TaskStateType.RUNNING));
+        assertFalse(req5.matches("bar1", -1, -1, TaskStateType.DONE));
+        assertFalse(req5.matches("baz1", -1, -1, TaskStateType.STOPPING));
+        assertFalse(req5.matches("baz1", -1, -1, TaskStateType.PENDING));
     }
 
     @Test
@@ -469,9 +471,9 @@ public class CoordinatorTest {
                 waitFor(coordinatorClient);
 
             assertEquals(0, coordinatorClient.tasks(
-                new TasksRequest(null, 10, 0, 10, 0, "")).tasks().size());
+                new TasksRequest(null, 10, 0, 10, 0, Optional.empty())).tasks().size());
             TasksResponse resp1 = coordinatorClient.tasks(
-                new TasksRequest(Arrays.asList(new String[] {"foo", "baz" }), 0, 0, 0, 0, ""));
+                new TasksRequest(Arrays.asList(new String[] {"foo", "baz" }), 0, 0, 0, 0, Optional.empty()));
             assertTrue(resp1.tasks().containsKey("foo"));
             assertFalse(resp1.tasks().containsKey("bar"));
             assertEquals(1, resp1.tasks().size());
@@ -489,13 +491,13 @@ public class CoordinatorTest {
                 waitFor(cluster.agentClient("node02"));
 
             TasksResponse resp2 = coordinatorClient.tasks(
-                new TasksRequest(null, 1, 0, 0, 0, ""));
+                new TasksRequest(null, 1, 0, 0, 0, Optional.empty()));
             assertTrue(resp2.tasks().containsKey("foo"));
             assertFalse(resp2.tasks().containsKey("bar"));
             assertEquals(1, resp2.tasks().size());
 
             assertEquals(0, coordinatorClient.tasks(
-                new TasksRequest(null, 3, 0, 0, 0, "")).tasks().size());
+                new TasksRequest(null, 3, 0, 0, 0, Optional.empty())).tasks().size());
         }
     }
 


### PR DESCRIPTION
Also ensures that the `/tasks/{taskId}` endpoint returns a semantically-correct 404 status code. It would previously return 500 since the `NotFoundException` was not handled anywhere.

cc @cmccabe 