### PR TITLE
DO NOT MERGE - KAFKA-1194 PARTIAL bug fix

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/MappedByteBuffers.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/MappedByteBuffers.java
@@ -70,15 +70,17 @@ public final class MappedByteBuffers {
     private MappedByteBuffers() {}
 
     public static void unmap(String resourceDescription, MappedByteBuffer buffer) throws IOException {
-        if (!buffer.isDirect())
-            throw new IllegalArgumentException("Unmapping only works with direct buffers");
-        if (UNMAP == null)
-            throw UNMAP_NOT_SUPPORTED_EXCEPTION;
+        if (buffer != null){
+            if (!buffer.isDirect())
+                throw new IllegalArgumentException("Unmapping only works with direct buffers");
+            if (UNMAP == null)
+                throw UNMAP_NOT_SUPPORTED_EXCEPTION;
 
-        try {
-            UNMAP.invokeExact((ByteBuffer) buffer);
-        } catch (Throwable throwable) {
-            throw new IOException("Unable to unmap the mapped buffer: " + resourceDescription, throwable);
+            try {
+                UNMAP.invokeExact((ByteBuffer) buffer);
+            } catch (Throwable throwable) {
+                throw new IOException("Unable to unmap the mapped buffer: " + resourceDescription, throwable);
+            }
         }
     }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1835,6 +1835,7 @@ class Log(@volatile var dir: File,
   private def deleteSegment(segment: LogSegment) {
     info(s"Scheduling log segment [baseOffset ${segment.baseOffset}, size ${segment.size}] for deletion.")
     lock synchronized {
+      segment.closeHandlers()
       segments.remove(segment.baseOffset)
       asyncDeleteSegment(segment)
     }


### PR DESCRIPTION
This is a partial fix to the retention mechanism on Windows.
It makes sure to close a segment file handles prior to deletion trial.
Why is it partial? As it cannot work together will the log compaction policy. 

Should work with a similar to the following configuration:

log.segment.bytes=1048576
log.retention.bytes= 5485760
log.retention.minutes = 1
log.retention.check.interval.minutes = 1
log.cleanup.policy = delete
log.cleaner.enable = false
# log.roll.ms = 10000 <= Can be specified but will not cause any failure without the above two lines of configuration (log.cleanup.policy, log.cleaner.enable)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
