### PR TITLE
KAFKA-7443: OffsetOutOfRangeException in restoring state store from changelog topic when start offset of local checkpoint is smaller than that of changelog topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -24,8 +24,6 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -63,7 +61,6 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private KafkaException exception;
     private AtomicBoolean wakeup;
     private boolean closed;
-    private static final Logger log = LoggerFactory.getLogger(MockConsumer.class);
 
     public MockConsumer(OffsetResetStrategy offsetResetStrategy) {
         this.subscriptions = new SubscriptionState(offsetResetStrategy);
@@ -192,9 +189,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
                 final List<ConsumerRecord<K, V>> recs = entry.getValue();
                 for (final ConsumerRecord<K, V> rec : recs) {
                     if (beginningOffsets.get(entry.getKey()) != null && beginningOffsets.get(entry.getKey()) > subscriptions.position(entry.getKey())) {
-                        log.info("poll offset {} less than changelog topic start offset {}, throw OffsetOutOfRangeException!", subscriptions.position(entry.getKey()), beginningOffsets.get(entry.getKey()));
-                        RuntimeException exception = new OffsetOutOfRangeException(Collections.singletonMap(entry.getKey(), subscriptions.position(entry.getKey())));
-                        throw exception;
+                        throw new OffsetOutOfRangeException(Collections.singletonMap(entry.getKey(), subscriptions.position(entry.getKey())));
                     }
 
                     if (assignment().contains(entry.getKey()) && rec.offset() >= subscriptions.position(entry.getKey())) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -191,8 +191,8 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
             if (!subscriptions.isPaused(entry.getKey())) {
                 final List<ConsumerRecord<K, V>> recs = entry.getValue();
                 for (final ConsumerRecord<K, V> rec : recs) {
-                    if(rec.offset() > subscriptions.position(entry.getKey())) {
-                        log.info("poll offset{} less than changelog topic start offset {}, throw OffsetOutOfRangeException!", rec.offset(), subscriptions.position(entry.getKey()));
+                    if (beginningOffsets.get(entry.getKey()) != null && beginningOffsets.get(entry.getKey()) > subscriptions.position(entry.getKey())) {
+                        log.info("poll offset {} less than changelog topic start offset {}, throw OffsetOutOfRangeException!", subscriptions.position(entry.getKey()), beginningOffsets.get(entry.getKey()));
                         RuntimeException exception = new OffsetOutOfRangeException(Collections.singletonMap(entry.getKey(), subscriptions.position(entry.getKey())));
                         throw exception;
                     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -193,7 +193,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
                 for (final ConsumerRecord<K, V> rec : recs) {
                     if(rec.offset() > subscriptions.position(entry.getKey())) {
                         log.info("poll offset{} less than changelog topic start offset {}, throw OffsetOutOfRangeException!", rec.offset(), subscriptions.position(entry.getKey()));
-                        RuntimeException exception = new OffsetOutOfRangeException(Collections.singletonMap(entry.getKey(), rec.offset()));
+                        RuntimeException exception = new OffsetOutOfRangeException(Collections.singletonMap(entry.getKey(), subscriptions.position(entry.getKey())));
                         throw exception;
                     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -107,6 +107,9 @@ public class StoreChangelogReader implements ChangelogReader {
                 needsInitializing.remove(partition);
                 needsRestoring.remove(partition);
 
+				final StateRestorer restorer = stateRestorers.get(partition);
+                restorer.setCheckpointOffset(StateRestorer.NO_CHECKPOINT);
+				
                 task.reinitializeStateStoresForPartitions(recoverableException.partitions());
             }
             restoreConsumer.seekToBeginning(partitions);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -109,7 +109,6 @@ public class StoreChangelogReader implements ChangelogReader {
 
                 final StateRestorer restorer = stateRestorers.get(partition);
                 restorer.setCheckpointOffset(StateRestorer.NO_CHECKPOINT);
-				
                 task.reinitializeStateStoresForPartitions(recoverableException.partitions());
             }
             restoreConsumer.seekToBeginning(partitions);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -107,7 +107,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 needsInitializing.remove(partition);
                 needsRestoring.remove(partition);
 
-				final StateRestorer restorer = stateRestorers.get(partition);
+                final StateRestorer restorer = stateRestorers.get(partition);
                 restorer.setCheckpointOffset(StateRestorer.NO_CHECKPOINT);
 				
                 task.reinitializeStateStoresForPartitions(recoverableException.partitions());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -161,6 +161,7 @@ public class StoreChangelogReaderTest {
     public void shouldRecoverFromOffsetOutOfRangeExceptionAndRestoreFromStart() {
         final int messages = 10;
         final int startOffset = 5;
+        final long expiredCheckpoint = 1L;
         assignPartition(messages, topicPartition);
         consumer.updateBeginningOffsets(Collections.singletonMap(topicPartition, (long) startOffset));
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, (long) (messages + startOffset)));
@@ -168,7 +169,12 @@ public class StoreChangelogReaderTest {
         addRecords(messages, topicPartition, startOffset);
         consumer.assign(Collections.<TopicPartition>emptyList());
 
-        final StateRestorer stateRestorer = new StateRestorer(topicPartition, restoreListener, 1L, Long.MAX_VALUE, true,
+        final StateRestorer stateRestorer = new StateRestorer(
+                topicPartition,
+                restoreListener,
+                expiredCheckpoint,
+                Long.MAX_VALUE,
+                true,
                 "storeName");
         changelogReader.register(stateRestorer);
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/KAFKA-7443 for details.
The fix set this state partition to "NO_CHECKPOINT" when the offset in local checkpoint file has expired and older than the current start offset of changelog topic, thus making this task to restore local state from the current beginning offset of changelog topic, avoiding falling into the infinite loop caused by this exception.

