### PR TITLE
MINOR: Catch NoRecordsException in testCommaSeparatedRegex() test

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -424,7 +424,8 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
     }
   }
 
-  private class NoRecordsException extends RuntimeException
+  // package-private for tests
+  private[tools] class NoRecordsException extends RuntimeException
 
   class MirrorMakerOptions(args: Array[String]) extends CommandDefaultOptions(args) {
 

--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -20,7 +20,7 @@ import java.util.Properties
 
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
-import kafka.tools.MirrorMaker.{ConsumerWrapper, MirrorMakerProducer}
+import kafka.tools.MirrorMaker.{ConsumerWrapper, MirrorMakerProducer, NoRecordsException}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
@@ -92,8 +92,8 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
           val data = mirrorMakerConsumer.receive()
           data.topic == topic && new String(data.value) == msg
         } catch {
-          // this exception is thrown if no record is returned within a short timeout, so safe to ignore
-          case _: TimeoutException => false
+          // these exceptions are thrown if no records are returned within the 1s timeout, so safe to ignore
+          case _: TimeoutException | _: NoRecordsException => false
         }
       }, "MirrorMaker consumer should read the expected message from the expected topic within the timeout")
     } finally consumer.close()

--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -92,8 +92,8 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
           val data = mirrorMakerConsumer.receive()
           data.topic == topic && new String(data.value) == msg
         } catch {
-          // these exceptions are thrown if no records are returned within the 1s timeout, so safe to ignore
-          case _: TimeoutException | _: NoRecordsException => false
+          // these exceptions are thrown if no records are returned within the timeout, so safe to ignore
+          case _: NoRecordsException => false
         }
       }, "MirrorMaker consumer should read the expected message from the expected topic within the timeout")
     } finally consumer.close()


### PR DESCRIPTION
This test sometimes fails with
```
kafka.tools.MirrorMaker$NoRecordsException
	at kafka.tools.MirrorMaker$ConsumerWrapper.receive(MirrorMaker.scala:483)
	at kafka.tools.MirrorMakerIntegrationTest$$anonfun$testCommaSeparatedRegex$1.apply$mcZ$sp(MirrorMakerIntegrationTest.scala:92)
	at kafka.utils.TestUtils$.waitUntilTrue(TestUtils.scala:738)
```
It is a bit puzzling as to why this happens in the first place, as the producer call is synchronous and the consumer uses `auto.offset.reset=earliest`, so it should always return records. But the test originally caught `TimeoutException` with the comment `// this exception is thrown if no record is returned within a short timeout, so safe to ignore`, so I think that it is consistent to catch the other error when no records are returned such that we can retry until the test timeout is hit

Now we properly wait until the timeout of `TestUtils.waitUntilTrue` passes until failing the test.
