### PR TITLE
KAFKA-7665: Replace BaseConsumerRecord with ConsumerRecord in MM

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -26,7 +26,6 @@ import java.util.{Collections, Properties}
 
 import com.yammer.metrics.core.Gauge
 import joptsimple.OptionParser
-import kafka.consumer.BaseConsumerRecord
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.{CommandLineUtils, CoreUtils, Logging, Whitelist}
 import org.apache.kafka.clients.consumer.{CommitFailedException, Consumer, ConsumerConfig, ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer, OffsetAndMetadata}
@@ -348,16 +347,6 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
 
     setName(threadName)
 
-    private def toBaseConsumerRecord(record: ConsumerRecord[Array[Byte], Array[Byte]]): BaseConsumerRecord =
-      BaseConsumerRecord(record.topic,
-        record.partition,
-        record.offset,
-        record.timestamp,
-        record.timestampType,
-        record.key,
-        record.value,
-        record.headers)
-
     override def run() {
       info(s"Starting mirror maker thread $threadName")
       try {
@@ -373,7 +362,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
               } else {
                 trace("Sending message with null value and offset %d.".format(data.offset))
               }
-              val records = messageHandler.handle(toBaseConsumerRecord(data))
+              val records = messageHandler.handle(data)
               records.asScala.foreach(producer.send)
               maybeFlushAndCommitOffsets()
             }
@@ -568,11 +557,11 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
    * If message.handler.args is specified. A constructor that takes in a String as argument must exist.
    */
   trait MirrorMakerMessageHandler {
-    def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]]
+    def handle(record: ConsumerRecord[Array[Byte], Array[Byte]]): util.List[ProducerRecord[Array[Byte], Array[Byte]]]
   }
 
   private[tools] object defaultMirrorMakerMessageHandler extends MirrorMakerMessageHandler {
-    override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
+    override def handle(record: ConsumerRecord[Array[Byte], Array[Byte]]): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
       val timestamp: java.lang.Long = if (record.timestamp == RecordBatch.NO_TIMESTAMP) null else record.timestamp
       Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, record.headers))
     }

--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -17,8 +17,9 @@
 
 package kafka.tools
 
-import kafka.consumer.BaseConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.record.{RecordBatch, TimestampType}
+
 import scala.collection.JavaConverters._
 import org.junit.Assert._
 import org.junit.Test
@@ -28,7 +29,19 @@ class MirrorMakerTest {
   @Test
   def testDefaultMirrorMakerMessageHandler() {
     val now = 12345L
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes, "value".getBytes)
+    val consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]] = new ConsumerRecord[Array[Byte], Array[Byte]](
+        "topic",
+        0,
+        1L,
+        now,
+        TimestampType.CREATE_TIME,
+        ConsumerRecord.NULL_CHECKSUM,
+        "key".getBytes.size,
+        "value".getBytes.size,
+        "key".getBytes,
+        "value".getBytes)
+
+    ("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes, "value".getBytes)
 
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)
@@ -43,8 +56,17 @@ class MirrorMakerTest {
 
   @Test
   def testDefaultMirrorMakerMessageHandlerWithNoTimestampInSourceMessage() {
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, RecordBatch.NO_TIMESTAMP, TimestampType.CREATE_TIME,
-      "key".getBytes, "value".getBytes)
+    val consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]] = new ConsumerRecord[Array[Byte], Array[Byte]](
+        "topic",
+        0,
+        1L,
+        RecordBatch.NO_TIMESTAMP,
+        TimestampType.CREATE_TIME,
+        ConsumerRecord.NULL_CHECKSUM,
+        "key".getBytes.size,
+        "value".getBytes.size,
+        "key".getBytes,
+        "value".getBytes)
 
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)
@@ -60,8 +82,17 @@ class MirrorMakerTest {
   @Test
   def testDefaultMirrorMakerMessageHandlerWithHeaders() {
     val now = 12345L
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes,
-      "value".getBytes)
+    val consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]] = new ConsumerRecord[Array[Byte], Array[Byte]](
+        "topic",
+        0,
+        1L,
+        now,
+        TimestampType.CREATE_TIME,
+        ConsumerRecord.NULL_CHECKSUM,
+        "key".getBytes.size,
+        "value".getBytes.size,
+        "key".getBytes,
+        "value".getBytes)
     consumerRecord.headers.add("headerKey", "headerValue".getBytes)
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7665

In MirrorMaker, the fix will replace BaseConsumerRecord with ConsumerRecord.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
