### PR TITLE
KAFKA-7638: Add support for multiple task creation in one request

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -40,7 +40,6 @@ import org.apache.kafka.trogdor.rest.TasksResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.BadRequestException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -100,7 +100,7 @@ public final class Coordinator {
     }
 
     public void createMultipleTasks(CreateMultipleTasksRequest request)
-        throws InvalidRequestException, RequestConflictException, BadRequestException {
+        throws Throwable {
         taskManager.createAndScheduleTasksAtomic(
             request.tasks().stream()
                 .map(req -> new TaskManager.TaskDetail(req.id(), req.spec()))

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -27,21 +27,21 @@ import org.apache.kafka.common.utils.Scheduler;
 import org.apache.kafka.trogdor.common.Node;
 import org.apache.kafka.trogdor.common.Platform;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
-import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
+import org.apache.kafka.trogdor.rest.CreateTasksRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.JsonRestServer;
 import org.apache.kafka.trogdor.rest.RequestConflictException;
 import org.apache.kafka.trogdor.rest.StopTaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRequest;
-import org.apache.kafka.trogdor.rest.TasksRequest;
 import org.apache.kafka.trogdor.rest.TaskState;
+import org.apache.kafka.trogdor.rest.TasksRequest;
 import org.apache.kafka.trogdor.rest.TasksResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
 
@@ -95,16 +95,12 @@ public final class Coordinator {
     }
 
     public void createTask(CreateTaskRequest request) throws Throwable {
-        taskManager.createAndScheduleTask(new TaskManager.TaskDetail(request.id(), request.spec()));
+        taskManager.createAndScheduleTasks(Collections.singletonMap(request.id(), request.spec()));
     }
 
-    public void createMultipleTasks(CreateMultipleTasksRequest request)
+    public void createMultipleTasks(CreateTasksRequest request)
         throws RequestConflictException, InvalidRequestException {
-        taskManager.createAndScheduleTasks(
-            request.tasks().stream()
-                .map(req -> new TaskManager.TaskDetail(req.id(), req.spec()))
-                .collect(Collectors.toList())
-        );
+        taskManager.createAndScheduleTasks(request.tasks());
     }
 
     public void stopTask(StopTaskRequest request) throws Throwable {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -100,8 +100,8 @@ public final class Coordinator {
     }
 
     public void createMultipleTasks(CreateMultipleTasksRequest request)
-        throws Throwable {
-        taskManager.createAndScheduleTasksAtomic(
+        throws RequestConflictException, InvalidRequestException {
+        taskManager.createAndScheduleTasks(
             request.tasks().stream()
                 .map(req -> new TaskManager.TaskDetail(req.id(), req.spec()))
                 .collect(Collectors.toList())

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -98,7 +98,7 @@ public final class Coordinator {
         taskManager.createAndScheduleTasks(Collections.singletonMap(request.id(), request.spec()));
     }
 
-    public void createMultipleTasks(CreateTasksRequest request)
+    public void createTasks(CreateTasksRequest request)
         throws RequestConflictException, InvalidRequestException {
         taskManager.createAndScheduleTasks(request.tasks());
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -216,7 +216,7 @@ public class CoordinatorClient {
             .help("Create a new task from a task spec.");
         actions.addArgument("--create-tasks")
             .action(store())
-            .type(List.class)
+            .type(String.class)
             .dest("create_tasks")
             .metavar("TASK_SPECS_JSON")
             .help("Create new tasks from multiple task specs.");

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -128,7 +128,7 @@ public class CoordinatorClient {
         resp.body();
     }
 
-    public void createMultipleTasks(CreateTasksRequest request) throws Exception {
+    public void createTasks(CreateTasksRequest request) throws Exception {
         HttpResponse<Empty> resp =
             JsonRestServer.httpRequest(log, url("/coordinator/task/creates"), "POST",
                 request, new TypeReference<Empty>() { }, maxTries);
@@ -278,7 +278,7 @@ public class CoordinatorClient {
         } else if (res.getString("create_tasks") != null) {
             CreateTasksRequest req = JsonUtil.JSON_SERDE.
                 readValue(res.getString("create_tasks"), CreateTasksRequest.class);
-            client.createMultipleTasks(req);
+            client.createTasks(req);
             System.out.print("Sent CreateTasksRequest for multiple tasks.");
         } else if (res.getString("stop_task") != null) {
             String taskId = res.getString("stop_task");

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -44,7 +44,6 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriBuilder;
 
 import java.util.Optional;
-import java.util.List;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -44,6 +44,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriBuilder;
 
 import java.util.Optional;
+import java.util.List;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
@@ -130,7 +131,7 @@ public class CoordinatorClient {
 
     public void createMultipleTasks(CreateMultipleTasksRequest request) throws Exception {
         HttpResponse<Empty> resp =
-            JsonRestServer.httpRequest(log, url("/coordinator/task/mass_create"), "POST",
+            JsonRestServer.httpRequest(log, url("/coordinator/task/creates"), "POST",
                 request, new TypeReference<Empty>() { }, maxTries);
         resp.body();
     }
@@ -213,6 +214,12 @@ public class CoordinatorClient {
             .dest("create_task")
             .metavar("TASK_SPEC_JSON")
             .help("Create a new task from a task spec.");
+        actions.addArgument("--create-tasks")
+            .action(store())
+            .type(List.class)
+            .dest("create_tasks")
+            .metavar("TASK_SPECS_JSON")
+            .help("Create new tasks from multiple task specs.");
         actions.addArgument("--stop-task")
             .action(store())
             .type(String.class)
@@ -269,9 +276,9 @@ public class CoordinatorClient {
                 readValue(res.getString("create_task"), CreateTaskRequest.class);
             client.createTask(req);
             System.out.printf("Sent CreateTaskRequest for task %s.", req.id());
-        } else if (res.getString("create_multiple_task") != null) {
+        } else if (res.getString("create_tasks") != null) {
             CreateMultipleTasksRequest req = JsonUtil.JSON_SERDE.
-                readValue(res.getString("create_multiple_task"), CreateMultipleTasksRequest.class);
+                readValue(res.getString("create_tasks"), CreateMultipleTasksRequest.class);
             client.createMultipleTasks(req);
             System.out.print("Sent CreateMultipleTasksRequest for multiple tasks.");
         } else if (res.getString("stop_task") != null) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -26,6 +26,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
+import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
@@ -123,6 +124,13 @@ public class CoordinatorClient {
     public void createTask(CreateTaskRequest request) throws Exception {
         HttpResponse<Empty> resp =
             JsonRestServer.httpRequest(log, url("/coordinator/task/create"), "POST",
+                request, new TypeReference<Empty>() { }, maxTries);
+        resp.body();
+    }
+
+    public void createMultipleTasks(CreateMultipleTasksRequest request) throws Exception {
+        HttpResponse<Empty> resp =
+            JsonRestServer.httpRequest(log, url("/coordinator/task/mass_create"), "POST",
                 request, new TypeReference<Empty>() { }, maxTries);
         resp.body();
     }
@@ -261,6 +269,11 @@ public class CoordinatorClient {
                 readValue(res.getString("create_task"), CreateTaskRequest.class);
             client.createTask(req);
             System.out.printf("Sent CreateTaskRequest for task %s.", req.id());
+        } else if (res.getString("create_multiple_task") != null) {
+            CreateMultipleTasksRequest req = JsonUtil.JSON_SERDE.
+                readValue(res.getString("create_multiple_task"), CreateMultipleTasksRequest.class);
+            client.createMultipleTasks(req);
+            System.out.print("Sent CreateMultipleTasksRequest for multiple tasks.");
         } else if (res.getString("stop_task") != null) {
             String taskId = res.getString("stop_task");
             client.stopTask(new StopTaskRequest(taskId));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -26,7 +26,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
-import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
+import org.apache.kafka.trogdor.rest.CreateTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
@@ -128,7 +128,7 @@ public class CoordinatorClient {
         resp.body();
     }
 
-    public void createMultipleTasks(CreateMultipleTasksRequest request) throws Exception {
+    public void createMultipleTasks(CreateTasksRequest request) throws Exception {
         HttpResponse<Empty> resp =
             JsonRestServer.httpRequest(log, url("/coordinator/task/creates"), "POST",
                 request, new TypeReference<Empty>() { }, maxTries);
@@ -276,10 +276,10 @@ public class CoordinatorClient {
             client.createTask(req);
             System.out.printf("Sent CreateTaskRequest for task %s.", req.id());
         } else if (res.getString("create_tasks") != null) {
-            CreateMultipleTasksRequest req = JsonUtil.JSON_SERDE.
-                readValue(res.getString("create_tasks"), CreateMultipleTasksRequest.class);
+            CreateTasksRequest req = JsonUtil.JSON_SERDE.
+                readValue(res.getString("create_tasks"), CreateTasksRequest.class);
             client.createMultipleTasks(req);
-            System.out.print("Sent CreateMultipleTasksRequest for multiple tasks.");
+            System.out.print("Sent CreateTasksRequest for multiple tasks.");
         } else if (res.getString("stop_task") != null) {
             String taskId = res.getString("stop_task");
             client.stopTask(new StopTaskRequest(taskId));

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -88,11 +88,11 @@ public class CoordinatorRestResource {
 
     @POST
     @Path("/task/creates")
-    public Response createMultipleTasks(CreateTasksRequest request) throws Throwable {
+    public Response createTasks(CreateTasksRequest request) throws Throwable {
         if (request.tasks().size() == 0)
             throw new BadRequestException("No tasks were given.");
 
-        coordinator().createMultipleTasks(request);
+        coordinator().createTasks(request);
         return Response.status(201).entity(Empty.INSTANCE).build();
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -18,7 +18,7 @@ package org.apache.kafka.trogdor.coordinator;
 
 import org.apache.kafka.trogdor.rest.CoordinatorShutdownRequest;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
-import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
+import org.apache.kafka.trogdor.rest.CreateTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
@@ -88,11 +88,9 @@ public class CoordinatorRestResource {
 
     @POST
     @Path("/task/creates")
-    public Response createMultipleTasks(CreateMultipleTasksRequest request) throws Throwable {
+    public Response createMultipleTasks(CreateTasksRequest request) throws Throwable {
         if (request.tasks().size() == 0)
             throw new BadRequestException("No tasks were given.");
-        if (request.tasks().stream().anyMatch(task -> task.id() == null || task.id().isEmpty()))
-            throw new BadRequestException("Tasks must have an ID");
 
         coordinator().createMultipleTasks(request);
         return Response.status(201).entity(Empty.INSTANCE).build();

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -16,11 +16,14 @@
  */
 package org.apache.kafka.trogdor.coordinator;
 
+import com.sun.javaws.exceptions.BadMimeTypeResponseException;
 import org.apache.kafka.trogdor.rest.CoordinatorShutdownRequest;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
+import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
+import org.apache.kafka.trogdor.rest.JsonRestServer;
 import org.apache.kafka.trogdor.rest.StopTaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRequest;
 import org.apache.kafka.trogdor.rest.TaskState;
@@ -79,9 +82,16 @@ public class CoordinatorRestResource {
 
     @POST
     @Path("/task/create")
-    public Empty createTask(CreateTaskRequest request) throws Throwable {
+    public Response createTask(CreateTaskRequest request) throws Throwable {
         coordinator().createTask(request);
-        return Empty.INSTANCE;
+        return Response.status(201).entity(Empty.INSTANCE).build();
+    }
+
+    @POST
+    @Path("/task/mass_create")
+    public Response createMultipleTask(CreateMultipleTasksRequest request) throws Throwable {
+        coordinator().createMultipleTasks(request);
+        return Response.status(201).entity(Empty.INSTANCE).build();
     }
 
     @PUT

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -30,6 +30,7 @@ import org.apache.kafka.trogdor.rest.TasksRequest;
 import org.apache.kafka.trogdor.rest.TasksResponse;
 
 import javax.servlet.ServletContext;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -86,8 +87,13 @@ public class CoordinatorRestResource {
     }
 
     @POST
-    @Path("/task/mass_create")
-    public Response createMultipleTask(CreateMultipleTasksRequest request) throws Throwable {
+    @Path("/task/creates")
+    public Response createMultipleTasks(CreateMultipleTasksRequest request) throws Throwable {
+        if (request.tasks().size() == 0)
+            throw new BadRequestException("No tasks were given.");
+        if (request.tasks().stream().anyMatch(task -> task.id() == null || task.id().isEmpty()))
+            throw new BadRequestException("Tasks must have an ID");
+
         coordinator().createMultipleTasks(request);
         return Response.status(201).entity(Empty.INSTANCE).build();
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -16,14 +16,12 @@
  */
 package org.apache.kafka.trogdor.coordinator;
 
-import com.sun.javaws.exceptions.BadMimeTypeResponseException;
 import org.apache.kafka.trogdor.rest.CoordinatorShutdownRequest;
 import org.apache.kafka.trogdor.rest.CoordinatorStatusResponse;
 import org.apache.kafka.trogdor.rest.CreateMultipleTasksRequest;
 import org.apache.kafka.trogdor.rest.CreateTaskRequest;
 import org.apache.kafka.trogdor.rest.DestroyTaskRequest;
 import org.apache.kafka.trogdor.rest.Empty;
-import org.apache.kafka.trogdor.rest.JsonRestServer;
 import org.apache.kafka.trogdor.rest.StopTaskRequest;
 import org.apache.kafka.trogdor.rest.TaskRequest;
 import org.apache.kafka.trogdor.rest.TaskState;

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -304,8 +304,11 @@ public final class TaskManager {
 
     /**
      * Atomically creates and schedules the given tasks. If any task fails creation, none get scheduled.
+     *
+     * @throws RequestConflictException - if a task with that ID already exists
+     * @throws BadRequestException - if there was any generic failure in creating the task
      */
-    public void createAndScheduleTasksAtomic(List<TaskDetail> tasks) throws BadRequestException, RequestConflictException {
+    public void createAndScheduleTasksAtomic(List<TaskDetail> tasks) throws Throwable {
         List<ManagedTask> managedTasks = new ArrayList<>();
         if (tasks.stream().map(task -> task.id).collect(Collectors.toSet()).size() < tasks.size())
             throw new RequestConflictException("Duplicate task IDs given");
@@ -315,6 +318,7 @@ public final class TaskManager {
                 managedTasks.add(createTask(task));
             } catch (Throwable e) {
                 log.info("Failed to create createTask(id={}, spec={}) error:", task.id, task.spec, e);
+                throw e;
             }
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateMultipleTasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateMultipleTasksRequest.java
@@ -19,29 +19,22 @@ package org.apache.kafka.trogdor.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.kafka.trogdor.task.TaskSpec;
+
+import java.util.List;
 
 /**
- * A request to the Trogdor coordinator to create a task.
+ * A request to the Trogdor coordinator to create mulitple tasks.
  */
-public class CreateTaskRequest extends Message {
-    private final String id;
-    private final TaskSpec spec;
+public class CreateMultipleTasksRequest extends Message {
+    private final List<CreateTaskRequest> tasks;
 
     @JsonCreator
-    public CreateTaskRequest(@JsonProperty("id") String id,
-            @JsonProperty("spec") TaskSpec spec) {
-        this.id = id;
-        this.spec = spec;
+    public CreateMultipleTasksRequest(@JsonProperty("tasks") List<CreateTaskRequest> tasks) {
+        this.tasks = tasks;
     }
 
     @JsonProperty
-    public String id() {
-        return id;
-    }
-
-    @JsonProperty
-    public TaskSpec spec() {
-        return spec;
+    public List<CreateTaskRequest> tasks() {
+        return tasks;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateMultipleTasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateMultipleTasksRequest.java
@@ -29,7 +29,7 @@ public class CreateMultipleTasksRequest extends Message {
     private final List<CreateTaskRequest> tasks;
 
     @JsonCreator
-    public CreateMultipleTasksRequest(@JsonProperty("tasks") List<CreateTaskRequest> tasks) {
+    public CreateMultipleTasksRequest(@JsonProperty(value = "tasks", required = true) List<CreateTaskRequest> tasks) {
         this.tasks = tasks;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
@@ -32,7 +32,7 @@ public class CreateTasksRequest extends Message {
 
     @JsonCreator
     public CreateTasksRequest(@JsonProperty(value = "tasks", required = true) Map<String, TaskSpec>  tasks) {
-        this.tasks = tasks == null ? Collections.EMPTY_MAP : Collections.unmodifiableMap(tasks);
+        this.tasks = tasks == null ? Collections.emptyMap() : Collections.unmodifiableMap(tasks);
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
@@ -19,22 +19,23 @@ package org.apache.kafka.trogdor.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kafka.trogdor.task.TaskSpec;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * A request to the Trogdor coordinator to create mulitple tasks.
  */
-public class CreateMultipleTasksRequest extends Message {
-    private final List<CreateTaskRequest> tasks;
+public class CreateTasksRequest extends Message {
+    private final Map<String, TaskSpec> tasks;
 
     @JsonCreator
-    public CreateMultipleTasksRequest(@JsonProperty(value = "tasks", required = true) List<CreateTaskRequest> tasks) {
+    public CreateTasksRequest(@JsonProperty(value = "tasks", required = true) Map<String, TaskSpec>  tasks) {
         this.tasks = tasks;
     }
 
     @JsonProperty
-    public List<CreateTaskRequest> tasks() {
+    public Map<String, TaskSpec> tasks() {
         return tasks;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/CreateTasksRequest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.kafka.trogdor.task.TaskSpec;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -31,7 +32,7 @@ public class CreateTasksRequest extends Message {
 
     @JsonCreator
     public CreateTasksRequest(@JsonProperty(value = "tasks", required = true) Map<String, TaskSpec>  tasks) {
-        this.tasks = tasks;
+        this.tasks = tasks == null ? Collections.EMPTY_MAP : Collections.unmodifiableMap(tasks);
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/RestExceptionMapper.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/RestExceptionMapper.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -43,7 +44,7 @@ public class RestExceptionMapper implements ExceptionMapper<Throwable> {
             return buildResponse(Response.Status.BAD_REQUEST, e);
         } else if (e instanceof InvalidTypeIdException) {
             return buildResponse(Response.Status.NOT_IMPLEMENTED, e);
-        } else if (e instanceof JsonMappingException) {
+        } else if (e instanceof JsonMappingException || e instanceof BadRequestException) {
             return buildResponse(Response.Status.BAD_REQUEST, e);
         } else if (e instanceof ClassNotFoundException) {
             return buildResponse(Response.Status.NOT_IMPLEMENTED, e);

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/ExpectedTasks.java
@@ -158,16 +158,13 @@ public class ExpectedTasks {
                 throw new RuntimeException(e);
             }
             StringBuilder errors = new StringBuilder();
-            if (tasks.tasks().size() < expected.size()) {
-                errors.append("We expected {} tasks but received {}", tasks.tasks().size(), expected.size());
-            } else {
-                for (Map.Entry<String, ExpectedTask> entry : expected.entrySet()) {
-                    String id = entry.getKey();
-                    ExpectedTask task = entry.getValue();
-                    String differences = task.compare(tasks.tasks().get(id));
-                    if (differences != null) {
-                        errors.append(differences);
-                    }
+
+            for (Map.Entry<String, ExpectedTask> entry : expected.entrySet()) {
+                String id = entry.getKey();
+                ExpectedTask task = entry.getValue();
+                String differences = task.compare(tasks.tasks().get(id));
+                if (differences != null) {
+                    errors.append(differences);
                 }
             }
 

--- a/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -103,7 +103,7 @@ public class CoordinatorTest {
             tasks.put("foo", fooSpec1);
             tasks.put("bar", fooSpec1);
             tasks.put("foobar", fooSpec1);
-            cluster.coordinatorClient().createMultipleTasks(
+            cluster.coordinatorClient().createTasks(
                 new CreateTasksRequest(tasks)
             );
             new ExpectedTasks()
@@ -140,7 +140,7 @@ public class CoordinatorTest {
             tasks.put("foo", fooSpec2);
             tasks.put("bar", fooSpec1);
             tasks.put("foobar", fooSpec1);
-            cluster.coordinatorClient().createMultipleTasks(
+            cluster.coordinatorClient().createTasks(
                 new CreateTasksRequest(tasks)
             );
 
@@ -160,7 +160,7 @@ public class CoordinatorTest {
             Map<String, TaskSpec> duplicateTasks = new HashMap<>();
             duplicateTasks.put("foo", fooSpec1);
             try {
-                cluster.coordinatorClient().createMultipleTasks(
+                cluster.coordinatorClient().createTasks(
                     new CreateTasksRequest(duplicateTasks)
                 );
                 fail("Expected to get an exception when submitting duplicate tasks.");
@@ -179,7 +179,7 @@ public class CoordinatorTest {
             differentAndDuplicateTasks.put("barfoo2", fooSpec1);
             differentAndDuplicateTasks.put("foo", fooSpec1); // duplicate id, different spec
             try {
-                cluster.coordinatorClient().createMultipleTasks(
+                cluster.coordinatorClient().createTasks(
                     new CreateTasksRequest(differentAndDuplicateTasks)
                 );
                 fail("Expected to get an exception when submitting duplicate tasks.");


### PR DESCRIPTION
[JIRA](https://issues.apache.org/jira/browse/KAFKA-7638)
Trogdor Coordinator now supports creation of multiple tasks in one request call.
This is exposed under `/coordinator/tasks/mass_create`
Sample body: 
```json
{"tasks": [{...}, {...}]}
```

Additional changes:
The /tasks/create endpoint (and now mass_create) return 400 with an error message whenever an error is encountered during the task creation. Previously, Trogdor would create the task as "DONE" and return a successful status code, making users manually inspect the tasks' status.
This, unfortunately, has the nasty downside of returning 400 when an unexpected internal server error occurs. 
I think that we can live with this for now and open up another KIP that could address error handling in the Trogdor Coordinator REST API.