### PR TITLE
MINOR: Fix flaky TransactionsTest

### DIFF
--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -80,14 +80,14 @@ class TransactionsTest(Test):
     def bounce_brokers(self, clean_shutdown):
        for node in self.kafka.nodes:
             if clean_shutdown:
-                self.kafka.restart_node(node, clean_shutdown = True)
+                self.kafka.restart_node(node, clean_shutdown = True, startup_timeout_sec=120)
             else:
                 self.kafka.stop_node(node, clean_shutdown = False)
                 wait_until(lambda: len(self.kafka.pids(node)) == 0 and not self.kafka.is_registered(node),
                            timeout_sec=self.kafka.zk_session_timeout + 5,
                            err_msg="Failed to see timely deregistration of \
                            hard-killed broker %s" % str(node.account))
-                self.kafka.start_node(node)
+                self.kafka.start_node(node, timeout_sec=120)
 
     def create_and_start_message_copier(self, input_topic, input_partition, output_topic, transactional_id):
         message_copier = TransactionalMessageCopier(


### PR DESCRIPTION
Log loading takes longer than 60s when the broker is bounced. Increasing the timeout to 120s.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
