### PR TITLE
KAFKA-7653 [WIP] Add KeySerde and ValueSerde types

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/FunctionConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/FunctionConversions.scala
@@ -43,6 +43,7 @@ object FunctionConversions {
     def asKeyValueMapper: KeyValueMapper[T, U, VR] = new KeyValueMapper[T, U, VR] {
       override def apply(key: T, value: U): VR = f(key, value)
     }
+
     def asValueJoiner: ValueJoiner[T, U, VR] = new ValueJoiner[T, U, VR] {
       override def apply(value1: T, value2: U): VR = f(value1, value2)
     }
@@ -110,4 +111,5 @@ object FunctionConversions {
       override def get(): Transformer[K, V, VO] = f()
     }
   }
+
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/FunctionsCompatConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/FunctionsCompatConversions.scala
@@ -47,6 +47,7 @@ private[scala] object FunctionsCompatConversions {
     def asKeyValueMapper: KeyValueMapper[T, U, VR] = new KeyValueMapper[T, U, VR] {
       override def apply(key: T, value: U): VR = f(key, value)
     }
+
     def asValueJoiner: ValueJoiner[T, U, VR] = new ValueJoiner[T, U, VR] {
       override def apply(value1: T, value2: U): VR = f(value1, value2)
     }
@@ -114,4 +115,5 @@ private[scala] object FunctionsCompatConversions {
       override def get(): Transformer[K, V, VO] = f()
     }
   }
+
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
@@ -19,7 +19,6 @@
  */
 package org.apache.kafka.streams.scala
 
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.kstream.{
   KGroupedStream => KGroupedStreamJ,
@@ -63,21 +62,21 @@ object ImplicitConversions {
   // we would also like to allow users implicit serdes
   // and these implicits will convert them to `Grouped`, `Produced` or `Consumed`
 
-  implicit def groupedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] =
+  implicit def groupedFromSerde[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): Grouped[K, V] =
     Grouped.`with`[K, V]
 
-  implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] =
+  implicit def consumedFromSerde[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): Consumed[K, V] =
     Consumed.`with`[K, V]
 
-  implicit def producedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Produced[K, V] =
+  implicit def producedFromSerde[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): Produced[K, V] =
     Produced.`with`[K, V]
 
-  implicit def materializedFromSerde[K, V, S <: StateStore](implicit keySerde: Serde[K],
-                                                            valueSerde: Serde[V]): Materialized[K, V, S] =
+  implicit def materializedFromSerde[K, V, S <: StateStore](implicit keySerde: KeySerde[K],
+                                                            valueSerde: ValueSerde[V]): Materialized[K, V, S] =
     Materialized.`with`[K, V, S]
 
