### PR TITLE
KAFKA-7667: Synchronous send support for kafka performance producer java application

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -45,359 +45,343 @@ import org.apache.kafka.common.utils.Utils;
 
 public class ProducerPerformance {
 
-	public static void main(String[] args) throws Exception {
-		ArgumentParser parser = argParser();
+    public static void main(String[] args) throws Exception {
+        ArgumentParser parser = argParser();
 
-		try {
-			Namespace res = parser.parseArgs(args);
+        try {
+            Namespace res = parser.parseArgs(args);
 
-			/* parse args */
-			String topicName = res.getString("topic");
-			long numRecords = res.getLong("numRecords");
-			Integer recordSize = res.getInt("recordSize");
-			int throughput = res.getInt("throughput");
-			List<String> producerProps = res.getList("producerConfig");
-			String producerConfig = res.getString("producerConfigFile");
-			String payloadFilePath = res.getString("payloadFile");
-			String transactionalId = res.getString("transactionalId");
-			boolean shouldPrintMetrics = res.getBoolean("printMetrics");
-			long transactionDurationMs = res.getLong("transactionDurationMs");
-			boolean synchronousSend = res.getBoolean("synchronousSend");
-			boolean transactionsEnabled = 0 < transactionDurationMs;
+            /* parse args */
+            String topicName = res.getString("topic");
+            long numRecords = res.getLong("numRecords");
+            Integer recordSize = res.getInt("recordSize");
+            int throughput = res.getInt("throughput");
+            List<String> producerProps = res.getList("producerConfig");
+            String producerConfig = res.getString("producerConfigFile");
+            String payloadFilePath = res.getString("payloadFile");
+            String transactionalId = res.getString("transactionalId");
+            boolean shouldPrintMetrics = res.getBoolean("printMetrics");
+            long transactionDurationMs = res.getLong("transactionDurationMs");
+            boolean synchronousSend = res.getBoolean("synchronousSend");
+            boolean transactionsEnabled = 0 < transactionDurationMs;
 
-			// since default value gets printed with the help text, we are
-			// escaping \n there and replacing it with correct value here.
-			String payloadDelimiter = res.getString("payloadDelimiter").equals("\\n") ? "\n"
-					: res.getString("payloadDelimiter");
+            // since default value gets printed with the help text, we are escaping \n there and replacing it with correct value here.
+            String payloadDelimiter = res.getString("payloadDelimiter").equals("\\n") ? "\n" : res.getString("payloadDelimiter");
 
-			if (producerProps == null && producerConfig == null) {
-				throw new ArgumentParserException("Either --producer-props or --producer.config must be specified.",
-						parser);
-			}
+            if (producerProps == null && producerConfig == null) {
+                throw new ArgumentParserException("Either --producer-props or --producer.config must be specified.", parser);
+            }
 
-			List<byte[]> payloadByteList = new ArrayList<>();
-			if (payloadFilePath != null) {
-				Path path = Paths.get(payloadFilePath);
-				System.out.println("Reading payloads from: " + path.toAbsolutePath());
-				if (Files.notExists(path) || Files.size(path) == 0) {
-					throw new IllegalArgumentException("File does not exist or empty file provided.");
-				}
+            List<byte[]> payloadByteList = new ArrayList<>();
+            if (payloadFilePath != null) {
+                Path path = Paths.get(payloadFilePath);
+                System.out.println("Reading payloads from: " + path.toAbsolutePath());
+                if (Files.notExists(path) || Files.size(path) == 0) {
+                    throw new IllegalArgumentException("File does not exist or empty file provided.");
+                }
 
-				String[] payloadList = new String(Files.readAllBytes(path), "UTF-8").split(payloadDelimiter);
+                String[] payloadList = new String(Files.readAllBytes(path), "UTF-8").split(payloadDelimiter);
 
-				System.out.println("Number of messages read: " + payloadList.length);
+                System.out.println("Number of messages read: " + payloadList.length);
 
-				for (String payload : payloadList) {
-					payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
-				}
-			}
+                for (String payload : payloadList) {
+                    payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
+                }
+            }
 
-			Properties props = new Properties();
-			if (producerConfig != null) {
-				props.putAll(Utils.loadProps(producerConfig));
-			}
-			if (producerProps != null)
-				for (String prop : producerProps) {
-					String[] pieces = prop.split("=");
-					if (pieces.length != 2)
-						throw new IllegalArgumentException("Invalid property: " + prop);
-					props.put(pieces[0], pieces[1]);
-				}
+            Properties props = new Properties();
+            if (producerConfig != null) {
+                props.putAll(Utils.loadProps(producerConfig));
+            }
+            if (producerProps != null)
+                for (String prop : producerProps) {
+                    String[] pieces = prop.split("=");
+                    if (pieces.length != 2)
+                        throw new IllegalArgumentException("Invalid property: " + prop);
+                    props.put(pieces[0], pieces[1]);
+                }
 
-			props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-					"org.apache.kafka.common.serialization.ByteArraySerializer");
-			props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-					"org.apache.kafka.common.serialization.ByteArraySerializer");
-			if (transactionsEnabled)
-				props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+            if (transactionsEnabled)
+                props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
 
-			KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props);
+            KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props);
+            if (transactionsEnabled)
+                producer.initTransactions();
 
-			if (transactionsEnabled)
-				producer.initTransactions();
+            /* setup perf test */
+            byte[] payload = null;
+            Random random = new Random(0);
+            if (recordSize != null) {
+                payload = new byte[recordSize];
+                for (int i = 0; i < payload.length; ++i)
+                    payload[i] = (byte) (random.nextInt(26) + 65);
+            }
+            ProducerRecord<byte[], byte[]> record;
+            Stats stats = new Stats(numRecords, 5000);
+            long startMs = System.currentTimeMillis();
 
-			/* setup perf test */
-			byte[] payload = null;
-			Random random = new Random(0);
-			if (recordSize != null) {
-				payload = new byte[recordSize];
-				for (int i = 0; i < payload.length; ++i)
-					payload[i] = (byte) (random.nextInt(26) + 65);
-			}
-			ProducerRecord<byte[], byte[]> record;
-			Stats stats = new Stats(numRecords, 5000);
-			long startMs = System.currentTimeMillis();
+            ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
 
-			ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
+            int currentTransactionSize = 0;
+            long transactionStartTime = 0;
+            for (int i = 0; i < numRecords; i++) {
+                if (transactionsEnabled && currentTransactionSize == 0) {
+                    producer.beginTransaction();
+                    transactionStartTime = System.currentTimeMillis();
+                }
+                if (payloadFilePath != null) {
+                    payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
+                }
+                record = new ProducerRecord<>(topicName, payload);
 
-			int currentTransactionSize = 0;
-			long transactionStartTime = 0;
-			for (int i = 0; i < numRecords; i++) {
-				if (transactionsEnabled && currentTransactionSize == 0) {
-					producer.beginTransaction();
-					transactionStartTime = System.currentTimeMillis();
-				}
+                long sendStartMs = System.currentTimeMillis();
 
-				if (payloadFilePath != null) {
-					payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
-				}
-				record = new ProducerRecord<>(topicName, payload);
+                if (synchronousSend) {
+                    int iteration = stats.updateIteration();
+                    try {
+                        RecordMetadata result = producer.send(record).get();
+                    } catch (Exception exception) {
+                        exception.printStackTrace();
+                    }
+                    long now = System.currentTimeMillis();
+                    int latency = (int) (now - sendStartMs);
+                    stats.record(iteration, latency, payload.length, now);
+                } else {
+                    Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
+                    producer.send(record, cb);
+                }
 
-				long sendStartMs = System.currentTimeMillis();
+                currentTransactionSize++;
+                if (transactionsEnabled && transactionDurationMs <= (sendStartMs - transactionStartTime)) {
+                    producer.commitTransaction();
+                    currentTransactionSize = 0;
+                }
+                if (throttler.shouldThrottle(i, sendStartMs)) {
+                    throttler.throttle();
+                }
+            }
 
-				/*
-				 * if sync send, perform actions done in callback function of
-				 * async send
-				 */
-				if (synchronousSend) {
-					int iteration = stats.updateIteration();
-					try {
-						RecordMetadata result = producer.send(record).get();
-					} catch (Exception exception) {
-						exception.printStackTrace();
-					}
+            if (transactionsEnabled && currentTransactionSize != 0)
+                producer.commitTransaction();
 
-					long now = System.currentTimeMillis();
-					int latency = (int) (now - sendStartMs);
-					stats.record(iteration, latency, payload.length, now);
-				} else {
-					Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
-					producer.send(record, cb);
-				}
+            if (!shouldPrintMetrics) {
+                producer.close();
 
-				currentTransactionSize++;
-				if (transactionsEnabled && transactionDurationMs <= (sendStartMs - transactionStartTime)) {
-					producer.commitTransaction();
-					currentTransactionSize = 0;
-				}
+                /* print final results */
+                stats.printTotal();
+            } else {
+                // Make sure all messages are sent before printing out the stats and the metrics
+                // We need to do this in a different branch for now since tests/kafkatest/sanity_checks/test_performance_services.py
+                // expects this class to work with older versions of the client jar that don't support flush().
+                producer.flush();
 
-				if (throttler.shouldThrottle(i, sendStartMs)) {
-					throttler.throttle();
-				}
-			}
+                /* print final results */
+                stats.printTotal();
 
-			if (transactionsEnabled && currentTransactionSize != 0)
-				producer.commitTransaction();
+                /* print out metrics */
+                ToolsUtils.printMetrics(producer.metrics());
+                producer.close();
+            }
+        } catch (ArgumentParserException e) {
+            if (args.length == 0) {
+                parser.printHelp();
+                Exit.exit(0);
+            } else {
+                parser.handleError(e);
+                Exit.exit(1);
+            }
+        }
 
