### PR TITLE
MINOR: Fix kafkatest/__init__.py to use dev0 instead of SNAPSHOT

### DIFF
--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '2.1.1-SNAPSHOT'
+__version__ = '2.1.1.dev0'


### PR DESCRIPTION
Fixes the system tests.