-  implicit def joinedFromKeyValueOtherSerde[K, V, VO](implicit keySerde: Serde[K],
-                                                      valueSerde: Serde[V],
-                                                      otherValueSerde: Serde[VO]): Joined[K, V, VO] =
+  implicit def joinedFromKeyValueOtherSerde[K, V, VO](implicit keySerde: KeySerde[K],
+                                                      valueSerde: ValueSerde[V],
+                                                      otherValueSerde: ValueSerde[VO]): Joined[K, V, VO] =
     Joined.`with`[K, V, VO]
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/KeySerde.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/KeySerde.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2018 Alexis Seigneurin.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.common.serialization.Serde
+
+trait KeySerde[T] {
+  def serde: Serde[T]
+}
+
+object KeySerde {
+
+  class WrapperKeySerde[T](inner: Serde[T]) extends KeySerde[T] {
+    override def serde: Serde[T] = inner
+  }
+
+  def apply[T](inner: Serde[T]): KeySerde[T] = new WrapperKeySerde[T](inner)
+}

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/Serdes.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/Serdes.scala
@@ -60,13 +60,30 @@ object Serdes {
     JSerdes.serdeFrom(
       new Serializer[T] {
         override def serialize(topic: String, data: T): Array[Byte] = serializer(topic, data)
+
         override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
         override def close(): Unit = ()
       },
       new Deserializer[T] {
         override def deserialize(topic: String, data: Array[Byte]): T = deserializer(topic, data).orNull
+
         override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
         override def close(): Unit = ()
       }
     )
+
+  object KeyValueAgnostic {
+    implicit def keySerdeFromSerde[T](implicit inner: Serde[T]): KeySerde[T] = KeySerde[T](inner)
+
+    implicit def valueSerdeFromSerde[T](implicit inner: Serde[T]): ValueSerde[T] = ValueSerde[T](inner)
+  }
+
+  implicit class SerdeExtensions[T](serde: Serde[T]) {
+    def asKeySerde: KeySerde[T] = KeySerde(serde)
+
+    def asValueSerde: ValueSerde[T] = ValueSerde(serde)
+  }
+
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ValueSerde.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ValueSerde.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2018 Alexis Seigneurin.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.common.serialization.Serde
+
+trait ValueSerde[T] {
+  def serde: Serde[T]
+}
+
+object ValueSerde {
+
+  class WrapperValueSerde[T](inner: Serde[T]) extends ValueSerde[T] {
+    override def serde: Serde[T] = inner
+  }
+
+  def apply[T](inner: Serde[T]): ValueSerde[T] = new WrapperValueSerde[T](inner)
+}

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Consumed.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Consumed.scala
@@ -16,18 +16,18 @@
  */
 package org.apache.kafka.streams.scala.kstream
 
-import org.apache.kafka.common.serialization.Serde
-import org.apache.kafka.streams.kstream.{Consumed => ConsumedJ}
 import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.kstream.{Consumed => ConsumedJ}
 import org.apache.kafka.streams.processor.TimestampExtractor
+import org.apache.kafka.streams.scala.{KeySerde, ValueSerde}
 
 object Consumed {
 
   /**
    * Create an instance of [[Consumed]] with the supplied arguments. `null` values are acceptable.
    *
-   * @tparam K                 key type
-   * @tparam V                 value type
+   * @tparam K key type
+   * @tparam V value type
    * @param timestampExtractor the timestamp extractor to used. If `null` the default timestamp extractor from
    *                           config will be used
    * @param resetPolicy        the offset reset policy to be used. If `null` the default reset policy from config
@@ -39,41 +39,41 @@ object Consumed {
   def `with`[K, V](
     timestampExtractor: TimestampExtractor,
     resetPolicy: Topology.AutoOffsetReset
-  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
-    ConsumedJ.`with`(keySerde, valueSerde, timestampExtractor, resetPolicy)
+  )(implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(keySerde.serde, valueSerde.serde, timestampExtractor, resetPolicy)
 
   /**
-   * Create an instance of [[Consumed]] with key and value [[Serde]]s.
+   * Create an instance of [[Consumed]] with [[KeySerde]] and [[ValueSerde]].
    *
-   * @tparam K         key type
-   * @tparam V         value type
+   * @tparam K key type
+   * @tparam V value type
    * @return a new instance of [[Consumed]]
    */
-  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
-    ConsumedJ.`with`(keySerde, valueSerde)
+  def `with`[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(keySerde.serde, valueSerde.serde)
 
   /**
    * Create an instance of [[Consumed]] with a [[TimestampExtractor]].
    *
    * @param timestampExtractor the timestamp extractor to used. If `null` the default timestamp extractor from
    *                           config will be used
-   * @tparam K                 key type
-   * @tparam V                 value type
+   * @tparam K key type
+   * @tparam V value type
    * @return a new instance of [[Consumed]]
    */
-  def `with`[K, V](timestampExtractor: TimestampExtractor)(implicit keySerde: Serde[K],
-                                                           valueSerde: Serde[V]): ConsumedJ[K, V] =
-    ConsumedJ.`with`(timestampExtractor).withKeySerde(keySerde).withValueSerde(valueSerde)
+  def `with`[K, V](timestampExtractor: TimestampExtractor)(implicit keySerde: KeySerde[K],
+                                                           valueSerde: ValueSerde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(timestampExtractor).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 
   /**
    * Create an instance of [[Consumed]] with a [[Topology.AutoOffsetReset]].
    *
-   * @tparam K          key type
-   * @tparam V          value type
+   * @tparam K key type
+   * @tparam V value type
    * @param resetPolicy the offset reset policy to be used. If `null` the default reset policy from config will be used
    * @return a new instance of [[Consumed]]
    */
-  def `with`[K, V](resetPolicy: Topology.AutoOffsetReset)(implicit keySerde: Serde[K],
-                                                          valueSerde: Serde[V]): ConsumedJ[K, V] =
-    ConsumedJ.`with`(resetPolicy).withKeySerde(keySerde).withValueSerde(valueSerde)
+  def `with`[K, V](resetPolicy: Topology.AutoOffsetReset)(implicit keySerde: KeySerde[K],
+                                                          valueSerde: ValueSerde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(resetPolicy).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Grouped.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Grouped.scala
@@ -17,14 +17,13 @@
 
 package org.apache.kafka.streams.scala.kstream
 
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream.{Grouped => GroupedJ}
+import org.apache.kafka.streams.scala.{KeySerde, ValueSerde}
 
 object Grouped {
 
   /**
-   * Construct a `Grouped` instance with the provided key and value [[Serde]]s.
-   * If the [[Serde]] params are `null` the default serdes defined in the configs will be used.
+   * Construct a `Grouped` instance with the provided [[KeySerde]] and [[ValueSerde]].
    *
    * @tparam K the key type
    * @tparam V the value type
@@ -32,21 +31,20 @@ object Grouped {
    * @param valueSerde valueSerde that will be used to materialize a stream
    * @return a new instance of [[Grouped]] configured with the provided serdes
    */
-  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): GroupedJ[K, V] =
-    GroupedJ.`with`(keySerde, valueSerde)
+  def `with`[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): GroupedJ[K, V] =
+    GroupedJ.`with`(keySerde.serde, valueSerde.serde)
 
   /**
-   * Construct a `Grouped` instance with the provided key and value [[Serde]]s.
-   * If the [[Serde]] params are `null` the default serdes defined in the configs will be used.
+   * Construct a `Grouped` instance with the provided [[KeySerde]] and [[ValueSerde]].
    *
    * @tparam K the key type
    * @tparam V the value type
-   * @param name the name used as part of a potential repartition topic
+   * @param name       the name used as part of a potential repartition topic
    * @param keySerde   keySerde that will be used to materialize a stream
    * @param valueSerde valueSerde that will be used to materialize a stream
    * @return a new instance of [[Grouped]] configured with the provided serdes
    */
-  def `with`[K, V](name: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): GroupedJ[K, V] =
-    GroupedJ.`with`(name, keySerde, valueSerde)
+  def `with`[K, V](name: String)(implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): GroupedJ[K, V] =
+    GroupedJ.`with`(name, keySerde.serde, valueSerde.serde)
 
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Joined.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Joined.scala
@@ -16,37 +16,37 @@
  */
 package org.apache.kafka.streams.scala.kstream
 
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream.{Joined => JoinedJ}
+import org.apache.kafka.streams.scala.{KeySerde, ValueSerde}
 
 object Joined {
 
   /**
-   * Create an instance of [[org.apache.kafka.streams.kstream.Joined]] with key, value, and otherValue [[Serde]]
+   * Create an instance of [[org.apache.kafka.streams.kstream.Joined]] with key, value, and otherValue [[ValueSerde]]
    * instances.
    * `null` values are accepted and will be replaced by the default serdes as defined in config.
    *
-   * @tparam K              key type
-   * @tparam V              value type
-   * @tparam VO             other value type
+   * @tparam K  key type
+   * @tparam V  value type
+   * @tparam VO other value type
    * @param keySerde        the key serde to use.
    * @param valueSerde      the value serde to use.
    * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
    * @return new [[org.apache.kafka.streams.kstream.Joined]] instance with the provided serdes
    */
-  def `with`[K, V, VO](implicit keySerde: Serde[K],
-                       valueSerde: Serde[V],
-                       otherValueSerde: Serde[VO]): JoinedJ[K, V, VO] =
-    JoinedJ.`with`(keySerde, valueSerde, otherValueSerde)
+  def `with`[K, V, VO](implicit keySerde: KeySerde[K],
+                       valueSerde: ValueSerde[V],
+                       otherValueSerde: ValueSerde[VO]): JoinedJ[K, V, VO] =
+    JoinedJ.`with`(keySerde.serde, valueSerde.serde, otherValueSerde.serde)
 
   /**
-   * Create an instance of [[org.apache.kafka.streams.kstream.Joined]] with key, value, and otherValue [[Serde]]
-   * instances.
+   * Create an instance of [[org.apache.kafka.streams.kstream.Joined]] with
+   * key [[KeySerde]], value [[ValueSerde]], and otherValue [[ValueSerde]] instances.
    * `null` values are accepted and will be replaced by the default serdes as defined in config.
    *
-   * @tparam K              key type
-   * @tparam V              value type
-   * @tparam VO             other value type
+   * @tparam K  key type
+   * @tparam V  value type
+   * @tparam VO other value type
    * @param name            name of possible repartition topic
    * @param keySerde        the key serde to use.
    * @param valueSerde      the value serde to use.
@@ -56,9 +56,10 @@ object Joined {
   // disable spotless scala, which wants to make a mess of the argument lists
   // format: off
   def `with`[K, V, VO](name: String)
-                      (implicit keySerde: Serde[K],
-                       valueSerde: Serde[V],
-                       otherValueSerde: Serde[VO]): JoinedJ[K, V, VO] =
-    JoinedJ.`with`(keySerde, valueSerde, otherValueSerde, name)
+                      (implicit keySerde: KeySerde[K],
+                       valueSerde: ValueSerde[V],
+                       otherValueSerde: ValueSerde[VO]): JoinedJ[K, V, VO] =
+    JoinedJ.`with`(keySerde.serde, valueSerde.serde, otherValueSerde.serde, name)
+
   // format:on
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Materialized.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Materialized.scala
@@ -16,43 +16,42 @@
  */
 package org.apache.kafka.streams.scala.kstream
 
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream.{Materialized => MaterializedJ}
 import org.apache.kafka.streams.processor.StateStore
-import org.apache.kafka.streams.scala.{ByteArrayKeyValueStore, ByteArraySessionStore, ByteArrayWindowStore}
+import org.apache.kafka.streams.scala._
 import org.apache.kafka.streams.state.{KeyValueBytesStoreSupplier, SessionBytesStoreSupplier, WindowBytesStoreSupplier}
 
 object Materialized {
 
   /**
-   * Materialize a [[StateStore]] with the provided key and value [[Serde]]s.
+   * Materialize a [[StateStore]] with the provided [[KeySerde]] and [[ValueSerde]].
    * An internal name will be used for the store.
    *
-   * @tparam K         key type
-   * @tparam V         value type
-   * @tparam S         store type
-   * @param keySerde   the key [[Serde]] to use.
-   * @param valueSerde the value [[Serde]] to use.
+   * @tparam K key type
+   * @tparam V value type
+   * @tparam S store type
+   * @param keySerde   the key [[KeySerde]] to use.
+   * @param valueSerde the value [[ValueSerde]] to use.
    * @return a new [[Materialized]] instance with the given key and value serdes
    */
-  def `with`[K, V, S <: StateStore](implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, S] =
-    MaterializedJ.`with`(keySerde, valueSerde)
+  def `with`[K, V, S <: StateStore](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): MaterializedJ[K, V, S] =
+    MaterializedJ.`with`(keySerde.serde, valueSerde.serde)
 
   /**
    * Materialize a [[StateStore]] with the given name.
    *
-   * @tparam K         key type of the store
-   * @tparam V         value type of the store
-   * @tparam S         type of the [[StateStore]]
+   * @tparam K key type of the store
+   * @tparam V value type of the store
+   * @tparam S type of the [[StateStore]]
    * @param storeName  the name of the underlying [[org.apache.kafka.streams.scala.kstream.KTable]] state store;
    *                   valid characters are ASCII alphanumerics, '.', '_' and '-'.
    * @param keySerde   the key serde to use.
    * @param valueSerde the value serde to use.
    * @return a new [[Materialized]] instance with the given storeName
    */
-  def as[K, V, S <: StateStore](storeName: String)(implicit keySerde: Serde[K],
-                                                   valueSerde: Serde[V]): MaterializedJ[K, V, S] =
-    MaterializedJ.as(storeName).withKeySerde(keySerde).withValueSerde(valueSerde)
+  def as[K, V, S <: StateStore](storeName: String)(implicit keySerde: KeySerde[K],
+                                                   valueSerde: ValueSerde[V]): MaterializedJ[K, V, S] =
+    MaterializedJ.as(storeName).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 
   /**
    * Materialize a [[org.apache.kafka.streams.state.WindowStore]] using the provided [[WindowBytesStoreSupplier]].
@@ -61,16 +60,17 @@ object Materialized {
    * Window stores are required to retain windows at least as long as (window size + window grace period).
    * Stores constructed via [[org.apache.kafka.streams.state.Stores]] already satisfy this contract.
    *
-   * @tparam K         key type of the store
-   * @tparam V         value type of the store
+   * @tparam K key type of the store
+   * @tparam V value type of the store
    * @param supplier   the [[WindowBytesStoreSupplier]] used to materialize the store
    * @param keySerde   the key serde to use.
    * @param valueSerde the value serde to use.
    * @return a new [[Materialized]] instance with the given supplier
    */
-  def as[K, V](supplier: WindowBytesStoreSupplier)(implicit keySerde: Serde[K],
-                                                   valueSerde: Serde[V]): MaterializedJ[K, V, ByteArrayWindowStore] =
-    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+  def as[K, V](
+    supplier: WindowBytesStoreSupplier
+  )(implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): MaterializedJ[K, V, ByteArrayWindowStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 
   /**
    * Materialize a [[org.apache.kafka.streams.state.SessionStore]] using the provided [[SessionBytesStoreSupplier]].
@@ -79,22 +79,23 @@ object Materialized {
    * Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
    * Stores constructed via [[org.apache.kafka.streams.state.Stores]] already satisfy this contract.
    *
-   * @tparam K         key type of the store
-   * @tparam V         value type of the store
+   * @tparam K key type of the store
+   * @tparam V value type of the store
    * @param supplier   the [[SessionBytesStoreSupplier]] used to materialize the store
    * @param keySerde   the key serde to use.
    * @param valueSerde the value serde to use.
    * @return a new [[Materialized]] instance with the given supplier
    */
-  def as[K, V](supplier: SessionBytesStoreSupplier)(implicit keySerde: Serde[K],
-                                                    valueSerde: Serde[V]): MaterializedJ[K, V, ByteArraySessionStore] =
-    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+  def as[K, V](
+    supplier: SessionBytesStoreSupplier
+  )(implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): MaterializedJ[K, V, ByteArraySessionStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 
   /**
    * Materialize a [[org.apache.kafka.streams.state.KeyValueStore]] using the provided [[KeyValueBytesStoreSupplier]].
    *
-   * @tparam K         key type of the store
-   * @tparam V         value type of the store
+   * @tparam K key type of the store
+   * @tparam V value type of the store
    * @param supplier   the [[KeyValueBytesStoreSupplier]] used to materialize the store
    * @param keySerde   the key serde to use.
    * @param valueSerde the value serde to use.
@@ -102,6 +103,6 @@ object Materialized {
    */
   def as[K, V](
     supplier: KeyValueBytesStoreSupplier
-  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, ByteArrayKeyValueStore] =
-    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+  )(implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): MaterializedJ[K, V, ByteArrayKeyValueStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde.serde).withValueSerde(valueSerde.serde)
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Produced.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Produced.scala
@@ -16,31 +16,31 @@
  */
 package org.apache.kafka.streams.scala.kstream
 
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream.{Produced => ProducedJ}
 import org.apache.kafka.streams.processor.StreamPartitioner
+import org.apache.kafka.streams.scala.{KeySerde, ValueSerde}
 
 object Produced {
 
   /**
    * Create a Produced instance with provided keySerde and valueSerde.
    *
-   * @tparam K         key type
-   * @tparam V         value type
+   * @tparam K key type
+   * @tparam V value type
    * @param keySerde   Serde to use for serializing the key
    * @param valueSerde Serde to use for serializing the value
    * @return A new [[Produced]] instance configured with keySerde and valueSerde
    * @see KStream#through(String, Produced)
    * @see KStream#to(String, Produced)
    */
-  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): ProducedJ[K, V] =
-    ProducedJ.`with`(keySerde, valueSerde)
+  def `with`[K, V](implicit keySerde: KeySerde[K], valueSerde: ValueSerde[V]): ProducedJ[K, V] =
+    ProducedJ.`with`(keySerde.serde, valueSerde.serde)
 
   /**
    * Create a Produced instance with provided keySerde, valueSerde, and partitioner.
    *
-   * @tparam K          key type
-   * @tparam V          value type
+   * @tparam K key type
+   * @tparam V value type
    * @param partitioner the function used to determine how records are distributed among partitions of the topic,
    *                    if not specified and `keySerde` provides a
    *                    [[org.apache.kafka.streams.kstream.internals.WindowedSerializer]] for the key
@@ -53,7 +53,7 @@ object Produced {
    * @see KStream#through(String, Produced)
    * @see KStream#to(String, Produced)
    */
-  def `with`[K, V](partitioner: StreamPartitioner[K, V])(implicit keySerde: Serde[K],
-                                                         valueSerde: Serde[V]): ProducedJ[K, V] =
-    ProducedJ.`with`(keySerde, valueSerde, partitioner)
+  def `with`[K, V](partitioner: StreamPartitioner[K, V])(implicit keySerde: KeySerde[K],
+                                                         valueSerde: ValueSerde[V]): ProducedJ[K, V] =
+    ProducedJ.`with`(keySerde.serde, valueSerde.serde, partitioner)
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
@@ -44,6 +44,7 @@ class StreamToTableJoinScalaIntegrationTestImplicitSerdes extends StreamToTableJ
     // Consumed and Joined instances. So all APIs below that accept Grouped, Produced, Consumed or Joined will
     // get these instances automatically
     import Serdes._
+    import KeyValueAgnostic._
 
     val streamsConfiguration: Properties = getStreamsConfiguration()
 
@@ -84,6 +85,7 @@ class StreamToTableJoinScalaIntegrationTestImplicitSerdes extends StreamToTableJ
     // Consumed and Joined instances. So all APIs below that accept Grouped, Produced, Consumed or Joined will
     // get these instances automatically
     import Serdes._
+    import KeyValueAgnostic._
 
     val streamsConfiguration: Properties = getStreamsConfiguration()
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -48,6 +48,8 @@ import _root_.scala.collection.JavaConverters._
  */
 class TopologyTest extends JUnitSuite {
 
+  import KeyValueAgnostic._
+
   val inputTopic = "input-topic"
   val userClicksTopic = "user-clicks-topic"
   val userRegionsTopic = "user-regions-topic"

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.test.{IntegrationTest, TestUtils}
 import ImplicitConversions._
+import org.apache.kafka.streams.scala.Serdes.KeyValueAgnostic
 import org.junit.experimental.categories.Category
 
 /**
@@ -49,6 +50,8 @@ import org.junit.experimental.categories.Category
  */
 @Category(Array(classOf[IntegrationTest]))
 class WordCountTest extends JUnitSuite with WordCountTestData {
+
+  import KeyValueAgnostic._
 
   private val privateCluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/GroupedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/GroupedTest.scala
@@ -27,6 +27,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class GroupedTest extends FlatSpec with Matchers {
 
+  import KeyValueAgnostic._
+
   "Create a Grouped" should "create a Grouped with Serdes" in {
     val grouped: Grouped[String, Long] = Grouped.`with`[String, Long]
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
@@ -27,6 +27,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class JoinedTest extends FlatSpec with Matchers {
 
+  import KeyValueAgnostic._
+
   "Create a Joined" should "create a Joined with Serdes" in {
     val joined: Joined[String, Long, Int] = Joined.`with`[String, Long, Int]
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -32,6 +32,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class KStreamTest extends FlatSpec with Matchers with TestDriver {
 
+  import KeyValueAgnostic._
+
   "filter a KStream" should "filter records satisfying the predicate" in {
     val builder = new StreamsBuilder()
     val sourceTopic = "source"

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -29,6 +29,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class KTableTest extends FlatSpec with Matchers with TestDriver {
 
+  import KeyValueAgnostic._
+
   "filter a KTable" should "filter records satisfying the predicate" in {
     val builder = new StreamsBuilder()
     val sourceTopic = "source"

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/MaterializedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/MaterializedTest.scala
@@ -31,6 +31,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class MaterializedTest extends FlatSpec with Matchers {
 
+  import KeyValueAgnostic._
+
   "Create a Materialized" should "create a Materialized with Serdes" in {
     val materialized: Materialized[String, Long, ByteArrayKeyValueStore] =
       Materialized.`with`[String, Long, ByteArrayKeyValueStore]

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -29,6 +29,8 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class ProducedTest extends FlatSpec with Matchers {
 
+  import KeyValueAgnostic._
+
   "Create a Produced" should "create a Produced with Serdes" in {
     val produced: Produced[String, Long] = Produced.`with`[String, Long]
 


### PR DESCRIPTION
## KAFKA-7653

https://issues.apache.org/jira/browse/KAFKA-7653

Added two new types `KeySerde[T]` and `ValueSerde[T]` and changed signatures of the relevant methods to accept `KeySerde` and `ValueSerde` instead of `Serde` as implicit params.

Also added `KeyValueAgnostic` object to `org.apache.kafka.streams.scala.Serdes`, to provide implicit conversions from `Key/ValueSerdes` to plain old `Serde` to help minimise impact on existing users

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

@guozhangwang @miguno @vvcephei 