-			if (!shouldPrintMetrics) {
-				producer.close();
+    }
 
-				/* print final results */
-				stats.printTotal();
-			} else {
-				// Make sure all messages are sent before printing out the stats
-				// and the metrics
-				// We need to do this in a different branch for now since
-				// tests/kafkatest/sanity_checks/test_performance_services.py
-				// expects this class to work with older versions of the client
-				// jar that don't support flush().
-				producer.flush();
+    /** Get the command-line argument parser. */
+    private static ArgumentParser argParser() {
+        ArgumentParser parser = ArgumentParsers.newArgumentParser("producer-performance").defaultHelp(true)
+                .description("This tool is used to verify the producer performance.");
 
-				/* print final results */
-				stats.printTotal();
+        MutuallyExclusiveGroup payloadOptions = parser.addMutuallyExclusiveGroup().required(true)
+                .description("either --record-size or --payload-file must be specified but not both.");
 
-				/* print out metrics */
-				ToolsUtils.printMetrics(producer.metrics());
-				producer.close();
-			}
-		} catch (ArgumentParserException e) {
-			if (args.length == 0) {
-				parser.printHelp();
-				Exit.exit(0);
-			} else {
-				parser.handleError(e);
-				Exit.exit(1);
-			}
-		}
+        parser.addArgument("--topic").action(store()).required(true).type(String.class).metavar("TOPIC")
+        .help("produce messages to this topic");
 
-	}
+        parser.addArgument("--num-records").action(store()).required(true).type(Long.class).metavar("NUM-RECORDS")
+        .dest("numRecords").help("number of messages to produce");
 
