### PR TITLE
kafkatest: Make ZooKeeper log in "DEBUG" mode by default

### DIFF
--- a/tests/kafkatest/services/templates/log4j.properties
+++ b/tests/kafkatest/services/templates/log4j.properties
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 log4j.rootLogger={{ log_level|default("DEBUG") }}, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/tests/kafkatest/services/templates/log4j.properties
+++ b/tests/kafkatest/services/templates/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger={{ log_level|default("DEBUG") }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.zookeeper={{ log_level|default("DEBUG") }}


### PR DESCRIPTION
This makes it consistent to Kafka's logs and will help debugging failing tests, especially in CI/CD environments