### PR TITLE
KAFKA-7528: Standardize on Min/Avg/Max Kafka metrics' default value - NaN

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
@@ -26,23 +26,32 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public class Avg extends SampledStat {
 
     public Avg() {
-        super(0.0);
+        super(Double.NaN);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value += value;
+        if (Double.isNaN(sample.value))
+            sample.value = value;
+        else
+            sample.value += value;
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double total = 0.0;
+        double total = Double.NaN;
         long count = 0;
         for (Sample s : samples) {
-            total += s.value;
+            if (Double.isNaN(s.value))
+                continue;
+            if (Double.isNaN(total))
+                total = s.value;
+            else
+                total += s.value;
+
             count += s.eventCount;
         }
-        return count == 0 ? 0 : total / count;
+        return count == 0 ? total : total / count;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
@@ -26,32 +26,23 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public class Avg extends SampledStat {
 
     public Avg() {
-        super(Double.NaN);
+        super(0.0);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        if (Double.isNaN(sample.value))
-            sample.value = value;
-        else
-            sample.value += value;
+        sample.value += value;
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double total = Double.NaN;
+        double total = 0;
         long count = 0;
         for (Sample s : samples) {
-            if (Double.isNaN(s.value))
-                continue;
-            if (Double.isNaN(total))
-                total = s.value;
-            else
-                total += s.value;
-
+            total += s.value;
             count += s.eventCount;
         }
-        return count == 0 ? total : total / count;
+        return count == 0 ? Double.NaN : total;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Avg.java
@@ -36,13 +36,14 @@ public class Avg extends SampledStat {
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double total = 0;
+        double total = 0.0;
         long count = 0;
         for (Sample s : samples) {
             total += s.value;
             count += s.eventCount;
         }
-        return count == 0 ? Double.NaN : total;
+        return count == 0 ? Double.NaN : total / count;
     }
 
 }
+

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
@@ -26,27 +26,21 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public final class Max extends SampledStat {
 
     public Max() {
-        super(Double.NaN);
+        super(Double.MIN_VALUE);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        if (Double.isNaN(sample.value))
-            sample.value = value;
-        else
-            sample.value = Math.max(sample.value, value);
+        sample.value = Math.max(sample.value, value);
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double max = Double.NaN;
+        double max = Double.MIN_VALUE;
         for (Sample sample : samples) {
-            if (Double.isNaN(max))
-                max = sample.value;
-            else if (!Double.isNaN(sample.value))
-                max = Math.max(max, sample.value);
+            max = Math.max(max, sample.value);
         }
-        return max;
+        return Math.abs(max - Double.MIN_VALUE) < 0.001 ? Double.NaN : max;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
@@ -26,19 +26,26 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public final class Max extends SampledStat {
 
     public Max() {
-        super(Double.NEGATIVE_INFINITY);
+        super(Double.NaN);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value = Math.max(sample.value, value);
+        if (Double.isNaN(sample.value))
+            sample.value = value;
+        else
+            sample.value = Math.max(sample.value, value);
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double max = Double.NEGATIVE_INFINITY;
-        for (Sample sample : samples)
-            max = Math.max(max, sample.value);
+        double max = Double.NaN;
+        for (Sample sample : samples) {
+            if (Double.isNaN(max))
+                max = sample.value;
+            else if (!Double.isNaN(sample.value))
+                max = Math.max(max, sample.value);
+        }
         return max;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
@@ -37,9 +37,12 @@ public final class Max extends SampledStat {
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
         double max = Double.NEGATIVE_INFINITY;
-        for (Sample sample : samples)
+        long count = 0;
+        for (Sample sample : samples) {
             max = Math.max(max, sample.value);
-        return samples.isEmpty() ? Double.NaN : max;
+            count += sample.eventCount;
+        }
+        return count == 0 ? Double.NaN : max;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Max.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public final class Max extends SampledStat {
 
     public Max() {
-        super(Double.MIN_VALUE);
+        super(Double.NEGATIVE_INFINITY);
     }
 
     @Override
@@ -36,11 +36,10 @@ public final class Max extends SampledStat {
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double max = Double.MIN_VALUE;
-        for (Sample sample : samples) {
+        double max = Double.NEGATIVE_INFINITY;
+        for (Sample sample : samples)
             max = Math.max(max, sample.value);
-        }
-        return Math.abs(max - Double.MIN_VALUE) < 0.001 ? Double.NaN : max;
+        return samples.isEmpty() ? Double.NaN : max;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
@@ -39,7 +39,7 @@ public class Min extends SampledStat {
         double min = Double.MAX_VALUE;
         for (Sample sample : samples)
             min = Math.min(min, sample.value);
-        return Math.abs(min - Double.MAX_VALUE) < 0.001 ? Double.NaN : min;
+        return samples.isEmpty() ? Double.NaN : min;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
@@ -37,9 +37,12 @@ public class Min extends SampledStat {
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
         double min = Double.MAX_VALUE;
-        for (Sample sample : samples)
+        long count = 0;
+        for (Sample sample : samples) {
             min = Math.min(min, sample.value);
-        return samples.isEmpty() ? Double.NaN : min;
+            count += sample.eventCount;
+        }
+        return count == 0 ? Double.NaN : min;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
@@ -26,26 +26,20 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public class Min extends SampledStat {
 
     public Min() {
-        super(Double.NaN);
+        super(Double.MAX_VALUE);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        if (Double.isNaN(sample.value))
-            sample.value = value;
-        else
-            sample.value = Math.min(sample.value, value);
+        sample.value = Math.min(sample.value, value);
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double min = Double.NaN;
+        double min = Double.MAX_VALUE;
         for (Sample sample : samples)
-            if (Double.isNaN(min))
-                min = sample.value;
-            else if (!Double.isNaN(sample.value))
-                min = Math.min(min, sample.value);
-        return min;
+            min = Math.min(min, sample.value);
+        return Math.abs(min - Double.MAX_VALUE) < 0.001 ? Double.NaN : min;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Min.java
@@ -26,19 +26,25 @@ import org.apache.kafka.common.metrics.MetricConfig;
 public class Min extends SampledStat {
 
     public Min() {
-        super(Double.MAX_VALUE);
+        super(Double.NaN);
     }
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value = Math.min(sample.value, value);
+        if (Double.isNaN(sample.value))
+            sample.value = value;
+        else
+            sample.value = Math.min(sample.value, value);
     }
 
     @Override
     public double combine(List<Sample> samples, MetricConfig config, long now) {
-        double min = Double.MAX_VALUE;
+        double min = Double.NaN;
         for (Sample sample : samples)
-            min = Math.min(min, sample.value);
+            if (Double.isNaN(min))
+                min = sample.value;
+            else if (!Double.isNaN(sample.value))
+                min = Math.min(min, sample.value);
         return min;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1600,8 +1600,8 @@ public class FetcherTest {
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
 
-        // recordsFetchLagMax should be initialized to negative infinity
-        assertEquals(Double.NEGATIVE_INFINITY, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+        // recordsFetchLagMax should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLagMax.metricValue(), EPSILON);
 
         // recordsFetchLagMax should be hw - fetchOffset after receiving an empty FetchResponse
         fetchRecords(tp0, MemoryRecords.EMPTY, Errors.NONE, 100L, 0);
@@ -1638,8 +1638,8 @@ public class FetcherTest {
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLeadMin = allMetrics.get(minLeadMetric);
 
-        // recordsFetchLeadMin should be initialized to MAX_VALUE
-        assertEquals(Double.MAX_VALUE, (Double) recordsFetchLeadMin.metricValue(), EPSILON);
+        // recordsFetchLeadMin should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLeadMin.metricValue(), EPSILON);
 
         // recordsFetchLeadMin should be position - logStartOffset after receiving an empty FetchResponse
         fetchRecords(tp0, MemoryRecords.EMPTY, Errors.NONE, 100L, -1L, 0L, 0);
@@ -1682,8 +1682,8 @@ public class FetcherTest {
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
 
-        // recordsFetchLagMax should be initialized to negative infinity
-        assertEquals(Double.NEGATIVE_INFINITY, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+        // recordsFetchLagMax should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLagMax.metricValue(), EPSILON);
 
         // recordsFetchLagMax should be lso - fetchOffset after receiving an empty FetchResponse
         fetchRecords(tp0, MemoryRecords.EMPTY, Errors.NONE, 100L, 50L, 0);

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -46,7 +46,7 @@ public class JmxReporterTest {
             sensor.add(metrics.metricName("pack.bean2.total", "grp2"), new Total());
 
             assertTrue(server.isRegistered(new ObjectName(":type=grp1")));
-            assertEquals(0.0, server.getAttribute(new ObjectName(":type=grp1"), "pack.bean1.avg"));
+            assertEquals(Double.NaN, server.getAttribute(new ObjectName(":type=grp1"), "pack.bean1.avg"));
             assertTrue(server.isRegistered(new ObjectName(":type=grp2")));
             assertEquals(0.0, server.getAttribute(new ObjectName(":type=grp2"), "pack.bean2.total"));
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -350,34 +350,48 @@ public class MetricsTest {
         assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
     }
 
+    /**
+     * Some implementations of SampledStat make sense to return NaN
+     * when there are no values set rather than the initial value
+     */
     @Test
-    public void testSampledStatInitialValue() {
-        // initialValue from each SampledStat is set as the initialValue on its Sample.
-        // The only way to test the initialValue is to infer it by having a SampledStat
-        // with expired Stats, because their values are reset to the initial values.
-        // Most implementations of combine on SampledStat end up returning the default
-        // value, so we can use this. This doesn't work for Percentiles though.
-        // This test looks a lot like testOldDataHasNoEffect because it's the same
-        // flow that leads to this state.
+    public void testSampledStatReturnsNaNWhenNoValuesExist() {
+        // This is tested by having a SampledStat with expired Stats,
+        // because their values get reset to the initial values.
         Max max = new Max();
         Min min = new Min();
         Avg avg = new Avg();
-        Count count = new Count();
-        Rate.SampledTotal sampledTotal = new Rate.SampledTotal();
-
         long windowMs = 100;
         int samples = 2;
         MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
         max.record(config, 50, time.milliseconds());
         min.record(config, 50, time.milliseconds());
         avg.record(config, 50, time.milliseconds());
-        count.record(config, 50, time.milliseconds());
-        sampledTotal.record(config, 50, time.milliseconds());
+
         time.sleep(samples * windowMs);
 
         assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
         assertEquals(Double.NaN, min.measure(config, time.milliseconds()), EPS);
         assertEquals(Double.NaN, avg.measure(config, time.milliseconds()), EPS);
+    }
+
+    /**
+     * Some implementations of SampledStat make sense to return the initial value
+     * when there are no values set
+     */
+    @Test
+    public void testSampledStatReturnsInitialValueWhenNoValuesExist() {
+        Count count = new Count();
+        Rate.SampledTotal sampledTotal = new Rate.SampledTotal();
+        long windowMs = 100;
+        int samples = 2;
+        MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
+
+        count.record(config, 50, time.milliseconds());
+        sampledTotal.record(config, 50, time.milliseconds());
+
+        time.sleep(samples * windowMs);
+
         assertEquals(0, count.measure(config, time.milliseconds()), EPS);
         assertEquals(0.0, sampledTotal.measure(config, time.milliseconds()), EPS);
     }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -347,7 +347,7 @@ public class MetricsTest {
         MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
         max.record(config, 50, time.milliseconds());
         time.sleep(samples * windowMs);
-        assertEquals(Double.NEGATIVE_INFINITY, max.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
     }
 
     @Test
@@ -375,9 +375,9 @@ public class MetricsTest {
         sampledTotal.record(config, 50, time.milliseconds());
         time.sleep(samples * windowMs);
 
-        assertEquals(Double.NEGATIVE_INFINITY, max.measure(config, time.milliseconds()), EPS);
-        assertEquals(Double.MAX_VALUE, min.measure(config, time.milliseconds()), EPS);
-        assertEquals(0.0, avg.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, min.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, avg.measure(config, time.milliseconds()), EPS);
         assertEquals(0, count.measure(config, time.milliseconds()), EPS);
         assertEquals(0.0, sampledTotal.measure(config, time.milliseconds()), EPS);
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -179,12 +179,14 @@ public class NioEchoServer extends Thread {
             long currentElapsedMs = time.milliseconds() - startMs;
             long thisMaxWaitMs = maxAggregateWaitMs - currentElapsedMs;
             String metricName = namePrefix + metricType.metricNameSuffix();
-            if (expectedValue == 0.0)
-                assertEquals(
-                        "Metric not updated " + metricName + " expected:<" + expectedValue + "> but was:<"
-                                + metricValue(metricName) + ">",
-                        metricType == MetricType.MAX ? Double.NEGATIVE_INFINITY : 0d, metricValue(metricName), EPS);
-            else if (metricType == MetricType.TOTAL)
+            if (expectedValue == 0.0) {
+                Double expected = expectedValue;
+                if (metricType == MetricType.MAX || metricType == MetricType.AVG)
+                    expected = Double.NaN;
+
+                assertEquals("Metric not updated " + metricName + " expected:<" + expectedValue + "> but was:<"
+                    + metricValue(metricName) + ">", expected, metricValue(metricName), EPS);
+            } else if (metricType == MetricType.TOTAL)
                 TestUtils.waitForCondition(() -> Math.abs(metricValue(metricName) - expectedValue) <= EPS,
                         thisMaxWaitMs, () -> "Metric not updated " + metricName + " expected:<" + expectedValue
                                 + "> but was:<" + metricValue(metricName) + ">");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -198,7 +198,7 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("status", "paused");
         assertTaskMetricValue("running-ratio", 0.0);
         assertTaskMetricValue("pause-ratio", 1.0);
-        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NaN);
 
         PowerMock.verifyAll();
     }
@@ -272,7 +272,7 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 1.0);
         assertTaskMetricValue("batch-size-avg", 0.5);
-        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NaN);
         assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
         assertTaskMetricValue("offset-commit-success-percentage", 0.0);
 
@@ -350,7 +350,7 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 0.0);
         assertTaskMetricValue("batch-size-avg", 0.0);
-        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NaN);
         assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
         assertTaskMetricValue("offset-commit-success-percentage", 0.0);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -861,7 +861,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         if (minimumPollCountExpected > 0) {
             assertTrue(pollBatchTimeMax >= 0.0d);
         }
-        assertTrue(pollBatchTimeAvg >= 0.0d);
+        assertTrue(Double.isNaN(pollBatchTimeAvg) || pollBatchTimeAvg > 0.0d);
         double activeCount = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-active-count");
         double activeCountMax = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-active-count-max");
         assertEquals(0, activeCount, 0.000001d);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1504,8 +1504,8 @@ public class DistributedHerderTest {
         assertEquals(isRebalancing ? 1.0d : 0.0d, rebalancing, 0.0001d);
         assertEquals(millisSinceLastRebalance, rebalanceTimeSinceLast, 0.0001d);
         if (rebalanceTime <= 0L) {
-            assertEquals(Double.NEGATIVE_INFINITY, rebalanceTimeMax, 0.0001d);
-            assertEquals(0.0d, rebalanceTimeAvg, 0.0001d);
+            assertEquals(Double.NaN, rebalanceTimeMax, 0.0001d);
+            assertEquals(Double.NaN, rebalanceTimeAvg, 0.0001d);
         } else {
             assertEquals(rebalanceTime, rebalanceTimeMax, 0.0001d);
             assertEquals(rebalanceTime, rebalanceTimeAvg, 0.0001d);

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -228,7 +228,7 @@ abstract class QuotaTestClients(topic: String,
     if (expectThrottle) {
       assertTrue(s"Client with id=$clientId should have been throttled", throttleMetricValue > 0)
     } else {
-      assertEquals(s"Client with id=$clientId should not have been throttled", 0.0, throttleMetricValue, 0.0)
+      assertTrue(s"Client with id=$clientId should not have been throttled", throttleMetricValue.isNaN)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -121,14 +121,14 @@ class RequestQuotaTest extends BaseRequestTest {
 
   @Test
   def testResponseThrottleTimeWhenBothProduceAndRequestQuotasViolated() {
-    val apiKey = ApiKeys.PRODUCE;
+    val apiKey = ApiKeys.PRODUCE
     submitTest(apiKey, () => checkSmallQuotaProducerRequestThrottleTime(apiKey))
     waitAndCheckResults()
   }
 
   @Test
   def testResponseThrottleTimeWhenBothFetchAndRequestQuotasViolated() {
-    val apiKey = ApiKeys.FETCH;
+    val apiKey = ApiKeys.FETCH
     submitTest(apiKey, () => checkSmallQuotaConsumerRequestThrottleTime(apiKey))
     waitAndCheckResults()
   }
@@ -475,7 +475,7 @@ class RequestQuotaTest extends BaseRequestTest {
     assertTrue(s"Throttle time metrics for produce quota not updated: $smallQuotaProducerClient",
       throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Produce) > 0)
     assertTrue(s"Throttle time metrics for request quota updated: $smallQuotaProducerClient",
-      throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Request) == 0)
+      throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Request).isNaN)
   }
 
   private def checkSmallQuotaConsumerRequestThrottleTime(apiKey: ApiKeys) {
@@ -488,7 +488,7 @@ class RequestQuotaTest extends BaseRequestTest {
     assertTrue(s"Throttle time metrics for consumer quota not updated: $smallQuotaConsumerClientId",
       throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Fetch) > 0)
     assertTrue(s"Throttle time metrics for request quota updated: $smallQuotaConsumerClient",
-      throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Request) == 0)
+      throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Request).isNaN)
   }
 
   private def checkUnthrottledClient(apiKey: ApiKeys) {
@@ -497,7 +497,7 @@ class RequestQuotaTest extends BaseRequestTest {
     val unthrottledClient = Client(unthrottledClientId, apiKey)
     unthrottledClient.runUntil(response => responseThrottleTime(apiKey, response) <= 0.0)
     assertEquals(1, unthrottledClient.correlationId)
-    assertTrue(s"Client should not have been throttled: $unthrottledClient", throttleTimeMetricValue(unthrottledClientId) <= 0.0)
+    assertTrue(s"Client should not have been throttled: $unthrottledClient", throttleTimeMetricValue(unthrottledClientId).isNaN)
   }
 
   private def checkExemptRequestMetric(apiKey: ApiKeys) {
@@ -507,7 +507,7 @@ class RequestQuotaTest extends BaseRequestTest {
     val updated = client.runUntil(response => exemptRequestMetricValue > exemptTarget)
 
     assertTrue(s"Exempt-request-time metric not updated: $client", updated)
-    assertTrue(s"Client should not have been throttled: $client", throttleTimeMetricValue(clientId) <= 0.0)
+    assertTrue(s"Client should not have been throttled: $client", throttleTimeMetricValue(clientId).isNaN)
   }
 
   private def checkUnauthorizedRequestThrottle(apiKey: ApiKeys) {


### PR DESCRIPTION
While metrics like `Min`, `Avg` and `Max` make sense to respective use `Double.MAX_VALUE`, `0.0` and `Double.MIN_VALUE` as default values to ease computation logic, exposing those values makes reading them a bit misleading. For instance, how would you differentiate whether your `-avg` metric has a value of 0 because it was given samples of 0 or no samples were fed to it?

It makes sense to standardize on the output of these metrics with something that clearly denotes that no values have been recorded.