-	/** Get the command-line argument parser. */
-	private static ArgumentParser argParser() {
-		ArgumentParser parser = ArgumentParsers.newArgumentParser("producer-performance").defaultHelp(true)
-				.description("This tool is used to verify the producer performance.");
+        payloadOptions.addArgument("--record-size").action(store()).required(false).type(Integer.class)
+        .metavar("RECORD-SIZE").dest("recordSize")
+        .help("message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
 
-		MutuallyExclusiveGroup payloadOptions = parser.addMutuallyExclusiveGroup().required(true)
-				.description("either --record-size or --payload-file must be specified but not both.");
+        payloadOptions.addArgument("--payload-file").action(store()).required(false).type(String.class)
+            .metavar("PAYLOAD-FILE").dest("payloadFile")
+            .help("file to read the message payloads from. This works only for UTF-8 encoded text files. "
+                + "Payloads will be read from this file and a payload will be randomly selected when sending messages. "
+                + "Note that you must provide exactly one of --record-size or --payload-file.");
 
-		parser.addArgument("--topic").action(store()).required(true).type(String.class).metavar("TOPIC")
-				.help("produce messages to this topic");
+        parser.addArgument("--payload-delimiter").action(store()).required(false).type(String.class)
+            .metavar("PAYLOAD-DELIMITER").dest("payloadDelimiter").setDefault("\\n")
+            .help("provides delimiter to be used when --payload-file is provided. " + "Defaults to new line. "
+                + "Note that this parameter will be ignored if --payload-file is not provided.");
 
-		parser.addArgument("--num-records").action(store()).required(true).type(Long.class).metavar("NUM-RECORDS")
-				.dest("numRecords").help("number of messages to produce");
+        parser.addArgument("--throughput").action(store()).required(true).type(Integer.class).metavar("THROUGHPUT")
+        .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
 
-		payloadOptions.addArgument("--record-size").action(store()).required(false).type(Integer.class)
-				.metavar("RECORD-SIZE").dest("recordSize")
-				.help("message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
+        parser.addArgument("--producer-props").nargs("+").required(false).metavar("PROP-NAME=PROP-VALUE")
+            .type(String.class).dest("producerConfig")
+            .help("kafka producer related configuration properties like bootstrap.servers,client.id etc. "
+                + "These configs take precedence over those passed via --producer.config.");
 
-		payloadOptions.addArgument("--payload-file").action(store()).required(false).type(String.class)
-				.metavar("PAYLOAD-FILE").dest("payloadFile")
-				.help("file to read the message payloads from. This works only for UTF-8 encoded text files. "
-						+ "Payloads will be read from this file and a payload will be randomly selected when sending messages. "
-						+ "Note that you must provide exactly one of --record-size or --payload-file.");
+        parser.addArgument("--producer.config").action(store()).required(false).type(String.class)
+        .metavar("CONFIG-FILE").dest("producerConfigFile").help("producer config properties file.");
 
-		parser.addArgument("--payload-delimiter").action(store()).required(false).type(String.class)
-				.metavar("PAYLOAD-DELIMITER").dest("payloadDelimiter").setDefault("\\n")
-				.help("provides delimiter to be used when --payload-file is provided. " + "Defaults to new line. "
-						+ "Note that this parameter will be ignored if --payload-file is not provided.");
+        parser.addArgument("--print-metrics").action(storeTrue()).type(Boolean.class).metavar("PRINT-METRICS")
+        .dest("printMetrics").help("print out metrics at the end of the test.");
 
-		parser.addArgument("--throughput").action(store()).required(true).type(Integer.class).metavar("THROUGHPUT")
-				.help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
+        parser.addArgument("--transactional-id").action(store()).required(false).type(String.class)
+        .metavar("TRANSACTIONAL-ID").dest("transactionalId")
+        .setDefault("performance-producer-default-transactional-id")
+        .help("The transactionalId to use if transaction-duration-ms is > 0. Useful when testing the performance of concurrent transactions.");
 
-		parser.addArgument("--producer-props").nargs("+").required(false).metavar("PROP-NAME=PROP-VALUE")
-				.type(String.class).dest("producerConfig")
-				.help("kafka producer related configuration properties like bootstrap.servers,client.id etc. "
-						+ "These configs take precedence over those passed via --producer.config.");
+        parser.addArgument("--transaction-duration-ms").action(store()).required(false).type(Long.class)
+        .metavar("TRANSACTION-DURATION").dest("transactionDurationMs").setDefault(0L)
+        .help("The max age of each transaction. The commitTransaction will be called after this time has elapsed. Transactions are only enabled if this value is positive.");
 
-		parser.addArgument("--producer.config").action(store()).required(false).type(String.class)
-				.metavar("CONFIG-FILE").dest("producerConfigFile").help("producer config properties file.");
+        parser.addArgument("--synchronous-send").action(storeTrue()).type(Boolean.class).metavar("SYNCHRONOUS-SEND")
+        .dest("synchronousSend").help("enable synchronous blocking send calls.");
 
-		parser.addArgument("--print-metrics").action(storeTrue()).type(Boolean.class).metavar("PRINT-METRICS")
-				.dest("printMetrics").help("print out metrics at the end of the test.");
+        return parser;
+    }
 
-		parser.addArgument("--transactional-id").action(store()).required(false).type(String.class)
-				.metavar("TRANSACTIONAL-ID").dest("transactionalId")
-				.setDefault("performance-producer-default-transactional-id")
-				.help("The transactionalId to use if transaction-duration-ms is > 0. Useful when testing the performance of concurrent transactions.");
+    private static class Stats {
+        private long start;
+        private long windowStart;
+        private int[] latencies;
+        private int sampling;
+        private int iteration;
+        private int index;
+        private long count;
+        private long bytes;
+        private int maxLatency;
+        private long totalLatency;
+        private long windowCount;
+        private int windowMaxLatency;
+        private long windowTotalLatency;
+        private long windowBytes;
+        private long reportingInterval;
 
-		parser.addArgument("--transaction-duration-ms").action(store()).required(false).type(Long.class)
-				.metavar("TRANSACTION-DURATION").dest("transactionDurationMs").setDefault(0L)
-				.help("The max age of each transaction. The commitTransaction will be called after this time has elapsed. Transactions are only enabled if this value is positive.");
+        public Stats(long numRecords, int reportingInterval) {
+            this.start = System.currentTimeMillis();
+            this.windowStart = System.currentTimeMillis();
+            this.iteration = 0;
+            this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
+            this.latencies = new int[(int) (numRecords / this.sampling) + 1];
+            this.index = 0;
+            this.maxLatency = 0;
+            this.totalLatency = 0;
+            this.windowCount = 0;
+            this.windowMaxLatency = 0;
+            this.windowTotalLatency = 0;
+            this.windowBytes = 0;
+            this.totalLatency = 0;
+            this.reportingInterval = reportingInterval;
+        }
 
-		parser.addArgument("--synchronous-send").action(storeTrue()).type(Boolean.class).metavar("SYNCHRONOUS-SEND")
-				.dest("synchronousSend").help("enable synchronous blocking send calls.");
+        public void record(int iter, int latency, int bytes, long time) {
+            this.count++;
+            this.bytes += bytes;
+            this.totalLatency += latency;
+            this.maxLatency = Math.max(this.maxLatency, latency);
+            this.windowCount++;
+            this.windowBytes += bytes;
+            this.windowTotalLatency += latency;
+            this.windowMaxLatency = Math.max(windowMaxLatency, latency);
+            if (iter % this.sampling == 0) {
+                this.latencies[index] = latency;
+                this.index++;
+            }
+            /* maybe report the recent perf */
+            if (time - windowStart >= reportingInterval) {
+                printWindow();
+                newWindow();
+            }
+        }
 
-		return parser;
-	}
+        public Callback nextCompletion(long start, int bytes, Stats stats) {
+            Callback cb = new PerfCallback(this.iteration, start, bytes, stats);
+            this.iteration++;
+            return cb;
+        }
 
-	private static class Stats {
-		private long start;
-		private long windowStart;
-		private int[] latencies;
-		private int sampling;
-		private int iteration;
-		private int index;
-		private long count;
-		private long bytes;
-		private int maxLatency;
-		private long totalLatency;
-		private long windowCount;
-		private int windowMaxLatency;
-		private long windowTotalLatency;
-		private long windowBytes;
-		private long reportingInterval;
+        public void printWindow() {
+            long ellapsed = System.currentTimeMillis() - windowStart;
+            double recsPerSec = 1000.0 * windowCount / (double) ellapsed;
+            double mbPerSec = 1000.0 * this.windowBytes / (double) ellapsed / (1024.0 * 1024.0);
+            System.out.printf(
+                    "%d records sent, %.1f records/sec (%.2f MB/sec), %.1f ms avg latency, %.1f max latency.%n",
+                    windowCount, recsPerSec, mbPerSec, windowTotalLatency / (double) windowCount,
+                    (double) windowMaxLatency);
+        }
 
-		public Stats(long numRecords, int reportingInterval) {
-			this.start = System.currentTimeMillis();
-			this.windowStart = System.currentTimeMillis();
-			this.iteration = 0;
-			this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
-			this.latencies = new int[(int) (numRecords / this.sampling) + 1];
-			this.index = 0;
-			this.maxLatency = 0;
-			this.totalLatency = 0;
-			this.windowCount = 0;
-			this.windowMaxLatency = 0;
-			this.windowTotalLatency = 0;
-			this.windowBytes = 0;
-			this.totalLatency = 0;
-			this.reportingInterval = reportingInterval;
-		}
+        public void newWindow() {
+            this.windowStart = System.currentTimeMillis();
+            this.windowCount = 0;
+            this.windowMaxLatency = 0;
+            this.windowTotalLatency = 0;
+            this.windowBytes = 0;
+        }
 
-		public void record(int iter, int latency, int bytes, long time) {
-			this.count++;
-			this.bytes += bytes;
-			this.totalLatency += latency;
-			this.maxLatency = Math.max(this.maxLatency, latency);
-			this.windowCount++;
-			this.windowBytes += bytes;
-			this.windowTotalLatency += latency;
-			this.windowMaxLatency = Math.max(windowMaxLatency, latency);
-			if (iter % this.sampling == 0) {
-				this.latencies[index] = latency;
-				this.index++;
-			}
-			/* maybe report the recent perf */
-			if (time - windowStart >= reportingInterval) {
-				printWindow();
-				newWindow();
-			}
-		}
+        public void printTotal() {
+            long elapsed = System.currentTimeMillis() - start;
+            double recsPerSec = 1000.0 * count / (double) elapsed;
+            double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
+            int[] percs = percentiles(this.latencies, index, 0.5, 0.95, 0.99, 0.999);
+            System.out.printf(
+                    "%d records sent, %f records/sec (%.2f MB/sec), %.2f ms avg latency, %.2f ms max latency, %d ms 50th, %d ms 95th, %d ms 99th, %d ms 99.9th.%n",
+                    count, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency, percs[0], percs[1],
+                    percs[2], percs[3]);
+        }
 
-		public Callback nextCompletion(long start, int bytes, Stats stats) {
-			Callback cb = new PerfCallback(this.iteration, start, bytes, stats);
-			this.iteration++;
-			return cb;
-		}
+        private static int[] percentiles(int[] latencies, int count, double... percentiles) {
+            int size = Math.min(count, latencies.length);
+            Arrays.sort(latencies, 0, size);
+            int[] values = new int[percentiles.length];
+            for (int i = 0; i < percentiles.length; i++) {
+                int index = (int) (percentiles[i] * size);
+                values[i] = latencies[index];
+            }
+            return values;
+        }
 
-		public void printWindow() {
-			long ellapsed = System.currentTimeMillis() - windowStart;
-			double recsPerSec = 1000.0 * windowCount / (double) ellapsed;
-			double mbPerSec = 1000.0 * this.windowBytes / (double) ellapsed / (1024.0 * 1024.0);
-			System.out.printf(
-					"%d records sent, %.1f records/sec (%.2f MB/sec), %.1f ms avg latency, %.1f max latency.%n",
-					windowCount, recsPerSec, mbPerSec, windowTotalLatency / (double) windowCount,
-					(double) windowMaxLatency);
-		}
+        public int updateIteration() {
+            // get the current value of iteration, and then increment.
+            int currentIteration = this.iteration;
+            this.iteration++;
+            return currentIteration;
+        }
+    }
 
-		public void newWindow() {
-			this.windowStart = System.currentTimeMillis();
-			this.windowCount = 0;
-			this.windowMaxLatency = 0;
-			this.windowTotalLatency = 0;
-			this.windowBytes = 0;
-		}
+    private static final class PerfCallback implements Callback {
+        private final long start;
+        private final int iteration;
+        private final int bytes;
+        private final Stats stats;
 
-		public void printTotal() {
-			long elapsed = System.currentTimeMillis() - start;
-			double recsPerSec = 1000.0 * count / (double) elapsed;
-			double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
-			int[] percs = percentiles(this.latencies, index, 0.5, 0.95, 0.99, 0.999);
-			System.out.printf(
-					"%d records sent, %f records/sec (%.2f MB/sec), %.2f ms avg latency, %.2f ms max latency, %d ms 50th, %d ms 95th, %d ms 99th, %d ms 99.9th.%n",
-					count, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency, percs[0], percs[1],
-					percs[2], percs[3]);
-		}
+        public PerfCallback(int iter, long start, int bytes, Stats stats) {
+            this.start = start;
+            this.stats = stats;
+            this.iteration = iter;
+            this.bytes = bytes;
+        }
 
-		private static int[] percentiles(int[] latencies, int count, double... percentiles) {
-			int size = Math.min(count, latencies.length);
-			Arrays.sort(latencies, 0, size);
-			int[] values = new int[percentiles.length];
-			for (int i = 0; i < percentiles.length; i++) {
-				int index = (int) (percentiles[i] * size);
-				values[i] = latencies[index];
-			}
-			return values;
-		}
-
-		public int updateIteration() {
-			// get the current value of iteration, and then increment.
-			int current_iteration = this.iteration;
-			this.iteration++;
-			return current_iteration;
-		}
-	}
-
-	private static final class PerfCallback implements Callback {
-		private final long start;
-		private final int iteration;
-		private final int bytes;
-		private final Stats stats;
-
-		public PerfCallback(int iter, long start, int bytes, Stats stats) {
-			this.start = start;
-			this.stats = stats;
-			this.iteration = iter;
-			this.bytes = bytes;
-		}
-
-		public void onCompletion(RecordMetadata metadata, Exception exception) {
-			long now = System.currentTimeMillis();
-			int latency = (int) (now - start);
-			this.stats.record(iteration, latency, bytes, now);
-			if (exception != null)
-				exception.printStackTrace();
-		}
-	}
+        public void onCompletion(RecordMetadata metadata, Exception exception) {
+            long now = System.currentTimeMillis();
+            int latency = (int) (now - start);
+            this.stats.record(iteration, latency, bytes, now);
+            if (exception != null)
+                exception.printStackTrace();
+        }
+    }
 
 }

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -151,7 +151,12 @@ public class ProducerPerformance {
 				 */
 				if (synchronousSend) {
 					int iteration = stats.updateIteration();
-					RecordMetadata result = producer.send(record).get();
+					try {
+						RecordMetadata result = producer.send(record).get();
+					} catch (Exception exception) {
+						exception.printStackTrace();
+					}
+
 					long now = System.currentTimeMillis();
 					int latency = (int) (now - sendStartMs);
 					stats.record(iteration, latency, payload.length, now);

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -45,385 +45,354 @@ import org.apache.kafka.common.utils.Utils;
 
 public class ProducerPerformance {
 
-    public static void main(String[] args) throws Exception {
-        ArgumentParser parser = argParser();
+	public static void main(String[] args) throws Exception {
+		ArgumentParser parser = argParser();
 
-        try {
-            Namespace res = parser.parseArgs(args);
+		try {
+			Namespace res = parser.parseArgs(args);
 
-            /* parse args */
-            String topicName = res.getString("topic");
-            long numRecords = res.getLong("numRecords");
-            Integer recordSize = res.getInt("recordSize");
-            int throughput = res.getInt("throughput");
-            List<String> producerProps = res.getList("producerConfig");
-            String producerConfig = res.getString("producerConfigFile");
-            String payloadFilePath = res.getString("payloadFile");
-            String transactionalId = res.getString("transactionalId");
-            boolean shouldPrintMetrics = res.getBoolean("printMetrics");
-            long transactionDurationMs = res.getLong("transactionDurationMs");
-            boolean transactionsEnabled =  0 < transactionDurationMs;
+			/* parse args */
+			String topicName = res.getString("topic");
+			long numRecords = res.getLong("numRecords");
+			Integer recordSize = res.getInt("recordSize");
+			int throughput = res.getInt("throughput");
+			List<String> producerProps = res.getList("producerConfig");
+			String producerConfig = res.getString("producerConfigFile");
+			String payloadFilePath = res.getString("payloadFile");
+			String transactionalId = res.getString("transactionalId");
+			boolean shouldPrintMetrics = res.getBoolean("printMetrics");
+			long transactionDurationMs = res.getLong("transactionDurationMs");
+			boolean synchronousSend = res.getBoolean("synchronousSend");
+			boolean transactionsEnabled = 0 < transactionDurationMs;
 
-            // since default value gets printed with the help text, we are escaping \n there and replacing it with correct value here.
-            String payloadDelimiter = res.getString("payloadDelimiter").equals("\\n") ? "\n" : res.getString("payloadDelimiter");
+			// since default value gets printed with the help text, we are
+			// escaping \n there and replacing it with correct value here.
+			String payloadDelimiter = res.getString("payloadDelimiter").equals("\\n") ? "\n"
+					: res.getString("payloadDelimiter");
 
-            if (producerProps == null && producerConfig == null) {
-                throw new ArgumentParserException("Either --producer-props or --producer.config must be specified.", parser);
-            }
+			if (producerProps == null && producerConfig == null) {
+				throw new ArgumentParserException("Either --producer-props or --producer.config must be specified.",
+						parser);
+			}
 
-            List<byte[]> payloadByteList = new ArrayList<>();
-            if (payloadFilePath != null) {
-                Path path = Paths.get(payloadFilePath);
-                System.out.println("Reading payloads from: " + path.toAbsolutePath());
-                if (Files.notExists(path) || Files.size(path) == 0)  {
-                    throw new  IllegalArgumentException("File does not exist or empty file provided.");
-                }
+			List<byte[]> payloadByteList = new ArrayList<>();
+			if (payloadFilePath != null) {
+				Path path = Paths.get(payloadFilePath);
+				System.out.println("Reading payloads from: " + path.toAbsolutePath());
+				if (Files.notExists(path) || Files.size(path) == 0) {
+					throw new IllegalArgumentException("File does not exist or empty file provided.");
+				}
 
-                String[] payloadList = new String(Files.readAllBytes(path), "UTF-8").split(payloadDelimiter);
+				String[] payloadList = new String(Files.readAllBytes(path), "UTF-8").split(payloadDelimiter);
 
-                System.out.println("Number of messages read: " + payloadList.length);
+				System.out.println("Number of messages read: " + payloadList.length);
 
-                for (String payload : payloadList) {
-                    payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
-                }
-            }
+				for (String payload : payloadList) {
+					payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
+				}
+			}
 
-            Properties props = new Properties();
-            if (producerConfig != null) {
-                props.putAll(Utils.loadProps(producerConfig));
-            }
-            if (producerProps != null)
-                for (String prop : producerProps) {
-                    String[] pieces = prop.split("=");
-                    if (pieces.length != 2)
-                        throw new IllegalArgumentException("Invalid property: " + prop);
-                    props.put(pieces[0], pieces[1]);
-                }
+			Properties props = new Properties();
+			if (producerConfig != null) {
+				props.putAll(Utils.loadProps(producerConfig));
+			}
+			if (producerProps != null)
+				for (String prop : producerProps) {
+					String[] pieces = prop.split("=");
+					if (pieces.length != 2)
+						throw new IllegalArgumentException("Invalid property: " + prop);
+					props.put(pieces[0], pieces[1]);
+				}
 
-            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
-            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
-            if (transactionsEnabled)
-                props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+			props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					"org.apache.kafka.common.serialization.ByteArraySerializer");
+			props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					"org.apache.kafka.common.serialization.ByteArraySerializer");
+			if (transactionsEnabled)
+				props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
 
-            KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props);
+			KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props);
 
-            if (transactionsEnabled)
-                producer.initTransactions();
+			if (transactionsEnabled)
+				producer.initTransactions();
 
-            /* setup perf test */
-            byte[] payload = null;
-            Random random = new Random(0);
-            if (recordSize != null) {
-                payload = new byte[recordSize];
-                for (int i = 0; i < payload.length; ++i)
-                    payload[i] = (byte) (random.nextInt(26) + 65);
-            }
-            ProducerRecord<byte[], byte[]> record;
-            Stats stats = new Stats(numRecords, 5000);
-            long startMs = System.currentTimeMillis();
+			/* setup perf test */
+			byte[] payload = null;
+			Random random = new Random(0);
+			if (recordSize != null) {
+				payload = new byte[recordSize];
+				for (int i = 0; i < payload.length; ++i)
+					payload[i] = (byte) (random.nextInt(26) + 65);
+			}
+			ProducerRecord<byte[], byte[]> record;
+			Stats stats = new Stats(numRecords, 5000);
+			long startMs = System.currentTimeMillis();
 
-            ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
+			ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
 
-            int currentTransactionSize = 0;
-            long transactionStartTime = 0;
-            for (int i = 0; i < numRecords; i++) {
-                if (transactionsEnabled && currentTransactionSize == 0) {
-                    producer.beginTransaction();
-                    transactionStartTime = System.currentTimeMillis();
-                }
+			int currentTransactionSize = 0;
+			long transactionStartTime = 0;
+			for (int i = 0; i < numRecords; i++) {
+				if (transactionsEnabled && currentTransactionSize == 0) {
+					producer.beginTransaction();
+					transactionStartTime = System.currentTimeMillis();
+				}
 
+				if (payloadFilePath != null) {
+					payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
+				}
+				record = new ProducerRecord<>(topicName, payload);
 
-                if (payloadFilePath != null) {
-                    payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
-                }
-                record = new ProducerRecord<>(topicName, payload);
+				long sendStartMs = System.currentTimeMillis();
 
-                long sendStartMs = System.currentTimeMillis();
-                Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
-                producer.send(record, cb);
+				/*
+				 * if sync send, perform actions done in callback function of
+				 * async send
+				 */
+				if (synchronousSend) {
+					int iteration = stats.updateIteration();
+					RecordMetadata result = producer.send(record).get();
+					long now = System.currentTimeMillis();
+					int latency = (int) (now - sendStartMs);
+					stats.record(iteration, latency, payload.length, now);
+				} else {
+					Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
+					producer.send(record, cb);
+				}
 
-                currentTransactionSize++;
-                if (transactionsEnabled && transactionDurationMs <= (sendStartMs - transactionStartTime)) {
-                    producer.commitTransaction();
-                    currentTransactionSize = 0;
-                }
+				currentTransactionSize++;
+				if (transactionsEnabled && transactionDurationMs <= (sendStartMs - transactionStartTime)) {
+					producer.commitTransaction();
+					currentTransactionSize = 0;
+				}
 
-                if (throttler.shouldThrottle(i, sendStartMs)) {
-                    throttler.throttle();
-                }
-            }
+				if (throttler.shouldThrottle(i, sendStartMs)) {
+					throttler.throttle();
+				}
+			}
 
-            if (transactionsEnabled && currentTransactionSize != 0)
-                producer.commitTransaction();
+			if (transactionsEnabled && currentTransactionSize != 0)
+				producer.commitTransaction();
 
-            if (!shouldPrintMetrics) {
-                producer.close();
+			if (!shouldPrintMetrics) {
+				producer.close();
 
-                /* print final results */
-                stats.printTotal();
-            } else {
-                // Make sure all messages are sent before printing out the stats and the metrics
-                // We need to do this in a different branch for now since tests/kafkatest/sanity_checks/test_performance_services.py
-                // expects this class to work with older versions of the client jar that don't support flush().
-                producer.flush();
+				/* print final results */
+				stats.printTotal();
+			} else {
+				// Make sure all messages are sent before printing out the stats
+				// and the metrics
+				// We need to do this in a different branch for now since
+				// tests/kafkatest/sanity_checks/test_performance_services.py
+				// expects this class to work with older versions of the client
+				// jar that don't support flush().
+				producer.flush();
 
-                /* print final results */
-                stats.printTotal();
+				/* print final results */
+				stats.printTotal();
 
-                /* print out metrics */
-                ToolsUtils.printMetrics(producer.metrics());
-                producer.close();
-            }
-        } catch (ArgumentParserException e) {
-            if (args.length == 0) {
-                parser.printHelp();
-                Exit.exit(0);
-            } else {
-                parser.handleError(e);
-                Exit.exit(1);
-            }
-        }
+				/* print out metrics */
+				ToolsUtils.printMetrics(producer.metrics());
+				producer.close();
+			}
+		} catch (ArgumentParserException e) {
+			if (args.length == 0) {
+				parser.printHelp();
+				Exit.exit(0);
+			} else {
+				parser.handleError(e);
+				Exit.exit(1);
+			}
+		}
 
-    }
+	}
 
