### PR TITLE
kafkatest: Match and compare `*-SNAPSHOT` versions in KafkaVersionTest

### DIFF
--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -33,25 +33,29 @@ def _kafka_jar_versions(proc_string):
         - kafka-streams-1.0.0-SNAPSHOT.jar
         - kafka-streams-0.11.0.0-SNAPSHOT.jar
     """
+    def match(regex_pattern):
+        # return the result from the first regex group
+        return [result[0] if isinstance(result, tuple) else result
+                for result in re.findall(regex_pattern, proc_string)]
 
     # Pattern example: kafka_2.11-1.0.0-SNAPSHOT.jar (we have to be careful not to partially match the 4 segment version string)
-    versions = re.findall("kafka_[0-9]+\.[0-9]+-([0-9]+\.[0-9]+\.[0-9]+)[\.-][a-zA-z]", proc_string)
+    versions = match("kafka_[0-9]+\.[0-9]+-([0-9]+\.[0-9]+\.[0-9]+(-[A-Z]+)?)")
 
     # Pattern example: kafka_2.11-0.11.0.0-SNAPSHOT.jar
-    versions.extend(re.findall("kafka_[0-9]+\.[0-9]+-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", proc_string))
+    versions.extend(match("kafka_[0-9]+\.[0-9]+-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[A-Z]+)?)"))
 
     # Pattern example: kafka-1.0.0/bin/../libs/* (i.e. the JARs are not listed explicitly, we have to be careful not to
     # partially match the 4 segment version)
-    versions.extend(re.findall("kafka-([0-9]+\.[0-9]+\.[0-9]+)/", proc_string))
+    versions.extend(match("kafka-([0-9]+\.[0-9]+\.[0-9]+)/"))
 
     # Pattern example: kafka-0.11.0.0/bin/../libs/* (i.e. the JARs are not listed explicitly)
-    versions.extend(re.findall("kafka-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", proc_string))
+    versions.extend(match("kafka-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"))
 
     # Pattern example: kafka-streams-1.0.0-SNAPSHOT.jar (we have to be careful not to partially match the 4 segment version string)
-    versions.extend(re.findall("kafka-[a-z]+-([0-9]+\.[0-9]+\.[0-9]+)[\.-][a-zA-z]", proc_string))
+    versions.extend(match("kafka-[a-z]+-([0-9]+\.[0-9]+\.[0-9]+(-[A-Z]+)?)"))
 
     # Pattern example: kafka-streams-0.11.0.0-SNAPSHOT.jar
-    versions.extend(re.findall("kafka-[a-z]+-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", proc_string))
+    versions.extend(match("kafka-[a-z]+-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[A-Z]+)?)"))
 
     return set(versions)
 


### PR DESCRIPTION
The `KafkaVersionTest` consistently fails with the following error:
```
[WARNING - 2018-11-25 16:41:50,917 - util - is_version - lineno:71]: <ducktape.cluster.cluster.ClusterNode object at 0x7fd5d0bd0b50>: kafka version mismatch: expected ['2.1.1-SNAPSHOT'], actual set([u'2.1.1']), ps line 18996 ?  
```
We should extend the version check to support snapshot versions