### PR TITLE
MINOR: Support long maxMessages in Trogdor consume/produce bench workers

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -91,7 +91,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     private final String consumerNode;
     private final String bootstrapServers;
     private final int targetMessagesPerSec;
-    private final int maxMessages;
+    private final long maxMessages;
     private final Map<String, String> consumerConf;
     private final Map<String, String> adminClientConf;
     private final Map<String, String> commonClientConf;
@@ -105,7 +105,7 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("consumerNode") String consumerNode,
                             @JsonProperty("bootstrapServers") String bootstrapServers,
                             @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
-                            @JsonProperty("maxMessages") int maxMessages,
+                            @JsonProperty("maxMessages") long maxMessages,
                             @JsonProperty("consumerGroup") String consumerGroup,
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
@@ -146,7 +146,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public int maxMessages() {
+    public long maxMessages() {
         return maxMessages;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -233,7 +233,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             long bytesConsumed = 0;
             long startTimeMs = Time.SYSTEM.milliseconds();
             long startBatchMs = startTimeMs;
-            int maxMessages = spec.maxMessages();
+            long maxMessages = spec.maxMessages();
             try {
                 while (messagesConsumed < maxMessages) {
                     ConsumerRecords<byte[], byte[]> records = consumer.poll();

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -64,7 +64,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final String producerNode;
     private final String bootstrapServers;
     private final int targetMessagesPerSec;
-    private final int maxMessages;
+    private final long maxMessages;
     private final PayloadGenerator keyGenerator;
     private final PayloadGenerator valueGenerator;
     private final Optional<TransactionGenerator> transactionGenerator;
@@ -80,7 +80,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("producerNode") String producerNode,
                          @JsonProperty("bootstrapServers") String bootstrapServers,
                          @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
-                         @JsonProperty("maxMessages") int maxMessages,
+                         @JsonProperty("maxMessages") long maxMessages,
                          @JsonProperty("keyGenerator") PayloadGenerator keyGenerator,
                          @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
                          @JsonProperty("transactionGenerator") Optional<TransactionGenerator> txGenerator,
@@ -124,7 +124,7 @@ public class ProduceBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public int maxMessages() {
+    public long maxMessages() {
         return maxMessages;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -225,7 +225,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     if (enableTransactions)
                         producer.initTransactions();
 
-                    int sentMessages = 0;
+                    long sentMessages = 0;
                     while (sentMessages < spec.maxMessages()) {
                         if (enableTransactions) {
                             boolean tookAction = takeTransactionAction();


### PR DESCRIPTION
Sometimes we might want to run intense longer-running benchmarks with Trogdor. We are currently limited to `2147483647`. If we use 100 bytes per message, this limits us to 2.4MB/s of throughput a day. (`((2147483647 * 100) / 1000000 / 86400)`)
We might want to have longer running tasks than a single day as well, so I think it makes sense to bump this to a long.

cc @cmccabe 