-    /** Get the command-line argument parser. */
-    private static ArgumentParser argParser() {
-        ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("producer-performance")
-                .defaultHelp(true)
-                .description("This tool is used to verify the producer performance.");
+	/** Get the command-line argument parser. */
+	private static ArgumentParser argParser() {
+		ArgumentParser parser = ArgumentParsers.newArgumentParser("producer-performance").defaultHelp(true)
+				.description("This tool is used to verify the producer performance.");
 
-        MutuallyExclusiveGroup payloadOptions = parser
-                .addMutuallyExclusiveGroup()
-                .required(true)
-                .description("either --record-size or --payload-file must be specified but not both.");
+		MutuallyExclusiveGroup payloadOptions = parser.addMutuallyExclusiveGroup().required(true)
+				.description("either --record-size or --payload-file must be specified but not both.");
 
-        parser.addArgument("--topic")
-                .action(store())
-                .required(true)
-                .type(String.class)
-                .metavar("TOPIC")
-                .help("produce messages to this topic");
+		parser.addArgument("--topic").action(store()).required(true).type(String.class).metavar("TOPIC")
+				.help("produce messages to this topic");
 
-        parser.addArgument("--num-records")
-                .action(store())
-                .required(true)
-                .type(Long.class)
-                .metavar("NUM-RECORDS")
-                .dest("numRecords")
-                .help("number of messages to produce");
+		parser.addArgument("--num-records").action(store()).required(true).type(Long.class).metavar("NUM-RECORDS")
+				.dest("numRecords").help("number of messages to produce");
 
-        payloadOptions.addArgument("--record-size")
-                .action(store())
-                .required(false)
-                .type(Integer.class)
-                .metavar("RECORD-SIZE")
-                .dest("recordSize")
-                .help("message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
+		payloadOptions.addArgument("--record-size").action(store()).required(false).type(Integer.class)
+				.metavar("RECORD-SIZE").dest("recordSize")
+				.help("message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
 
-        payloadOptions.addArgument("--payload-file")
-                .action(store())
-                .required(false)
-                .type(String.class)
-                .metavar("PAYLOAD-FILE")
-                .dest("payloadFile")
-                .help("file to read the message payloads from. This works only for UTF-8 encoded text files. " +
-                        "Payloads will be read from this file and a payload will be randomly selected when sending messages. " +
-                        "Note that you must provide exactly one of --record-size or --payload-file.");
+		payloadOptions.addArgument("--payload-file").action(store()).required(false).type(String.class)
+				.metavar("PAYLOAD-FILE").dest("payloadFile")
+				.help("file to read the message payloads from. This works only for UTF-8 encoded text files. "
+						+ "Payloads will be read from this file and a payload will be randomly selected when sending messages. "
+						+ "Note that you must provide exactly one of --record-size or --payload-file.");
 
-        parser.addArgument("--payload-delimiter")
-                .action(store())
-                .required(false)
-                .type(String.class)
-                .metavar("PAYLOAD-DELIMITER")
-                .dest("payloadDelimiter")
-                .setDefault("\\n")
-                .help("provides delimiter to be used when --payload-file is provided. " +
-                        "Defaults to new line. " +
-                        "Note that this parameter will be ignored if --payload-file is not provided.");
+		parser.addArgument("--payload-delimiter").action(store()).required(false).type(String.class)
+				.metavar("PAYLOAD-DELIMITER").dest("payloadDelimiter").setDefault("\\n")
+				.help("provides delimiter to be used when --payload-file is provided. " + "Defaults to new line. "
+						+ "Note that this parameter will be ignored if --payload-file is not provided.");
 
-        parser.addArgument("--throughput")
-                .action(store())
-                .required(true)
-                .type(Integer.class)
-                .metavar("THROUGHPUT")
-                .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
+		parser.addArgument("--throughput").action(store()).required(true).type(Integer.class).metavar("THROUGHPUT")
+				.help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
 
-        parser.addArgument("--producer-props")
-                 .nargs("+")
-                 .required(false)
-                 .metavar("PROP-NAME=PROP-VALUE")
-                 .type(String.class)
-                 .dest("producerConfig")
-                 .help("kafka producer related configuration properties like bootstrap.servers,client.id etc. " +
-                         "These configs take precedence over those passed via --producer.config.");
+		parser.addArgument("--producer-props").nargs("+").required(false).metavar("PROP-NAME=PROP-VALUE")
+				.type(String.class).dest("producerConfig")
+				.help("kafka producer related configuration properties like bootstrap.servers,client.id etc. "
+						+ "These configs take precedence over those passed via --producer.config.");
 
-        parser.addArgument("--producer.config")
-                .action(store())
-                .required(false)
-                .type(String.class)
-                .metavar("CONFIG-FILE")
-                .dest("producerConfigFile")
-                .help("producer config properties file.");
+		parser.addArgument("--producer.config").action(store()).required(false).type(String.class)
+				.metavar("CONFIG-FILE").dest("producerConfigFile").help("producer config properties file.");
 
-        parser.addArgument("--print-metrics")
-                .action(storeTrue())
-                .type(Boolean.class)
-                .metavar("PRINT-METRICS")
-                .dest("printMetrics")
-                .help("print out metrics at the end of the test.");
+		parser.addArgument("--print-metrics").action(storeTrue()).type(Boolean.class).metavar("PRINT-METRICS")
+				.dest("printMetrics").help("print out metrics at the end of the test.");
 
-        parser.addArgument("--transactional-id")
-               .action(store())
-               .required(false)
-               .type(String.class)
-               .metavar("TRANSACTIONAL-ID")
-               .dest("transactionalId")
-               .setDefault("performance-producer-default-transactional-id")
-               .help("The transactionalId to use if transaction-duration-ms is > 0. Useful when testing the performance of concurrent transactions.");
+		parser.addArgument("--transactional-id").action(store()).required(false).type(String.class)
+				.metavar("TRANSACTIONAL-ID").dest("transactionalId")
+				.setDefault("performance-producer-default-transactional-id")
+				.help("The transactionalId to use if transaction-duration-ms is > 0. Useful when testing the performance of concurrent transactions.");
 
-        parser.addArgument("--transaction-duration-ms")
-               .action(store())
-               .required(false)
-               .type(Long.class)
-               .metavar("TRANSACTION-DURATION")
-               .dest("transactionDurationMs")
-               .setDefault(0L)
-               .help("The max age of each transaction. The commitTransaction will be called after this time has elapsed. Transactions are only enabled if this value is positive.");
+		parser.addArgument("--transaction-duration-ms").action(store()).required(false).type(Long.class)
+				.metavar("TRANSACTION-DURATION").dest("transactionDurationMs").setDefault(0L)
+				.help("The max age of each transaction. The commitTransaction will be called after this time has elapsed. Transactions are only enabled if this value is positive.");
 
+		parser.addArgument("--synchronous-send").action(storeTrue()).type(Boolean.class).metavar("SYNCHRONOUS-SEND")
+				.dest("synchronousSend").help("enable synchronous blocking send calls.");
 
-        return parser;
-    }
+		return parser;
+	}
 
-    private static class Stats {
-        private long start;
-        private long windowStart;
-        private int[] latencies;
-        private int sampling;
-        private int iteration;
-        private int index;
-        private long count;
-        private long bytes;
-        private int maxLatency;
-        private long totalLatency;
-        private long windowCount;
-        private int windowMaxLatency;
-        private long windowTotalLatency;
-        private long windowBytes;
-        private long reportingInterval;
+	private static class Stats {
+		private long start;
+		private long windowStart;
+		private int[] latencies;
+		private int sampling;
+		private int iteration;
+		private int index;
+		private long count;
+		private long bytes;
+		private int maxLatency;
+		private long totalLatency;
+		private long windowCount;
+		private int windowMaxLatency;
+		private long windowTotalLatency;
+		private long windowBytes;
+		private long reportingInterval;
 
-        public Stats(long numRecords, int reportingInterval) {
-            this.start = System.currentTimeMillis();
-            this.windowStart = System.currentTimeMillis();
-            this.iteration = 0;
-            this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
-            this.latencies = new int[(int) (numRecords / this.sampling) + 1];
-            this.index = 0;
-            this.maxLatency = 0;
-            this.totalLatency = 0;
-            this.windowCount = 0;
-            this.windowMaxLatency = 0;
-            this.windowTotalLatency = 0;
-            this.windowBytes = 0;
-            this.totalLatency = 0;
-            this.reportingInterval = reportingInterval;
-        }
+		public Stats(long numRecords, int reportingInterval) {
+			this.start = System.currentTimeMillis();
+			this.windowStart = System.currentTimeMillis();
+			this.iteration = 0;
+			this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
+			this.latencies = new int[(int) (numRecords / this.sampling) + 1];
+			this.index = 0;
+			this.maxLatency = 0;
+			this.totalLatency = 0;
+			this.windowCount = 0;
+			this.windowMaxLatency = 0;
+			this.windowTotalLatency = 0;
+			this.windowBytes = 0;
+			this.totalLatency = 0;
+			this.reportingInterval = reportingInterval;
+		}
 
-        public void record(int iter, int latency, int bytes, long time) {
-            this.count++;
-            this.bytes += bytes;
-            this.totalLatency += latency;
-            this.maxLatency = Math.max(this.maxLatency, latency);
-            this.windowCount++;
-            this.windowBytes += bytes;
-            this.windowTotalLatency += latency;
-            this.windowMaxLatency = Math.max(windowMaxLatency, latency);
-            if (iter % this.sampling == 0) {
-                this.latencies[index] = latency;
-                this.index++;
-            }
-            /* maybe report the recent perf */
-            if (time - windowStart >= reportingInterval) {
-                printWindow();
-                newWindow();
-            }
-        }
+		public void record(int iter, int latency, int bytes, long time) {
+			this.count++;
+			this.bytes += bytes;
+			this.totalLatency += latency;
+			this.maxLatency = Math.max(this.maxLatency, latency);
+			this.windowCount++;
+			this.windowBytes += bytes;
+			this.windowTotalLatency += latency;
+			this.windowMaxLatency = Math.max(windowMaxLatency, latency);
+			if (iter % this.sampling == 0) {
+				this.latencies[index] = latency;
+				this.index++;
+			}
+			/* maybe report the recent perf */
+			if (time - windowStart >= reportingInterval) {
+				printWindow();
+				newWindow();
+			}
+		}
 
-        public Callback nextCompletion(long start, int bytes, Stats stats) {
-            Callback cb = new PerfCallback(this.iteration, start, bytes, stats);
-            this.iteration++;
-            return cb;
-        }
+		public Callback nextCompletion(long start, int bytes, Stats stats) {
+			Callback cb = new PerfCallback(this.iteration, start, bytes, stats);
+			this.iteration++;
+			return cb;
+		}
 
-        public void printWindow() {
-            long ellapsed = System.currentTimeMillis() - windowStart;
-            double recsPerSec = 1000.0 * windowCount / (double) ellapsed;
-            double mbPerSec = 1000.0 * this.windowBytes / (double) ellapsed / (1024.0 * 1024.0);
-            System.out.printf("%d records sent, %.1f records/sec (%.2f MB/sec), %.1f ms avg latency, %.1f max latency.%n",
-                              windowCount,
-                              recsPerSec,
-                              mbPerSec,
-                              windowTotalLatency / (double) windowCount,
-                              (double) windowMaxLatency);
-        }
+		public void printWindow() {
+			long ellapsed = System.currentTimeMillis() - windowStart;
+			double recsPerSec = 1000.0 * windowCount / (double) ellapsed;
+			double mbPerSec = 1000.0 * this.windowBytes / (double) ellapsed / (1024.0 * 1024.0);
+			System.out.printf(
+					"%d records sent, %.1f records/sec (%.2f MB/sec), %.1f ms avg latency, %.1f max latency.%n",
+					windowCount, recsPerSec, mbPerSec, windowTotalLatency / (double) windowCount,
+					(double) windowMaxLatency);
+		}
 
-        public void newWindow() {
-            this.windowStart = System.currentTimeMillis();
-            this.windowCount = 0;
-            this.windowMaxLatency = 0;
-            this.windowTotalLatency = 0;
-            this.windowBytes = 0;
-        }
+		public void newWindow() {
+			this.windowStart = System.currentTimeMillis();
+			this.windowCount = 0;
+			this.windowMaxLatency = 0;
+			this.windowTotalLatency = 0;
+			this.windowBytes = 0;
+		}
 
-        public void printTotal() {
-            long elapsed = System.currentTimeMillis() - start;
-            double recsPerSec = 1000.0 * count / (double) elapsed;
-            double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
-            int[] percs = percentiles(this.latencies, index, 0.5, 0.95, 0.99, 0.999);
-            System.out.printf("%d records sent, %f records/sec (%.2f MB/sec), %.2f ms avg latency, %.2f ms max latency, %d ms 50th, %d ms 95th, %d ms 99th, %d ms 99.9th.%n",
-                              count,
-                              recsPerSec,
-                              mbPerSec,
-                              totalLatency / (double) count,
-                              (double) maxLatency,
-                              percs[0],
-                              percs[1],
-                              percs[2],
-                              percs[3]);
-        }
+		public void printTotal() {
+			long elapsed = System.currentTimeMillis() - start;
+			double recsPerSec = 1000.0 * count / (double) elapsed;
+			double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
+			int[] percs = percentiles(this.latencies, index, 0.5, 0.95, 0.99, 0.999);
+			System.out.printf(
+					"%d records sent, %f records/sec (%.2f MB/sec), %.2f ms avg latency, %.2f ms max latency, %d ms 50th, %d ms 95th, %d ms 99th, %d ms 99.9th.%n",
+					count, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency, percs[0], percs[1],
+					percs[2], percs[3]);
+		}
 
-        private static int[] percentiles(int[] latencies, int count, double... percentiles) {
-            int size = Math.min(count, latencies.length);
-            Arrays.sort(latencies, 0, size);
-            int[] values = new int[percentiles.length];
-            for (int i = 0; i < percentiles.length; i++) {
-                int index = (int) (percentiles[i] * size);
-                values[i] = latencies[index];
-            }
-            return values;
-        }
-    }
+		private static int[] percentiles(int[] latencies, int count, double... percentiles) {
+			int size = Math.min(count, latencies.length);
+			Arrays.sort(latencies, 0, size);
+			int[] values = new int[percentiles.length];
+			for (int i = 0; i < percentiles.length; i++) {
+				int index = (int) (percentiles[i] * size);
+				values[i] = latencies[index];
+			}
+			return values;
+		}
 
-    private static final class PerfCallback implements Callback {
-        private final long start;
-        private final int iteration;
-        private final int bytes;
-        private final Stats stats;
+		public int updateIteration() {
+			// get the current value of iteration, and then increment.
+			int current_iteration = this.iteration;
+			this.iteration++;
+			return current_iteration;
+		}
+	}
 
-        public PerfCallback(int iter, long start, int bytes, Stats stats) {
-            this.start = start;
-            this.stats = stats;
-            this.iteration = iter;
-            this.bytes = bytes;
-        }
+	private static final class PerfCallback implements Callback {
+		private final long start;
+		private final int iteration;
+		private final int bytes;
+		private final Stats stats;
 
-        public void onCompletion(RecordMetadata metadata, Exception exception) {
-            long now = System.currentTimeMillis();
-            int latency = (int) (now - start);
-            this.stats.record(iteration, latency, bytes, now);
-            if (exception != null)
-                exception.printStackTrace();
-        }
-    }
+		public PerfCallback(int iter, long start, int bytes, Stats stats) {
+			this.start = start;
+			this.stats = stats;
+			this.iteration = iter;
+			this.bytes = bytes;
+		}
+
+		public void onCompletion(RecordMetadata metadata, Exception exception) {
+			long now = System.currentTimeMillis();
+			int latency = (int) (now - start);
+			this.stats.record(iteration, latency, bytes, now);
+			if (exception != null)
+				exception.printStackTrace();
+		}
+	}
 
 }


### PR DESCRIPTION
ProducerPerformance java application now supports synchronous blocking sends to produce messages to kafka brokers.

Till now, performance producer application supported only asynchronous sends with a callback function registered.
this would be enough when trying to load the kafka brokers without bothering much on the replication & producer responses.

But when kafka brokers replication capacity has to be loaded, asynchronous sends would not suffice.
So synchronous blocking send calls are now supported with all the existing metrics calculation of producer performance.

A boolean command line flag --synchronous-send has been added to enable/disable this feature.
Blocking .get() calls are now done upon each send, and as of this commit ResultMetadata is not being used or logged.
A new function has been introduced in the Stats class to update and get the iteration counter.


Tests done:

Comparison tests were done with and without synchronous sends.

below were the configurations of kafka cluster:
No of brokers: 3
CPU per broker: 10 cores
Memory : 32GB
Topic partitions : 1
replication factor : 3
min.insync.replicas: 1 (default).
producer acks level : 1(default),  response after only leader write.

Similar configurations were given for performance producer with & without synchronous sends enabled.
It was observed that, synchronous producer was producing records approximately 5 times slower than asynchronous producer
but with guarantee of replication before subsequent sends.

So this clearly indicates the impact of replication in brokers. And these tests would help optimise resources in 
kafka broker from replication performance point of view.

Attached results snapshot of performance producer run with/without synchronous send flag enabled.