### PR TITLE
KAFKA-2607: Review Time interface and its usage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -307,7 +307,7 @@ public class NetworkClient implements KafkaClient {
 
         selector.close(nodeId);
         List<ApiKeys> requestTypes = new ArrayList<>();
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         for (InFlightRequest request : inFlightRequests.clearAll(nodeId)) {
             if (request.isInternalRequest) {
                 if (request.header.apiKey() == ApiKeys.METADATA) {
@@ -538,7 +538,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         // process completed actions
-        long updatedNow = this.time.milliseconds();
+        long updatedNow = this.time.absoluteMilliseconds();
         List<ClientResponse> responses = new ArrayList<>();
         handleCompletedSends(responses, updatedNow);
         handleCompletedReceives(responses, updatedNow);
@@ -992,7 +992,7 @@ public class NetworkClient implements KafkaClient {
         public void handleAuthenticationFailure(AuthenticationException exception) {
             metadataFetchInProgress = false;
             if (metadata.updateRequested())
-                metadata.failedUpdate(time.milliseconds(), exception);
+                metadata.failedUpdate(time.absoluteMilliseconds(), exception);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -59,13 +59,13 @@ public final class NetworkClientUtils {
         if (timeoutMs < 0) {
             throw new IllegalArgumentException("Timeout needs to be greater than 0");
         }
-        long startTime = time.milliseconds();
+        long startTime = time.absoluteMilliseconds();
         long expiryTime = startTime + timeoutMs;
 
         if (isReady(client, node, startTime) ||  client.ready(node, startTime))
             return true;
 
-        long attemptStartTime = time.milliseconds();
+        long attemptStartTime = time.absoluteMilliseconds();
         while (!client.isReady(node, attemptStartTime) && attemptStartTime < expiryTime) {
             if (client.connectionFailed(node)) {
                 throw new IOException("Connection to " + node + " failed.");
@@ -74,7 +74,7 @@ public final class NetworkClientUtils {
             client.poll(pollTimeout, attemptStartTime);
             if (client.authenticationException(node) != null)
                 throw client.authenticationException(node);
-            attemptStartTime = time.milliseconds();
+            attemptStartTime = time.absoluteMilliseconds();
         }
         return client.isReady(node, attemptStartTime);
     }
@@ -91,9 +91,9 @@ public final class NetworkClientUtils {
      */
     public static ClientResponse sendAndReceive(KafkaClient client, ClientRequest request, Time time) throws IOException {
         try {
-            client.send(request, time.milliseconds());
+            client.send(request, time.absoluteMilliseconds());
             while (client.active()) {
-                List<ClientResponse> responses = client.poll(Long.MAX_VALUE, time.milliseconds());
+                List<ClientResponse> responses = client.poll(Long.MAX_VALUE, time.absoluteMilliseconds());
                 for (ClientResponse response : responses) {
                     if (response.requestHeader().correlationId() == request.correlationId()) {
                         if (response.wasDisconnected()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -716,7 +716,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     true, false, clusterResourceListeners);
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
-            this.metadata.bootstrap(addresses, time.milliseconds());
+            this.metadata.bootstrap(addresses, time.absoluteMilliseconds());
             String metricGrpPrefix = "consumer";
             ConsumerMetrics metricsRegistry = new ConsumerMetrics(metricsTags.keySet(), "consumer");
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time);
@@ -1081,7 +1081,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 // make sure the offsets of topic partitions the consumer is unsubscribing from
                 // are committed since there will be no following rebalance
                 if (coordinator != null)
-                    this.coordinator.maybeAutoCommitOffsetsAsync(time.milliseconds());
+                    this.coordinator.maybeAutoCommitOffsetsAsync(time.absoluteMilliseconds());
 
                 log.debug("Subscribed to partition(s): {}", Utils.join(partitions, ", "));
                 this.subscriptions.assignFromUser(new HashSet<>(partitions));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -995,7 +995,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         }
 
                         client.pollNoWakeup();
-                        long now = time.milliseconds();
+                        long now = time.absoluteMilliseconds();
 
                         if (coordinatorUnknown()) {
                             if (findCoordinatorFuture != null || lookupCoordinator().failed())

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -329,7 +329,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                     // reduce the number of rebalances caused by single topic creation by asking consumer to
                     // refresh metadata before re-joining the group as long as the refresh backoff time has
                     // passed.
-                    if (this.metadata.timeToAllowUpdate(time.milliseconds()) == 0) {
+                    if (this.metadata.timeToAllowUpdate(time.absoluteMilliseconds()) == 0) {
                         this.metadata.requestUpdate();
                     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -121,7 +121,7 @@ public class ConsumerNetworkClient implements Closeable {
     public RequestFuture<ClientResponse> send(Node node,
                                               AbstractRequest.Builder<?> requestBuilder,
                                               int requestTimeoutMs) {
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         RequestFutureCompletionHandler completionHandler = new RequestFutureCompletionHandler();
         ClientRequest clientRequest = client.newClientRequest(node.idString(), requestBuilder, now, true,
                 requestTimeoutMs, completionHandler);
@@ -135,7 +135,7 @@ public class ConsumerNetworkClient implements Closeable {
     public Node leastLoadedNode() {
         lock.lock();
         try {
-            return client.leastLoadedNode(time.milliseconds());
+            return client.leastLoadedNode(time.absoluteMilliseconds());
         } finally {
             lock.unlock();
         }
@@ -516,7 +516,7 @@ public class ConsumerNetworkClient implements Closeable {
     public boolean isUnavailable(Node node) {
         lock.lock();
         try {
-            return client.connectionFailed(node) && client.connectionDelay(node, time.milliseconds()) > 0;
+            return client.connectionFailed(node) && client.connectionDelay(node, time.absoluteMilliseconds()) > 0;
         } finally {
             lock.unlock();
         }
@@ -545,7 +545,7 @@ public class ConsumerNetworkClient implements Closeable {
     public void tryConnect(Node node) {
         lock.lock();
         try {
-            client.ready(node, time.milliseconds());
+            client.ready(node, time.absoluteMilliseconds());
         } finally {
             lock.unlock();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -70,12 +70,12 @@ public final class Heartbeat {
     }
 
     public void failHeartbeat() {
-        update(time.milliseconds());
+        update(time.absoluteMilliseconds());
         heartbeatTimer.reset(retryBackoffMs);
     }
 
     public void receiveHeartbeat() {
-        update(time.milliseconds());
+        update(time.absoluteMilliseconds());
         sessionTimer.reset(sessionTimeoutMs);
     }
 
@@ -99,14 +99,14 @@ public final class Heartbeat {
     }
 
     public void resetTimeouts() {
-        update(time.milliseconds());
+        update(time.absoluteMilliseconds());
         sessionTimer.reset(sessionTimeoutMs);
         pollTimer.reset(maxPollIntervalMs);
         heartbeatTimer.reset(heartbeatIntervalMs);
     }
 
     public void resetSessionTimeout() {
-        update(time.milliseconds());
+        update(time.absoluteMilliseconds());
         sessionTimer.reset(sessionTimeoutMs);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -416,7 +416,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             } else {
                 this.metadata = new Metadata(retryBackoffMs, config.getLong(ProducerConfig.METADATA_MAX_AGE_CONFIG),
                     true, true, clusterResourceListeners);
-                this.metadata.bootstrap(addresses, time.milliseconds());
+                this.metadata.bootstrap(addresses, time.absoluteMilliseconds());
             }
             this.errors = this.metrics.sensor("errors");
             this.sender = newSender(logContext, kafkaClient, this.metadata);
@@ -893,7 +893,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             int serializedSize = AbstractRecords.estimateSizeInBytesUpperBound(apiVersions.maxUsableProduceMagic(),
                     compressionType, serializedKey, serializedValue, headers);
             ensureValidRecordSize(serializedSize);
-            long timestamp = record.timestamp() == null ? time.milliseconds() : record.timestamp();
+            long timestamp = record.timestamp() == null ? time.absoluteMilliseconds() : record.timestamp();
             log.trace("Sending record {} with callback {} to topic {} partition {}", record, callback, record.topic(), partition);
             // producer callback will make sure to call both 'callback' and interceptor callback
             Callback interceptCallback = new InterceptorCallback<>(callback, this.interceptors, tp);
@@ -967,7 +967,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         if (partitionsCount != null && (partition == null || partition < partitionsCount))
             return new ClusterAndWaitTime(cluster, 0);
 
-        long begin = time.milliseconds();
+        long begin = time.absoluteMilliseconds();
         long remainingWaitMs = maxWaitMs;
         long elapsed;
         // Issue metadata requests until we have metadata for the topic or maxWaitTimeMs is exceeded.
@@ -986,7 +986,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 throw new TimeoutException("Failed to update metadata after " + maxWaitMs + " ms.");
             }
             cluster = metadata.fetch();
-            elapsed = time.milliseconds() - begin;
+            elapsed = time.absoluteMilliseconds() - begin;
             if (elapsed >= maxWaitMs)
                 throw new TimeoutException("Failed to update metadata after " + maxWaitMs + " ms.");
             if (cluster.unauthorizedTopics().contains(topic))

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -127,13 +127,13 @@ public class BufferPool {
                     // loop over and over until we have a buffer or have reserved
                     // enough memory to allocate one
                     while (accumulated < size) {
-                        long startWaitNs = time.nanoseconds();
+                        long startWaitNs = time.relativeNanoseconds();
                         long timeNs;
                         boolean waitingTimeElapsed;
                         try {
                             waitingTimeElapsed = !moreMemory.await(remainingTimeToBlockNs, TimeUnit.NANOSECONDS);
                         } finally {
-                            long endWaitNs = time.nanoseconds();
+                            long endWaitNs = time.relativeNanoseconds();
                             timeNs = Math.max(0L, endWaitNs - startWaitNs);
                             recordWaitTime(timeNs);
                         }
@@ -187,7 +187,7 @@ public class BufferPool {
 
     // Protected for testing
     protected void recordWaitTime(long timeNs) {
-        this.waitTime.record(timeNs, time.milliseconds());
+        this.waitTime.record(timeNs, time.absoluteMilliseconds());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/FutureRecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/FutureRecordMetadata.java
@@ -70,14 +70,14 @@ public final class FutureRecordMetadata implements Future<RecordMetadata> {
     @Override
     public RecordMetadata get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         // Handle overflow.
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         long timeoutMillis = unit.toMillis(timeout);
         long deadline = Long.MAX_VALUE - timeoutMillis < now ? Long.MAX_VALUE : now + timeoutMillis;
         boolean occurred = this.result.await(timeout, unit);
         if (!occurred)
             throw new TimeoutException("Timeout after waiting for " + timeoutMillis + " ms.");
         if (nextRecordMetadata != null)
-            return nextRecordMetadata.get(deadline - time.milliseconds(), TimeUnit.MILLISECONDS);
+            return nextRecordMetadata.get(deadline - time.absoluteMilliseconds(), TimeUnit.MILLISECONDS);
         return valueOrError();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -220,8 +220,8 @@ public final class RecordAccumulator {
                 }
 
                 MemoryRecordsBuilder recordsBuilder = recordsBuilder(buffer, maxUsableMagic);
-                ProducerBatch batch = new ProducerBatch(tp, recordsBuilder, time.milliseconds());
-                FutureRecordMetadata future = Utils.notNull(batch.tryAppend(timestamp, key, value, headers, callback, time.milliseconds()));
+                ProducerBatch batch = new ProducerBatch(tp, recordsBuilder, time.absoluteMilliseconds());
+                FutureRecordMetadata future = Utils.notNull(batch.tryAppend(timestamp, key, value, headers, callback, time.absoluteMilliseconds()));
 
                 dq.addLast(batch);
                 incomplete.add(batch);
@@ -257,7 +257,7 @@ public final class RecordAccumulator {
                                          Callback callback, Deque<ProducerBatch> deque) {
         ProducerBatch last = deque.peekLast();
         if (last != null) {
-            FutureRecordMetadata future = last.tryAppend(timestamp, key, value, headers, callback, time.milliseconds());
+            FutureRecordMetadata future = last.tryAppend(timestamp, key, value, headers, callback, time.absoluteMilliseconds());
             if (future == null)
                 last.closeForRecordAppends();
             else

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -230,7 +230,7 @@ public class Sender implements Runnable {
         // main loop, runs until close is called
         while (running) {
             try {
-                run(time.milliseconds());
+                run(time.absoluteMilliseconds());
             } catch (Exception e) {
                 log.error("Uncaught error in kafka producer I/O thread: ", e);
             }
@@ -243,7 +243,7 @@ public class Sender implements Runnable {
         // wait until these are completed.
         while (!forceClose && (this.accumulator.hasUndrained() || this.client.inFlightRequestCount() > 0)) {
             try {
-                run(time.milliseconds());
+                run(time.absoluteMilliseconds());
             } catch (Exception e) {
                 log.error("Uncaught error in kafka producer I/O thread: ", e);
             }
@@ -479,12 +479,12 @@ public class Sender implements Runnable {
     private ClientResponse sendAndAwaitInitProducerIdRequest(Node node) throws IOException {
         String nodeId = node.idString();
         InitProducerIdRequest.Builder builder = new InitProducerIdRequest.Builder(null);
-        ClientRequest request = client.newClientRequest(nodeId, builder, time.milliseconds(), true, requestTimeoutMs, null);
+        ClientRequest request = client.newClientRequest(nodeId, builder, time.absoluteMilliseconds(), true, requestTimeoutMs, null);
         return NetworkClientUtils.sendAndReceive(client, request, time);
     }
 
     private Node awaitLeastLoadedNodeReady(long remainingTimeMs) throws IOException {
-        Node node = client.leastLoadedNode(time.milliseconds());
+        Node node = client.leastLoadedNode(time.absoluteMilliseconds());
         if (node != null && NetworkClientUtils.awaitReady(client, node, time, remainingTimeMs)) {
             return node;
         }
@@ -781,7 +781,7 @@ public class Sender implements Runnable {
                 produceRecordsByPartition, transactionalId);
         RequestCompletionHandler callback = new RequestCompletionHandler() {
             public void onComplete(ClientResponse response) {
-                handleProduceResponse(response, recordsByPartition, time.milliseconds());
+                handleProduceResponse(response, recordsByPartition, time.absoluteMilliseconds());
             }
         };
 
@@ -902,7 +902,7 @@ public class Sender implements Runnable {
         }
 
         public void updateProduceRequestMetrics(Map<Integer, List<ProducerBatch>> batches) {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
             for (List<ProducerBatch> nodeBatch : batches.values()) {
                 int records = 0;
                 for (ProducerBatch batch : nodeBatch) {
@@ -937,7 +937,7 @@ public class Sender implements Runnable {
         }
 
         public void recordRetries(String topic, int count) {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
             this.retrySensor.record(count, now);
             String topicRetryName = "topic." + topic + ".record-retries";
             Sensor topicRetrySensor = this.metrics.getSensor(topicRetryName);
@@ -946,7 +946,7 @@ public class Sender implements Runnable {
         }
 
         public void recordErrors(String topic, int count) {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
             this.errorSensor.record(count, now);
             String topicErrorName = "topic." + topic + ".record-errors";
             Sensor topicErrorSensor = this.metrics.getSensor(topicErrorName);
@@ -955,7 +955,7 @@ public class Sender implements Runnable {
         }
 
         public void recordLatency(String node, long latency) {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
             this.requestTimeSensor.record(latency, now);
             if (!node.isEmpty()) {
                 String nodeTimeName = "node-" + node + ".latency";

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -55,12 +55,12 @@ public final class KafkaMetric implements Metric {
     @Override
     @Deprecated
     public double value() {
-        return measurableValue(time.milliseconds());
+        return measurableValue(time.absoluteMilliseconds());
     }
 
     @Override
     public Object metricValue() {
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         synchronized (this.lock) {
             if (this.metricValueProvider instanceof Measurable)
                 return ((Measurable) metricValueProvider).measure(config, now);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -112,7 +112,7 @@ public final class Sensor {
         this.config = config;
         this.time = time;
         this.inactiveSensorExpirationTimeMs = TimeUnit.MILLISECONDS.convert(inactiveSensorExpirationTimeSeconds, TimeUnit.SECONDS);
-        this.lastRecordTime = time.milliseconds();
+        this.lastRecordTime = time.absoluteMilliseconds();
         this.recordingLevel = recordingLevel;
         this.metricLock = new Object();
         checkForest(new HashSet<Sensor>());
@@ -156,7 +156,7 @@ public final class Sensor {
      */
     public void record(double value) {
         if (shouldRecord()) {
-            record(value, time.milliseconds());
+            record(value, time.absoluteMilliseconds());
         }
     }
 
@@ -193,7 +193,7 @@ public final class Sensor {
      * Check if we have violated our quota for any metric that has a configured quota
      */
     public void checkQuotas() {
-        checkQuotas(time.milliseconds());
+        checkQuotas(time.absoluteMilliseconds());
     }
 
     public void checkQuotas(long timeMs) {
@@ -287,7 +287,7 @@ public final class Sensor {
      *        false otherwise
      */
     public boolean hasExpired() {
-        return (time.milliseconds() - this.lastRecordTime) > this.inactiveSensorExpirationTimeMs;
+        return (time.absoluteMilliseconds() - this.lastRecordTime) > this.inactiveSensorExpirationTimeMs;
     }
 
     synchronized List<KafkaMetric> metrics() {

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
@@ -43,7 +43,7 @@ public class RecordsUtil {
         // maintain the batch along with the decompressed records to avoid the need to decompress again
         List<RecordBatchAndRecords> recordBatchAndRecordsList = new ArrayList<>();
         int totalSizeEstimate = 0;
-        long startNanos = time.nanoseconds();
+        long startNanos = time.relativeNanoseconds();
 
         for (RecordBatch batch : batches) {
             if (toMagic < RecordBatch.MAGIC_VALUE_V2) {
@@ -94,7 +94,7 @@ public class RecordsUtil {
 
         buffer.flip();
         RecordConversionStats stats = new RecordConversionStats(temporaryMemoryBytes, numRecordsConverted,
-                time.nanoseconds() - startNanos);
+                time.relativeNanoseconds() - startNanos);
         return new ConvertedRecords<>(MemoryRecords.readableRecords(buffer), stats);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -347,7 +347,7 @@ public class SaslClientAuthenticator implements Authenticator {
             this.saslState = saslState;
             LOG.debug("Set SASL client state to {}", saslState);
             if (saslState == SaslState.COMPLETE) {
-                reauthInfo.setAuthenticationEndAndSessionReauthenticationTimes(time.nanoseconds());
+                reauthInfo.setAuthenticationEndAndSessionReauthenticationTimes(time.relativeNanoseconds());
                 if (!reauthInfo.reauthenticating())
                     transportLayer.removeInterestOps(SelectionKey.OP_WRITE);
                 else

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -655,8 +655,8 @@ public class SaslServerAuthenticator implements Authenticator {
 
         private long calcCompletionTimesAndReturnSessionLifetimeMs() {
             long retvalSessionLifetimeMs = 0L;
-            long authenticationEndMs = time.milliseconds();
-            authenticationEndNanos = time.nanoseconds();
+            long authenticationEndMs = time.absoluteMilliseconds();
+            authenticationEndNanos = time.relativeNanoseconds();
             Long credentialExpirationMs = (Long) saslServer
                     .getNegotiatedProperty(SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY);
             Long connectionsMaxReauthMs = connectionsMaxReauthMsByMechanism.get(saslMechanism);

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -371,11 +371,11 @@ public class KerberosLogin extends AbstractLogin {
     }
 
     private long currentElapsedTime() {
-        return time.hiResClockMs();
+        return time.relativeMilliseconds();
     }
 
     private long currentWallTime() {
-        return time.milliseconds();
+        return time.absoluteMilliseconds();
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
@@ -420,7 +420,7 @@ public abstract class ExpiringCredentialRefreshingLogin implements AutoCloseable
     }
 
     private long currentMs() {
-        return time.milliseconds();
+        return time.absoluteMilliseconds();
     }
 
     private boolean isLogoutRequiredBeforeLoggingBackIn() {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
@@ -203,7 +203,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandler implements AuthenticateCal
         String claimsJson;
         try {
             claimsJson = String.format("{%s,%s%s}", expClaimText(Long.parseLong(lifetimeSecondsValueToUse)),
-                    claimOrHeaderJsonText("iat", time.milliseconds() / 1000.0),
+                    claimOrHeaderJsonText("iat", time.absoluteMilliseconds() / 1000.0),
                     commaPrependedStringNumberAndListClaimsJsonText());
         } catch (NumberFormatException e) {
             throw new OAuthBearerConfigException(e.getMessage());
@@ -341,6 +341,6 @@ public class OAuthBearerUnsecuredLoginCallbackHandler implements AuthenticateCal
     }
 
     private String expClaimText(long lifetimeSeconds) {
-        return claimOrHeaderJsonText("exp", time.milliseconds() / 1000.0 + lifetimeSeconds);
+        return claimOrHeaderJsonText("exp", time.absoluteMilliseconds() / 1000.0 + lifetimeSeconds);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandler.java
@@ -160,7 +160,7 @@ public class OAuthBearerUnsecuredValidatorCallbackHandler implements Authenticat
         int allowableClockSkewMs = allowableClockSkewMs();
         OAuthBearerUnsecuredJws unsecuredJwt = new OAuthBearerUnsecuredJws(tokenValue, principalClaimName,
                 scopeClaimName);
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         OAuthBearerValidationUtils
                 .validateClaimForExistenceAndType(unsecuredJwt, true, principalClaimName, String.class)
                 .throwExceptionIfFailed();

--- a/clients/src/main/java/org/apache/kafka/common/utils/SystemTime.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SystemTime.java
@@ -23,12 +23,12 @@ package org.apache.kafka.common.utils;
 public class SystemTime implements Time {
 
     @Override
-    public long milliseconds() {
+    public long absoluteMilliseconds() {
         return System.currentTimeMillis();
     }
 
     @Override
-    public long nanoseconds() {
+    public long relativeNanoseconds() {
         return System.nanoTime();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Time.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Time.java
@@ -29,15 +29,25 @@ public interface Time {
     Time SYSTEM = new SystemTime();
 
     /**
-     * Returns the current time in milliseconds.
+     * Returns the number of milliseconds since midnight UTC on 1/1/1970.
+     *
+     * This value is likely less precise than relative time.
      */
-    long milliseconds();
+    long absoluteMilliseconds();
 
     /**
-     * Returns the value returned by `nanoseconds` converted into milliseconds.
+     * Returns the current value of the running JVM's high-resolution time source, rounded down to milliseconds.
+     *
+     * <p>This method can only be used to measure elapsed time and is
+     * not related to any other notion of system or wall-clock time.
+     * The value returned represents nanoseconds since some fixed but
+     * arbitrary <i>origin</i> time (perhaps in the future, so values
+     * may be negative).  The same origin is used by all invocations of
+     * this method in an instance of a Java virtual machine; other
+     * virtual machine instances are likely to use a different origin.
      */
-    default long hiResClockMs() {
-        return TimeUnit.NANOSECONDS.toMillis(nanoseconds());
+    default long relativeMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(relativeNanoseconds());
     }
 
     /**
@@ -51,7 +61,7 @@ public interface Time {
      * this method in an instance of a Java virtual machine; other
      * virtual machine instances are likely to use a different origin.
      */
-    long nanoseconds();
+    long relativeNanoseconds();
 
     /**
      * Sleep for the given number of milliseconds

--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -115,7 +115,7 @@ public class Timer {
      * the update will be ignored.
      */
     public void update() {
-        update(time.milliseconds());
+        update(time.absoluteMilliseconds());
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -72,18 +72,18 @@ public class InFlightRequestsTest {
     public void testTimedOutNodes() {
         Time time = new MockTime();
 
-        addRequest("A", time.milliseconds(), 50);
-        addRequest("B", time.milliseconds(), 200);
-        addRequest("B", time.milliseconds(), 100);
+        addRequest("A", time.absoluteMilliseconds(), 50);
+        addRequest("B", time.absoluteMilliseconds(), 200);
+        addRequest("B", time.absoluteMilliseconds(), 100);
 
         time.sleep(50);
-        assertEquals(Collections.emptyList(), inFlightRequests.nodesWithTimedOutRequests(time.milliseconds()));
+        assertEquals(Collections.emptyList(), inFlightRequests.nodesWithTimedOutRequests(time.absoluteMilliseconds()));
 
         time.sleep(25);
-        assertEquals(Collections.singletonList("A"), inFlightRequests.nodesWithTimedOutRequests(time.milliseconds()));
+        assertEquals(Collections.singletonList("A"), inFlightRequests.nodesWithTimedOutRequests(time.absoluteMilliseconds()));
 
         time.sleep(50);
-        assertEquals(Arrays.asList("A", "B"), inFlightRequests.nodesWithTimedOutRequests(time.milliseconds()));
+        assertEquals(Arrays.asList("A", "B"), inFlightRequests.nodesWithTimedOutRequests(time.absoluteMilliseconds()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -175,7 +175,7 @@ public class MockClient implements KafkaClient {
 
     @Override
     public void disconnect(String node) {
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         Iterator<ClientRequest> iter = requests.iterator();
         while (iter.hasNext()) {
             ClientRequest request = iter.next();
@@ -206,7 +206,7 @@ public class MockClient implements KafkaClient {
                 short version = nodeApiVersions.latestUsableVersion(request.apiKey(), builder.oldestAllowedVersion(),
                     builder.latestAllowedVersion());
                 ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
-                    request.createdTimeMs(), time.milliseconds(), true, null,
+                    request.createdTimeMs(), time.absoluteMilliseconds(), true, null,
                         new AuthenticationException("Authentication failed"), null);
                 responses.add(resp);
                 return;
@@ -231,7 +231,7 @@ public class MockClient implements KafkaClient {
                         request.apiKey() + " with version " + version);
 
             ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
-                    request.createdTimeMs(), time.milliseconds(), futureResp.disconnected,
+                    request.createdTimeMs(), time.absoluteMilliseconds(), futureResp.disconnected,
                     unsupportedVersionException, null, futureResp.responseBody);
             responses.add(resp);
             iterator.remove();
@@ -335,7 +335,7 @@ public class MockClient implements KafkaClient {
         requests.remove(clientRequest);
         short version = clientRequest.requestBuilder().latestAllowedVersion();
         responses.add(new ClientResponse(clientRequest.makeHeader(version), clientRequest.callback(), clientRequest.destination(),
-                clientRequest.createdTimeMs(), time.milliseconds(), false, null, null, response));
+                clientRequest.createdTimeMs(), time.absoluteMilliseconds(), false, null, null, response));
     }
 
 
@@ -345,7 +345,7 @@ public class MockClient implements KafkaClient {
         ClientRequest request = requests.poll();
         short version = request.requestBuilder().latestAllowedVersion();
         responses.add(new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
-                request.createdTimeMs(), time.milliseconds(), disconnected, null, null, response));
+                request.createdTimeMs(), time.absoluteMilliseconds(), disconnected, null, null, response));
     }
 
     public void respondFrom(AbstractResponse response, Node node) {
@@ -360,7 +360,7 @@ public class MockClient implements KafkaClient {
                 iterator.remove();
                 short version = request.requestBuilder().latestAllowedVersion();
                 responses.add(new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
-                        request.createdTimeMs(), time.milliseconds(), disconnected, null, null, response));
+                        request.createdTimeMs(), time.absoluteMilliseconds(), disconnected, null, null, response));
                 return;
             }
         }
@@ -588,7 +588,7 @@ public class MockClient implements KafkaClient {
         }
 
         boolean contains(T element) {
-            return contains(element, time.milliseconds());
+            return contains(element, time.absoluteMilliseconds());
         }
 
         boolean contains(T element, long now) {
@@ -596,7 +596,7 @@ public class MockClient implements KafkaClient {
         }
 
         void add(T element, long durationMs) {
-            elements.put(element, time.milliseconds() + durationMs);
+            elements.put(element, time.absoluteMilliseconds() + durationMs);
         }
 
         long expirationDelayMs(T element, long now) {
@@ -667,7 +667,7 @@ public class MockClient implements KafkaClient {
                         + "Expected topics: " + update.topics()
                         + ", asked topics: " + metadata.topics());
             }
-            metadata.update(update.updateResponse, time.milliseconds());
+            metadata.update(update.updateResponse, time.absoluteMilliseconds());
             this.lastUpdate = update;
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
@@ -81,7 +81,7 @@ public class AdminClientUnitTestEnv implements AutoCloseable {
             }
         });
 
-        metadataManager.update(cluster, time.milliseconds());
+        metadataManager.update(cluster, time.absoluteMilliseconds());
         this.adminClient = KafkaAdminClient.createInternal(adminClientConfig, metadataManager, mockClient, time);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -321,12 +321,12 @@ public class KafkaAdminClientTest {
             AtomicLong secondAttemptTime = new AtomicLong(0);
 
             mockClient.prepareResponse(body -> {
-                firstAttemptTime.set(time.milliseconds());
+                firstAttemptTime.set(time.absoluteMilliseconds());
                 return body instanceof CreateTopicsRequest;
             }, null, true);
 
             mockClient.prepareResponse(body -> {
-                secondAttemptTime.set(time.milliseconds());
+                secondAttemptTime.set(time.absoluteMilliseconds());
                 return body instanceof CreateTopicsRequest;
             }, new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
@@ -46,43 +46,43 @@ public class AdminMetadataManagerTest {
     public void testMetadataReady() {
         // Metadata is not ready on initialization
         assertFalse(mgr.isReady());
-        assertEquals(0, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(0, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
         // Metadata is not ready when bootstrap servers are set
         mgr.update(Cluster.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 9999))),
-                time.milliseconds());
+                time.absoluteMilliseconds());
         assertFalse(mgr.isReady());
-        assertEquals(0, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(0, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
-        mgr.update(mockCluster(), time.milliseconds());
+        mgr.update(mockCluster(), time.absoluteMilliseconds());
         assertTrue(mgr.isReady());
-        assertEquals(metadataExpireMs, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(metadataExpireMs, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
         time.sleep(metadataExpireMs);
-        assertEquals(0, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(0, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testMetadataRefreshBackoff() {
-        mgr.transitionToUpdatePending(time.milliseconds());
-        assertEquals(Long.MAX_VALUE, mgr.metadataFetchDelayMs(time.milliseconds()));
+        mgr.transitionToUpdatePending(time.absoluteMilliseconds());
+        assertEquals(Long.MAX_VALUE, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
         mgr.updateFailed(new RuntimeException());
-        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
         // Even if we explicitly request an update, the backoff should be respected
         mgr.requestUpdate();
-        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
 
         time.sleep(refreshBackoffMs);
-        assertEquals(0, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(0, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testAuthenticationFailure() {
-        mgr.transitionToUpdatePending(time.milliseconds());
+        mgr.transitionToUpdatePending(time.absoluteMilliseconds());
         mgr.updateFailed(new AuthenticationException("Authentication failed"));
-        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
+        assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.absoluteMilliseconds()));
         try {
             mgr.isReady();
             fail("Expected AuthenticationException to be thrown");
@@ -90,7 +90,7 @@ public class AdminMetadataManagerTest {
             // Expected
         }
 
-        mgr.update(mockCluster(), time.milliseconds());
+        mgr.update(mockCluster(), time.absoluteMilliseconds());
         assertTrue(mgr.isReady());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -423,7 +423,7 @@ public class KafkaConsumerTest {
 
         // respond to the outstanding fetch so that we have data available on the next poll
         client.respondFrom(fetchResponse(tp0, 0, 5), node);
-        client.poll(0, time.milliseconds());
+        client.poll(0, time.absoluteMilliseconds());
 
         client.prepareResponseFrom(fetchResponse(tp0, 5, 0), node);
         AtomicBoolean heartbeatReceived = prepareHeartbeatResponse(client, coordinator);
@@ -688,7 +688,7 @@ public class KafkaConsumerTest {
 
         // respond to the outstanding fetch so that we have data available on the next poll
         client.respondFrom(fetchResponse(tp0, 0, 5), node);
-        client.poll(0, time.milliseconds());
+        client.poll(0, time.absoluteMilliseconds());
 
         time.sleep(autoCommitIntervalMs);
 
@@ -789,7 +789,7 @@ public class KafkaConsumerTest {
 
         // respond to the outstanding fetch so that we have data available on the next poll
         client.respondFrom(fetchResponse(tp0, 0, 5), node);
-        client.poll(0, time.milliseconds());
+        client.poll(0, time.absoluteMilliseconds());
 
         consumer.wakeup();
 
@@ -925,7 +925,7 @@ public class KafkaConsumerTest {
         fetches1.put(tp0, new FetchInfo(0, 1));
         fetches1.put(t2p0, new FetchInfo(0, 10));
         client.respondFrom(fetchResponse(fetches1), node);
-        client.poll(0, time.milliseconds());
+        client.poll(0, time.absoluteMilliseconds());
 
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1));
 
@@ -933,7 +933,7 @@ public class KafkaConsumerTest {
         fetches1.put(tp0, new FetchInfo(1, 0));
         fetches1.put(t2p0, new FetchInfo(10, 0));
         client.respondFrom(fetchResponse(fetches1), node);
-        client.poll(0, time.milliseconds());
+        client.poll(0, time.absoluteMilliseconds());
 
         // verify that the fetch occurred as expected
         assertEquals(11, records.count());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -111,9 +111,9 @@ public class AbstractCoordinatorTest {
         // after backing off, we should be able to connect.
         mockClient.blackout(coordinatorNode, 10L);
 
-        long initialTime = mockTime.milliseconds();
+        long initialTime = mockTime.absoluteMilliseconds();
         coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE));
-        long endTime = mockTime.milliseconds();
+        long endTime = mockTime.absoluteMilliseconds();
 
         assertTrue(endTime - initialTime >= RETRY_BACKOFF_MS);
     }
@@ -202,7 +202,7 @@ public class AbstractCoordinatorTest {
             long startMs = System.currentTimeMillis();
             while (System.currentTimeMillis() - startMs < 1000) {
                 Thread.sleep(10);
-                coordinator.pollHeartbeat(mockTime.milliseconds());
+                coordinator.pollHeartbeat(mockTime.absoluteMilliseconds());
             }
             fail("Expected pollHeartbeat to raise an error in 1 second");
         } catch (RuntimeException exception) {
@@ -230,7 +230,7 @@ public class AbstractCoordinatorTest {
         }, heartbeatResponse(Errors.NONE));
 
         mockTime.sleep(HEARTBEAT_INTERVAL_MS);
-        coordinator.pollHeartbeat(mockTime.milliseconds());
+        coordinator.pollHeartbeat(mockTime.absoluteMilliseconds());
 
         if (!heartbeatDone.await(1, TimeUnit.SECONDS)) {
             fail("Should have received a heartbeat request after calling pollHeartbeat");

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -654,10 +654,10 @@ public class ConsumerCoordinatorTest {
 
         assertTrue(coordinator.coordinatorUnknown());
         assertFalse(coordinator.poll(time.timer(0)));
-        assertEquals(time.milliseconds(), heartbeat.lastPollTime());
+        assertEquals(time.absoluteMilliseconds(), heartbeat.lastPollTime());
 
         time.sleep(rebalanceTimeoutMs - 1);
-        assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertFalse(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
     }
 
     @Test
@@ -864,7 +864,7 @@ public class ConsumerCoordinatorTest {
         assertFalse(coordinator.rejoinNeededOrPending());
 
         // a new partition is added to the topic
-        metadata.update(TestUtils.metadataUpdateWith(1, singletonMap(topic1, 2)), time.milliseconds());
+        metadata.update(TestUtils.metadataUpdateWith(1, singletonMap(topic1, 2)), time.absoluteMilliseconds());
 
         // we should detect the change and ask for reassignment
         assertTrue(coordinator.rejoinNeededOrPending());
@@ -1680,7 +1680,7 @@ public class ConsumerCoordinatorTest {
         coordinator.refreshCommittedOffsetsIfNeeded(time.timer(Long.MAX_VALUE));
 
         assertEquals(Collections.singleton(t1p), subscriptions.missingFetchPositions());
-        assertEquals(Collections.emptySet(), subscriptions.partitionsNeedingReset(time.milliseconds()));
+        assertEquals(Collections.emptySet(), subscriptions.partitionsNeedingReset(time.absoluteMilliseconds()));
         assertFalse(subscriptions.hasAllFetchPositions());
         assertEquals(null, subscriptions.position(t1p));
     }
@@ -1709,7 +1709,7 @@ public class ConsumerCoordinatorTest {
 
         assertEquals(Collections.emptySet(), subscriptions.missingFetchPositions());
         assertFalse(subscriptions.hasAllFetchPositions());
-        assertEquals(Collections.singleton(t1p), subscriptions.partitionsNeedingReset(time.milliseconds()));
+        assertEquals(Collections.singleton(t1p), subscriptions.partitionsNeedingReset(time.absoluteMilliseconds()));
         assertEquals(OffsetResetStrategy.EARLIEST, subscriptions.resetStrategy(t1p));
         assertTrue(coordinator.coordinatorUnknown());
     }
@@ -1915,7 +1915,7 @@ public class ConsumerCoordinatorTest {
 
         // async commit offset should find coordinator
         time.sleep(autoCommitIntervalMs); // sleep for a while to ensure auto commit does happen
-        coordinator.maybeAutoCommitOffsetsAsync(time.milliseconds());
+        coordinator.maybeAutoCommitOffsetsAsync(time.absoluteMilliseconds());
         assertFalse(coordinator.coordinatorUnknown());
         assertEquals(100L, subscriptions.position(t1p).longValue());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -341,7 +341,7 @@ public class FetcherTest {
         builder.append(0L, "key".getBytes(), null);
         builder.close();
 
-        MemoryRecords.writeEndTransactionalMarker(buffer, 1L, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+        MemoryRecords.writeEndTransactionalMarker(buffer, 1L, time.absoluteMilliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
                 new EndTransactionMarker(ControlRecordType.ABORT, 0));
 
         buffer.flip();
@@ -852,7 +852,7 @@ public class FetcherTest {
         client.prepareResponse(fullFetchResponse(tp0, this.records, Errors.NOT_LEADER_FOR_PARTITION, 100L, 0));
         consumerClient.poll(time.timer(0));
         assertEquals(0, fetcher.fetchedRecords().size());
-        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+        assertEquals(0L, metadata.timeToNextUpdate(time.absoluteMilliseconds()));
     }
 
     @Test
@@ -864,7 +864,7 @@ public class FetcherTest {
         client.prepareResponse(fullFetchResponse(tp0, this.records, Errors.UNKNOWN_TOPIC_OR_PARTITION, 100L, 0));
         consumerClient.poll(time.timer(0));
         assertEquals(0, fetcher.fetchedRecords().size());
-        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+        assertEquals(0L, metadata.timeToNextUpdate(time.absoluteMilliseconds()));
     }
 
     @Test
@@ -1553,25 +1553,25 @@ public class FetcherTest {
         short apiVersionsResponseVersion = ApiKeys.API_VERSIONS.latestVersion();
         ByteBuffer buffer = ApiVersionsResponse.createApiVersionsResponse(400, RecordBatch.CURRENT_MAGIC_VALUE).serialize(apiVersionsResponseVersion, new ResponseHeader(0));
         selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
-        while (!client.ready(node, time.milliseconds())) {
-            client.poll(1, time.milliseconds());
+        while (!client.ready(node, time.absoluteMilliseconds())) {
+            client.poll(1, time.absoluteMilliseconds());
             // If a throttled response is received, advance the time to ensure progress.
-            time.sleep(client.throttleDelayMs(node, time.milliseconds()));
+            time.sleep(client.throttleDelayMs(node, time.absoluteMilliseconds()));
         }
         selector.clear();
 
         for (int i = 1; i <= 3; i++) {
             int throttleTimeMs = 100 * i;
             FetchRequest.Builder builder = FetchRequest.Builder.forConsumer(100, 100, new LinkedHashMap<>());
-            ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
-            client.send(request, time.milliseconds());
-            client.poll(1, time.milliseconds());
+            ClientRequest request = client.newClientRequest(node.idString(), builder, time.absoluteMilliseconds(), true);
+            client.send(request, time.absoluteMilliseconds());
+            client.poll(1, time.absoluteMilliseconds());
             FetchResponse response = fullFetchResponse(tp0, nextRecords, Errors.NONE, i, throttleTimeMs);
             buffer = response.serialize(ApiKeys.FETCH.latestVersion(), new ResponseHeader(request.correlationId()));
             selector.completeReceive(new NetworkReceive(node.idString(), buffer));
-            client.poll(1, time.milliseconds());
+            client.poll(1, time.absoluteMilliseconds());
             // If a throttled response is received, advance the time to ensure progress.
-            time.sleep(client.throttleDelayMs(node, time.milliseconds()));
+            time.sleep(client.throttleDelayMs(node, time.absoluteMilliseconds()));
             selector.clear();
         }
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
@@ -2011,8 +2011,8 @@ public class FetcherTest {
         int currentOffset = 0;
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()));
 
         abortTransaction(buffer, 1L, currentOffset);
 
@@ -2045,8 +2045,8 @@ public class FetcherTest {
         int currentOffset = 0;
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()));
 
         currentOffset += commitTransaction(buffer, 1L, currentOffset);
         buffer.flip();
@@ -2161,16 +2161,16 @@ public class FetcherTest {
         int currentOffset = 0;
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "abort1-1".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "abort1-2".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "abort1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "abort1-2".getBytes(), "value".getBytes()));
 
         currentOffset += abortTransaction(buffer, 1L, currentOffset);
         // Duplicate abort -- should be ignored.
         currentOffset += abortTransaction(buffer, 1L, currentOffset);
         // Now commit a transaction.
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "commit1-1".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "commit1-2".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "commit1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "commit1-2".getBytes(), "value".getBytes()));
         commitTransaction(buffer, 1L, currentOffset);
         buffer.flip();
 
@@ -2383,8 +2383,8 @@ public class FetcherTest {
         int currentOffset = 0;
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()));
 
         abortTransaction(buffer, 1L, currentOffset);
 
@@ -2417,8 +2417,8 @@ public class FetcherTest {
         long currentOffset = 0;
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "abort1-1".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "abort1-2".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "abort1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "abort1-2".getBytes(), "value".getBytes()));
 
         currentOffset += abortTransaction(buffer, 1L, currentOffset);
         buffer.flip();
@@ -2653,12 +2653,12 @@ public class FetcherTest {
         // Empty control batch should not cause an exception
         DefaultRecordBatch.writeEmptyHeader(buffer, RecordBatch.MAGIC_VALUE_V2, 1L,
                 (short) 0, -1, 0, 0,
-                RecordBatch.NO_PARTITION_LEADER_EPOCH, TimestampType.CREATE_TIME, time.milliseconds(),
+                RecordBatch.NO_PARTITION_LEADER_EPOCH, TimestampType.CREATE_TIME, time.absoluteMilliseconds(),
                 true, true);
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
-                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.absoluteMilliseconds(), "key".getBytes(), "value".getBytes()));
 
         commitTransaction(buffer, 1L, currentOffset);
         buffer.flip();
@@ -2698,7 +2698,7 @@ public class FetcherTest {
 
     private int appendTransactionalRecords(ByteBuffer buffer, long pid, long baseOffset, int baseSequence, SimpleRecord... records) {
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
-                TimestampType.CREATE_TIME, baseOffset, time.milliseconds(), pid, (short) 0, baseSequence, true,
+                TimestampType.CREATE_TIME, baseOffset, time.absoluteMilliseconds(), pid, (short) 0, baseSequence, true,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH);
 
         for (SimpleRecord record : records) {
@@ -2715,7 +2715,7 @@ public class FetcherTest {
     private int commitTransaction(ByteBuffer buffer, long producerId, long baseOffset) {
         short producerEpoch = 0;
         int partitionLeaderEpoch = 0;
-        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.absoluteMilliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
                 new EndTransactionMarker(ControlRecordType.COMMIT, 0));
         return 1;
     }
@@ -2723,7 +2723,7 @@ public class FetcherTest {
     private int abortTransaction(ByteBuffer buffer, long producerId, long baseOffset) {
         short producerEpoch = 0;
         int partitionLeaderEpoch = 0;
-        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.absoluteMilliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
                 new EndTransactionMarker(ControlRecordType.ABORT, 0));
         return 1;
     }
@@ -2739,7 +2739,7 @@ public class FetcherTest {
         TopicPartition t2p0 = new TopicPartition(topicName2, 0);
         // Expect a metadata refresh.
         metadata.bootstrap(ClientUtils.parseAndValidateAddresses(Collections.singletonList("1.1.1.1:1111"),
-                ClientDnsLookup.DEFAULT), time.milliseconds());
+                ClientDnsLookup.DEFAULT), time.absoluteMilliseconds());
 
         Map<String, Integer> partitionNumByTopic = new HashMap<>();
         partitionNumByTopic.put(topicName, 2);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
@@ -36,72 +36,72 @@ public class HeartbeatTest {
 
     @Test
     public void testShouldHeartbeat() {
-        heartbeat.sentHeartbeat(time.milliseconds());
+        heartbeat.sentHeartbeat(time.absoluteMilliseconds());
         time.sleep((long) ((float) heartbeatIntervalMs * 1.1));
-        assertTrue(heartbeat.shouldHeartbeat(time.milliseconds()));
+        assertTrue(heartbeat.shouldHeartbeat(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testShouldNotHeartbeat() {
-        heartbeat.sentHeartbeat(time.milliseconds());
+        heartbeat.sentHeartbeat(time.absoluteMilliseconds());
         time.sleep(heartbeatIntervalMs / 2);
-        assertFalse(heartbeat.shouldHeartbeat(time.milliseconds()));
+        assertFalse(heartbeat.shouldHeartbeat(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testTimeToNextHeartbeat() {
-        heartbeat.sentHeartbeat(time.milliseconds());
-        assertEquals(heartbeatIntervalMs, heartbeat.timeToNextHeartbeat(time.milliseconds()));
+        heartbeat.sentHeartbeat(time.absoluteMilliseconds());
+        assertEquals(heartbeatIntervalMs, heartbeat.timeToNextHeartbeat(time.absoluteMilliseconds()));
 
         time.sleep(heartbeatIntervalMs);
-        assertEquals(0, heartbeat.timeToNextHeartbeat(time.milliseconds()));
+        assertEquals(0, heartbeat.timeToNextHeartbeat(time.absoluteMilliseconds()));
 
         time.sleep(heartbeatIntervalMs);
-        assertEquals(0, heartbeat.timeToNextHeartbeat(time.milliseconds()));
+        assertEquals(0, heartbeat.timeToNextHeartbeat(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testSessionTimeoutExpired() {
-        heartbeat.sentHeartbeat(time.milliseconds());
+        heartbeat.sentHeartbeat(time.absoluteMilliseconds());
         time.sleep(sessionTimeoutMs + 5);
-        assertTrue(heartbeat.sessionTimeoutExpired(time.milliseconds()));
+        assertTrue(heartbeat.sessionTimeoutExpired(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testResetSession() {
-        heartbeat.sentHeartbeat(time.milliseconds());
+        heartbeat.sentHeartbeat(time.absoluteMilliseconds());
         time.sleep(sessionTimeoutMs + 5);
         heartbeat.resetSessionTimeout();
-        assertFalse(heartbeat.sessionTimeoutExpired(time.milliseconds()));
+        assertFalse(heartbeat.sessionTimeoutExpired(time.absoluteMilliseconds()));
 
         // Resetting the session timeout should not reset the poll timeout
         time.sleep(maxPollIntervalMs + 1);
         heartbeat.resetSessionTimeout();
-        assertTrue(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertTrue(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testResetTimeouts() {
         time.sleep(maxPollIntervalMs);
-        assertTrue(heartbeat.sessionTimeoutExpired(time.milliseconds()));
-        assertEquals(0, heartbeat.timeToNextHeartbeat(time.milliseconds()));
-        assertTrue(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertTrue(heartbeat.sessionTimeoutExpired(time.absoluteMilliseconds()));
+        assertEquals(0, heartbeat.timeToNextHeartbeat(time.absoluteMilliseconds()));
+        assertTrue(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
 
         heartbeat.resetTimeouts();
-        assertFalse(heartbeat.sessionTimeoutExpired(time.milliseconds()));
-        assertEquals(heartbeatIntervalMs, heartbeat.timeToNextHeartbeat(time.milliseconds()));
-        assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertFalse(heartbeat.sessionTimeoutExpired(time.absoluteMilliseconds()));
+        assertEquals(heartbeatIntervalMs, heartbeat.timeToNextHeartbeat(time.absoluteMilliseconds()));
+        assertFalse(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
     }
 
     @Test
     public void testPollTimeout() {
-        assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertFalse(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
         time.sleep(maxPollIntervalMs / 2);
 
-        assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertFalse(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
         time.sleep(maxPollIntervalMs / 2 + 1);
 
-        assertTrue(heartbeat.pollTimeoutExpired(time.milliseconds()));
+        assertTrue(heartbeat.pollTimeoutExpired(time.absoluteMilliseconds()));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -443,7 +443,7 @@ public class KafkaProducerTest {
                         Thread.yield();
                     MetadataResponse updateResponse = TestUtils.metadataUpdateWith("kafka-cluster", 1,
                             singletonMap(topic, Errors.UNKNOWN_TOPIC_OR_PARTITION), emptyMap());
-                    metadata.update(updateResponse, time.milliseconds());
+                    metadata.update(updateResponse, time.absoluteMilliseconds());
                     time.sleep(60 * 1000L);
                 }
             });
@@ -483,7 +483,7 @@ public class KafkaProducerTest {
         String topic = "topic";
         Metadata metadata = new Metadata(0, 90000, true);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap(topic, 1));
-        metadata.update(initialUpdateResponse, Time.SYSTEM.milliseconds());
+        metadata.update(initialUpdateResponse, Time.SYSTEM.absoluteMilliseconds());
 
         KafkaProducer<String, String> producer = new KafkaProducer<>(configs, keySerializer, valueSerializer, metadata,
                 null, null, Time.SYSTEM);
@@ -551,7 +551,7 @@ public class KafkaProducerTest {
 
         Metadata metadata = new Metadata(0, 90000, true);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap(topic, 1));
-        metadata.update(initialUpdateResponse, Time.SYSTEM.milliseconds());
+        metadata.update(initialUpdateResponse, Time.SYSTEM.absoluteMilliseconds());
 
         @SuppressWarnings("unchecked") // it is safe to suppress, since this is a mock class
                 ProducerInterceptors<String, String> interceptors = mock(ProducerInterceptors.class);
@@ -590,7 +590,7 @@ public class KafkaProducerTest {
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
         Metadata metadata = new Metadata(0, Long.MAX_VALUE, true);
-        metadata.update(initialUpdateResponse, time.milliseconds());
+        metadata.update(initialUpdateResponse, time.absoluteMilliseconds());
 
         MockClient client = new MockClient(time, metadata);
 
@@ -611,7 +611,7 @@ public class KafkaProducerTest {
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
         Metadata metadata = new Metadata(0, Long.MAX_VALUE, true);
-        metadata.update(initialUpdateResponse, time.milliseconds());
+        metadata.update(initialUpdateResponse, time.absoluteMilliseconds());
 
         MockClient client = new MockClient(time, metadata);
 
@@ -639,7 +639,7 @@ public class KafkaProducerTest {
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
         Metadata metadata = new Metadata(0, Long.MAX_VALUE, true);
-        metadata.update(initialUpdateResponse, time.milliseconds());
+        metadata.update(initialUpdateResponse, time.absoluteMilliseconds());
 
         MockClient client = new MockClient(time, metadata);
 
@@ -681,7 +681,7 @@ public class KafkaProducerTest {
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
         Metadata metadata = new Metadata(0, Long.MAX_VALUE, true);
-        metadata.update(initialUpdateResponse, time.milliseconds());
+        metadata.update(initialUpdateResponse, time.absoluteMilliseconds());
         MockClient client = new MockClient(time, metadata);
 
         Producer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(), new StringSerializer(),

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -168,7 +168,7 @@ public class BufferPoolTest {
         // The third buffer will be de-allocated after maxBlockTimeMs since the most recent allocation
         delayedDeallocate(pool, buffer3, maxBlockTimeMs / 2 * 5);
 
-        long beginTimeMs = Time.SYSTEM.milliseconds();
+        long beginTimeMs = Time.SYSTEM.absoluteMilliseconds();
         try {
             pool.allocate(10, maxBlockTimeMs);
             fail("The buffer allocated more memory than its maximum value 10");
@@ -177,7 +177,7 @@ public class BufferPoolTest {
         }
         // Thread scheduling sometimes means that deallocation varies by this point
         assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
-        long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
+        long durationMs = Time.SYSTEM.absoluteMilliseconds() - beginTimeMs;
         assertTrue("TimeoutException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
         assertTrue("TimeoutException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 1000);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -143,7 +143,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
 
         transactionManager.maybeAddPartitionToTransaction(tp0);
-        FutureRecordMetadata sendFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        FutureRecordMetadata sendFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
@@ -164,7 +164,7 @@ public class TransactionManagerTest {
 
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
 
         transactionManager.beginCommit();
@@ -234,13 +234,13 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         transactionManager.beginAbort();
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
@@ -261,13 +261,13 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         transactionManager.beginCommit();
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
@@ -288,7 +288,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         transactionManager.transitionToAbortableError(new KafkaException());
         assertTrue(transactionManager.hasOngoingTransaction());
@@ -297,7 +297,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
@@ -318,7 +318,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         transactionManager.transitionToFatalError(new KafkaException());
         assertFalse(transactionManager.hasOngoingTransaction());
@@ -338,7 +338,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertFalse(transactionManager.hasPartitionsToAdd());
         assertTrue(transactionManager.isPartitionAdded(partition));
@@ -365,7 +365,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.CONCURRENT_TRANSACTIONS);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
@@ -386,7 +386,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.COORDINATOR_NOT_AVAILABLE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
@@ -407,7 +407,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.isPartitionPendingAdd(partition));
 
         prepareAddPartitionsToTxn(partition, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(partition));
 
         TopicPartition otherPartition = new TopicPartition("foo", 1);
@@ -477,7 +477,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         // Send the AddPartitionsToTxn request and leave it in-flight
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         transactionManager.transitionToAbortableError(new KafkaException());
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -510,7 +510,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         // Send the AddPartitionsToTxn request and leave it in-flight
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         transactionManager.transitionToFatalError(new KafkaException());
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -528,7 +528,7 @@ public class TransactionManagerTest {
 
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasPartitionsToAdd());
         transactionManager.transitionToAbortableError(new KafkaException());
 
@@ -546,7 +546,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasPartitionsToAdd());
         transactionManager.transitionToFatalError(new KafkaException());
 
@@ -597,7 +597,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -606,13 +606,13 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, pid, epoch);
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
 
-        sender.run(time.milliseconds());  // send produce request.
+        sender.run(time.absoluteMilliseconds());  // send produce request.
         assertTrue(responseFuture.isDone());
 
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
@@ -624,7 +624,7 @@ public class TransactionManagerTest {
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
 
-        sender.run(time.milliseconds());  // Send AddOffsetsRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddOffsetsRequest
         assertTrue(transactionManager.hasPendingOffsetCommits());  // We should now have created and queued the offset commit request.
         assertFalse(addOffsetsResult.isCompleted()); // the result doesn't complete until TxnOffsetCommit returns
 
@@ -635,19 +635,19 @@ public class TransactionManagerTest {
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
 
         assertEquals(null, transactionManager.coordinator(CoordinatorType.GROUP));
-        sender.run(time.milliseconds());  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
-        sender.run(time.milliseconds());  // send find coordinator for group request
+        sender.run(time.absoluteMilliseconds());  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
+        sender.run(time.absoluteMilliseconds());  // send find coordinator for group request
         assertNotNull(transactionManager.coordinator(CoordinatorType.GROUP));
         assertTrue(transactionManager.hasPendingOffsetCommits());
 
-        sender.run(time.milliseconds());  // send TxnOffsetCommitRequest commit.
+        sender.run(time.absoluteMilliseconds());  // send TxnOffsetCommitRequest commit.
 
         assertFalse(transactionManager.hasPendingOffsetCommits());
         assertTrue(addOffsetsResult.isCompleted());  // We should only be done after both RPCs complete.
 
         transactionManager.beginCommit();
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());  // commit.
+        sender.run(time.absoluteMilliseconds());  // commit.
 
         assertFalse(transactionManager.hasOngoingTransaction());
         assertFalse(transactionManager.isCompleting());
@@ -660,11 +660,11 @@ public class TransactionManagerTest {
         // It finds the coordinator and then gets a PID.
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, true, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator, connection lost.
+        sender.run(time.absoluteMilliseconds());  // find coordinator, connection lost.
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
     }
 
@@ -681,8 +681,8 @@ public class TransactionManagerTest {
             }
         });
 
-        sender.run(time.milliseconds()); // InitProducerRequest is queued
-        sender.run(time.milliseconds()); // FindCoordinator is queued after peeking InitProducerRequest
+        sender.run(time.absoluteMilliseconds()); // InitProducerRequest is queued
+        sender.run(time.absoluteMilliseconds()); // FindCoordinator is queued after peeking InitProducerRequest
         assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedVersionException);
     }
@@ -691,8 +691,8 @@ public class TransactionManagerTest {
     public void testUnsupportedInitTransactions() {
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds()); // InitProducerRequest is queued
-        sender.run(time.milliseconds()); // FindCoordinator is queued after peeking InitProducerRequest
+        sender.run(time.absoluteMilliseconds()); // InitProducerRequest is queued
+        sender.run(time.absoluteMilliseconds()); // FindCoordinator is queued after peeking InitProducerRequest
 
         assertFalse(transactionManager.hasError());
         assertNotNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
@@ -707,7 +707,7 @@ public class TransactionManagerTest {
             }
         });
 
-        sender.run(time.milliseconds()); // InitProducerRequest is dequeued
+        sender.run(time.absoluteMilliseconds()); // InitProducerRequest is dequeued
         assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedVersionException);
     }
@@ -726,14 +726,14 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.run(time.milliseconds());  // FindCoordinator Enqueued
+        sender.run(time.absoluteMilliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Enqueued
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.run(time.milliseconds());  // FindCoordinator Returned
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Returned
 
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp, Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT));
-        sender.run(time.milliseconds());  // TxnOffsetCommit Handled
+        sender.run(time.absoluteMilliseconds());  // TxnOffsetCommit Handled
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof UnsupportedForMessageFormatException);
@@ -751,24 +751,24 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         prepareInitPidResponse(Errors.NONE, true, pid, epoch);
         // send pid to coordinator, should get disconnected before receiving the response, and resend the
         // FindCoordinator and InitPid requests.
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertEquals(null, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.run(time.milliseconds());  // get pid and epoch
+        sender.run(time.absoluteMilliseconds());  // get pid and epoch
 
         assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
         assertTrue(transactionManager.hasProducerId());
@@ -784,15 +784,15 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // one loop to realize we need a coordinator.
-        sender.run(time.milliseconds());  // next loop to find coordintor.
+        sender.run(time.absoluteMilliseconds());  // one loop to realize we need a coordinator.
+        sender.run(time.absoluteMilliseconds());  // next loop to find coordintor.
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         client.disconnect(brokerNode.idString());
         client.blackout(brokerNode, 100);
         // send pid to coordinator. Should get disconnected before the send and resend the FindCoordinator
         // and InitPid requests.
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         time.sleep(110);  // waiting for the blackout period for the node to expire.
 
         assertEquals(null, transactionManager.coordinator(CoordinatorType.TRANSACTION));
@@ -800,11 +800,11 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.run(time.milliseconds());  // get pid and epoch
+        sender.run(time.absoluteMilliseconds());  // get pid and epoch
 
         assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
         assertTrue(transactionManager.hasProducerId());
@@ -820,23 +820,23 @@ public class TransactionManagerTest {
         final short epoch = 1;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.NOT_COORDINATOR, false, pid, epoch);
-        sender.run(time.milliseconds());  // send pid, get not coordinator. Should resend the FindCoordinator and InitPid requests
+        sender.run(time.absoluteMilliseconds());  // send pid, get not coordinator. Should resend the FindCoordinator and InitPid requests
 
         assertEquals(null, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         assertFalse(transactionManager.hasProducerId());
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertFalse(initPidResult.isCompleted());
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.run(time.milliseconds());  // get pid and epoch
+        sender.run(time.absoluteMilliseconds());  // get pid and epoch
 
         assertTrue(initPidResult.isCompleted()); // The future should only return after the second round of retries succeed.
         assertTrue(transactionManager.hasProducerId());
@@ -849,13 +849,13 @@ public class TransactionManagerTest {
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, false,
                 CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
 
-        sender.run(time.milliseconds()); // one more run to fail the InitProducerId future
+        sender.run(time.absoluteMilliseconds()); // one more run to fail the InitProducerId future
         assertTrue(initPidResult.isCompleted());
         assertFalse(initPidResult.isSuccessful());
         assertTrue(initPidResult.error() instanceof TransactionalIdAuthorizationException);
@@ -868,12 +868,12 @@ public class TransactionManagerTest {
         final long pid = 13131L;
         TransactionalRequestResult initPidResult = transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, false, pid, RecordBatch.NO_PRODUCER_EPOCH);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.hasError());
         assertTrue(initPidResult.isCompleted());
@@ -896,12 +896,12 @@ public class TransactionManagerTest {
                 singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(39L)), consumerGroupId);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.run(time.milliseconds());  // FindCoordinator Enqueued
+        sender.run(time.absoluteMilliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Enqueued
 
         prepareFindCoordinatorResponse(Errors.GROUP_AUTHORIZATION_FAILED, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.run(time.milliseconds());  // FindCoordinator Failed
-        sender.run(time.milliseconds());  // TxnOffsetCommit Aborted
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Failed
+        sender.run(time.absoluteMilliseconds());  // TxnOffsetCommit Aborted
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof GroupAuthorizationException);
         assertTrue(sendOffsetsResult.isCompleted());
@@ -928,14 +928,14 @@ public class TransactionManagerTest {
                 singletonMap(tp1, new OffsetAndMetadata(39L)), consumerGroupId);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.run(time.milliseconds());  // FindCoordinator Enqueued
+        sender.run(time.absoluteMilliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Enqueued
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.run(time.milliseconds());  // FindCoordinator Returned
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Returned
 
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp1, Errors.GROUP_AUTHORIZATION_FAILED));
-        sender.run(time.milliseconds());  // TxnOffsetCommit Handled
+        sender.run(time.absoluteMilliseconds());  // TxnOffsetCommit Handled
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof GroupAuthorizationException);
@@ -964,7 +964,7 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
 
         prepareAddOffsetsToTxnResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // AddOffsetsToTxn Handled
+        sender.run(time.absoluteMilliseconds());  // AddOffsetsToTxn Handled
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
@@ -989,14 +989,14 @@ public class TransactionManagerTest {
                 singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
-        sender.run(time.milliseconds());  // FindCoordinator Enqueued
+        sender.run(time.absoluteMilliseconds());  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Enqueued
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
-        sender.run(time.milliseconds());  // FindCoordinator Returned
+        sender.run(time.absoluteMilliseconds());  // FindCoordinator Returned
 
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, singletonMap(tp, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED));
-        sender.run(time.milliseconds());  // TxnOffsetCommit Handled
+        sender.run(time.absoluteMilliseconds());  // TxnOffsetCommit Handled
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
@@ -1024,7 +1024,7 @@ public class TransactionManagerTest {
         errors.put(tp1, Errors.OPERATION_NOT_ATTEMPTED);
 
         prepareAddPartitionsToTxn(errors);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TopicAuthorizationException);
@@ -1051,20 +1051,20 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(unauthorizedPartition, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(unauthorizedPartition, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.hasAbortableError());
         transactionManager.beginAbort();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(responseFuture.isDone());
         assertFutureFailed(responseFuture);
 
         // No partitions added, so no need to prepare EndTxn response
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isReady());
         assertFalse(transactionManager.hasPartitionsToAdd());
         assertFalse(accumulator.hasIncomplete());
@@ -1074,23 +1074,23 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(responseFuture.isDone());
         assertNotNull(responseFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.isReady());
     }
@@ -1107,16 +1107,16 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
-        Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
+        Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.absoluteMilliseconds(),
                 "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
 
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
-        Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
+        Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.absoluteMilliseconds(),
                 "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.hasAbortableError());
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.isPartitionAdded(unauthorizedPartition));
@@ -1125,7 +1125,7 @@ public class TransactionManagerTest {
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
         transactionManager.beginAbort();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         // neither produce request has been sent, so they should both be failed immediately
         assertFutureFailed(authorizedTopicProduceFuture);
         assertFutureFailed(unauthorizedTopicProduceFuture);
@@ -1138,23 +1138,23 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(nextTransactionFuture.isDone());
         assertNotNull(nextTransactionFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.isReady());
     }
@@ -1171,29 +1171,29 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
-        Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(tp0, time.milliseconds(),
+        Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(tp0, time.absoluteMilliseconds(),
                 "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
 
         accumulator.beginFlush();
         prepareProduceResponse(Errors.REQUEST_TIMED_OUT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(authorizedTopicProduceFuture.isDone());
         assertTrue(accumulator.hasIncomplete());
 
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
-        Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
+        Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.absoluteMilliseconds(),
                 "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.hasAbortableError());
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.isPartitionAdded(unauthorizedPartition));
         assertFalse(authorizedTopicProduceFuture.isDone());
 
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFutureFailed(unauthorizedTopicProduceFuture);
         assertTrue(authorizedTopicProduceFuture.isDone());
         assertNotNull(authorizedTopicProduceFuture.get());
@@ -1201,7 +1201,7 @@ public class TransactionManagerTest {
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
         transactionManager.beginAbort();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         // neither produce request has been sent, so they should both be failed immediately
         assertTrue(transactionManager.isReady());
         assertFalse(transactionManager.hasPartitionsToAdd());
@@ -1212,23 +1212,23 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isPartitionAdded(tp0));
         assertFalse(transactionManager.hasPartitionsToAdd());
 
         transactionManager.beginCommit();
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(nextTransactionFuture.isDone());
         assertNotNull(nextTransactionFuture.get());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.isReady());
     }
@@ -1245,7 +1245,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp);
 
         prepareAddPartitionsToTxn(tp, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(transactionManager.hasError());
         assertTrue(transactionManager.lastError() instanceof TransactionalIdAuthorizationException);
@@ -1263,7 +1263,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -1278,13 +1278,13 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
-        sender.run(time.milliseconds());  // AddPartitions.
+        sender.run(time.absoluteMilliseconds());  // AddPartitions.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertFalse(responseFuture.isDone());
         assertFalse(commitResult.isCompleted());
 
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());  // Produce.
+        sender.run(time.absoluteMilliseconds());  // Produce.
         assertTrue(responseFuture.isDone());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
@@ -1292,7 +1292,7 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasOngoingTransaction());
         assertTrue(transactionManager.isCompleting());
 
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(commitResult.isCompleted());
         assertFalse(transactionManager.hasOngoingTransaction());
     }
@@ -1308,7 +1308,7 @@ public class TransactionManagerTest {
         // User does one producer.sed
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -1317,13 +1317,13 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.transactionContainsPartition(tp0));
 
         // Sender flushes one add partitions. The produce goes next.
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
 
         // In the mean time, the user does a second produce to a different partition
         transactionManager.maybeAddPartitionToTransaction(tp1);
-        Future<RecordMetadata> secondResponseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> secondResponseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp1, epoch, pid);
@@ -1335,14 +1335,14 @@ public class TransactionManagerTest {
         assertFalse(secondResponseFuture.isDone());
 
         // The second add partitions should go out here.
-        sender.run(time.milliseconds());  // send second add partitions request
+        sender.run(time.absoluteMilliseconds());  // send second add partitions request
         assertTrue(transactionManager.transactionContainsPartition(tp1));
 
         assertFalse(responseFuture.isDone());
         assertFalse(secondResponseFuture.isDone());
 
         // Finally we get to the produce.
-        sender.run(time.milliseconds());  // send produce request
+        sender.run(time.absoluteMilliseconds());  // send produce request
 
         assertTrue(responseFuture.isDone());
         assertTrue(secondResponseFuture.isDone());
@@ -1358,15 +1358,15 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.INVALID_PRODUCER_EPOCH, pid, epoch);
-        sender.run(time.milliseconds()); // Add partitions.
+        sender.run(time.absoluteMilliseconds()); // Add partitions.
 
-        sender.run(time.milliseconds());  // send produce.
+        sender.run(time.absoluteMilliseconds());  // send produce.
 
         assertTrue(responseFuture.isDone());
         assertTrue(transactionManager.hasError());
@@ -1383,7 +1383,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         TransactionalRequestResult commitResult = transactionManager.beginCommit();
@@ -1391,11 +1391,11 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
 
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
         assertFalse(commitResult.isCompleted());
-        sender.run(time.milliseconds());  // Send Produce Request, returns OutOfOrderSequenceException.
+        sender.run(time.absoluteMilliseconds());  // Send Produce Request, returns OutOfOrderSequenceException.
 
-        sender.run(time.milliseconds());  // try to commit.
+        sender.run(time.absoluteMilliseconds());  // try to commit.
         assertTrue(commitResult.isCompleted());  // commit should be cancelled with exception without being sent.
 
         try {
@@ -1414,7 +1414,7 @@ public class TransactionManagerTest {
         // Commit is not allowed, so let's abort and try again.
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.run(time.milliseconds());  // Send abort request. It is valid to transition from ERROR to ABORT
+        sender.run(time.absoluteMilliseconds());  // Send abort request. It is valid to transition from ERROR to ABORT
 
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -1431,7 +1431,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -1439,11 +1439,11 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
 
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
-        sender.run(time.milliseconds());  // Send Produce Request, returns OutOfOrderSequenceException.
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send Produce Request, returns OutOfOrderSequenceException.
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
-        sender.run(time.milliseconds());  // try to abort
+        sender.run(time.absoluteMilliseconds());  // try to abort
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
@@ -1459,14 +1459,14 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
-        sender.run(time.milliseconds());  // Send Produce Request
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send Produce Request
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         assertTrue(transactionManager.isAborting());
@@ -1474,13 +1474,13 @@ public class TransactionManagerTest {
 
         sendProduceResponse(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, pid, epoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
-        sender.run(time.milliseconds());  // receive the produce response
+        sender.run(time.absoluteMilliseconds());  // receive the produce response
 
         // we do not transition to ABORTABLE_ERROR since we were already aborting
         assertTrue(transactionManager.isAborting());
         assertFalse(transactionManager.hasError());
 
-        sender.run(time.milliseconds());  // handle the abort
+        sender.run(time.absoluteMilliseconds());  // handle the abort
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
@@ -1496,23 +1496,23 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(accumulator.hasUndrained());
 
         // committing the transaction should cause the unsent batch to be flushed
         transactionManager.beginCommit();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
         assertFalse(responseFuture.isDone());
 
         // until the produce future returns, we will not send EndTxn
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
@@ -1520,17 +1520,17 @@ public class TransactionManagerTest {
 
         // now the produce response returns
         sendProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(responseFuture.isDone());
         assertFalse(accumulator.hasUndrained());
         assertFalse(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
 
         // now we send EndTxn
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.hasInFlightTransactionalRequest());
         sendEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
         assertTrue(transactionManager.isReady());
     }
@@ -1545,29 +1545,29 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(accumulator.hasUndrained());
 
         accumulator.beginFlush();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
 
         // now we begin the commit with the produce request still pending
         transactionManager.beginCommit();
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
         assertFalse(responseFuture.isDone());
 
         // until the produce future returns, we will not send EndTxn
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(accumulator.hasUndrained());
         assertTrue(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
@@ -1575,17 +1575,17 @@ public class TransactionManagerTest {
 
         // now the produce response returns
         sendProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(responseFuture.isDone());
         assertFalse(accumulator.hasUndrained());
         assertFalse(accumulator.hasIncomplete());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
 
         // now we send EndTxn
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.hasInFlightTransactionalRequest());
         sendEndTxnResponse(Errors.NONE, TransactionResult.COMMIT, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertFalse(transactionManager.hasInFlightTransactionalRequest());
         assertTrue(transactionManager.isReady());
     }
@@ -1600,20 +1600,20 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
 
         transactionManager.transitionToAbortableError(new KafkaException());
         sendAddPartitionsToTxnResponse(Errors.NOT_COORDINATOR, tp0, epoch, pid);
-        sender.run(time.milliseconds()); // AddPartitions returns
+        sender.run(time.absoluteMilliseconds()); // AddPartitions returns
         assertTrue(transactionManager.hasAbortableError());
 
         assertNull(transactionManager.coordinator(CoordinatorType.TRANSACTION));
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds()); // FindCoordinator handled
+        sender.run(time.absoluteMilliseconds()); // FindCoordinator handled
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
         assertTrue(transactionManager.hasAbortableError());
     }
@@ -1628,7 +1628,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -1636,7 +1636,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         // note since no partitions were added to the transaction, no EndTxn will be sent
 
-        sender.run(time.milliseconds());  // try to abort
+        sender.run(time.absoluteMilliseconds());  // try to abort
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
         assertTrue(transactionManager.isReady());  // make sure we are ready for a transaction now.
@@ -1660,10 +1660,10 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, producerEpoch, producerId);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
-        sender.run(time.milliseconds());  // Send AddPartitions and let it fail
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitions and let it fail
         assertFalse(responseFuture.isDone());
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
@@ -1672,8 +1672,8 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, producerEpoch, producerId);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, producerId, producerEpoch);
 
-        sender.run(time.milliseconds());  // Resend AddPartitions
-        sender.run(time.milliseconds());  // Send EndTxn
+        sender.run(time.absoluteMilliseconds());  // Resend AddPartitions
+        sender.run(time.absoluteMilliseconds());  // Send EndTxn
 
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -1699,11 +1699,11 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, producerEpoch, producerId);
         prepareProduceResponse(Errors.REQUEST_TIMED_OUT, producerId, producerEpoch);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
-        sender.run(time.milliseconds());  // Send AddPartitions
-        sender.run(time.milliseconds());  // Send ProduceRequest and let it fail
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitions
+        sender.run(time.absoluteMilliseconds());  // Send ProduceRequest and let it fail
 
         assertFalse(responseFuture.isDone());
 
@@ -1713,8 +1713,8 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, producerId, producerEpoch);
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, producerId, producerEpoch);
 
-        sender.run(time.milliseconds());  // Resend ProduceRequest
-        sender.run(time.milliseconds());  // Send EndTxn
+        sender.run(time.absoluteMilliseconds());  // Resend ProduceRequest
+        sender.run(time.absoluteMilliseconds());  // Send EndTxn
 
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -1734,21 +1734,21 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, epoch, pid);
 
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
         assertFalse(transactionManager.transactionContainsPartition(tp0));  // The partition should not yet be added.
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest successfully.
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest successfully.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
 
-        sender.run(time.milliseconds());  // Send ProduceRequest.
+        sender.run(time.absoluteMilliseconds());  // Send ProduceRequest.
         assertTrue(responseFuture.isDone());
     }
 
@@ -1778,7 +1778,7 @@ public class TransactionManagerTest {
         TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(offsets, consumerGroupId);
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
 
-        sender.run(time.milliseconds());  // send AddOffsetsToTxnResult
+        sender.run(time.absoluteMilliseconds());  // send AddOffsetsToTxnResult
 
         assertFalse(addOffsetsResult.isCompleted());  // The request should complete only after the TxnOffsetCommit completes.
 
@@ -1790,19 +1790,19 @@ public class TransactionManagerTest {
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
 
         assertNull(transactionManager.coordinator(CoordinatorType.GROUP));
-        sender.run(time.milliseconds());  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
-        sender.run(time.milliseconds());  // send find coordinator for group request
+        sender.run(time.absoluteMilliseconds());  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
+        sender.run(time.absoluteMilliseconds());  // send find coordinator for group request
         assertNotNull(transactionManager.coordinator(CoordinatorType.GROUP));
         assertTrue(transactionManager.hasPendingOffsetCommits());
 
-        sender.run(time.milliseconds());  // send TxnOffsetCommitRequest request.
+        sender.run(time.absoluteMilliseconds());  // send TxnOffsetCommitRequest request.
 
         assertTrue(transactionManager.hasPendingOffsetCommits());  // The TxnOffsetCommit failed.
         assertFalse(addOffsetsResult.isCompleted());  // We should only be done after both RPCs complete successfully.
 
         txnOffsetCommitResponse.put(tp1, Errors.NONE);
         prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
-        sender.run(time.milliseconds());  // Send TxnOffsetCommitRequest again.
+        sender.run(time.absoluteMilliseconds());  // Send TxnOffsetCommitRequest again.
 
         assertTrue(addOffsetsResult.isCompleted());
         assertTrue(addOffsetsResult.isSuccessful());
@@ -1824,12 +1824,12 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
         prepareAddPartitionsToTxnResponse(Errors.TOPIC_AUTHORIZATION_FAILED, tp0, epoch, pid);
-        sender.run(time.milliseconds());  // Send AddPartitionsRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitionsRequest
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
         assertFalse(abortResult.isCompleted());
 
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
     }
@@ -1851,10 +1851,10 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
         prepareAddOffsetsToTxnResponse(Errors.GROUP_AUTHORIZATION_FAILED, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // Send AddOffsetsToTxnRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddOffsetsToTxnRequest
         assertFalse(abortResult.isCompleted());
 
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(transactionManager.isReady());
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -1877,10 +1877,10 @@ public class TransactionManagerTest {
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
         prepareAddOffsetsToTxnResponse(Errors.UNKNOWN_SERVER_ERROR, consumerGroupId, pid, epoch);
-        sender.run(time.milliseconds());  // Send AddOffsetsToTxnRequest
+        sender.run(time.absoluteMilliseconds());  // Send AddOffsetsToTxnRequest
         assertFalse(abortResult.isCompleted());
 
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
         assertTrue(abortResult.isCompleted());
         assertFalse(abortResult.isSuccessful());
         assertTrue(transactionManager.hasFatalError());
@@ -1893,10 +1893,10 @@ public class TransactionManagerTest {
         doInitTransactions(pid, epoch);
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT);
         transactionManager.maybeAddPartitionToTransaction(tp1);
-        accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
+        accumulator.append(tp1, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT);
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
@@ -1913,7 +1913,7 @@ public class TransactionManagerTest {
         nodes.add(node1);
         nodes.add(node2);
         Map<Integer, List<ProducerBatch>> drainedBatches = accumulator.drain(cluster, nodes, Integer.MAX_VALUE,
-                time.milliseconds());
+                time.absoluteMilliseconds());
 
         // We shouldn't drain batches which haven't been added to the transaction yet.
         assertTrue(drainedBatches.containsKey(node1.id()));
@@ -1931,13 +1931,13 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp1);
         prepareAddPartitionsToTxn(tp1, Errors.NONE);
-        sender.run(time.milliseconds());  // Send AddPartitions, tp1 should be in the transaction now.
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitions, tp1 should be in the transaction now.
 
         assertTrue(transactionManager.transactionContainsPartition(tp1));
 
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxn(tp0, Errors.TOPIC_AUTHORIZATION_FAILED);
-        sender.run(time.milliseconds());  // Send AddPartitions, should be in abortable state.
+        sender.run(time.absoluteMilliseconds());  // Send AddPartitions, should be in abortable state.
 
         assertTrue(transactionManager.hasAbortableError());
         assertTrue(transactionManager.isSendToPartitionAllowed(tp1));
@@ -1947,11 +1947,11 @@ public class TransactionManagerTest {
         PartitionInfo part1 = new PartitionInfo(topic, 1, node1, null, null);
         Cluster cluster = new Cluster(null, Arrays.asList(node1), Arrays.asList(part1),
                 Collections.<String>emptySet(), Collections.<String>emptySet());
-        accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
+        accumulator.append(tp1, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT);
         Map<Integer, List<ProducerBatch>> drainedBatches = accumulator.drain(cluster, Collections.singleton(node1),
                 Integer.MAX_VALUE,
-                time.milliseconds());
+                time.absoluteMilliseconds());
 
         // We should drain the appended record since we are in abortable state and the partition has already been
         // added to the transaction.
@@ -1967,7 +1967,7 @@ public class TransactionManagerTest {
         doInitTransactions(pid, epoch);
         transactionManager.beginTransaction();
         // Don't execute transactionManager.maybeAddPartitionToTransaction(tp0). This should result in an error on drain.
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT);
         Node node1 = new Node(0, "localhost", 1111);
         PartitionInfo part1 = new PartitionInfo(topic, 0, node1, null, null);
@@ -1977,7 +1977,7 @@ public class TransactionManagerTest {
         Set<Node> nodes = new HashSet<>();
         nodes.add(node1);
         Map<Integer, List<ProducerBatch>> drainedBatches = accumulator.drain(cluster, nodes, Integer.MAX_VALUE,
-                time.milliseconds());
+                time.absoluteMilliseconds());
 
         // We shouldn't drain batches which haven't been added to the transaction yet.
         assertTrue(drainedBatches.containsKey(node1.id()));
@@ -1993,19 +1993,19 @@ public class TransactionManagerTest {
 
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.NOT_LEADER_FOR_PARTITION, pid, epoch);
-        sender.run(time.milliseconds()); // Add partitions
-        sender.run(time.milliseconds()); // Produce
+        sender.run(time.absoluteMilliseconds()); // Add partitions
+        sender.run(time.absoluteMilliseconds()); // Produce
 
         assertFalse(responseFuture.isDone());
 
         transactionManager.transitionToAbortableError(new KafkaException());
         prepareProduceResponse(Errors.NONE, pid, epoch);
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());
 
         assertTrue(responseFuture.isDone());
         assertNotNull(responseFuture.get()); // should throw the exception which caused the transaction to be aborted.
@@ -2021,7 +2021,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -2030,7 +2030,7 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
@@ -2044,7 +2044,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.run(time.milliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
+        sender.run(time.absoluteMilliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
         assertTrue(responseFuture.isDone());
 
         try {
@@ -2068,9 +2068,9 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         transactionManager.maybeAddPartitionToTransaction(tp1);
 
-        Future<RecordMetadata> firstBatchResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> firstBatchResponse = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
-        Future<RecordMetadata> secondBatchResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> secondBatchResponse = accumulator.append(tp1, time.absoluteMilliseconds(), "key".getBytes(),
                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(firstBatchResponse.isDone());
@@ -2083,7 +2083,7 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.transactionContainsPartition(tp1));
@@ -2100,7 +2100,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.run(time.milliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
+        sender.run(time.absoluteMilliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
         assertTrue(firstBatchResponse.isDone());
         assertTrue(secondBatchResponse.isDone());
 
@@ -2132,7 +2132,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -2141,7 +2141,7 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
@@ -2157,7 +2157,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.run(time.milliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
+        sender.run(time.absoluteMilliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
         assertTrue(responseFuture.isDone());
 
         try {
@@ -2167,7 +2167,7 @@ public class TransactionManagerTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof  TimeoutException);
         }
-        sender.run(time.milliseconds());  // the commit shouldn't be completed without being sent since the produce request failed.
+        sender.run(time.absoluteMilliseconds());  // the commit shouldn't be completed without being sent since the produce request failed.
 
         assertTrue(commitResult.isCompleted());
         assertFalse(commitResult.isSuccessful());  // the commit shouldn't succeed since the produce request failed.
@@ -2181,7 +2181,7 @@ public class TransactionManagerTest {
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);
 
-        sender.run(time.milliseconds());  // send the abort.
+        sender.run(time.absoluteMilliseconds());  // send the abort.
 
         assertTrue(abortResult.isCompleted());
         assertTrue(abortResult.isSuccessful());
@@ -2199,7 +2199,7 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
 
         assertFalse(responseFuture.isDone());
@@ -2208,13 +2208,13 @@ public class TransactionManagerTest {
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
-        sender.run(time.milliseconds());  // send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
         assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
 
         prepareProduceResponse(Errors.NOT_LEADER_FOR_PARTITION, pid, epoch);
-        sender.run(time.milliseconds());  // send the produce request.
+        sender.run(time.absoluteMilliseconds());  // send the produce request.
 
         assertFalse(responseFuture.isDone());
 
@@ -2228,7 +2228,7 @@ public class TransactionManagerTest {
         client.disconnect(clusterNode.idString());
         client.blackout(clusterNode, 100);
 
-        sender.run(time.milliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
+        sender.run(time.absoluteMilliseconds());  // We should try to flush the produce, but expire it instead without sending anything.
         assertTrue(responseFuture.isDone());
 
         try {
@@ -2238,8 +2238,8 @@ public class TransactionManagerTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof  TimeoutException);
         }
-        sender.run(time.milliseconds());  // Transition to fatal error since we have unresolved batches.
-        sender.run(time.milliseconds());  // Fail the queued transactional requests
+        sender.run(time.absoluteMilliseconds());  // Transition to fatal error since we have unresolved batches.
+        sender.run(time.absoluteMilliseconds());  // Fail the queued transactional requests
 
         assertTrue(commitResult.isCompleted());
         assertFalse(commitResult.isSuccessful());  // the commit should have been dropped.
@@ -2284,11 +2284,11 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.absoluteMilliseconds(), "key".getBytes(),
                 "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT).future;
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxn(tp0, error);
-        sender.run(time.milliseconds());  // attempt send addPartitions.
+        sender.run(time.absoluteMilliseconds());  // attempt send addPartitions.
         assertTrue(transactionManager.hasError());
         assertFalse(transactionManager.transactionContainsPartition(tp0));
     }
@@ -2449,12 +2449,12 @@ public class TransactionManagerTest {
     private void doInitTransactions(long pid, short epoch) {
         transactionManager.initializeTransactions();
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.TRANSACTION, transactionalId);
-        sender.run(time.milliseconds());  // find coordinator
-        sender.run(time.milliseconds());
+        sender.run(time.absoluteMilliseconds());  // find coordinator
+        sender.run(time.absoluteMilliseconds());
         assertEquals(brokerNode, transactionManager.coordinator(CoordinatorType.TRANSACTION));
 
         prepareInitPidResponse(Errors.NONE, false, pid, epoch);
-        sender.run(time.milliseconds());  // get pid.
+        sender.run(time.absoluteMilliseconds());  // get pid.
         assertTrue(transactionManager.hasProducerId());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -319,24 +319,24 @@ public class MetricsTest {
     public void testEventWindowing() {
         Count count = new Count();
         MetricConfig config = new MetricConfig().eventWindow(1).samples(2);
-        count.record(config, 1.0, time.milliseconds());
-        count.record(config, 1.0, time.milliseconds());
-        assertEquals(2.0, count.measure(config, time.milliseconds()), EPS);
-        count.record(config, 1.0, time.milliseconds()); // first event times out
-        assertEquals(2.0, count.measure(config, time.milliseconds()), EPS);
+        count.record(config, 1.0, time.absoluteMilliseconds());
+        count.record(config, 1.0, time.absoluteMilliseconds());
+        assertEquals(2.0, count.measure(config, time.absoluteMilliseconds()), EPS);
+        count.record(config, 1.0, time.absoluteMilliseconds()); // first event times out
+        assertEquals(2.0, count.measure(config, time.absoluteMilliseconds()), EPS);
     }
 
     @Test
     public void testTimeWindowing() {
         Count count = new Count();
         MetricConfig config = new MetricConfig().timeWindow(1, TimeUnit.MILLISECONDS).samples(2);
-        count.record(config, 1.0, time.milliseconds());
+        count.record(config, 1.0, time.absoluteMilliseconds());
         time.sleep(1);
-        count.record(config, 1.0, time.milliseconds());
-        assertEquals(2.0, count.measure(config, time.milliseconds()), EPS);
+        count.record(config, 1.0, time.absoluteMilliseconds());
+        assertEquals(2.0, count.measure(config, time.absoluteMilliseconds()), EPS);
         time.sleep(1);
-        count.record(config, 1.0, time.milliseconds()); // oldest event times out
-        assertEquals(2.0, count.measure(config, time.milliseconds()), EPS);
+        count.record(config, 1.0, time.absoluteMilliseconds()); // oldest event times out
+        assertEquals(2.0, count.measure(config, time.absoluteMilliseconds()), EPS);
     }
 
     @Test
@@ -345,9 +345,9 @@ public class MetricsTest {
         long windowMs = 100;
         int samples = 2;
         MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
-        max.record(config, 50, time.milliseconds());
+        max.record(config, 50, time.absoluteMilliseconds());
         time.sleep(samples * windowMs);
-        assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, max.measure(config, time.absoluteMilliseconds()), EPS);
     }
 
     /**
@@ -364,15 +364,15 @@ public class MetricsTest {
         long windowMs = 100;
         int samples = 2;
         MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
-        max.record(config, 50, time.milliseconds());
-        min.record(config, 50, time.milliseconds());
-        avg.record(config, 50, time.milliseconds());
+        max.record(config, 50, time.absoluteMilliseconds());
+        min.record(config, 50, time.absoluteMilliseconds());
+        avg.record(config, 50, time.absoluteMilliseconds());
 
         time.sleep(samples * windowMs);
 
-        assertEquals(Double.NaN, max.measure(config, time.milliseconds()), EPS);
-        assertEquals(Double.NaN, min.measure(config, time.milliseconds()), EPS);
-        assertEquals(Double.NaN, avg.measure(config, time.milliseconds()), EPS);
+        assertEquals(Double.NaN, max.measure(config, time.absoluteMilliseconds()), EPS);
+        assertEquals(Double.NaN, min.measure(config, time.absoluteMilliseconds()), EPS);
+        assertEquals(Double.NaN, avg.measure(config, time.absoluteMilliseconds()), EPS);
     }
 
     /**
@@ -387,13 +387,13 @@ public class MetricsTest {
         int samples = 2;
         MetricConfig config = new MetricConfig().timeWindow(windowMs, TimeUnit.MILLISECONDS).samples(samples);
 
-        count.record(config, 50, time.milliseconds());
-        sampledTotal.record(config, 50, time.milliseconds());
+        count.record(config, 50, time.absoluteMilliseconds());
+        sampledTotal.record(config, 50, time.absoluteMilliseconds());
 
         time.sleep(samples * windowMs);
 
-        assertEquals(0, count.measure(config, time.milliseconds()), EPS);
-        assertEquals(0.0, sampledTotal.measure(config, time.milliseconds()), EPS);
+        assertEquals(0, count.measure(config, time.absoluteMilliseconds()), EPS);
+        assertEquals(0.0, sampledTotal.measure(config, time.absoluteMilliseconds()), EPS);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -512,7 +512,7 @@ public class MetricsTest {
         assertEquals("Rate(0...2) = 2.666", sum / elapsedSecs, (Double) rateMetric.metricValue(), EPS);
         assertEquals("Count rate(0...2) = 0.02666", count / elapsedSecs, (Double) countRateMetric.metricValue(), EPS);
         assertEquals("Elapsed Time = 75 seconds", elapsedSecs,
-                ((Rate) rateMetric.measurable()).windowSize(cfg, time.milliseconds()) / 1000, EPS);
+                ((Rate) rateMetric.measurable()).windowSize(cfg, time.absoluteMilliseconds()) / 1000, EPS);
         assertEquals(sum, (Double) totalMetric.metricValue(), EPS);
         assertEquals(count, (Double) countTotalMetric.metricValue(), EPS);
 
@@ -586,11 +586,11 @@ public class MetricsTest {
     }
 
     private void record(Rate rate, MetricConfig config, int value) {
-        rate.record(config, value, time.milliseconds());
+        rate.record(config, value, time.absoluteMilliseconds());
     }
 
     private Double measure(Measurable rate, MetricConfig config) {
-        return rate.measure(config, time.milliseconds());
+        return rate.measure(config, time.absoluteMilliseconds());
     }
     
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
@@ -82,23 +82,23 @@ public class FrequenciesTest {
 
         // Record 2 windows worth of values
         for (int i = 0; i != 25; ++i) {
-            frequencies.record(config, 0.0, time.milliseconds());
+            frequencies.record(config, 0.0, time.absoluteMilliseconds());
         }
         for (int i = 0; i != 75; ++i) {
-            frequencies.record(config, 1.0, time.milliseconds());
+            frequencies.record(config, 1.0, time.absoluteMilliseconds());
         }
-        assertEquals(0.25, falseMetric.stat().measure(config, time.milliseconds()), DELTA);
-        assertEquals(0.75, trueMetric.stat().measure(config, time.milliseconds()), DELTA);
+        assertEquals(0.25, falseMetric.stat().measure(config, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.75, trueMetric.stat().measure(config, time.absoluteMilliseconds()), DELTA);
 
         // Record 2 more windows worth of values
         for (int i = 0; i != 40; ++i) {
-            frequencies.record(config, 0.0, time.milliseconds());
+            frequencies.record(config, 0.0, time.absoluteMilliseconds());
         }
         for (int i = 0; i != 60; ++i) {
-            frequencies.record(config, 1.0, time.milliseconds());
+            frequencies.record(config, 1.0, time.absoluteMilliseconds());
         }
-        assertEquals(0.40, falseMetric.stat().measure(config, time.milliseconds()), DELTA);
-        assertEquals(0.60, trueMetric.stat().measure(config, time.milliseconds()), DELTA);
+        assertEquals(0.40, falseMetric.stat().measure(config, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.60, trueMetric.stat().measure(config, time.absoluteMilliseconds()), DELTA);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class FrequenciesTest {
 
         // Record 2 windows worth of values
         for (int i = 0; i != 100; ++i) {
-            frequencies.record(config, i % 4 + 1, time.milliseconds());
+            frequencies.record(config, i % 4 + 1, time.absoluteMilliseconds());
         }
         assertEquals(0.25, (Double) metric1.metricValue(), DELTA);
         assertEquals(0.25, (Double) metric2.metricValue(), DELTA);
@@ -131,7 +131,7 @@ public class FrequenciesTest {
 
         // Record 2 windows worth of values
         for (int i = 0; i != 100; ++i) {
-            frequencies.record(config, i % 2 + 1, time.milliseconds());
+            frequencies.record(config, i % 2 + 1, time.absoluteMilliseconds());
         }
         assertEquals(0.50, (Double) metric1.metricValue(), DELTA);
         assertEquals(0.50, (Double) metric2.metricValue(), DELTA);
@@ -141,7 +141,7 @@ public class FrequenciesTest {
         // Record 1 window worth of values to overlap with the last window
         // that is half 1.0 and half 2.0
         for (int i = 0; i != 50; ++i) {
-            frequencies.record(config, 4.0, time.milliseconds());
+            frequencies.record(config, 4.0, time.absoluteMilliseconds());
         }
         assertEquals(0.25, (Double) metric1.metricValue(), DELTA);
         assertEquals(0.25, (Double) metric2.metricValue(), DELTA);

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -174,9 +174,9 @@ public class NioEchoServer extends Thread {
     public void waitForMetrics(String namePrefix, final double expectedValue, Set<MetricType> metricTypes)
             throws InterruptedException {
         long maxAggregateWaitMs = 15000;
-        long startMs = time.milliseconds();
+        long startMs = time.absoluteMilliseconds();
         for (MetricType metricType : metricTypes) {
-            long currentElapsedMs = time.milliseconds() - startMs;
+            long currentElapsedMs = time.absoluteMilliseconds() - startMs;
             long thisMaxWaitMs = maxAggregateWaitMs - currentElapsedMs;
             String metricName = namePrefix + metricType.metricNameSuffix();
             if (expectedValue == 0.0) {
@@ -249,7 +249,7 @@ public class NioEchoServer extends Thread {
     private static boolean maybeBeginServerReauthentication(KafkaChannel channel, NetworkReceive networkReceive, Time time) {
         try {
             if (TestUtils.apiKeyFrom(networkReceive) == ApiKeys.SASL_HANDSHAKE) {
-                return channel.maybeBeginServerReauthentication(networkReceive, () -> time.nanoseconds());
+                return channel.maybeBeginServerReauthentication(networkReceive, () -> time.relativeNanoseconds());
             }
         } catch (Exception e) {
             // ignore

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -49,7 +49,7 @@ public class LazyDownConversionRecordsTest {
      */
     @Test
     public void testConversionOfCommitMarker() throws IOException {
-        MemoryRecords recordsToConvert = MemoryRecords.withEndTransactionMarker(0, Time.SYSTEM.milliseconds(), RecordBatch.NO_PARTITION_LEADER_EPOCH,
+        MemoryRecords recordsToConvert = MemoryRecords.withEndTransactionMarker(0, Time.SYSTEM.absoluteMilliseconds(), RecordBatch.NO_PARTITION_LEADER_EPOCH,
                 1, (short) 1, new EndTransactionMarker(ControlRecordType.COMMIT, 0));
         MemoryRecords convertedRecords = convertRecords(recordsToConvert, (byte) 1, recordsToConvert.sizeInBytes());
         ByteBuffer buffer = convertedRecords.buffer();

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -87,12 +87,12 @@ public class SaslAuthenticatorFailureDelayTest {
         saslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         credentialCache = new CredentialCache();
         SaslAuthenticatorTest.TestLogin.loginCount.set(0);
-        startTimeMs = time.milliseconds();
+        startTimeMs = time.absoluteMilliseconds();
     }
 
     @After
     public void teardown() throws Exception {
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         if (server != null)
             this.server.close();
         if (selector != null)
@@ -153,9 +153,9 @@ public class SaslAuthenticatorFailureDelayTest {
                 "Timeout waiting for connection close");
 
         // Try forcing completion of delayed channel close
-        TestUtils.waitForCondition(() -> time.milliseconds() > startTimeMs + failedAuthenticationDelayMs + 1,
+        TestUtils.waitForCondition(() -> time.absoluteMilliseconds() > startTimeMs + failedAuthenticationDelayMs + 1,
                 "Timeout when waiting for auth failure response timeout to elapse");
-        NetworkTestUtils.completeDelayedChannelClose(server.selector(), time.nanoseconds());
+        NetworkTestUtils.completeDelayedChannelClose(server.selector(), time.relativeNanoseconds());
     }
 
     private void poll(Selector selector) {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1469,10 +1469,10 @@ public class SaslAuthenticatorTest {
         server.verifyReauthenticationMetrics(0, 0);
         double successfulReauthentications = 0;
         int desiredNumReauthentications = 5;
-        long startMs = Time.SYSTEM.milliseconds();
+        long startMs = Time.SYSTEM.absoluteMilliseconds();
         long timeoutMs = startMs + 1000 * 15; // stop after 15 seconds
         while (successfulReauthentications < desiredNumReauthentications
-                && Time.SYSTEM.milliseconds() < timeoutMs) {
+                && Time.SYSTEM.absoluteMilliseconds() < timeoutMs) {
             checkClientConnection(node);
             successfulReauthentications = server.metricValue("successful-reauthentication-total");
         }
@@ -2094,7 +2094,7 @@ public class SaslAuthenticatorTest {
                             try {
                                 claimsJson = String.format("{%s,%s,%s}",
                                         expClaimText(Long.parseLong(lifetimeSecondsValueToUse)),
-                                        claimOrHeaderJsonText("iat", time.milliseconds() / 1000.0),
+                                        claimOrHeaderJsonText("iat", time.absoluteMilliseconds() / 1000.0),
                                         claimOrHeaderJsonText("sub", changedPrincipalNameToUse));
                             } catch (NumberFormatException e) {
                                 throw new OAuthBearerConfigException(e.getMessage());
@@ -2125,7 +2125,7 @@ public class SaslAuthenticatorTest {
         }
 
         private static String expClaimText(long lifetimeSeconds) {
-            return claimOrHeaderJsonText("exp", time.milliseconds() / 1000.0 + lifetimeSeconds);
+            return claimOrHeaderJsonText("exp", time.absoluteMilliseconds() / 1000.0 + lifetimeSeconds);
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLoginTest.java
@@ -129,7 +129,7 @@ public class ExpiringCredentialRefreshingLoginTest {
 
         private ExpiringCredential internalNewExpiringCredential() {
             return new ExpiringCredential() {
-                private final long createMs = time.milliseconds();
+                private final long createMs = time.absoluteMilliseconds();
                 private final long expireTimeMs = createMs + lifetimeMillis;
 
                 @Override
@@ -264,7 +264,7 @@ public class ExpiringCredentialRefreshingLoginTest {
                 when(mockLoginContext.getSubject()).thenReturn(subject);
 
                 MockTime mockTime = new MockTime();
-                long startMs = mockTime.milliseconds();
+                long startMs = mockTime.absoluteMilliseconds();
                 /*
                  * Identify the lifetime of each expiring credential
                  */
@@ -315,7 +315,7 @@ public class ExpiringCredentialRefreshingLoginTest {
                 testExpiringCredentialRefreshingLogin.login();
                 assertTrue(testLoginContextFactory.refresherThreadStartedFuture().isDone());
                 testLoginContextFactory.refresherThreadDoneFuture().get(1L, TimeUnit.SECONDS);
-                assertEquals(expectedFinalMs, mockTime.milliseconds());
+                assertEquals(expectedFinalMs, mockTime.absoluteMilliseconds());
                 for (int i = 0; i < numExpectedRefreshes; ++i) {
                     KafkaFutureImpl<Long> waiter = waiters.get(i);
                     assertTrue(waiter.isDone());
@@ -352,7 +352,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         when(mockLoginContext.getSubject()).thenReturn(subject);
 
         MockTime mockTime = new MockTime();
-        long startMs = mockTime.milliseconds();
+        long startMs = mockTime.absoluteMilliseconds();
         /*
          * Identify the lifetime of each expiring credential
          */
@@ -405,7 +405,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         testExpiringCredentialRefreshingLogin.login();
         assertTrue(testLoginContextFactory.refresherThreadStartedFuture().isDone());
         testLoginContextFactory.refresherThreadDoneFuture().get(1L, TimeUnit.SECONDS);
-        assertEquals(expectedFinalMs, mockTime.milliseconds());
+        assertEquals(expectedFinalMs, mockTime.absoluteMilliseconds());
         for (int i = 0; i < numExpectedRefreshes; ++i) {
             KafkaFutureImpl<Long> waiter = waiters.get(i);
             assertTrue(waiter.isDone());
@@ -430,7 +430,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         when(mockLoginContext.getSubject()).thenReturn(subject);
 
         MockTime mockTime = new MockTime();
-        long startMs = mockTime.milliseconds();
+        long startMs = mockTime.absoluteMilliseconds();
         /*
          * Identify the lifetime of each expiring credential
          */
@@ -485,7 +485,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         testExpiringCredentialRefreshingLogin.login();
         assertTrue(testLoginContextFactory.refresherThreadStartedFuture().isDone());
         testLoginContextFactory.refresherThreadDoneFuture().get(1L, TimeUnit.SECONDS);
-        assertEquals(expectedFinalMs, mockTime.milliseconds());
+        assertEquals(expectedFinalMs, mockTime.absoluteMilliseconds());
         for (int i = 0; i < numExpectedRefreshes; ++i) {
             KafkaFutureImpl<Long> waiter = waiters.get(i);
             assertTrue(waiter.isDone());
@@ -511,7 +511,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         when(mockLoginContext.getSubject()).thenReturn(subject);
 
         MockTime mockTime = new MockTime();
-        long startMs = mockTime.milliseconds();
+        long startMs = mockTime.absoluteMilliseconds();
         /*
          * Identify the lifetime of each expiring credential
          */
@@ -565,7 +565,7 @@ public class ExpiringCredentialRefreshingLoginTest {
         testExpiringCredentialRefreshingLogin.login();
         assertTrue(testLoginContextFactory.refresherThreadStartedFuture().isDone());
         testLoginContextFactory.refresherThreadDoneFuture().get(1L, TimeUnit.SECONDS);
-        assertEquals(expectedFinalMs, mockTime.milliseconds());
+        assertEquals(expectedFinalMs, mockTime.absoluteMilliseconds());
         for (int i = 0; i < numExpectedRefreshes; ++i) {
             KafkaFutureImpl<Long> waiter = waiters.get(i);
             assertTrue(waiter.isDone());

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
@@ -82,7 +82,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
         callbackHandler.handle(new Callback[] {callback});
         OAuthBearerUnsecuredJws jws = (OAuthBearerUnsecuredJws) callback.token();
         assertNotNull("create token failed", jws);
-        long startMs = mockTime.milliseconds();
+        long startMs = mockTime.absoluteMilliseconds();
         confirmCorrectValues(jws, user, startMs, 1000 * 60 * 60);
         assertEquals(new HashSet<>(Arrays.asList("sub", "iat", "exp")), jws.claims().keySet());
     }
@@ -118,7 +118,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
             callbackHandler.handle(new Callback[] {callback});
             OAuthBearerUnsecuredJws jws = (OAuthBearerUnsecuredJws) callback.token();
             assertNotNull("create token failed", jws);
-            long startMs = mockTime.milliseconds();
+            long startMs = mockTime.absoluteMilliseconds();
             confirmCorrectValues(jws, user, startMs, lifetmeSeconds * 1000);
             Map<String, Object> claims = jws.claims();
             assertEquals(new HashSet<>(Arrays.asList(actualScopeClaimName, principalClaimName, "iat", "exp", "number",

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandlerTest.java
@@ -50,7 +50,7 @@ public class OAuthBearerUnsecuredValidatorCallbackHandlerTest {
     private static final long LIFETIME_SECONDS_TO_USE = 1000 * 60 * 60;
     private static final String EXPIRATION_TIME_CLAIM_TEXT = expClaimText(LIFETIME_SECONDS_TO_USE);
     private static final String TOO_EARLY_EXPIRATION_TIME_CLAIM_TEXT = expClaimText(0);
-    private static final String ISSUED_AT_CLAIM_TEXT = claimOrHeaderText("iat", MOCK_TIME.milliseconds() / 1000.0);
+    private static final String ISSUED_AT_CLAIM_TEXT = claimOrHeaderText("iat", MOCK_TIME.absoluteMilliseconds() / 1000.0);
     private static final String SCOPE_CLAIM_TEXT = claimOrHeaderText("scope", "scope1");
     private static final Map<String, String> MODULE_OPTIONS_MAP_NO_SCOPE_REQUIRED;
     static {
@@ -177,6 +177,6 @@ public class OAuthBearerUnsecuredValidatorCallbackHandlerTest {
     }
 
     private static String expClaimText(long lifetimeSeconds) {
-        return claimOrHeaderText("exp", MOCK_TIME.milliseconds() / 1000.0 + lifetimeSeconds);
+        return claimOrHeaderText("exp", MOCK_TIME.absoluteMilliseconds() / 1000.0 + lifetimeSeconds);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
@@ -62,7 +62,7 @@ public class OAuthBearerValidationUtilsTest {
 
     @Test
     public void validateIssuedAt() {
-        long nowMs = TIME.milliseconds();
+        long nowMs = TIME.absoluteMilliseconds();
         double nowClaimValue = ((double) nowMs) / 1000;
         for (boolean exists : new boolean[] {true, false}) {
             StringBuilder sb = new StringBuilder("{");
@@ -99,7 +99,7 @@ public class OAuthBearerValidationUtilsTest {
 
     @Test
     public void validateExpirationTime() {
-        long nowMs = TIME.milliseconds();
+        long nowMs = TIME.absoluteMilliseconds();
         double nowClaimValue = ((double) nowMs) / 1000;
         StringBuilder sb = new StringBuilder("{");
         appendJsonText(sb, "exp", nowClaimValue);
@@ -126,7 +126,7 @@ public class OAuthBearerValidationUtilsTest {
 
     @Test
     public void validateExpirationTimeAndIssuedAtConsistency() throws OAuthBearerIllegalTokenException {
-        long nowMs = TIME.milliseconds();
+        long nowMs = TIME.absoluteMilliseconds();
         double nowClaimValue = ((double) nowMs) / 1000;
         for (boolean issuedAtExists : new boolean[] {true, false}) {
             if (!issuedAtExists) {
@@ -160,7 +160,7 @@ public class OAuthBearerValidationUtilsTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void validateScope() {
-        long nowMs = TIME.milliseconds();
+        long nowMs = TIME.absoluteMilliseconds();
         double nowClaimValue = ((double) nowMs) / 1000;
         final List<String> noScope = Collections.emptyList();
         final List<String> scope1 = Arrays.asList("scope1");

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
@@ -54,7 +54,7 @@ public class MockScheduler implements Scheduler, MockTime.MockTimeListener {
 
     @Override
     public synchronized void tick() {
-        long timeMs = time.milliseconds();
+        long timeMs = time.absoluteMilliseconds();
         while (true) {
             Map.Entry<Long, List<KafkaFutureImpl<Long>>> entry = waiters.firstEntry();
             if ((entry == null) || (entry.getKey() > timeMs)) {
@@ -68,7 +68,7 @@ public class MockScheduler implements Scheduler, MockTime.MockTimeListener {
     }
 
     public synchronized void addWaiter(long delayMs, KafkaFutureImpl<Long> waiter) {
-        long timeMs = time.milliseconds();
+        long timeMs = time.absoluteMilliseconds();
         if (delayMs <= 0) {
             waiter.complete(timeMs);
         } else {

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockTime.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockTime.java
@@ -60,13 +60,13 @@ public class MockTime implements Time {
     }
 
     @Override
-    public long milliseconds() {
+    public long absoluteMilliseconds() {
         maybeSleep(autoTickMs);
         return timeMs.get();
     }
 
     @Override
-    public long nanoseconds() {
+    public long relativeNanoseconds() {
         maybeSleep(autoTickMs);
         return highResTimeNs.get();
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockTimeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockTimeTest.java
@@ -32,19 +32,19 @@ public class MockTimeTest {
     @Test
     public void testAdvanceClock() {
         MockTime time = new MockTime(0, 100, 200);
-        Assert.assertEquals(100, time.milliseconds());
-        Assert.assertEquals(200, time.nanoseconds());
+        Assert.assertEquals(100, time.absoluteMilliseconds());
+        Assert.assertEquals(200, time.relativeNanoseconds());
         time.sleep(1);
-        Assert.assertEquals(101, time.milliseconds());
-        Assert.assertEquals(1000200, time.nanoseconds());
+        Assert.assertEquals(101, time.absoluteMilliseconds());
+        Assert.assertEquals(1000200, time.relativeNanoseconds());
     }
 
     @Test
     public void testAutoTickMs() {
         MockTime time = new MockTime(1, 100, 200);
-        Assert.assertEquals(101, time.milliseconds());
-        Assert.assertEquals(2000200, time.nanoseconds());
-        Assert.assertEquals(103, time.milliseconds());
-        Assert.assertEquals(104, time.milliseconds());
+        Assert.assertEquals(101, time.absoluteMilliseconds());
+        Assert.assertEquals(2000200, time.relativeNanoseconds());
+        Assert.assertEquals(103, time.absoluteMilliseconds());
+        Assert.assertEquals(104, time.absoluteMilliseconds());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
@@ -40,7 +40,7 @@ public class TimerTest {
         assertEquals(100, timer.elapsedMs());
 
         time.sleep(400);
-        timer.update(time.milliseconds());
+        timer.update(time.absoluteMilliseconds());
 
         assertEquals(0, timer.remainingMs());
         assertEquals(500, timer.elapsedMs());
@@ -49,7 +49,7 @@ public class TimerTest {
         // Going over the expiration is fine and the elapsed time can exceed
         // the initial timeout. However, remaining time should be stuck at 0.
         time.sleep(200);
-        timer.update(time.milliseconds());
+        timer.update(time.absoluteMilliseconds());
         assertTrue(timer.isExpired());
         assertEquals(0, timer.remainingMs());
         assertEquals(700, timer.elapsedMs());
@@ -115,11 +115,11 @@ public class TimerTest {
         long currentTimeMs = timer.currentTimeMs();
 
         timer.sleep(200);
-        assertEquals(time.milliseconds(), timer.currentTimeMs());
+        assertEquals(time.absoluteMilliseconds(), timer.currentTimeMs());
         assertEquals(currentTimeMs + 200, timer.currentTimeMs());
 
         timer.sleep(1000);
-        assertEquals(time.milliseconds(), timer.currentTimeMs());
+        assertEquals(time.absoluteMilliseconds(), timer.currentTimeMs());
         assertEquals(currentTimeMs + 500, timer.currentTimeMs());
         assertTrue(timer.isExpired());
     }

--- a/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
+++ b/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
@@ -82,13 +82,13 @@ public class Microbenchmarks {
             public void run() {
                 time.sleep(1);
                 int counter = 0;
-                long start = time.nanoseconds();
+                long start = time.relativeNanoseconds();
                 for (int i = 0; i < iters; i++) {
                     synchronized (lock) {
                         counter++;
                     }
                 }
-                System.out.println("synchronized: " + ((time.nanoseconds() - start) / iters));
+                System.out.println("synchronized: " + ((time.relativeNanoseconds() - start) / iters));
                 System.out.println(counter);
                 done.set(true);
             }
@@ -119,13 +119,13 @@ public class Microbenchmarks {
             public void run() {
                 time.sleep(1);
                 int counter = 0;
-                long start = time.nanoseconds();
+                long start = time.relativeNanoseconds();
                 for (int i = 0; i < iters; i++) {
                     lock2.lock();
                     counter++;
                     lock2.unlock();
                 }
-                System.out.println("lock: " + ((time.nanoseconds() - start) / iters));
+                System.out.println("lock: " + ((time.relativeNanoseconds() - start) / iters));
                 System.out.println(counter);
                 done.set(true);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -63,7 +63,7 @@ public class ConnectDistributed {
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect distributed worker initializing ...");
-            long initStart = time.hiResClockMs();
+            long initStart = time.relativeMilliseconds();
             WorkerInfo initInfo = new WorkerInfo();
             initInfo.logAll();
 
@@ -102,7 +102,7 @@ public class ConnectDistributed {
                     kafkaClusterId, statusBackingStore, configBackingStore,
                     advertisedUrl.toString());
             final Connect connect = new Connect(herder, rest);
-            log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);
+            log.info("Kafka Connect distributed worker initialization took {}ms", time.relativeMilliseconds() - initStart);
             try {
                 connect.start();
             } catch (Exception e) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -65,7 +65,7 @@ public class ConnectStandalone {
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect standalone worker initializing ...");
-            long initStart = time.hiResClockMs();
+            long initStart = time.relativeMilliseconds();
             WorkerInfo initInfo = new WorkerInfo();
             initInfo.logAll();
 
@@ -89,7 +89,7 @@ public class ConnectStandalone {
 
             Herder herder = new StandaloneHerder(worker, kafkaClusterId);
             final Connect connect = new Connect(herder, rest);
-            log.info("Kafka Connect standalone worker initialization took {}ms", time.hiResClockMs() - initStart);
+            log.info("Kafka Connect standalone worker initialization took {}ms", time.relativeMilliseconds() - initStart);
 
             try {
                 connect.start();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -184,7 +184,7 @@ public class Worker {
     public void stop() {
         log.info("Worker stopping");
 
-        long started = time.milliseconds();
+        long started = time.absoluteMilliseconds();
         long limit = started + config.getLong(WorkerConfig.TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG);
 
         if (!connectors.isEmpty()) {
@@ -197,7 +197,7 @@ public class Worker {
             stopAndAwaitTasks();
         }
 
-        long timeoutMs = limit - time.milliseconds();
+        long timeoutMs = limit - time.absoluteMilliseconds();
         sourceTaskOffsetCommitter.close(timeoutMs);
 
         offsetBackingStore.stop();
@@ -588,10 +588,10 @@ public class Worker {
     }
 
     private void awaitStopTasks(Collection<ConnectorTaskId> ids) {
-        long now = time.milliseconds();
+        long now = time.absoluteMilliseconds();
         long deadline = now + config.getLong(WorkerConfig.TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG);
         for (ConnectorTaskId id : ids) {
-            long remaining = Math.max(0, deadline - time.milliseconds());
+            long remaining = Math.max(0, deadline - time.absoluteMilliseconds());
             awaitStopTask(id, remaining);
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -123,7 +123,7 @@ class WorkerSinkTask extends WorkerTask {
         this.origOffsets = new HashMap<>();
         this.pausedForRedelivery = false;
         this.rebalanceException = null;
-        this.nextCommit = time.milliseconds() +
+        this.nextCommit = time.absoluteMilliseconds() +
                 workerConfig.getLong(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG);
         this.committing = false;
         this.commitSeqno = 0;
@@ -203,7 +203,7 @@ class WorkerSinkTask extends WorkerTask {
         final long offsetCommitIntervalMs = workerConfig.getLong(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG);
 
         try {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
 
             // Maybe commit
             if (!committing && (context.isCommitRequested() || now >= nextCommit)) {
@@ -256,7 +256,7 @@ class WorkerSinkTask extends WorkerTask {
                     this, seqno, commitSeqno);
             sinkTaskMetricsGroup.recordOffsetCommitSkip();
         } else {
-            long durationMillis = time.milliseconds() - commitStarted;
+            long durationMillis = time.absoluteMilliseconds() - commitStarted;
             if (error != null) {
                 log.error("{} Commit of offsets threw an unexpected exception for sequence number {}: {}",
                         this, seqno, committedOffsets, error);
@@ -561,10 +561,10 @@ class WorkerSinkTask extends WorkerTask {
         try {
             // Since we reuse the messageBatch buffer, ensure we give the task its own copy
             log.trace("{} Delivering batch of {} messages to task", this, messageBatch.size());
-            long start = time.milliseconds();
+            long start = time.absoluteMilliseconds();
             task.put(new ArrayList<>(messageBatch));
             recordBatch(messageBatch.size());
-            sinkTaskMetricsGroup.recordPut(time.milliseconds() - start);
+            sinkTaskMetricsGroup.recordPut(time.absoluteMilliseconds() - start);
             currentOffsets.putAll(origOffsets);
             messageBatch.clear();
             // If we had paused all consumer topic partitions to try to redeliver data, then we should resume any that
@@ -614,7 +614,7 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     private void closePartitions() {
-        commitOffsets(time.milliseconds(), true);
+        commitOffsets(time.absoluteMilliseconds(), true);
         sinkTaskMetricsGroup.recordPartitionCount(0);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -377,41 +377,41 @@ abstract class WorkerTask implements Runnable {
 
         @Override
         public void onStartup(ConnectorTaskId id) {
-            taskStateTimer.changeState(State.RUNNING, time.milliseconds());
+            taskStateTimer.changeState(State.RUNNING, time.absoluteMilliseconds());
             delegateListener.onStartup(id);
         }
 
         @Override
         public void onFailure(ConnectorTaskId id, Throwable cause) {
-            taskStateTimer.changeState(State.FAILED, time.milliseconds());
+            taskStateTimer.changeState(State.FAILED, time.absoluteMilliseconds());
             delegateListener.onFailure(id, cause);
         }
 
         @Override
         public void onPause(ConnectorTaskId id) {
-            taskStateTimer.changeState(State.PAUSED, time.milliseconds());
+            taskStateTimer.changeState(State.PAUSED, time.absoluteMilliseconds());
             delegateListener.onPause(id);
         }
 
         @Override
         public void onResume(ConnectorTaskId id) {
-            taskStateTimer.changeState(State.RUNNING, time.milliseconds());
+            taskStateTimer.changeState(State.RUNNING, time.absoluteMilliseconds());
             delegateListener.onResume(id);
         }
 
         @Override
         public void onShutdown(ConnectorTaskId id) {
-            taskStateTimer.changeState(State.UNASSIGNED, time.milliseconds());
+            taskStateTimer.changeState(State.UNASSIGNED, time.absoluteMilliseconds());
             delegateListener.onShutdown(id);
         }
 
         public void recordState(TargetState state) {
             switch (state) {
                 case STARTED:
-                    taskStateTimer.changeState(State.RUNNING, time.milliseconds());
+                    taskStateTimer.changeState(State.RUNNING, time.absoluteMilliseconds());
                     break;
                 case PAUSED:
-                    taskStateTimer.changeState(State.PAUSED, time.milliseconds());
+                    taskStateTimer.changeState(State.PAUSED, time.absoluteMilliseconds());
                     break;
                 default:
                     break;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -253,7 +253,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
 
         // Process any external requests
-        final long now = time.milliseconds();
+        final long now = time.absoluteMilliseconds();
         long nextRequestTimeoutMs = Long.MAX_VALUE;
         while (true) {
             final DistributedHerderRequest next = peekWithoutException();
@@ -806,7 +806,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // We only mark this as resolved once we've actually started work, which allows us to correctly track whether
         // what work is currently active and running. If we bail early, the main tick loop + having requested rejoin
         // guarantees we'll attempt to rejoin before executing this method again.
-        herderMetrics.rebalanceSucceeded(time.milliseconds());
+        herderMetrics.rebalanceSucceeded(time.absoluteMilliseconds());
         rebalanceResolved = true;
         return true;
     }
@@ -1061,7 +1061,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     DistributedHerderRequest addRequest(long delayMs, Callable<Void> action, Callback<Void> callback) {
-        DistributedHerderRequest req = new DistributedHerderRequest(time.milliseconds() + delayMs, requestSeqNum.incrementAndGet(), action, callback);
+        DistributedHerderRequest req = new DistributedHerderRequest(time.absoluteMilliseconds() + delayMs, requestSeqNum.incrementAndGet(), action, callback);
         requests.add(req);
         if (peekWithoutException() == req)
             member.wakeup();
@@ -1218,7 +1218,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 DistributedHerder.this.assignment = assignment;
                 DistributedHerder.this.generation = generation;
                 rebalanceResolved = false;
-                herderMetrics.rebalanceStarted(time.milliseconds());
+                herderMetrics.rebalanceStarted(time.absoluteMilliseconds());
             }
 
             // Delete the statuses of all connectors removed prior to the start of this rebalance. This has to

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -112,19 +112,19 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
 
     public void poll(long timeout) {
         // poll for io until the timeout expires
-        final long start = time.milliseconds();
+        final long start = time.absoluteMilliseconds();
         long now = start;
         long remaining;
 
         do {
             if (coordinatorUnknown()) {
                 ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
-                now = time.milliseconds();
+                now = time.absoluteMilliseconds();
             }
 
             if (rejoinNeededOrPending()) {
                 ensureActiveGroup();
-                now = time.milliseconds();
+                now = time.absoluteMilliseconds();
             }
 
             pollHeartbeat(now);
@@ -137,7 +137,7 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
             long pollTimeout = Math.min(Math.max(0, remaining), timeToNextHeartbeat(now));
             client.poll(time.timer(pollTimeout));
 
-            now = time.milliseconds();
+            now = time.absoluteMilliseconds();
             elapsed = now - start;
             remaining = timeout - elapsed;
         } while (remaining > 0);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -98,7 +98,7 @@ public class WorkerGroupMember {
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
                     config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
-            this.metadata.bootstrap(addresses, time.milliseconds());
+            this.metadata.bootstrap(addresses, time.absoluteMilliseconds());
             String metricGrpPrefix = "connect";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time);
             NetworkClient netClient = new NetworkClient(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorHandlingMetrics.java
@@ -138,7 +138,7 @@ public class ErrorHandlingMetrics {
      * Record the time of error.
      */
     public void recordErrorTimestamp() {
-        this.lastErrorTime = time.milliseconds();
+        this.lastErrorTime = time.absoluteMilliseconds();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -120,7 +120,7 @@ public class RetryWithToleranceOperator {
      */
     protected <V> V execAndRetry(Operation<V> operation) throws Exception {
         int attempt = 0;
-        long startTime = time.milliseconds();
+        long startTime = time.absoluteMilliseconds();
         long deadline = startTime + errorRetryTimeout;
         do {
             try {
@@ -204,7 +204,7 @@ public class RetryWithToleranceOperator {
 
     // Visible for testing
     boolean checkRetry(long startTime) {
-        return (time.milliseconds() - startTime) < errorRetryTimeout;
+        return (time.absoluteMilliseconds() - startTime) < errorRetryTimeout;
     }
 
     // Visible for testing
@@ -214,8 +214,8 @@ public class RetryWithToleranceOperator {
         if (delay > errorMaxDelayInMillis) {
             delay = ThreadLocalRandom.current().nextLong(errorMaxDelayInMillis);
         }
-        if (delay + time.milliseconds() > deadline) {
-            delay = deadline - time.milliseconds();
+        if (delay + time.absoluteMilliseconds() > deadline) {
+            delay = deadline - time.absoluteMilliseconds();
         }
         log.debug("Sleeping for {} millis", delay);
         time.sleep(delay);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -132,10 +132,10 @@ public class KafkaBasedLog<K, V> {
 
         // We expect that the topics will have been created either manually by the user or automatically by the herder
         List<PartitionInfo> partitionInfos = null;
-        long started = time.milliseconds();
-        while (partitionInfos == null && time.milliseconds() - started < CREATE_TOPIC_TIMEOUT_MS) {
+        long started = time.absoluteMilliseconds();
+        while (partitionInfos == null && time.absoluteMilliseconds() - started < CREATE_TOPIC_TIMEOUT_MS) {
             partitionInfos = consumer.partitionsFor(topic);
-            Utils.sleep(Math.min(time.milliseconds() - started, 1000));
+            Utils.sleep(Math.min(time.absoluteMilliseconds() - started, 1000));
         }
         if (partitionInfos == null)
             throw new ConnectException("Could not look up partition metadata for offset backing store topic in" +

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/StateTrackerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/StateTrackerTest.java
@@ -48,52 +48,52 @@ public class StateTrackerTest {
     @Test
     public void currentState() {
         for (State state : State.values()) {
-            tracker.changeState(state, time.milliseconds());
+            tracker.changeState(state, time.absoluteMilliseconds());
             assertEquals(state, tracker.currentState());
         }
     }
 
     @Test
     public void calculateDurations() {
-        tracker.changeState(State.UNASSIGNED, time.milliseconds());
+        tracker.changeState(State.UNASSIGNED, time.absoluteMilliseconds());
         time.sleep(1000L);
-        assertEquals(1.0d, tracker.durationRatio(State.UNASSIGNED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.RUNNING, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(1.0d, tracker.durationRatio(State.UNASSIGNED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RUNNING, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.absoluteMilliseconds()), DELTA);
 
-        tracker.changeState(State.RUNNING, time.milliseconds());
+        tracker.changeState(State.RUNNING, time.absoluteMilliseconds());
         time.sleep(3000L);
-        assertEquals(0.25d, tracker.durationRatio(State.UNASSIGNED, time.milliseconds()), DELTA);
-        assertEquals(0.75d, tracker.durationRatio(State.RUNNING, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.25d, tracker.durationRatio(State.UNASSIGNED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.75d, tracker.durationRatio(State.RUNNING, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.absoluteMilliseconds()), DELTA);
 
-        tracker.changeState(State.PAUSED, time.milliseconds());
+        tracker.changeState(State.PAUSED, time.absoluteMilliseconds());
         time.sleep(4000L);
-        assertEquals(0.125d, tracker.durationRatio(State.UNASSIGNED, time.milliseconds()), DELTA);
-        assertEquals(0.375d, tracker.durationRatio(State.RUNNING, time.milliseconds()), DELTA);
-        assertEquals(0.500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.125d, tracker.durationRatio(State.UNASSIGNED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.375d, tracker.durationRatio(State.RUNNING, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.500d, tracker.durationRatio(State.PAUSED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.absoluteMilliseconds()), DELTA);
 
-        tracker.changeState(State.RUNNING, time.milliseconds());
+        tracker.changeState(State.RUNNING, time.absoluteMilliseconds());
         time.sleep(8000L);
-        assertEquals(0.0625d, tracker.durationRatio(State.UNASSIGNED, time.milliseconds()), DELTA);
-        assertEquals(0.6875d, tracker.durationRatio(State.RUNNING, time.milliseconds()), DELTA);
-        assertEquals(0.2500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0625d, tracker.durationRatio(State.UNASSIGNED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.6875d, tracker.durationRatio(State.RUNNING, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.2500d, tracker.durationRatio(State.PAUSED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.absoluteMilliseconds()), DELTA);
 
-        tracker.changeState(State.FAILED, time.milliseconds());
+        tracker.changeState(State.FAILED, time.absoluteMilliseconds());
         time.sleep(16000L);
-        assertEquals(0.03125d, tracker.durationRatio(State.UNASSIGNED, time.milliseconds()), DELTA);
-        assertEquals(0.34375d, tracker.durationRatio(State.RUNNING, time.milliseconds()), DELTA);
-        assertEquals(0.12500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
-        assertEquals(0.50000d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
-        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.03125d, tracker.durationRatio(State.UNASSIGNED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.34375d, tracker.durationRatio(State.RUNNING, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.12500d, tracker.durationRatio(State.PAUSED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.50000d, tracker.durationRatio(State.FAILED, time.absoluteMilliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.absoluteMilliseconds()), DELTA);
 
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -168,7 +168,7 @@ public class RetryWithToleranceOperatorTest {
         String result = retryWithToleranceOperator.execAndHandleError(mockOperation, Exception.class);
         assertFalse(retryWithToleranceOperator.failed());
         assertEquals("Success", result);
-        assertEquals(expectedWait, time.hiResClockMs());
+        assertEquals(expectedWait, time.relativeMilliseconds());
 
         PowerMock.verifyAll();
     }
@@ -186,7 +186,7 @@ public class RetryWithToleranceOperatorTest {
         String result = retryWithToleranceOperator.execAndHandleError(mockOperation, Exception.class);
         assertTrue(retryWithToleranceOperator.failed());
         assertNull(result);
-        assertEquals(expectedWait, time.hiResClockMs());
+        assertEquals(expectedWait, time.relativeMilliseconds());
 
         PowerMock.verifyAll();
     }
@@ -220,29 +220,29 @@ public class RetryWithToleranceOperatorTest {
         MockTime time = new MockTime(0, 0, 0);
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(5, 5000, NONE, time);
 
-        long prevTs = time.hiResClockMs();
+        long prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(1, 5000);
-        assertEquals(300, time.hiResClockMs() - prevTs);
+        assertEquals(300, time.relativeMilliseconds() - prevTs);
 
-        prevTs = time.hiResClockMs();
+        prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(2, 5000);
-        assertEquals(600, time.hiResClockMs() - prevTs);
+        assertEquals(600, time.relativeMilliseconds() - prevTs);
 
-        prevTs = time.hiResClockMs();
+        prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(3, 5000);
-        assertEquals(1200, time.hiResClockMs() - prevTs);
+        assertEquals(1200, time.relativeMilliseconds() - prevTs);
 
-        prevTs = time.hiResClockMs();
+        prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(4, 5000);
-        assertEquals(2400, time.hiResClockMs() - prevTs);
+        assertEquals(2400, time.relativeMilliseconds() - prevTs);
 
-        prevTs = time.hiResClockMs();
+        prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(5, 5000);
-        assertEquals(500, time.hiResClockMs() - prevTs);
+        assertEquals(500, time.relativeMilliseconds() - prevTs);
 
-        prevTs = time.hiResClockMs();
+        prevTs = time.relativeMilliseconds();
         retryWithToleranceOperator.backoff(6, 5000);
-        assertEquals(0, time.hiResClockMs() - prevTs);
+        assertEquals(0, time.relativeMilliseconds() - prevTs);
 
         PowerMock.verifyAll();
     }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -398,7 +398,7 @@ class Partition(val topicPartition: TopicPartition,
 
       val isNewLeader = !leaderReplicaIdOpt.contains(localBrokerId)
       val curLeaderLogEndOffset = leaderReplica.logEndOffset.messageOffset
-      val curTimeMs = time.milliseconds
+      val curTimeMs = time.absoluteMilliseconds
       // initialize lastCaughtUpTime of replicas as well as their lastFetchTimeMs and lastFetchLeaderLogEndOffset.
       (assignedReplicas - leaderReplica).foreach { replica =>
         val lastCaughtUpTimeMs = if (inSyncReplicas.contains(replica)) curTimeMs else 0L
@@ -583,7 +583,7 @@ class Partition(val topicPartition: TopicPartition,
    * Note There is no need to acquire the leaderIsrUpdate lock here
    * since all callers of this private API acquire that lock
    */
-  private def maybeIncrementLeaderHW(leaderReplica: Replica, curTime: Long = time.milliseconds): Boolean = {
+  private def maybeIncrementLeaderHW(leaderReplica: Replica, curTime: Long = time.absoluteMilliseconds): Boolean = {
     val allLogEndOffsets = assignedReplicas.filter { replica =>
       curTime - replica.lastCaughtUpTimeMs <= replicaLagTimeMaxMs || inSyncReplicas.contains(replica)
     }.map(_.logEndOffset)
@@ -674,7 +674,7 @@ class Partition(val topicPartition: TopicPartition,
     val candidateReplicas = inSyncReplicas - leaderReplica
 
     val laggingReplicas = candidateReplicas.filter(r =>
-      r.logEndOffset.messageOffset != leaderReplica.logEndOffset.messageOffset && (time.milliseconds - r.lastCaughtUpTimeMs) > maxLagMs)
+      r.logEndOffset.messageOffset != leaderReplica.logEndOffset.messageOffset && (time.absoluteMilliseconds - r.lastCaughtUpTimeMs) > maxLagMs)
     if (laggingReplicas.nonEmpty)
       debug("Lagging replicas are %s".format(laggingReplicas.map(_.brokerId).mkString(",")))
 

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -52,7 +52,7 @@ abstract class InterBrokerSendThread(name: String,
   }
 
   override def doWork() {
-    var now = time.milliseconds()
+    var now = time.absoluteMilliseconds()
 
     generateRequests().foreach { request =>
       val completionHandler = request.handler
@@ -64,7 +64,7 @@ abstract class InterBrokerSendThread(name: String,
     try {
       val timeout = sendRequests(now)
       networkClient.poll(timeout, now)
-      now = time.milliseconds()
+      now = time.absoluteMilliseconds()
       checkDisconnects(now)
       failExpiredRequests(now)
       unsentRequests.clean()

--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -82,7 +82,7 @@ class ZkNodeChangeNotificationListener(private val zkClient: KafkaZkClient,
       val notifications = zkClient.getChildren(seqNodeRoot).sorted
       if (notifications.nonEmpty) {
         info(s"Processing notification(s) to $seqNodeRoot")
-        val now = time.milliseconds
+        val now = time.absoluteMilliseconds
         for (notification <- notifications) {
           val changeId = changeNumber(notification)
           if (changeId > lastExecutedChange) {

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -81,7 +81,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
       val stateInfoOpt = brokerStateInfo.get(brokerId)
       stateInfoOpt match {
         case Some(stateInfo) =>
-          stateInfo.messageQueue.put(QueueItem(apiKey, request, callback, time.milliseconds()))
+          stateInfo.messageQueue.put(QueueItem(apiKey, request, callback, time.absoluteMilliseconds()))
         case None =>
           warn(s"Not sending request $request to broker $brokerId, since it is offline.")
       }
@@ -222,7 +222,7 @@ class RequestSendThread(val controllerId: Int,
     def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)
 
     val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
-    requestRateAndQueueTimeMetrics.update(time.milliseconds() - enqueueTimeMs, TimeUnit.MILLISECONDS)
+    requestRateAndQueueTimeMetrics.update(time.absoluteMilliseconds() - enqueueTimeMs, TimeUnit.MILLISECONDS)
 
     var clientResponse: ClientResponse = null
     try {
@@ -237,7 +237,7 @@ class RequestSendThread(val controllerId: Int,
           }
           else {
             val clientRequest = networkClient.newClientRequest(brokerNode.idString, requestBuilder,
-              time.milliseconds(), true)
+              time.absoluteMilliseconds(), true)
             clientResponse = NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
             isSendSuccessful = true
           }
@@ -276,7 +276,7 @@ class RequestSendThread(val controllerId: Int,
 
   private def brokerReady(): Boolean = {
     try {
-      if (!NetworkClientUtils.isReady(networkClient, brokerNode, time.milliseconds())) {
+      if (!NetworkClientUtils.isReady(networkClient, brokerNode, time.absoluteMilliseconds())) {
         if (!NetworkClientUtils.awaitReady(networkClient, brokerNode, time, socketTimeoutMs))
           throw new SocketTimeoutException(s"Failed to connect within $socketTimeoutMs ms")
 

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -82,7 +82,7 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
         case controllerEvent =>
           _state = controllerEvent.state
 
-          eventQueueTimeHist.update(time.milliseconds() - controllerEvent.enqueueTimeMs)
+          eventQueueTimeHist.update(time.absoluteMilliseconds() - controllerEvent.enqueueTimeMs)
 
           try {
             rateAndTimeMetrics(state).time {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1665,7 +1665,7 @@ private[controller] class ControllerStats extends KafkaMetricsGroup {
 }
 
 sealed trait ControllerEvent {
-  val enqueueTimeMs: Long = Time.SYSTEM.milliseconds()
+  val enqueueTimeMs: Long = Time.SYSTEM.absoluteMilliseconds()
 
   def state: ControllerState
   def process(): Unit

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -675,7 +675,7 @@ class GroupCoordinator(val brokerId: Int,
    */
   private def completeAndScheduleNextHeartbeatExpiration(group: GroupMetadata, member: MemberMetadata) {
     // complete current heartbeat expectation
-    member.latestHeartbeat = time.milliseconds()
+    member.latestHeartbeat = time.absoluteMilliseconds()
     val memberKey = MemberKey(member.groupId, member.memberId)
     heartbeatPurgatory.checkAndComplete(memberKey)
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -177,7 +177,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private[group] val lock = new ReentrantLock
 
   private var state: GroupState = initialState
-  var currentStateTimestamp: Option[Long] = Some(time.milliseconds())
+  var currentStateTimestamp: Option[Long] = Some(time.absoluteMilliseconds())
   var protocolType: Option[String] = None
   var generationId = 0
   private var leaderId: Option[String] = None
@@ -261,7 +261,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def transitionTo(groupState: GroupState) {
     assertValidTransition(groupState)
     state = groupState
-    currentStateTimestamp = Some(time.milliseconds())
+    currentStateTimestamp = Some(time.absoluteMilliseconds())
   }
 
   def selectProtocol: String = {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -934,7 +934,7 @@ private[log] class Cleaner(val id: Int,
  * A simple struct for collecting stats about log cleaning
  */
 private class CleanerStats(time: Time = Time.SYSTEM) {
-  val startTime = time.milliseconds
+  val startTime = time.absoluteMilliseconds
   var mapCompleteTime = -1L
   var endTime = -1L
   var bytesRead = 0L
@@ -969,11 +969,11 @@ private class CleanerStats(time: Time = Time.SYSTEM) {
   }
 
   def indexDone() {
-    mapCompleteTime = time.milliseconds
+    mapCompleteTime = time.absoluteMilliseconds
   }
 
   def allDone() {
-    endTime = time.milliseconds
+    endTime = time.absoluteMilliseconds
   }
 
   def elapsedSecs = (endTime - startTime)/1000.0

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -100,7 +100,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
               uncleanablePartitions.get(dir.getAbsolutePath) match {
                 case Some(partitions) => {
                   val lastClean = allCleanerCheckpoints
-                  val now = Time.SYSTEM.milliseconds
+                  val now = Time.SYSTEM.absoluteMilliseconds
                   partitions.map { tp =>
                     val log = logs.get(tp)
                     val (firstDirtyOffset, firstUncleanableDirtyOffset) = LogCleanerManager.cleanableOffsets(log, tp, lastClean, now)
@@ -122,8 +122,8 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   newGauge("max-dirty-percent", new Gauge[Int] { def value = (100 * dirtiestLogCleanableRatio).toInt })
 
   /* a gauge for tracking the time since the last log cleaner run, in milli seconds */
-  @volatile private var timeOfLastRun : Long = Time.SYSTEM.milliseconds
-  newGauge("time-since-last-run-ms", new Gauge[Long] { def value = Time.SYSTEM.milliseconds - timeOfLastRun })
+  @volatile private var timeOfLastRun : Long = Time.SYSTEM.absoluteMilliseconds
+  newGauge("time-since-last-run-ms", new Gauge[Long] { def value = Time.SYSTEM.absoluteMilliseconds - timeOfLastRun })
 
   /**
    * @return the position processed for all logs.
@@ -167,7 +167,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     */
   def grabFilthiestCompactedLog(time: Time): Option[LogToClean] = {
     inLock(lock) {
-      val now = time.milliseconds
+      val now = time.absoluteMilliseconds
       this.timeOfLastRun = now
       val lastClean = allCleanerCheckpoints
       val dirtyLogs = logs.filter {

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -249,7 +249,7 @@ class LogManager(logDirs: Seq[File],
   }
 
   private def addLogToBeDeleted(log: Log): Unit = {
-    this.logsToBeDeleted.add((log, time.milliseconds()))
+    this.logsToBeDeleted.add((log, time.absoluteMilliseconds()))
   }
 
   // Only for testing
@@ -300,7 +300,7 @@ class LogManager(logDirs: Seq[File],
    */
   private def loadLogs(): Unit = {
     info("Loading logs.")
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     val threadPools = ArrayBuffer.empty[ExecutorService]
     val offlineDirs = mutable.Set.empty[(String, IOException)]
     val jobs = mutable.Map.empty[File, Seq[Future[_]]]
@@ -381,7 +381,7 @@ class LogManager(logDirs: Seq[File],
       threadPools.foreach(_.shutdown())
     }
 
-    info(s"Logs loading complete in ${time.milliseconds - startMs} ms.")
+    info(s"Logs loading complete in ${time.absoluteMilliseconds - startMs} ms.")
   }
 
   /**
@@ -749,7 +749,7 @@ class LogManager(logDirs: Seq[File],
       def nextDeleteDelayMs: Long = {
         if (!logsToBeDeleted.isEmpty) {
           val (_, scheduleTimeMs) = logsToBeDeleted.peek()
-          scheduleTimeMs + currentDefaultConfig.fileDeleteDelayMs - time.milliseconds()
+          scheduleTimeMs + currentDefaultConfig.fileDeleteDelayMs - time.absoluteMilliseconds()
         } else
           currentDefaultConfig.fileDeleteDelayMs
       }
@@ -892,7 +892,7 @@ class LogManager(logDirs: Seq[File],
   def cleanupLogs() {
     debug("Beginning log cleanup...")
     var total = 0
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
 
     // clean current logs.
     val deletableLogs = {
@@ -926,7 +926,7 @@ class LogManager(logDirs: Seq[File],
     }
 
     debug(s"Log cleanup completed. $total files deleted in " +
-                  (time.milliseconds - startMs) / 1000 + " seconds")
+                  (time.absoluteMilliseconds - startMs) / 1000 + " seconds")
   }
 
   /**
@@ -965,7 +965,7 @@ class LogManager(logDirs: Seq[File],
 
     for ((topicPartition, log) <- currentLogs.toList ++ futureLogs.toList) {
       try {
-        val timeSinceLastFlush = time.milliseconds - log.lastFlushTime
+        val timeSinceLastFlush = time.absoluteMilliseconds - log.lastFlushTime
         debug(s"Checking if flush is needed on ${topicPartition.topic} flush interval ${log.config.flushMs}" +
               s" last flushed ${log.lastFlushTime} time since last flush: $timeSinceLastFlush")
         if(timeSinceLastFlush >= log.config.flushMs)

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -85,7 +85,7 @@ class LogSegment private[log] (val log: FileRecords,
     else throw new NoSuchFileException(s"Offset index file ${offsetIndex.file.getAbsolutePath} does not exist")
   }
 
-  private var created = time.milliseconds
+  private var created = time.absoluteMilliseconds
 
   /* the number of bytes since we last added an entry in the offset index */
   private var bytesSinceLastIndexEntry = 0
@@ -431,7 +431,7 @@ class LogSegment private[log] (val log: FileRecords,
 
     val bytesTruncated = if (mapping == null) 0 else log.truncateTo(mapping.position)
     if (log.sizeInBytes == 0) {
-      created = time.milliseconds
+      created = time.absoluteMilliseconds
       rollingBasedTimestamp = None
     }
 

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -130,7 +130,7 @@ private[kafka] object LogValidator extends Logging {
                                                    toMagicValue: Byte,
                                                    partitionLeaderEpoch: Int,
                                                    isFromClient: Boolean): ValidationAndOffsetAssignResult = {
-    val startNanos = time.nanoseconds
+    val startNanos = time.relativeNanoseconds
     val sizeInBytesAfterConversion = AbstractRecords.estimateSizeInBytes(toMagicValue, offsetCounter.value,
       CompressionType.NONE, records.records)
 
@@ -156,7 +156,7 @@ private[kafka] object LogValidator extends Logging {
 
     val info = builder.info
     val recordConversionStats = new RecordConversionStats(builder.uncompressedBytesWritten,
-      builder.numRecords, time.nanoseconds - startNanos)
+      builder.numRecords, time.relativeNanoseconds - startNanos)
     ValidationAndOffsetAssignResult(
       validatedRecords = convertedRecords,
       maxTimestamp = info.maxTimestamp,
@@ -338,7 +338,7 @@ private[kafka] object LogValidator extends Logging {
                                            partitionLeaderEpoch: Int,
                                            isFromClient: Boolean,
                                            uncompresssedSizeInBytes: Int): ValidationAndOffsetAssignResult = {
-    val startNanos = time.nanoseconds
+    val startNanos = time.relativeNanoseconds
     val estimatedSize = AbstractRecords.estimateSizeInBytes(magic, offsetCounter.value, compressionType,
       validatedRecords.asJava)
     val buffer = ByteBuffer.allocate(estimatedSize)
@@ -359,7 +359,7 @@ private[kafka] object LogValidator extends Logging {
     // to rebuild the records (including recompression if enabled).
     val conversionCount = builder.numRecords
     val recordConversionStats = new RecordConversionStats(uncompresssedSizeInBytes + builder.uncompressedBytesWritten,
-      conversionCount, time.nanoseconds - startNanos)
+      conversionCount, time.relativeNanoseconds - startNanos)
 
     ValidationAndOffsetAssignResult(
       validatedRecords = records,

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -111,12 +111,12 @@ object RequestChannel extends Logging {
     trace(s"Processor $processor received request: ${requestDesc(true)}")
 
     def requestThreadTimeNanos = {
-      if (apiLocalCompleteTimeNanos == -1L) apiLocalCompleteTimeNanos = Time.SYSTEM.nanoseconds
+      if (apiLocalCompleteTimeNanos == -1L) apiLocalCompleteTimeNanos = Time.SYSTEM.relativeNanoseconds
       math.max(apiLocalCompleteTimeNanos - requestDequeueTimeNanos, 0L)
     }
 
     def updateRequestMetrics(networkThreadTimeNanos: Long, response: Response) {
-      val endTimeNanos = Time.SYSTEM.nanoseconds
+      val endTimeNanos = Time.SYSTEM.relativeNanoseconds
       // In some corner cases, apiLocalCompleteTimeNanos may not be set when the request completes if the remote
       // processing time is really small. This value is set in KafkaApis from a request handling thread.
       // This may be read in a network thread before the actual update happens in KafkaApis which will cause us to
@@ -223,7 +223,7 @@ object RequestChannel extends Logging {
 
   abstract class Response(val request: Request) {
     locally {
-      val nowNs = Time.SYSTEM.nanoseconds
+      val nowNs = Time.SYSTEM.relativeNanoseconds
       request.responseCompleteTimeNanos = nowNs
       if (request.apiLocalCompleteTimeNanos == -1L)
         request.apiLocalCompleteTimeNanos = nowNs

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -707,7 +707,7 @@ private[kafka] class Processor(val id: Int,
   }
 
   private def nowNanosSupplier = new Supplier[java.lang.Long] {
-    override def get(): java.lang.Long = time.nanoseconds()
+    override def get(): java.lang.Long = time.relativeNanoseconds()
   }
 
   private def poll() {
@@ -729,7 +729,7 @@ private[kafka] class Processor(val id: Int,
             if (header.apiKey() == ApiKeys.SASL_HANDSHAKE && channel.maybeBeginServerReauthentication(receive, nowNanosSupplier))
               trace(s"Begin re-authentication: $channel")
             else {
-              val nowNanos = time.nanoseconds()
+              val nowNanos = time.relativeNanoseconds()
               if (channel.serverAuthenticationSessionExpired(nowNanos)) {
                 channel.disconnect()
                 debug(s"Disconnected expired channel: $channel : $header")
@@ -879,7 +879,7 @@ private[kafka] class Processor(val id: Int,
   private def dequeueResponse(): RequestChannel.Response = {
     val response = responseQueue.poll()
     if (response != null)
-      response.request.responseDequeueTimeNanos = Time.SYSTEM.nanoseconds
+      response.request.responseDequeueTimeNanos = Time.SYSTEM.relativeNanoseconds
     response
   }
 

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -286,7 +286,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
    * next request is processed.
    */
   def recordNoThrottle(clientSensors: ClientSensors, value: Double) {
-    clientSensors.quotaSensor.record(value, time.milliseconds(), false)
+    clientSensors.quotaSensor.record(value, time.absoluteMilliseconds(), false)
   }
 
   /**
@@ -327,7 +327,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     val quota = config.quota()
     val difference = clientMetric.metricValue.asInstanceOf[Double] - quota.bound
     // Use the precise window used by the rate calculation
-    val throttleTimeMs = difference / quota.bound * rateMetric.windowSize(config, time.milliseconds())
+    val throttleTimeMs = difference / quota.bound * rateMetric.windowSize(config, time.absoluteMilliseconds())
     throttleTimeMs.round
   }
 

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -49,14 +49,14 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
   def maybeRecordAndGetThrottleTimeMs(request: RequestChannel.Request): Int = {
     if (request.apiRemoteCompleteTimeNanos == -1) {
       // When this callback is triggered, the remote API call has completed
-      request.apiRemoteCompleteTimeNanos = time.nanoseconds
+      request.apiRemoteCompleteTimeNanos = time.relativeNanoseconds
     }
 
     if (quotasEnabled) {
       request.recordNetworkThreadTimeCallback = Some(timeNanos => recordNoThrottle(
         getOrCreateQuotaSensors(request.session, request.header.clientId), nanosToPercentage(timeNanos)))
       recordAndGetThrottleTimeMs(request.session, request.header.clientId,
-        nanosToPercentage(request.requestThreadTimeNanos), time.milliseconds())
+        nanosToPercentage(request.requestThreadTimeNanos), time.absoluteMilliseconds())
     } else {
       0
     }

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -269,7 +269,7 @@ class DelegationTokenManager(val config: KafkaConfig,
       lock.synchronized {
         val tokenId = CoreUtils.generateUuidAsBase64
 
-        val issueTimeStamp = time.milliseconds
+        val issueTimeStamp = time.absoluteMilliseconds
         val maxLifeTime = if (maxLifeTimeMs <= 0) tokenMaxLifetime else Math.min(maxLifeTimeMs, tokenMaxLifetime)
         val maxLifeTimeStamp = issueTimeStamp + maxLifeTime
         val expiryTimeStamp = Math.min(maxLifeTimeStamp, issueTimeStamp + defaultTokenRenewTime)
@@ -303,7 +303,7 @@ class DelegationTokenManager(val config: KafkaConfig,
       lock.synchronized  {
         getToken(hmac) match {
           case Some(token) => {
-            val now = time.milliseconds
+            val now = time.absoluteMilliseconds
             val tokenInfo =  token.tokenInfo
 
             if (!allowedToRenew(principal, tokenInfo)) {
@@ -404,7 +404,7 @@ class DelegationTokenManager(val config: KafkaConfig,
         getToken(hmac) match {
           case Some(token) =>  {
             val tokenInfo =  token.tokenInfo
-            val now = time.milliseconds
+            val now = time.absoluteMilliseconds
 
             if (!allowedToRenew(principal, tokenInfo)) {
               expireResponseCallback(Errors.DELEGATION_TOKEN_OWNER_MISMATCH, -1)
@@ -455,7 +455,7 @@ class DelegationTokenManager(val config: KafkaConfig,
   def expireTokens(): Unit = {
     lock.synchronized {
       for (tokenInfo <- getAllTokenInformation) {
-        val now = time.milliseconds
+        val now = time.absoluteMilliseconds
         if (tokenInfo.maxTimestamp < now || tokenInfo.expiryTimestamp < now) {
           info(s"Delegation token expired for token: ${tokenInfo.tokenId} for owner: ${tokenInfo.owner}")
           removeToken(tokenInfo.tokenId)

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -378,7 +378,7 @@ class FullFetchContext(private val time: Time,
       })
       cachedPartitions
     }
-    val responseSessionId = cache.maybeCreateSession(time.milliseconds(), isFromFollower,
+    val responseSessionId = cache.maybeCreateSession(time.absoluteMilliseconds(), isFromFollower,
         updates.size, () => createNewSession)
     debug(s"Full fetch context with session id $responseSessionId returning " +
       s"${partitionsToLogString(updates.keySet)}")

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -49,10 +49,10 @@ class KafkaRequestHandler(id: Int,
       // Since meter is calculated as total_recorded_value / time_window and
       // time_window is independent of the number of threads, each recorded idle
       // time should be discounted by # threads.
-      val startSelectTime = time.nanoseconds
+      val startSelectTime = time.relativeNanoseconds
 
       val req = requestChannel.receiveRequest(300)
-      val endTime = time.nanoseconds
+      val endTime = time.relativeNanoseconds
       val idleTime = endTime - startSelectTime
       aggregateIdleMeter.mark(idleTime / totalHandlerThreads.get)
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -502,7 +502,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
               val controlledShutdownRequest = new ControlledShutdownRequest.Builder(config.brokerId,
                 controlledShutdownApiVersion)
               val request = networkClient.newClientRequest(node(prevController).idString, controlledShutdownRequest,
-                time.milliseconds(), true)
+                time.absoluteMilliseconds(), true)
               val clientResponse = NetworkClientUtils.sendAndReceive(networkClient, request, time)
 
               val shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]

--- a/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
@@ -96,7 +96,7 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
         throw new SocketTimeoutException(s"Failed to connect within $socketTimeout ms")
       else {
         val clientRequest = networkClient.newClientRequest(sourceBroker.id.toString, requestBuilder,
-          time.milliseconds(), true)
+          time.absoluteMilliseconds(), true)
         NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
       }
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -466,10 +466,10 @@ class ReplicaManager(val config: KafkaConfig,
                     delayedProduceLock: Option[Lock] = None,
                     recordConversionStatsCallback: Map[TopicPartition, RecordConversionStats] => Unit = _ => ()) {
     if (isValidRequiredAcks(requiredAcks)) {
-      val sTime = time.milliseconds
+      val sTime = time.absoluteMilliseconds
       val localProduceResults = appendToLocalLog(internalTopicsAllowed = internalTopicsAllowed,
         isFromClient = isFromClient, entriesPerPartition, requiredAcks)
-      debug("Produce to local log in %d ms".format(time.milliseconds - sTime))
+      debug("Produce to local log in %d ms".format(time.absoluteMilliseconds - sTime))
 
       val produceStatus = localProduceResults.map { case (topicPartition, result) =>
         topicPartition ->
@@ -667,9 +667,9 @@ class ReplicaManager(val config: KafkaConfig,
   def deleteRecords(timeout: Long,
                     offsetPerPartition: Map[TopicPartition, Long],
                     responseCallback: Map[TopicPartition, DeleteRecordsResponse.PartitionResponse] => Unit) {
-    val timeBeforeLocalDeleteRecords = time.milliseconds
+    val timeBeforeLocalDeleteRecords = time.absoluteMilliseconds
     val localDeleteRecordsResults = deleteRecordsOnLocalLog(offsetPerPartition)
-    debug("Delete records on local log in %d ms".format(time.milliseconds - timeBeforeLocalDeleteRecords))
+    debug("Delete records on local log in %d ms".format(time.absoluteMilliseconds - timeBeforeLocalDeleteRecords))
 
     val deleteRecordsStatus = localDeleteRecordsResults.map { case (topicPartition, result) =>
       topicPartition ->
@@ -893,7 +893,7 @@ class ReplicaManager(val config: KafkaConfig,
 
         val partition = getPartitionOrException(tp, expectLeader = fetchOnlyFromLeader)
         val adjustedMaxBytes = math.min(fetchInfo.maxBytes, limitBytes)
-        val fetchTimeMs = time.milliseconds
+        val fetchTimeMs = time.absoluteMilliseconds
 
         // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition
         val readInfo = partition.readRecords(

--- a/core/src/main/scala/kafka/server/ThrottledChannel.scala
+++ b/core/src/main/scala/kafka/server/ThrottledChannel.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.common.utils.Time
   */
 class ThrottledChannel(val request: RequestChannel.Request, val time: Time, val throttleTimeMs: Int, channelThrottlingCallback: Response => Unit)
   extends Delayed with Logging {
-  var endTime = time.milliseconds + throttleTimeMs
+  var endTime = time.absoluteMilliseconds + throttleTimeMs
 
   // Notify the socket server that throttling has started for this channel.
   channelThrottlingCallback(new RequestChannel.StartThrottlingResponse(request))
@@ -47,7 +47,7 @@ class ThrottledChannel(val request: RequestChannel.Request, val time: Time, val 
   }
 
   override def getDelay(unit: TimeUnit): Long = {
-    unit.convert(endTime - time.milliseconds, TimeUnit.MILLISECONDS)
+    unit.convert(endTime - time.absoluteMilliseconds, TimeUnit.MILLISECONDS)
   }
 
   override def compareTo(d: Delayed): Int = {

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -125,7 +125,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
         trace("Committing offsets.")
         try {
           consumerWrapper.commit()
-          lastSuccessfulCommitTime = time.milliseconds
+          lastSuccessfulCommitTime = time.absoluteMilliseconds
           retryNeeded = false
         } catch {
           case e: WakeupException =>

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -71,7 +71,7 @@ object ReplicaVerificationTool extends Logging {
   val dateFormat = new SimpleDateFormat(dateFormatString)
 
   def getCurrentTimeString() = {
-    ReplicaVerificationTool.dateFormat.format(new Date(Time.SYSTEM.milliseconds))
+    ReplicaVerificationTool.dateFormat.format(new Date(Time.SYSTEM.absoluteMilliseconds))
   }
 
   def main(args: Array[String]): Unit = {
@@ -258,7 +258,7 @@ private class ReplicaBuffer(expectedReplicasPerTopicPartition: Map[TopicPartitio
   private val recordsCache = new Pool[TopicPartition, Pool[Int, FetchResponse.PartitionData[MemoryRecords]]]
   private val fetcherBarrier = new AtomicReference(new CountDownLatch(expectedNumFetchers))
   private val verificationBarrier = new AtomicReference(new CountDownLatch(1))
-  @volatile private var lastReportTime = Time.SYSTEM.milliseconds
+  @volatile private var lastReportTime = Time.SYSTEM.absoluteMilliseconds
   private var maxLag: Long = -1L
   private var offsetWithMaxLag: Long = -1L
   private var maxLagTopicAndPartition: TopicPartition = null
@@ -363,7 +363,7 @@ private class ReplicaBuffer(expectedReplicasPerTopicPartition: Map[TopicPartitio
       }
       fetchResponsePerReplica.clear()
     }
-    val currentTimeMs = Time.SYSTEM.milliseconds
+    val currentTimeMs = Time.SYSTEM.absoluteMilliseconds
     if (currentTimeMs - lastReportTime > reportInterval) {
       println(ReplicaVerificationTool.dateFormat.format(new Date(currentTimeMs)) + ": max lag is "
         + maxLag + " for partition " + maxLagTopicAndPartition + " at offset " + offsetWithMaxLag
@@ -486,7 +486,7 @@ private class ReplicaFetcherBlockingSend(sourceNode: Node,
         throw new SocketTimeoutException(s"Failed to connect within $socketTimeout ms")
       else {
         val clientRequest = networkClient.newClientRequest(sourceNode.id.toString, requestBuilder,
-          time.milliseconds(), true)
+          time.absoluteMilliseconds(), true)
         NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
       }
     }

--- a/core/src/main/scala/kafka/utils/DelayedItem.scala
+++ b/core/src/main/scala/kafka/utils/DelayedItem.scala
@@ -25,7 +25,7 @@ import scala.math._
 
 class DelayedItem(val delayMs: Long) extends Delayed with Logging {
 
-  private val dueMs = Time.SYSTEM.milliseconds + delayMs
+  private val dueMs = Time.SYSTEM.absoluteMilliseconds + delayMs
 
   def this(delay: Long, unit: TimeUnit) = this(unit.toMillis(delay))
 
@@ -33,7 +33,7 @@ class DelayedItem(val delayMs: Long) extends Delayed with Logging {
    * The remaining delay time
    */
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(dueMs - Time.SYSTEM.milliseconds, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(dueMs - Time.SYSTEM.absoluteMilliseconds, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -46,7 +46,7 @@ class Throttler(desiredRatePerSec: Double,
   private val lock = new Object
   private val meter = newMeter(metricName, units, TimeUnit.SECONDS)
   private val checkIntervalNs = TimeUnit.MILLISECONDS.toNanos(checkIntervalMs)
-  private var periodStartNs: Long = time.nanoseconds
+  private var periodStartNs: Long = time.relativeNanoseconds
   private var observedSoFar: Double = 0.0
   
   def maybeThrottle(observed: Double) {
@@ -56,7 +56,7 @@ class Throttler(desiredRatePerSec: Double,
     meter.mark(observed.toLong)
     lock synchronized {
       observedSoFar += observed
-      val now = time.nanoseconds
+      val now = time.relativeNanoseconds
       val elapsedNs = now - periodStartNs
       // if we have completed an interval AND we have observed something, maybe
       // we should take a little nap
@@ -73,7 +73,7 @@ class Throttler(desiredRatePerSec: Double,
             time.sleep(sleepTime)
           }
         }
-        periodStartNs = time.nanoseconds()
+        periodStartNs = time.relativeNanoseconds()
         observedSoFar = 0
       }
     }

--- a/core/src/main/scala/kafka/utils/timer/Timer.scala
+++ b/core/src/main/scala/kafka/utils/timer/Timer.scala
@@ -55,7 +55,7 @@ trait Timer {
 class SystemTimer(executorName: String,
                   tickMs: Long = 1,
                   wheelSize: Int = 20,
-                  startMs: Long = Time.SYSTEM.hiResClockMs) extends Timer {
+                  startMs: Long = Time.SYSTEM.relativeMilliseconds) extends Timer {
 
   // timeout timer
   private[this] val taskExecutor = Executors.newFixedThreadPool(1, new ThreadFactory() {
@@ -81,7 +81,7 @@ class SystemTimer(executorName: String,
   def add(timerTask: TimerTask): Unit = {
     readLock.lock()
     try {
-      addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + Time.SYSTEM.hiResClockMs))
+      addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + Time.SYSTEM.relativeMilliseconds))
     } finally {
       readLock.unlock()
     }

--- a/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
+++ b/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
@@ -118,7 +118,7 @@ private[timer] class TimerTaskList(taskCounter: AtomicInteger) extends Delayed {
   }
 
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(getExpiration - Time.SYSTEM.hiResClockMs, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(getExpiration - Time.SYSTEM.relativeMilliseconds, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -101,7 +101,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * @throws ControllerMovedException if fail to create /controller or fail to increment controller epoch.
    */
   def registerControllerAndIncrementControllerEpoch(controllerId: Int): (Int, Int) = {
-    val timestamp = time.milliseconds()
+    val timestamp = time.absoluteMilliseconds()
 
     // Read /controller_epoch to get the current controller epoch and zkVersion,
     // create /controller_epoch with initial value if not exists

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -125,7 +125,7 @@ object BrokerIdZNode {
       PortKey -> port,
       EndpointsKey -> advertisedEndpoints.map(_.connectionString).toBuffer.asJava,
       JmxPortKey -> jmxPort,
-      TimestampKey -> Time.SYSTEM.milliseconds().toString
+      TimestampKey -> Time.SYSTEM.absoluteMilliseconds().toString
     )
     rack.foreach(rack => if (version >= 3) jsonMap += (RackKey -> rack))
 

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -168,9 +168,9 @@ class ZooKeeperClient(connectString: String,
     // Safe to cast as we always create a response of the right type
     def callback(response: AsyncResponse): Unit = processResponse(response.asInstanceOf[Req#Response])
 
-    def responseMetadata(sendTimeMs: Long) = new ResponseMetadata(sendTimeMs, receivedTimeMs = time.hiResClockMs())
+    def responseMetadata(sendTimeMs: Long) = new ResponseMetadata(sendTimeMs, receivedTimeMs = time.relativeMilliseconds())
 
-    val sendTimeMs = time.hiResClockMs()
+    val sendTimeMs = time.relativeMilliseconds()
     request match {
       case ExistsRequest(path, ctx, _) =>
         zooKeeper.exists(path, shouldWatch(request), new StatCallback {

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1062,11 +1062,11 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:22")
     config.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "0")
     client = AdminClient.create(config)
-    val startTimeMs = Time.SYSTEM.milliseconds()
+    val startTimeMs = Time.SYSTEM.absoluteMilliseconds()
     val future = client.createTopics(Seq("mytopic", "mytopic2").map(new NewTopic(_, 1, 1)).asJava,
       new CreateTopicsOptions().timeoutMs(2)).all()
     assertFutureExceptionTypeEquals(future, classOf[TimeoutException])
-    val endTimeMs = Time.SYSTEM.milliseconds()
+    val endTimeMs = Time.SYSTEM.absoluteMilliseconds()
     assertTrue("Expected the timeout to take at least one millisecond.", endTimeMs > startTimeMs);
   }
 

--- a/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
+++ b/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
@@ -75,10 +75,10 @@ class InterBrokerSendThreadTest {
       EasyMock.same(handler.handler)))
       .andReturn(clientRequest)
 
-    EasyMock.expect(networkClient.ready(node, time.milliseconds()))
+    EasyMock.expect(networkClient.ready(node, time.absoluteMilliseconds()))
       .andReturn(true)
 
-    EasyMock.expect(networkClient.send(clientRequest, time.milliseconds()))
+    EasyMock.expect(networkClient.send(clientRequest, time.absoluteMilliseconds()))
 
     EasyMock.expect(networkClient.poll(EasyMock.anyLong(), EasyMock.anyLong()))
       .andReturn(new util.ArrayList())
@@ -112,7 +112,7 @@ class InterBrokerSendThreadTest {
       EasyMock.same(requestAndCompletionHandler.handler)))
       .andReturn(clientRequest)
 
-    EasyMock.expect(networkClient.ready(node, time.milliseconds()))
+    EasyMock.expect(networkClient.ready(node, time.absoluteMilliseconds()))
       .andReturn(false)
 
     EasyMock.expect(networkClient.connectionDelay(EasyMock.anyObject(), EasyMock.anyLong()))
@@ -145,20 +145,20 @@ class InterBrokerSendThreadTest {
       override def generateRequests() = List[RequestAndCompletionHandler](handler)
     }
 
-    val clientRequest = new ClientRequest("dest", request, 0, "1", time.milliseconds(), true,
+    val clientRequest = new ClientRequest("dest", request, 0, "1", time.absoluteMilliseconds(), true,
       requestTimeoutMs, handler.handler)
     time.sleep(1500)
 
     EasyMock.expect(networkClient.newClientRequest(EasyMock.eq("1"),
       EasyMock.same(handler.request),
-      EasyMock.eq(time.milliseconds()),
+      EasyMock.eq(time.absoluteMilliseconds()),
       EasyMock.eq(true),
       EasyMock.eq(requestTimeoutMs),
       EasyMock.same(handler.handler)))
       .andReturn(clientRequest)
 
     // make the node unready so the request is not cleared
-    EasyMock.expect(networkClient.ready(node, time.milliseconds()))
+    EasyMock.expect(networkClient.ready(node, time.absoluteMilliseconds()))
       .andReturn(false)
 
     EasyMock.expect(networkClient.connectionDelay(EasyMock.anyObject(), EasyMock.anyLong()))

--- a/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
+++ b/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
@@ -276,7 +276,7 @@ object TestPurgatoryPerformance {
 
     private class Scheduled(val operation: FakeOperation) extends Delayed {
       def getDelay(unit: TimeUnit): Long = {
-        unit.convert(max(operation.completesAt - Time.SYSTEM.milliseconds, 0), TimeUnit.MILLISECONDS)
+        unit.convert(max(operation.completesAt - Time.SYSTEM.absoluteMilliseconds, 0), TimeUnit.MILLISECONDS)
       }
 
       def compareTo(d: Delayed): Int = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -638,7 +638,7 @@ class PartitionTest {
                     leaderLogStartOffset = leaderReplica.logStartOffset,
                     leaderLogEndOffset = leaderReplica.logEndOffset.messageOffset,
                     followerLogStartOffset = 0,
-                    fetchTimeMs = time.milliseconds,
+                    fetchTimeMs = time.absoluteMilliseconds,
                     readSize = 10240,
                     lastStableOffset = None)
     }
@@ -677,7 +677,7 @@ class PartitionTest {
     val buf = ByteBuffer.allocate(DefaultRecordBatch.sizeInBytes(records.asJava))
     val builder = MemoryRecords.builder(
       buf, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.LOG_APPEND_TIME,
-      baseOffset, time.milliseconds, partitionLeaderEpoch)
+      baseOffset, time.absoluteMilliseconds, partitionLeaderEpoch)
     records.foreach(builder.append)
     builder.build()
   }

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -78,7 +78,7 @@ class ReplicaTest {
 
     assertEquals(initialHighWatermark, replica.highWatermark.messageOffset)
 
-    val expiredTimestamp = time.milliseconds() - 1000
+    val expiredTimestamp = time.absoluteMilliseconds() - 1000
     for (i <- 0 until 100) {
       val records = TestUtils.singletonRecords(value = s"test$i".getBytes, timestamp = expiredTimestamp)
       log.appendAsLeader(records, leaderEpoch = 0)
@@ -92,7 +92,7 @@ class ReplicaTest {
 
   @Test
   def testCannotDeleteSegmentsAtOrAboveHighWatermark(): Unit = {
-    val expiredTimestamp = time.milliseconds() - 1000
+    val expiredTimestamp = time.absoluteMilliseconds() - 1000
     for (i <- 0 until 100) {
       val records = TestUtils.singletonRecords(value = s"test$i".getBytes, timestamp = expiredTimestamp)
       log.appendAsLeader(records, leaderEpoch = 0)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -212,7 +212,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     }
     override def runWithCallback(member: GroupMember, responseCallback: CommitOffsetCallback): Unit = {
       val tp = new TopicPartition("topic", 0)
-      val offsets = immutable.Map(tp -> OffsetAndMetadata(1, "", Time.SYSTEM.milliseconds()))
+      val offsets = immutable.Map(tp -> OffsetAndMetadata(1, "", Time.SYSTEM.absoluteMilliseconds()))
       groupCoordinator.handleCommitOffsets(member.groupId, member.memberId, member.generationId,
           offsets, responseCallback)
     }
@@ -225,7 +225,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
   class CommitTxnOffsetsOperation extends CommitOffsetsOperation {
     override def runWithCallback(member: GroupMember, responseCallback: CommitOffsetCallback): Unit = {
       val tp = new TopicPartition("topic", 0)
-      val offsets = immutable.Map(tp -> OffsetAndMetadata(1, "", Time.SYSTEM.milliseconds()))
+      val offsets = immutable.Map(tp -> OffsetAndMetadata(1, "", Time.SYSTEM.absoluteMilliseconds()))
       val producerId = 1000L
       val producerEpoch : Short = 2
       // When transaction offsets are appended to the log, transactions may be scheduled for

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -890,7 +890,7 @@ class GroupCoordinatorTest extends JUnitSuite {
     val offset = 97L
     val metadata = "some metadata"
     val leaderEpoch = Optional.of[Integer](15)
-    val offsetAndMetadata = OffsetAndMetadata(offset, leaderEpoch, metadata, timer.time.milliseconds())
+    val offsetAndMetadata = OffsetAndMetadata(offset, leaderEpoch, metadata, timer.time.absoluteMilliseconds())
 
     val commitOffsetResult = commitOffsets(groupId, OffsetCommitRequest.DEFAULT_MEMBER_ID,
       OffsetCommitRequest.DEFAULT_GENERATION_ID, Map(tp -> offsetAndMetadata))
@@ -1759,7 +1759,7 @@ class GroupCoordinatorTest extends JUnitSuite {
   }
 
   private def offsetAndMetadata(offset: Long): OffsetAndMetadata = {
-    OffsetAndMetadata(offset, "", timer.time.milliseconds())
+    OffsetAndMetadata(offset, "", timer.time.absoluteMilliseconds())
   }
 
 }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -544,10 +544,10 @@ class GroupMetadataManagerTest {
   private def completeTransactionalOffsetCommit(buffer: ByteBuffer, producerId: Long, producerEpoch: Short, baseOffset: Long,
                                                 isCommit: Boolean): Int = {
     val builder = MemoryRecords.builder(buffer, RecordBatch.MAGIC_VALUE_V2, CompressionType.NONE,
-      TimestampType.LOG_APPEND_TIME, baseOffset, time.milliseconds(), producerId, producerEpoch, 0, true, true,
+      TimestampType.LOG_APPEND_TIME, baseOffset, time.absoluteMilliseconds(), producerId, producerEpoch, 0, true, true,
       RecordBatch.NO_PARTITION_LEADER_EPOCH)
     val controlRecordType = if (isCommit) ControlRecordType.COMMIT else ControlRecordType.ABORT
-    builder.appendEndTxnMarker(time.milliseconds(), new EndTransactionMarker(controlRecordType, 0))
+    builder.appendEndTxnMarker(time.absoluteMilliseconds(), new EndTransactionMarker(controlRecordType, 0))
     builder.build()
     1
   }
@@ -934,7 +934,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.milliseconds()))
+    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.absoluteMilliseconds()))
 
     expectAppendMessage(Errors.NONE)
     EasyMock.replay(replicaManager)
@@ -976,7 +976,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsetAndMetadata = OffsetAndMetadata(offset, "", time.milliseconds())
+    val offsetAndMetadata = OffsetAndMetadata(offset, "", time.absoluteMilliseconds())
     val offsets = immutable.Map(topicPartition -> offsetAndMetadata)
 
     val capturedResponseCallback = appendAndCaptureCallback()
@@ -1017,7 +1017,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.milliseconds()))
+    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.absoluteMilliseconds()))
 
     val capturedResponseCallback = appendAndCaptureCallback()
     EasyMock.replay(replicaManager)
@@ -1056,7 +1056,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.milliseconds()))
+    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.absoluteMilliseconds()))
 
     val capturedResponseCallback = appendAndCaptureCallback()
     EasyMock.replay(replicaManager)
@@ -1094,7 +1094,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.milliseconds()))
+    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.absoluteMilliseconds()))
 
     EasyMock.replay(replicaManager)
 
@@ -1136,7 +1136,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.milliseconds()))
+    val offsets = immutable.Map(topicPartition -> OffsetAndMetadata(offset, "", time.absoluteMilliseconds()))
 
     val capturedResponseCallback = appendAndCaptureCallback()
     EasyMock.replay(replicaManager)
@@ -1175,7 +1175,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.addGroup(group)
 
     // expire the offset after 1 millisecond
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     val offsets = immutable.Map(
       topicPartition1 -> OffsetAndMetadata(offset, "", startMs, startMs + 1),
       topicPartition2 -> OffsetAndMetadata(offset, "", startMs, startMs + 3))
@@ -1330,7 +1330,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.addGroup(group)
 
     // expire the offset after 1 millisecond
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     val offsets = immutable.Map(
       topicPartition1 -> OffsetAndMetadata(offset, Optional.empty(), "", startMs, Some(startMs + 1)),
       topicPartition2 -> OffsetAndMetadata(offset, "", startMs, startMs + 3))
@@ -1409,7 +1409,7 @@ class GroupMetadataManagerTest {
     group.transitionTo(PreparingRebalance)
     group.initNextGeneration()
 
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     // old clients, expiry timestamp is explicitly set
     val tp1OffsetAndMetadata = OffsetAndMetadata(offset, "", startMs, startMs + 1)
     val tp2OffsetAndMetadata = OffsetAndMetadata(offset, "", startMs, startMs + 3)
@@ -1503,7 +1503,7 @@ class GroupMetadataManagerTest {
     EasyMock.verify(replicaManager)
 
     // advance time to just before the offset of last partition is to be expired, no offset should expire
-    time.sleep(group.currentStateTimestamp.get + defaultOffsetRetentionMs - time.milliseconds() - 1)
+    time.sleep(group.currentStateTimestamp.get + defaultOffsetRetentionMs - time.absoluteMilliseconds() - 1)
 
     groupMetadataManager.cleanupGroupMetadata()
 
@@ -1561,7 +1561,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.addGroup(group)
 
     // expire the offset after 1 and 3 milliseconds (old clients) and after default retention (new clients)
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     // old clients, expiry timestamp is explicitly set
     val tp1OffsetAndMetadata = OffsetAndMetadata(offset, "", startMs)
     // new clients, no per-partition expiry timestamp, offsets of group expire together
@@ -1585,7 +1585,7 @@ class GroupMetadataManagerTest {
 
     // do not expire offsets while within retention period since commit timestamp
     val expiryTimestamp = offsets.get(topicPartition1).get.commitTimestamp + defaultOffsetRetentionMs
-    time.sleep(expiryTimestamp - time.milliseconds() - 1)
+    time.sleep(expiryTimestamp - time.absoluteMilliseconds() - 1)
 
     groupMetadataManager.cleanupGroupMetadata()
 
@@ -1709,7 +1709,7 @@ class GroupMetadataManagerTest {
       offset = 537L,
       leaderEpoch = Optional.of(15),
       metadata = "metadata",
-      commitTimestamp = time.milliseconds(),
+      commitTimestamp = time.absoluteMilliseconds(),
       expireTimestamp = None)
 
     def verifySerde(apiVersion: ApiVersion, expectedOffsetCommitValueVersion: Int): Unit = {
@@ -1751,8 +1751,8 @@ class GroupMetadataManagerTest {
       offset = 537L,
       leaderEpoch = Optional.empty(),
       metadata = "metadata",
-      commitTimestamp = time.milliseconds(),
-      expireTimestamp = Some(time.milliseconds() + 1000))
+      commitTimestamp = time.absoluteMilliseconds(),
+      expireTimestamp = Some(time.absoluteMilliseconds() + 1000))
 
     def verifySerde(apiVersion: ApiVersion): Unit = {
       val bytes = GroupMetadataManager.offsetCommitValue(offsetAndMetadata, apiVersion)
@@ -1870,7 +1870,7 @@ class GroupMetadataManagerTest {
     val memberProtocols = List((protocol, Array.emptyByteArray))
     val member = new MemberMetadata(memberId, groupId, "clientId", "clientHost", 30000, 10000, protocolType, memberProtocols)
     val group = GroupMetadata.loadGroup(groupId, Stable, generation, protocolType, protocol, memberId,
-      if (apiVersion >= KAFKA_2_1_IV0) Some(time.milliseconds()) else None, Seq(member), time)
+      if (apiVersion >= KAFKA_2_1_IV0) Some(time.absoluteMilliseconds()) else None, Seq(member), time)
     val groupMetadataKey = GroupMetadataManager.groupMetadataKey(groupId)
     val groupMetadataValue = GroupMetadataManager.groupMetadataValue(group, Map(memberId -> new Array[Byte](assignmentSize)), apiVersion)
     new SimpleRecord(groupMetadataKey, groupMetadataValue)
@@ -1934,7 +1934,7 @@ class GroupMetadataManagerTest {
                                            apiVersion: ApiVersion = ApiVersion.latestVersion,
                                            retentionTimeOpt: Option[Long] = None): Seq[SimpleRecord] = {
     committedOffsets.map { case (topicPartition, offset) =>
-      val commitTimestamp = time.milliseconds()
+      val commitTimestamp = time.absoluteMilliseconds()
       val offsetAndMetadata = retentionTimeOpt match {
         case Some(retentionTimeMs) =>
           val expirationTime = commitTimestamp + retentionTimeMs

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -473,7 +473,7 @@ class GroupMetadataTest extends JUnitSuite {
   }
 
   private def offsetAndMetadata(offset: Long): OffsetAndMetadata = {
-    OffsetAndMetadata(offset, "", Time.SYSTEM.milliseconds())
+    OffsetAndMetadata(offset, "", Time.SYSTEM.absoluteMilliseconds())
   }
 
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -372,7 +372,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     override def run(): Unit = {
       transactions.foreach { txn =>
         transactionMetadata(txn).foreach { txnMetadata =>
-          txnMetadata.txnLastUpdateTimestamp = time.milliseconds() - txnConfig.transactionalIdExpirationMs
+          txnMetadata.txnLastUpdateTimestamp = time.absoluteMilliseconds() - txnConfig.transactionalIdExpirationMs
         }
       }
       txnStateManager.enableTransactionalIdExpiration()

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -139,7 +139,7 @@ class TransactionCoordinatorTest {
     initPidGenericMocks(transactionalId)
 
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, (Short.MaxValue - 1).toShort,
-      txnTimeoutMs, Empty, mutable.Set.empty, time.milliseconds(), time.milliseconds())
+      txnTimeoutMs, Empty, mutable.Set.empty, time.absoluteMilliseconds(), time.absoluteMilliseconds())
 
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
@@ -286,7 +286,7 @@ class TransactionCoordinatorTest {
 
   def validateSuccessfulAddPartitions(previousState: TransactionState): Unit = {
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, previousState,
-      mutable.Set.empty, time.milliseconds(), time.milliseconds())
+      mutable.Set.empty, time.absoluteMilliseconds(), time.absoluteMilliseconds())
 
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
@@ -333,7 +333,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldReplyWithInvalidPidMappingOnEndTxnWhenPidDosentMatchMapped(): Unit = {
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
-      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, 10, 0, 0, Ongoing, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())))))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, 10, 0, 0, Ongoing, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())))))
     EasyMock.replay(transactionManager)
 
     coordinator.handleEndTransaction(transactionalId, 0, 0, TransactionResult.COMMIT, errorsCallback)
@@ -344,7 +344,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldReplyWithProducerFencedOnEndTxnWhenEpochIsNotSameAsTransaction(): Unit = {
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
-      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, Ongoing, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())))))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, Ongoing, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())))))
     EasyMock.replay(transactionManager)
 
     coordinator.handleEndTransaction(transactionalId, producerId, 0, TransactionResult.COMMIT, errorsCallback)
@@ -355,7 +355,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldReturnOkOnEndTxnWhenStatusIsCompleteCommitAndResultIsCommit(): Unit ={
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
-      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteCommit, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())))))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteCommit, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())))))
     EasyMock.replay(transactionManager)
 
     coordinator.handleEndTransaction(transactionalId, producerId, 1, TransactionResult.COMMIT, errorsCallback)
@@ -365,7 +365,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldReturnOkOnEndTxnWhenStatusIsCompleteAbortAndResultIsAbort(): Unit ={
-    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteAbort, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteAbort, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
     EasyMock.replay(transactionManager)
@@ -377,7 +377,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldReturnInvalidTxnRequestOnEndTxnRequestWhenStatusIsCompleteAbortAndResultIsNotAbort(): Unit = {
-    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteAbort, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteAbort, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
     EasyMock.replay(transactionManager)
@@ -389,7 +389,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldReturnInvalidTxnRequestOnEndTxnRequestWhenStatusIsCompleteCommitAndResultIsNotCommit(): Unit = {
-    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteCommit, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, 1, 1, CompleteCommit, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
     EasyMock.replay(transactionManager)
@@ -402,7 +402,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldReturnConcurrentTxnRequestOnEndTxnRequestWhenStatusIsPrepareCommit(): Unit = {
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
-      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, PrepareCommit, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())))))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, PrepareCommit, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())))))
     EasyMock.replay(transactionManager)
 
     coordinator.handleEndTransaction(transactionalId, producerId, 1, TransactionResult.COMMIT, errorsCallback)
@@ -413,7 +413,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldReturnInvalidTxnRequestOnEndTxnRequestWhenStatusIsPrepareAbort(): Unit = {
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
-      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, PrepareAbort, collection.mutable.Set.empty[TopicPartition], 0, time.milliseconds())))))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, new TransactionMetadata(transactionalId, producerId, 1, 1, PrepareAbort, collection.mutable.Set.empty[TopicPartition], 0, time.absoluteMilliseconds())))))
     EasyMock.replay(transactionManager)
 
     coordinator.handleEndTransaction(transactionalId, producerId, 1, TransactionResult.COMMIT, errorsCallback)
@@ -507,7 +507,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingState(): Unit = {
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, Ongoing,
-      partitions, time.milliseconds(), time.milliseconds())
+      partitions, time.absoluteMilliseconds(), time.absoluteMilliseconds())
 
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
       .andReturn(true)
@@ -521,11 +521,11 @@ class TransactionCoordinatorTest {
       .anyTimes()
 
     val originalMetadata = new TransactionMetadata(transactionalId, producerId, (producerEpoch + 1).toShort,
-      txnTimeoutMs, Ongoing, partitions, time.milliseconds(), time.milliseconds())
+      txnTimeoutMs, Ongoing, partitions, time.absoluteMilliseconds(), time.absoluteMilliseconds())
     EasyMock.expect(transactionManager.appendTransactionToLog(
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
-      EasyMock.eq(originalMetadata.prepareAbortOrCommit(PrepareAbort, time.milliseconds())),
+      EasyMock.eq(originalMetadata.prepareAbortOrCommit(PrepareAbort, time.absoluteMilliseconds())),
       EasyMock.capture(capturedErrorsCallback),
       EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
@@ -545,7 +545,7 @@ class TransactionCoordinatorTest {
   @Test
   def shouldUseLastEpochToFenceWhenEpochsAreExhausted(): Unit = {
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, (Short.MaxValue - 1).toShort,
-      txnTimeoutMs, Ongoing, partitions, time.milliseconds(), time.milliseconds())
+      txnTimeoutMs, Ongoing, partitions, time.absoluteMilliseconds(), time.absoluteMilliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
 
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
@@ -568,8 +568,8 @@ class TransactionCoordinatorTest {
         txnTimeoutMs = txnTimeoutMs,
         txnState = PrepareAbort,
         topicPartitions = partitions.toSet,
-        txnStartTimestamp = time.milliseconds(),
-        txnLastUpdateTimestamp = time.milliseconds())),
+        txnStartTimestamp = time.absoluteMilliseconds(),
+        txnLastUpdateTimestamp = time.absoluteMilliseconds())),
       EasyMock.capture(capturedErrorsCallback),
       EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
@@ -600,7 +600,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldAbortExpiredTransactionsInOngoingStateAndBumpEpoch(): Unit = {
-    val now = time.milliseconds()
+    val now = time.absoluteMilliseconds()
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, Ongoing,
       partitions, now, now)
 
@@ -636,8 +636,8 @@ class TransactionCoordinatorTest {
   @Test
   def shouldNotAbortExpiredTransactionsThatHaveAPendingStateTransition(): Unit = {
     val metadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, Ongoing,
-      partitions, time.milliseconds(), time.milliseconds())
-    metadata.prepareAbortOrCommit(PrepareCommit, time.milliseconds())
+      partitions, time.absoluteMilliseconds(), time.absoluteMilliseconds())
+    metadata.prepareAbortOrCommit(PrepareCommit, time.absoluteMilliseconds())
 
     EasyMock.expect(transactionManager.timedOutTransactions())
       .andReturn(List(TransactionalIdAndProducerIdEpoch(transactionalId, producerId, producerEpoch)))
@@ -675,7 +675,7 @@ class TransactionCoordinatorTest {
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
       .andReturn(true)
 
-    val metadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, state, mutable.Set.empty[TopicPartition], time.milliseconds(), time.milliseconds())
+    val metadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, state, mutable.Set.empty[TopicPartition], time.absoluteMilliseconds(), time.absoluteMilliseconds())
     EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, metadata))))
 
@@ -700,13 +700,13 @@ class TransactionCoordinatorTest {
 
     assertEquals(InitProducerIdResult(producerId, (producerEpoch + 1).toShort, Errors.NONE), result)
     assertEquals(newTxnTimeoutMs, metadata.txnTimeoutMs)
-    assertEquals(time.milliseconds(), metadata.txnLastUpdateTimestamp)
+    assertEquals(time.absoluteMilliseconds(), metadata.txnLastUpdateTimestamp)
     assertEquals((producerEpoch + 1).toShort, metadata.producerEpoch)
     assertEquals(producerId, metadata.producerId)
   }
 
   private def mockPrepare(transactionState: TransactionState, runCallback: Boolean = false): TransactionMetadata = {
-    val now = time.milliseconds()
+    val now = time.absoluteMilliseconds()
     val originalMetadata = new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs,
       Ongoing, partitions, now, now)
 
@@ -730,7 +730,7 @@ class TransactionCoordinatorTest {
       }).once()
 
     new TransactionMetadata(transactionalId, producerId, producerEpoch, txnTimeoutMs, transactionState, partitions,
-      time.milliseconds(), time.milliseconds())
+      time.absoluteMilliseconds(), time.absoluteMilliseconds())
   }
 
   def initProducerIdMockCallback(ret: InitProducerIdResult): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -118,8 +118,8 @@ class TransactionMarkerChannelManagerTest {
 
     EasyMock.replay(metadataCache)
 
-    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
-    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.absoluteMilliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.absoluteMilliseconds()))
 
     assertEquals(2, txnMarkerPurgatory.watched)
     assertEquals(2, channelManager.queueForBroker(broker1.id).get.totalNumMarkers)
@@ -161,8 +161,8 @@ class TransactionMarkerChannelManagerTest {
 
     EasyMock.replay(metadataCache)
 
-    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
-    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.absoluteMilliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.absoluteMilliseconds()))
 
     assertEquals(1, txnMarkerPurgatory.watched)
     assertEquals(1, channelManager.queueForBroker(broker2.id).get.totalNumMarkers)
@@ -194,8 +194,8 @@ class TransactionMarkerChannelManagerTest {
 
     EasyMock.replay(metadataCache)
 
-    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
-    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.absoluteMilliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.absoluteMilliseconds()))
 
     assertEquals(2, txnMarkerPurgatory.watched)
     assertEquals(1, channelManager.queueForBroker(broker2.id).get.totalNumMarkers)
@@ -243,8 +243,8 @@ class TransactionMarkerChannelManagerTest {
 
     EasyMock.replay(metadataCache)
 
-    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
-    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.absoluteMilliseconds()))
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.absoluteMilliseconds()))
 
     assertEquals(2, txnMarkerPurgatory.watched)
     assertEquals(2, channelManager.queueForBroker(broker1.id).get.totalNumMarkers)
@@ -280,7 +280,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.absoluteMilliseconds())
 
     EasyMock.expect(txnStateManager.appendTransactionToLog(
       EasyMock.eq(transactionalId2),
@@ -329,7 +329,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.absoluteMilliseconds())
 
     EasyMock.expect(txnStateManager.appendTransactionToLog(
       EasyMock.eq(transactionalId2),
@@ -378,7 +378,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.absoluteMilliseconds())
 
     EasyMock.expect(txnStateManager.appendTransactionToLog(
       EasyMock.eq(transactionalId2),

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -40,9 +40,9 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Empty,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
 
-    val transitMetadata = txnMetadata.prepareIncrementProducerEpoch(30000, time.milliseconds())
+    val transitMetadata = txnMetadata.prepareIncrementProducerEpoch(30000, time.absoluteMilliseconds())
     txnMetadata.completeTransitionTo(transitMetadata)
     assertEquals(producerId, txnMetadata.producerId)
     assertEquals(0, txnMetadata.producerEpoch)
@@ -61,9 +61,9 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Empty,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
 
-    val transitMetadata = txnMetadata.prepareIncrementProducerEpoch(30000, time.milliseconds())
+    val transitMetadata = txnMetadata.prepareIncrementProducerEpoch(30000, time.absoluteMilliseconds())
     txnMetadata.completeTransitionTo(transitMetadata)
     assertEquals(producerId, txnMetadata.producerId)
     assertEquals(producerEpoch + 1, txnMetadata.producerEpoch)
@@ -82,10 +82,10 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Empty,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
 
-    txnMetadata.prepareIncrementProducerEpoch(30000, time.milliseconds())
+    txnMetadata.prepareIncrementProducerEpoch(30000, time.absoluteMilliseconds())
   }
 
   @Test
@@ -101,7 +101,7 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Ongoing,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
 
     val fencingTransitMetadata = txnMetadata.prepareFenceProducerEpoch()
@@ -111,7 +111,7 @@ class TransactionMetadataTest {
     // We should reset the pending state to make way for the abort transition.
     txnMetadata.pendingState = None
 
-    val transitMetadata = txnMetadata.prepareAbortOrCommit(PrepareAbort, time.milliseconds())
+    val transitMetadata = txnMetadata.prepareAbortOrCommit(PrepareAbort, time.absoluteMilliseconds())
     txnMetadata.completeTransitionTo(transitMetadata)
     assertEquals(producerId, transitMetadata.producerId)
   }
@@ -129,7 +129,7 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Ongoing,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
     txnMetadata.prepareFenceProducerEpoch()
   }
@@ -147,10 +147,10 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = Empty,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
 
     val newProducerId = 9893L
-    val transitMetadata = txnMetadata.prepareProducerIdRotation(newProducerId, 30000, time.milliseconds())
+    val transitMetadata = txnMetadata.prepareProducerIdRotation(newProducerId, 30000, time.absoluteMilliseconds())
     txnMetadata.completeTransitionTo(transitMetadata)
     assertEquals(newProducerId, txnMetadata.producerId)
     assertEquals(0, txnMetadata.producerEpoch)
@@ -183,9 +183,9 @@ class TransactionMetadataTest {
       txnTimeoutMs = 30000,
       state = state,
       topicPartitions = mutable.Set.empty,
-      txnLastUpdateTimestamp = time.milliseconds())
+      txnLastUpdateTimestamp = time.absoluteMilliseconds())
     val newProducerId = 9893L
-    txnMetadata.prepareProducerIdRotation(newProducerId, 30000, time.milliseconds())
+    txnMetadata.prepareProducerIdRotation(newProducerId, 30000, time.absoluteMilliseconds())
   }
 
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -220,7 +220,7 @@ class TransactionStateManagerTest {
 
     // update the metadata to ongoing with two partitions
     val newMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
-      new TopicPartition("topic1", 1)), time.milliseconds())
+      new TopicPartition("topic1", 1)), time.absoluteMilliseconds())
 
     // append the new metadata into log
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch, newMetadata, assertCallback)
@@ -235,26 +235,26 @@ class TransactionStateManagerTest {
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
     expectedError = Errors.COORDINATOR_NOT_AVAILABLE
-    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
 
     prepareForTxnMessageAppend(Errors.UNKNOWN_TOPIC_OR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
     prepareForTxnMessageAppend(Errors.REQUEST_TIMED_OUT)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
@@ -267,14 +267,14 @@ class TransactionStateManagerTest {
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
     expectedError = Errors.NOT_COORDINATOR
-    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
 
     prepareForTxnMessageAppend(Errors.NOT_LEADER_FOR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
     prepareForTxnMessageAppend(Errors.NONE)
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
@@ -297,7 +297,7 @@ class TransactionStateManagerTest {
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
     expectedError = Errors.COORDINATOR_LOAD_IN_PROGRESS
-    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
 
     prepareForTxnMessageAppend(Errors.NONE)
     transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
@@ -311,14 +311,14 @@ class TransactionStateManagerTest {
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
     expectedError = Errors.UNKNOWN_SERVER_ERROR
-    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
 
     prepareForTxnMessageAppend(Errors.MESSAGE_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
     prepareForTxnMessageAppend(Errors.RECORD_LIST_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
@@ -331,7 +331,7 @@ class TransactionStateManagerTest {
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
     expectedError = Errors.COORDINATOR_NOT_AVAILABLE
-    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.absoluteMilliseconds())
 
     prepareForTxnMessageAppend(Errors.UNKNOWN_TOPIC_OR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback, _ => true)
@@ -350,7 +350,7 @@ class TransactionStateManagerTest {
     expectedError = Errors.NOT_COORDINATOR
 
     val newMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
-      new TopicPartition("topic1", 1)), time.milliseconds())
+      new TopicPartition("topic1", 1)), time.absoluteMilliseconds())
 
     // modify the cache while trying to append the new metadata
     txnMetadata1.producerEpoch = (txnMetadata1.producerEpoch + 1).toShort
@@ -369,7 +369,7 @@ class TransactionStateManagerTest {
     expectedError = Errors.INVALID_PRODUCER_EPOCH
 
     val newMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
-      new TopicPartition("topic1", 1)), time.milliseconds())
+      new TopicPartition("topic1", 1)), time.absoluteMilliseconds())
 
     // modify the cache while trying to append the new metadata
     txnMetadata1.pendingState = None
@@ -489,7 +489,7 @@ class TransactionStateManagerTest {
 
     val partition = new TopicPartition(TRANSACTION_STATE_TOPIC_NAME, transactionManager.partitionFor(transactionalId1))
     val recordsByPartition = Map(partition -> MemoryRecords.withRecords(TransactionLog.EnforcedCompressionType,
-      new SimpleRecord(time.milliseconds() + txnConfig.removeExpiredTransactionalIdsIntervalMs, TransactionLog.keyToBytes(transactionalId1), null)))
+      new SimpleRecord(time.absoluteMilliseconds() + txnConfig.removeExpiredTransactionalIdsIntervalMs, TransactionLog.keyToBytes(transactionalId1), null)))
 
     txnState match {
       case Empty | CompleteCommit | CompleteAbort =>
@@ -516,11 +516,11 @@ class TransactionStateManagerTest {
 
     EasyMock.replay(replicaManager)
 
-    txnMetadata1.txnLastUpdateTimestamp = time.milliseconds() - txnConfig.transactionalIdExpirationMs
+    txnMetadata1.txnLastUpdateTimestamp = time.absoluteMilliseconds() - txnConfig.transactionalIdExpirationMs
     txnMetadata1.state = txnState
     transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
-    txnMetadata2.txnLastUpdateTimestamp = time.milliseconds()
+    txnMetadata2.txnLastUpdateTimestamp = time.absoluteMilliseconds()
     transactionManager.putTransactionStateIfNotExists(transactionalId2, txnMetadata2)
 
     transactionManager.enableTransactionalIdExpiration()
@@ -565,7 +565,7 @@ class TransactionStateManagerTest {
                                   producerId: Long,
                                   state: TransactionState = Empty,
                                   txnTimeout: Int = transactionTimeoutMs): TransactionMetadata = {
-    TransactionMetadata(transactionalId, producerId, 0.toShort, txnTimeout, state, time.milliseconds())
+    TransactionMetadata(transactionalId, producerId, 0.toShort, txnTimeout, state, time.absoluteMilliseconds())
   }
 
   private def prepareTxnLog(topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/log/LogCleanerLagIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerLagIntegrationTest.scala
@@ -55,7 +55,7 @@ class LogCleanerLagIntegrationTest(compressionCodecName: String) extends Abstrac
     val log = cleaner.logs.get(topicPartitions(0))
 
     // t = T0
-    val T0 = time.milliseconds
+    val T0 = time.absoluteMilliseconds
     val appends0 = writeDups(numKeys = 100, numDups = 3, log, codec, timestamp = T0)
     val startSizeBlock0 = log.size
     debug(s"total log size at T0: $startSizeBlock0")
@@ -76,7 +76,7 @@ class LogCleanerLagIntegrationTest(compressionCodecName: String) extends Abstrac
     // t = T1 > T0 + compactionLag
     // advance to time a bit more than one compaction lag from start
     time.sleep(compactionLag/2 + 1)
-    val T1 = time.milliseconds
+    val T1 = time.absoluteMilliseconds
 
     // write another block of data
     val appends1 = appends0 ++ writeDups(numKeys = 100, numDups = 3, log, codec, timestamp = T1)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -116,7 +116,7 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
 
     val (log, _) = runCleanerAndCheckCompacted(100)
     // should delete old segments
-    log.logSegments.foreach(_.lastModified = time.milliseconds - (2 * retentionMs))
+    log.logSegments.foreach(_.lastModified = time.absoluteMilliseconds - (2 * retentionMs))
 
     TestUtils.waitUntilTrue(() => log.numberOfSegments == 1, "There should only be 1 segment remaining", 10000L)
     assertEquals(1, log.numberOfSegments)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1436,20 +1436,20 @@ class LogCleanerTest extends JUnitSuite {
     // Append a message with a large timestamp.
     log.appendAsLeader(TestUtils.singletonRecords(value = "0".getBytes,
                                           key = "0".getBytes,
-                                          timestamp = time.milliseconds() + logConfig.deleteRetentionMs + 10000), leaderEpoch = 0)
+                                          timestamp = time.absoluteMilliseconds() + logConfig.deleteRetentionMs + 10000), leaderEpoch = 0)
     log.roll()
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 0, log.activeSegment.baseOffset))
     // Append a tombstone with a small timestamp and roll out a new log segment.
     log.appendAsLeader(TestUtils.singletonRecords(value = null,
                                           key = "0".getBytes,
-                                          timestamp = time.milliseconds() - logConfig.deleteRetentionMs - 10000), leaderEpoch = 0)
+                                          timestamp = time.absoluteMilliseconds() - logConfig.deleteRetentionMs - 10000), leaderEpoch = 0)
     log.roll()
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 1, log.activeSegment.baseOffset))
     assertEquals("The tombstone should be retained.", 1, log.logSegments.head.log.batches.iterator.next().lastOffset)
     // Append a message and roll out another log segment.
     log.appendAsLeader(TestUtils.singletonRecords(value = "1".getBytes,
                                           key = "1".getBytes,
-                                          timestamp = time.milliseconds()), leaderEpoch = 0)
+                                          timestamp = time.absoluteMilliseconds()), leaderEpoch = 0)
     log.roll()
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 2, log.activeSegment.baseOffset))
     assertEquals("The tombstone should be retained.", 1, log.logSegments.head.log.batches.iterator.next().lastOffset)
@@ -1532,7 +1532,7 @@ class LogCleanerTest extends JUnitSuite {
     keys: Seq[Int] => {
       val simpleRecords = keys.map { key =>
         val keyBytes = key.toString.getBytes
-        new SimpleRecord(time.milliseconds(), keyBytes, keyBytes) // the value doesn't matter since we validate offsets
+        new SimpleRecord(time.absoluteMilliseconds(), keyBytes, keyBytes) // the value doesn't matter since we validate offsets
       }
       val records = if (isTransactional)
         MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence, simpleRecords: _*)
@@ -1543,10 +1543,10 @@ class LogCleanerTest extends JUnitSuite {
     }
   }
 
-  private def commitMarker(producerId: Long, producerEpoch: Short, timestamp: Long = time.milliseconds()): MemoryRecords =
+  private def commitMarker(producerId: Long, producerEpoch: Short, timestamp: Long = time.absoluteMilliseconds()): MemoryRecords =
     endTxnMarker(producerId, producerEpoch, ControlRecordType.COMMIT, 0L, timestamp)
 
-  private def abortMarker(producerId: Long, producerEpoch: Short, timestamp: Long = time.milliseconds()): MemoryRecords =
+  private def abortMarker(producerId: Long, producerEpoch: Short, timestamp: Long = time.absoluteMilliseconds()): MemoryRecords =
     endTxnMarker(producerId, producerEpoch, ControlRecordType.ABORT, 0L, timestamp)
 
   private def endTxnMarker(producerId: Long, producerEpoch: Short, controlRecordType: ControlRecordType,

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -121,7 +121,7 @@ class LogManagerTest {
     assertTrue("There should be more than one segment now.", log.numberOfSegments > 1)
     log.onHighWatermarkIncremented(log.logEndOffset)
 
-    log.logSegments.foreach(_.log.file.setLastModified(time.milliseconds))
+    log.logSegments.foreach(_.log.file.setLastModified(time.absoluteMilliseconds))
 
     time.sleep(maxLogAgeMs + 1)
     assertEquals("Now there should only be only one segment in the index.", 1, log.numberOfSegments)
@@ -222,7 +222,7 @@ class LogManagerTest {
     val numSegments = log.numberOfSegments
     assertTrue("There should be more than one segment now.", log.numberOfSegments > 1)
 
-    log.logSegments.foreach(_.log.file.setLastModified(time.milliseconds))
+    log.logSegments.foreach(_.log.file.setLastModified(time.absoluteMilliseconds))
 
     time.sleep(maxLogAgeMs + 1)
     assertEquals("number of segments shouldn't have changed", numSegments, log.numberOfSegments)

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -171,24 +171,24 @@ class LogSegmentTest {
 
     time.sleep(500)
     reopened.truncateTo(57)
-    assertEquals(0, reopened.timeWaitedForRoll(time.milliseconds(), RecordBatch.NO_TIMESTAMP))
+    assertEquals(0, reopened.timeWaitedForRoll(time.absoluteMilliseconds(), RecordBatch.NO_TIMESTAMP))
     assertFalse(reopened.timeIndex.isFull)
     assertFalse(reopened.offsetIndex.isFull)
 
     var rollParams = RollParams(maxSegmentMs, maxSegmentBytes = Int.MaxValue, RecordBatch.NO_TIMESTAMP,
-      maxOffsetInMessages = 100L, messagesSize = 1024, time.milliseconds())
+      maxOffsetInMessages = 100L, messagesSize = 1024, time.absoluteMilliseconds())
     assertFalse(reopened.shouldRoll(rollParams))
 
     // The segment should not be rolled even if maxSegmentMs has been exceeded
     time.sleep(maxSegmentMs + 1)
-    assertEquals(maxSegmentMs + 1, reopened.timeWaitedForRoll(time.milliseconds(), RecordBatch.NO_TIMESTAMP))
+    assertEquals(maxSegmentMs + 1, reopened.timeWaitedForRoll(time.absoluteMilliseconds(), RecordBatch.NO_TIMESTAMP))
     rollParams = RollParams(maxSegmentMs, maxSegmentBytes = Int.MaxValue, RecordBatch.NO_TIMESTAMP,
-      maxOffsetInMessages = 100L, messagesSize = 1024, time.milliseconds())
+      maxOffsetInMessages = 100L, messagesSize = 1024, time.absoluteMilliseconds())
     assertFalse(reopened.shouldRoll(rollParams))
 
     // But we should still roll the segment if we cannot fit the next offset
     rollParams = RollParams(maxSegmentMs, maxSegmentBytes = Int.MaxValue, RecordBatch.NO_TIMESTAMP,
-      maxOffsetInMessages = Int.MaxValue.toLong + 200L, messagesSize = 1024, time.milliseconds())
+      maxOffsetInMessages = Int.MaxValue.toLong + 200L, messagesSize = 1024, time.absoluteMilliseconds())
     assertTrue(reopened.shouldRoll(rollParams))
   }
 
@@ -224,10 +224,10 @@ class LogSegmentTest {
 
     // If the segment is empty after truncation, the create time should be reset
     time.sleep(500)
-    assertEquals(500, seg.timeWaitedForRoll(time.milliseconds(), RecordBatch.NO_TIMESTAMP))
+    assertEquals(500, seg.timeWaitedForRoll(time.absoluteMilliseconds(), RecordBatch.NO_TIMESTAMP))
 
     seg.truncateTo(0)
-    assertEquals(0, seg.timeWaitedForRoll(time.milliseconds(), RecordBatch.NO_TIMESTAMP))
+    assertEquals(0, seg.timeWaitedForRoll(time.absoluteMilliseconds(), RecordBatch.NO_TIMESTAMP))
     assertFalse(seg.timeIndex.isFull)
     assertFalse(seg.offsetIndex.isFull)
     assertNull("Segment should be empty.", seg.read(0, None, 1024))

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -182,7 +182,7 @@ class LogValidatorTest {
       records,
       offsetCounter = new LongRef(0),
       time = time,
-      now = time.milliseconds(),
+      now = time.absoluteMilliseconds(),
       sourceCodec = DefaultCompressionCodec,
       targetCodec = DefaultCompressionCodec,
       compactedTopic = false,

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -96,7 +96,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     tokenManager.startup
 
     tokenManager.createToken(owner, renewer, -1 , createTokenResultCallBack)
-    val issueTime = time.milliseconds
+    val issueTime = time.absoluteMilliseconds
     val tokenId = createTokenResult.tokenId
     val password = DelegationTokenManager.createHmac(tokenId, masterKey)
     assertEquals(CreateTokenResult(issueTime, issueTime + renewTimeMsDefault,  issueTime + maxLifeTimeMsDefault, tokenId, password, Errors.NONE), createTokenResult)
@@ -113,7 +113,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     tokenManager.startup
 
     tokenManager.createToken(owner, renewer, -1 , createTokenResultCallBack)
-    val issueTime = time.milliseconds
+    val issueTime = time.absoluteMilliseconds
     val maxLifeTime = issueTime + maxLifeTimeMsDefault
     val tokenId = createTokenResult.tokenId
     val password = DelegationTokenManager.createHmac(tokenId, masterKey)
@@ -130,14 +130,14 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
 
     // try renew with default time period
     time.sleep(24 * 60 * 60 * 1000L)
-    var expectedExpiryStamp = time.milliseconds + renewTimeMsDefault
+    var expectedExpiryStamp = time.absoluteMilliseconds + renewTimeMsDefault
     tokenManager.renewToken(owner, ByteBuffer.wrap(password), -1 , renewResponseCallback)
     assertEquals(expectedExpiryStamp, expiryTimeStamp)
     assertEquals(Errors.NONE, error)
 
     // try renew with specific time period
     time.sleep(24 * 60 * 60 * 1000L)
-    expectedExpiryStamp = time.milliseconds + 1 * 60 * 60 * 1000L
+    expectedExpiryStamp = time.absoluteMilliseconds + 1 * 60 * 60 * 1000L
     tokenManager.renewToken(owner, ByteBuffer.wrap(password), 1 * 60 * 60 * 1000L , renewResponseCallback)
     assertEquals(expectedExpiryStamp, expiryTimeStamp)
     assertEquals(Errors.NONE, error)
@@ -161,7 +161,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     tokenManager.startup
 
     tokenManager.createToken(owner, renewer, -1 , createTokenResultCallBack)
-    val issueTime = time.milliseconds
+    val issueTime = time.absoluteMilliseconds
     val tokenId = createTokenResult.tokenId
     val password = DelegationTokenManager.createHmac(tokenId, masterKey)
     assertEquals(CreateTokenResult(issueTime, issueTime + renewTimeMsDefault,  issueTime + maxLifeTimeMsDefault, tokenId, password, Errors.NONE), createTokenResult)
@@ -177,7 +177,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
 
     //try expire token at a timestamp
     time.sleep(24 * 60 * 60 * 1000L)
-    val expectedExpiryStamp = time.milliseconds + 2 * 60 * 60 * 1000L
+    val expectedExpiryStamp = time.absoluteMilliseconds + 2 * 60 * 60 * 1000L
     tokenManager.expireToken(owner, ByteBuffer.wrap(password), 2 * 60 * 60 * 1000L, renewResponseCallback)
     assertEquals(expectedExpiryStamp, expiryTimeStamp)
 
@@ -186,7 +186,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     tokenManager.expireToken(owner, ByteBuffer.wrap(password), -1, renewResponseCallback)
     assert(tokenManager.getToken(tokenId).isEmpty)
     assertEquals(Errors.NONE, error)
-    assertEquals(time.milliseconds, expiryTimeStamp)
+    assertEquals(time.absoluteMilliseconds, expiryTimeStamp)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -581,7 +581,7 @@ class AbstractFetcherThreadTest {
         lastOffset = lastOffset,
         maxTimestamp = maxTimestamp,
         offsetOfMaxTimestamp = offsetOfMaxTimestamp,
-        logAppendTime = Time.SYSTEM.milliseconds(),
+        logAppendTime = Time.SYSTEM.absoluteMilliseconds(),
         logStartOffset = state.logStartOffset,
         recordConversionStats = RecordConversionStats.EMPTY,
         sourceCodec = NoCompressionCodec,

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -71,7 +71,7 @@ class ClientQuotaManagerTest {
 
   private def maybeRecord(quotaManager: ClientQuotaManager, user: String, clientId: String, value: Double): Int = {
     val principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, user)
-    quotaManager.maybeRecordAndGetThrottleTimeMs(Session(principal, null), clientId, value, time.milliseconds())
+    quotaManager.maybeRecordAndGetThrottleTimeMs(Session(principal, null), clientId, value, time.absoluteMilliseconds())
   }
 
   private def throttle(quotaManager: ClientQuotaManager, user: String, clientId: String, throttleTimeMs: Int,

--- a/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
@@ -65,13 +65,13 @@ class DelayedOperationTest {
   @Test
   def testRequestExpiry() {
     val expiration = 20L
-    val start = Time.SYSTEM.hiResClockMs
+    val start = Time.SYSTEM.relativeMilliseconds
     val r1 = new MockDelayedOperation(expiration)
     val r2 = new MockDelayedOperation(200000L)
     assertFalse("r1 not satisfied and hence watched", purgatory.tryCompleteElseWatch(r1, Array("test1")))
     assertFalse("r2 not satisfied and hence watched", purgatory.tryCompleteElseWatch(r2, Array("test2")))
     r1.awaitExpiration()
-    val elapsed = Time.SYSTEM.hiResClockMs - start
+    val elapsed = Time.SYSTEM.relativeMilliseconds - start
     assertTrue("r1 completed due to expiration", r1.isCompleted)
     assertFalse("r2 hasn't completed", r2.isCompleted)
     assertTrue(s"Time for expiration $elapsed should at least $expiration", elapsed >= expiration)

--- a/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
@@ -89,7 +89,7 @@ class IsrExpirationTest {
                                                     leaderLogStartOffset = 0L,
                                                     leaderLogEndOffset = leaderLogEndOffset,
                                                     followerLogStartOffset = 0L,
-                                                    fetchTimeMs = time.milliseconds,
+                                                    fetchTimeMs = time.absoluteMilliseconds,
                                                     readSize = -1,
                                                     lastStableOffset = None))
     var partition0OSR = partition0.getOutOfSyncReplicas(leaderReplica, configs.head.replicaLagTimeMaxMs)
@@ -144,7 +144,7 @@ class IsrExpirationTest {
                                                     leaderLogStartOffset = 0L,
                                                     leaderLogEndOffset = leaderLogEndOffset,
                                                     followerLogStartOffset = 0L,
-                                                    fetchTimeMs = time.milliseconds,
+                                                    fetchTimeMs = time.absoluteMilliseconds,
                                                     readSize = -1,
                                                     lastStableOffset = None))
 
@@ -161,7 +161,7 @@ class IsrExpirationTest {
                             leaderLogStartOffset = 0L,
                             leaderLogEndOffset = leaderLogEndOffset,
                             followerLogStartOffset = 0L,
-                            fetchTimeMs = time.milliseconds,
+                            fetchTimeMs = time.absoluteMilliseconds,
                             readSize = -1,
                             lastStableOffset = None))
     }
@@ -181,7 +181,7 @@ class IsrExpirationTest {
                             leaderLogStartOffset = 0L,
                             leaderLogEndOffset = leaderLogEndOffset,
                             followerLogStartOffset = 0L,
-                            fetchTimeMs = time.milliseconds,
+                            fetchTimeMs = time.absoluteMilliseconds,
                             readSize = -1,
                             lastStableOffset = None))
     }
@@ -210,7 +210,7 @@ class IsrExpirationTest {
         leaderLogStartOffset = 0L,
         leaderLogEndOffset = leaderLogEndOffset,
         followerLogStartOffset = 0L,
-        fetchTimeMs = time.milliseconds,
+        fetchTimeMs = time.absoluteMilliseconds,
         readSize = -1,
         lastStableOffset = None))
     var partition0OSR = partition0.getOutOfSyncReplicas(leaderReplica, configs.head.replicaLagTimeMaxMs)
@@ -243,7 +243,7 @@ class IsrExpirationTest {
                                                     leaderLogStartOffset = 0L,
                                                     leaderLogEndOffset = 0L,
                                                     followerLogStartOffset = 0L,
-                                                    fetchTimeMs = time.milliseconds,
+                                                    fetchTimeMs = time.absoluteMilliseconds,
                                                     readSize = -1,
                                                     lastStableOffset = None))
     // set the leader and its hw and the hw update time

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -169,7 +169,7 @@ class LogOffsetTest extends BaseRequestTest {
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)
     log.flush()
 
-    val now = time.milliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
+    val now = time.absoluteMilliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
 
     val offsets = log.legacyFetchOffsetsBefore(now, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)

--- a/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
@@ -132,7 +132,7 @@ class SimpleFetchTest {
                                                           leaderLogStartOffset = 0L,
                                                           leaderLogEndOffset = leo.messageOffset,
                                                           followerLogStartOffset = 0L,
-                                                          fetchTimeMs = time.milliseconds,
+                                                          fetchTimeMs = time.absoluteMilliseconds,
                                                           readSize = -1,
                                                           lastStableOffset = None))
 

--- a/core/src/test/scala/unit/kafka/server/epoch/util/ReplicaFetcherMockBlockingSend.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/util/ReplicaFetcherMockBlockingSend.scala
@@ -62,7 +62,7 @@ class ReplicaFetcherMockBlockingSend(offsets: java.util.Map[TopicPartition, Epoc
 
     //Send the request to the mock client
     val clientRequest = request(requestBuilder)
-    client.send(clientRequest, time.milliseconds())
+    client.send(clientRequest, time.absoluteMilliseconds())
 
     //Create a suitable response based on the API key
     val response = requestBuilder.apiKey() match {
@@ -83,14 +83,14 @@ class ReplicaFetcherMockBlockingSend(offsets: java.util.Map[TopicPartition, Epoc
 
     //Use mock client to create the appropriate response object
     client.respondFrom(response, new Node(destination.id, destination.host, destination.port))
-    client.poll(30, time.milliseconds()).iterator().next()
+    client.poll(30, time.absoluteMilliseconds()).iterator().next()
   }
 
   private def request(requestBuilder: Builder[_ <: AbstractRequest]): ClientRequest = {
     client.newClientRequest(
       destination.id.toString,
       requestBuilder,
-      time.milliseconds(),
+      time.absoluteMilliseconds(),
       true)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.utils.Time
  * Example usage
  * <code>
  *   val time = new MockTime
- *   time.scheduler.schedule("a task", println("hello world: " + time.milliseconds), delay = 1000)
+ *   time.scheduler.schedule("a task", println("hello world: " + time.absoluteMilliseconds), delay = 1000)
  *   time.sleep(1001) // this should cause our scheduled task to fire
  * </code>
  *   
@@ -57,7 +57,7 @@ class MockScheduler(val time: Time) extends Scheduler {
    */
   def tick() {
     this synchronized {
-      val now = time.milliseconds
+      val now = time.absoluteMilliseconds
       while(tasks.nonEmpty && tasks.head.nextExecution <= now) {
         /* pop and execute the task with the lowest next execution time */
         val curr = tasks.dequeue
@@ -73,7 +73,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   
   def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) {
     this synchronized {
-      tasks += MockTask(name, fun, time.milliseconds + delay, period = period)
+      tasks += MockTask(name, fun, time.absoluteMilliseconds + delay, period = period)
       tick()
     }
   }

--- a/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
@@ -36,24 +36,24 @@ class ThrottlerTest {
                                   time = mockTime)
 
     // Observe desiredCountPerInterval at t1
-    val t1 = mockTime.milliseconds()
+    val t1 = mockTime.absoluteMilliseconds()
     throttler.maybeThrottle(desiredCountPerInterval)
-    assertEquals(t1, mockTime.milliseconds())
+    assertEquals(t1, mockTime.absoluteMilliseconds())
 
     // Observe desiredCountPerInterval at t1 + throttleCheckIntervalMs + 1,
     mockTime.sleep(throttleCheckIntervalMs + 1)
     throttler.maybeThrottle(desiredCountPerInterval)
-    val t2 = mockTime.milliseconds()
+    val t2 = mockTime.absoluteMilliseconds()
     assertTrue(t2 >= t1 + 2 * throttleCheckIntervalMs)
 
     // Observe desiredCountPerInterval at t2
     throttler.maybeThrottle(desiredCountPerInterval)
-    assertEquals(t2, mockTime.milliseconds())
+    assertEquals(t2, mockTime.absoluteMilliseconds())
 
     // Observe desiredCountPerInterval at t2 + throttleCheckIntervalMs + 1
     mockTime.sleep(throttleCheckIntervalMs + 1)
     throttler.maybeThrottle(desiredCountPerInterval)
-    val t3 = mockTime.milliseconds()
+    val t3 = mockTime.absoluteMilliseconds()
     assertTrue(t3 >= t2 + 2 * throttleCheckIntervalMs)
 
     val elapsedTimeMs = t3 - t1

--- a/core/src/test/scala/unit/kafka/utils/timer/MockTimer.scala
+++ b/core/src/test/scala/unit/kafka/utils/timer/MockTimer.scala
@@ -30,7 +30,7 @@ class MockTimer extends Timer {
       timerTask.run()
     else {
       taskQueue synchronized {
-        taskQueue.enqueue(new TimerTaskEntry(timerTask, timerTask.delayMs + time.milliseconds))
+        taskQueue.enqueue(new TimerTaskEntry(timerTask, timerTask.delayMs + time.absoluteMilliseconds))
       }
     }
   }
@@ -39,7 +39,7 @@ class MockTimer extends Timer {
     time.sleep(timeoutMs)
 
     var executed = false
-    val now = time.milliseconds
+    val now = time.absoluteMilliseconds
 
     var hasMore = true
     while (hasMore) {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -214,7 +214,7 @@ public class KafkaStreams implements AutoCloseable {
     protected volatile State state = State.CREATED;
 
     private boolean waitOnState(final State targetState, final long waitMs) {
-        final long begin = time.milliseconds();
+        final long begin = time.absoluteMilliseconds();
         synchronized (stateLock) {
             long elapsedMs = 0L;
             while (state != targetState) {
@@ -229,7 +229,7 @@ public class KafkaStreams implements AutoCloseable {
                     log.debug("Cannot transit to {} within {}ms", targetState, waitMs);
                     return false;
                 }
-                elapsedMs = time.milliseconds() - begin;
+                elapsedMs = time.absoluteMilliseconds() - begin;
             }
             return true;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -231,7 +231,7 @@ public class GlobalStreamThread extends Thread {
             for (final Map.Entry<TopicPartition, Long> entry : partitionOffsets.entrySet()) {
                 globalConsumer.seek(entry.getKey(), entry.getValue());
             }
-            lastFlush = time.milliseconds();
+            lastFlush = time.absoluteMilliseconds();
         }
 
         void pollAndUpdate() {
@@ -240,7 +240,7 @@ public class GlobalStreamThread extends Thread {
                 for (final ConsumerRecord<byte[], byte[]> record : received) {
                     stateMaintainer.update(record);
                 }
-                final long now = time.milliseconds();
+                final long now = time.absoluteMilliseconds();
                 if (now >= lastFlush + flushInterval) {
                     stateMaintainer.flushState();
                     lastFlush = now;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -88,11 +88,11 @@ public class ProcessorNode<K, V> {
     public void init(final InternalProcessorContext context) {
         try {
             nodeMetrics = new NodeMetrics(context.metrics(), name, context);
-            final long startNs = time.nanoseconds();
+            final long startNs = time.relativeNanoseconds();
             if (processor != null) {
                 processor.init(context);
             }
-            nodeMetrics.nodeCreationSensor.record(time.nanoseconds() - startNs);
+            nodeMetrics.nodeCreationSensor.record(time.relativeNanoseconds() - startNs);
         } catch (final Exception e) {
             throw new StreamsException(String.format("failed to initialize processor %s", name), e);
         }
@@ -100,11 +100,11 @@ public class ProcessorNode<K, V> {
 
     public void close() {
         try {
-            final long startNs = time.nanoseconds();
+            final long startNs = time.relativeNanoseconds();
             if (processor != null) {
                 processor.close();
             }
-            nodeMetrics.nodeDestructionSensor.record(time.nanoseconds() - startNs);
+            nodeMetrics.nodeDestructionSensor.record(time.relativeNanoseconds() - startNs);
             nodeMetrics.removeAllSensors();
         } catch (final Exception e) {
             throw new StreamsException(String.format("failed to close processor %s", name), e);
@@ -113,15 +113,15 @@ public class ProcessorNode<K, V> {
 
 
     public void process(final K key, final V value) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         processor.process(key, value);
-        nodeMetrics.nodeProcessTimeSensor.record(time.nanoseconds() - startNs);
+        nodeMetrics.nodeProcessTimeSensor.record(time.relativeNanoseconds() - startNs);
     }
 
     public void punctuate(final long timestamp, final Punctuator punctuator) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         punctuator.punctuate(timestamp);
-        nodeMetrics.nodePunctuateTimeSensor.record(time.nanoseconds() - startNs);
+        nodeMetrics.nodePunctuateTimeSensor.record(time.relativeNanoseconds() - startNs);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -280,7 +280,7 @@ public class StateDirectory {
             if (!locks.containsKey(id)) {
                 try {
                     if (lock(id)) {
-                        final long now = time.milliseconds();
+                        final long now = time.absoluteMilliseconds();
                         final long lastModifiedMs = taskDir.lastModified();
                         if (now > lastModifiedMs + cleanupDelayMs || manualUserCall) {
                             if (!manualUserCall) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -437,7 +437,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
      */
     // visible for testing
     void commit(final boolean startNewTransaction) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         log.debug("Committing");
 
         flushState();
@@ -472,7 +472,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
         commitNeeded = false;
         commitRequested = false;
-        taskMetrics.taskCommitTimeSensor.record(time.nanoseconds() - startNs);
+        taskMetrics.taskCommitTimeSensor.record(time.relativeNanoseconds() - startNs);
     }
 
     @Override
@@ -735,7 +735,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 return schedule(0L, interval, type, punctuator);
             case WALL_CLOCK_TIME:
                 // align punctuation to now, punctuate after interval has elapsed
-                return schedule(time.milliseconds() + interval, interval, type, punctuator);
+                return schedule(time.absoluteMilliseconds() + interval, interval, type, punctuator);
             default:
                 throw new IllegalArgumentException("Unrecognized PunctuationType: " + type);
         }
@@ -809,7 +809,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
     public boolean maybePunctuateSystemTime() {
-        final long timestamp = time.milliseconds();
+        final long timestamp = time.absoluteMilliseconds();
 
         final boolean punctuated = systemTimePunctuationQueue.mayPunctuate(timestamp, PunctuationType.WALL_CLOCK_TIME, this);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -265,7 +265,7 @@ public class StreamThread extends Thread {
                 streamThread.setStateListener(null);
                 return;
             }
-            final long start = time.milliseconds();
+            final long start = time.absoluteMilliseconds();
             try {
                 if (streamThread.setState(State.PARTITIONS_ASSIGNED) == null) {
                     return;
@@ -285,7 +285,7 @@ public class StreamThread extends Thread {
                         "\tcurrent active tasks: {}\n" +
                         "\tcurrent standby tasks: {}\n" +
                         "\tprevious active tasks: {}\n",
-                    time.milliseconds() - start,
+                    time.absoluteMilliseconds() - start,
                     taskManager.activeTaskIds(),
                     taskManager.standbyTaskIds(),
                     taskManager.prevActiveTaskIds());
@@ -303,7 +303,7 @@ public class StreamThread extends Thread {
                 taskManager.standbyTaskIds());
 
             if (streamThread.setState(State.PARTITIONS_REVOKED) != null) {
-                final long start = time.milliseconds();
+                final long start = time.absoluteMilliseconds();
                 try {
                     // suspend active tasks
                     if (streamThread.assignmentErrorCode.get() == StreamsPartitionAssignor.Error.VERSION_PROBING.code()) {
@@ -324,7 +324,7 @@ public class StreamThread extends Thread {
                     log.info("partition revocation took {} ms.\n" +
                             "\tsuspended active tasks: {}\n" +
                             "\tsuspended standby tasks: {}",
-                        time.milliseconds() - start,
+                        time.absoluteMilliseconds() - start,
                         taskManager.suspendedActiveTaskIds(),
                         taskManager.suspendedStandbyTaskIds());
                 }
@@ -806,7 +806,7 @@ public class StreamThread extends Thread {
     void runOnce() {
         final ConsumerRecords<byte[], byte[]> records;
 
-        now = time.milliseconds();
+        now = time.absoluteMilliseconds();
 
         if (state == State.PARTITIONS_ASSIGNED) {
             // try to fetch some records with zero poll millis
@@ -1084,7 +1084,7 @@ public class StreamThread extends Thread {
                     standbyRecords = remainingStandbyRecords;
 
                     if (log.isDebugEnabled()) {
-                        log.debug("Updated standby tasks {} in {}ms", taskManager.standbyTaskIds(), time.milliseconds() - now);
+                        log.debug("Updated standby tasks {} in {}ms", taskManager.standbyTaskIds(), time.absoluteMilliseconds() - now);
                     }
                 }
                 processStandbyRecords = false;
@@ -1149,7 +1149,7 @@ public class StreamThread extends Thread {
      */
     private long advanceNowAndComputeLatency() {
         final long previous = now;
-        now = time.milliseconds();
+        now = time.absoluteMilliseconds();
 
         return Math.max(now - previous, 0);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -233,11 +233,11 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
 
     private V measureLatency(final Action<V> action,
                              final Sensor sensor) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             return action.execute();
         } finally {
-            metrics.recordLatency(sensor, startNs, time.nanoseconds());
+            metrics.recordLatency(sensor, startNs, time.relativeNanoseconds());
         }
     }
 
@@ -263,7 +263,7 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
                                         final Sensor sensor) {
             this.iter = iter;
             this.sensor = sensor;
-            this.startNs = time.nanoseconds();
+            this.startNs = time.relativeNanoseconds();
         }
 
         @Override
@@ -289,7 +289,7 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
             try {
                 iter.close();
             } finally {
-                metrics.recordLatency(this.sensor, this.startNs, time.nanoseconds());
+                metrics.recordLatency(this.sensor, this.startNs, time.relativeNanoseconds());
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -84,14 +84,14 @@ public class MeteredSessionStore<K, V> extends WrappedStateStore.AbstractStateSt
         final Sensor restoreTime = createTaskAndStoreLatencyAndThroughputSensors(DEBUG, "restore", metrics, metricsGroup, taskName, name(), taskTags, storeTags);
 
         // register and possibly restore the state from the logs
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             inner.init(context, root);
         } finally {
             this.metrics.recordLatency(
                 restoreTime,
                 startNs,
-                time.nanoseconds()
+                time.relativeNanoseconds()
             );
         }
     }
@@ -140,7 +140,7 @@ public class MeteredSessionStore<K, V> extends WrappedStateStore.AbstractStateSt
     @Override
     public void remove(final Windowed<K> sessionKey) {
         Objects.requireNonNull(sessionKey, "sessionKey can't be null");
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             final Bytes key = keyBytes(sessionKey.key());
             inner.remove(new Windowed<>(key, sessionKey.window()));
@@ -148,14 +148,14 @@ public class MeteredSessionStore<K, V> extends WrappedStateStore.AbstractStateSt
             final String message = String.format(e.getMessage(), sessionKey.key());
             throw new ProcessorStateException(message, e);
         } finally {
-            this.metrics.recordLatency(removeTime, startNs, time.nanoseconds());
+            this.metrics.recordLatency(removeTime, startNs, time.relativeNanoseconds());
         }
     }
 
     @Override
     public void put(final Windowed<K> sessionKey, final V aggregate) {
         Objects.requireNonNull(sessionKey, "sessionKey can't be null");
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             final Bytes key = keyBytes(sessionKey.key());
             this.inner.put(new Windowed<>(key, sessionKey.window()), serdes.rawValue(aggregate));
@@ -163,7 +163,7 @@ public class MeteredSessionStore<K, V> extends WrappedStateStore.AbstractStateSt
             final String message = String.format(e.getMessage(), sessionKey.key(), aggregate);
             throw new ProcessorStateException(message, e);
         } finally {
-            this.metrics.recordLatency(this.putTime, startNs, time.nanoseconds());
+            this.metrics.recordLatency(this.putTime, startNs, time.relativeNanoseconds());
         }
     }
 
@@ -186,11 +186,11 @@ public class MeteredSessionStore<K, V> extends WrappedStateStore.AbstractStateSt
 
     @Override
     public void flush() {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             this.inner.flush();
         } finally {
-            this.metrics.recordLatency(this.flushTime, startNs, time.nanoseconds());
+            this.metrics.recordLatency(this.flushTime, startNs, time.relativeNanoseconds());
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -84,14 +84,14 @@ public class MeteredWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
         final Sensor restoreTime = createTaskAndStoreLatencyAndThroughputSensors(DEBUG, "restore", metrics, metricsGroup, taskName, name(), taskTags, storeTags);
 
         // register and possibly restore the state from the logs
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             inner.init(context, root);
         } finally {
             this.metrics.recordLatency(
                 restoreTime,
                 startNs,
-                time.nanoseconds()
+                time.relativeNanoseconds()
             );
         }
     }
@@ -109,14 +109,14 @@ public class MeteredWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
 
     @Override
     public void put(final K key, final V value, final long windowStartTimestamp) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             inner.put(keyBytes(key), serdes.rawValue(value), windowStartTimestamp);
         } catch (final ProcessorStateException e) {
             final String message = String.format(e.getMessage(), key, value);
             throw new ProcessorStateException(message, e);
         } finally {
-            metrics.recordLatency(this.putTime, startNs, time.nanoseconds());
+            metrics.recordLatency(this.putTime, startNs, time.relativeNanoseconds());
         }
     }
 
@@ -126,7 +126,7 @@ public class MeteredWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
 
     @Override
     public V fetch(final K key, final long timestamp) {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             final byte[] result = inner.fetch(keyBytes(key), timestamp);
             if (result == null) {
@@ -134,7 +134,7 @@ public class MeteredWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
             }
             return serdes.valueFrom(result);
         } finally {
-            metrics.recordLatency(this.fetchTime, startNs, time.nanoseconds());
+            metrics.recordLatency(this.fetchTime, startNs, time.relativeNanoseconds());
         }
     }
 
@@ -175,11 +175,11 @@ public class MeteredWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
 
     @Override
     public void flush() {
-        final long startNs = time.nanoseconds();
+        final long startNs = time.relativeNanoseconds();
         try {
             inner.flush();
         } finally {
-            metrics.recordLatency(flushTime, startNs, time.nanoseconds());
+            metrics.recordLatency(flushTime, startNs, time.relativeNanoseconds());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
@@ -41,7 +41,7 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V> {
         this.sensor = sensor;
         this.metrics = metrics;
         this.serdes = serdes;
-        this.startNs = time.nanoseconds();
+        this.startNs = time.relativeNanoseconds();
         this.time = time;
     }
 
@@ -66,7 +66,7 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V> {
         try {
             iter.close();
         } finally {
-            metrics.recordLatency(this.sensor, this.startNs, time.nanoseconds());
+            metrics.recordLatency(this.sensor, this.startNs, time.relativeNanoseconds());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
@@ -43,7 +43,7 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
         this.sensor = sensor;
         this.metrics = metrics;
         this.serdes = serdes;
-        this.startNs = time.nanoseconds();
+        this.startNs = time.relativeNanoseconds();
         this.time = time;
     }
 
@@ -73,7 +73,7 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
         try {
             iter.close();
         } finally {
-            metrics.recordLatency(sensor, startNs, time.nanoseconds());
+            metrics.recordLatency(sensor, startNs, time.relativeNanoseconds());
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -221,7 +221,7 @@ public abstract class AbstractResetIntegrationTest {
 
         for (final KeyValue<Long, String> record : records) {
             mockTime.sleep(10);
-            IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(INPUT_TOPIC, Collections.singleton(record), producerConfig, mockTime.milliseconds());
+            IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(INPUT_TOPIC, Collections.singleton(record), producerConfig, mockTime.absoluteMilliseconds());
         }
     }
 
@@ -340,7 +340,7 @@ public abstract class AbstractResetIntegrationTest {
             INTERMEDIATE_USER_TOPIC,
             Collections.singleton(badMessage),
                 producerConfig,
-            mockTime.milliseconds());
+            mockTime.absoluteMilliseconds());
 
         // RESET
         streams = new KafkaStreams(setupTopologyWithIntermediateUserTopic(OUTPUT_TOPIC_2_RERUN), streamsConfig);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
@@ -341,7 +341,7 @@ public class GlobalKTableEOSIntegrationTest {
                                 LongSerializer.class,
                                 StringSerializer.class,
                                 properties),
-                mockTime.milliseconds());
+                mockTime.absoluteMilliseconds());
     }
 
     private void produceInitialGlobalTableValues() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
@@ -172,7 +172,7 @@ public class KStreamAggregationDedupIntegrationTest {
 
     @Test
     public void shouldGroupByKey() throws Exception {
-        final long timestamp = mockTime.milliseconds();
+        final long timestamp = mockTime.absoluteMilliseconds();
         produceMessages(timestamp);
         produceMessages(timestamp);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -153,7 +153,7 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldReduce() throws Exception {
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
         groupedStream
             .reduce(reducer, Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("reduce-by-key"))
             .toStream()
@@ -161,7 +161,7 @@ public class KStreamAggregationIntegrationTest {
 
         startStreams();
 
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
 
         final List<KeyValue<String, String>> results = receiveMessages(
             new StringDeserializer(),
@@ -193,10 +193,10 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldReduceWindowed() throws Exception {
-        final long firstBatchTimestamp = mockTime.milliseconds();
+        final long firstBatchTimestamp = mockTime.absoluteMilliseconds();
         mockTime.sleep(1000);
         produceMessages(firstBatchTimestamp);
-        final long secondBatchTimestamp = mockTime.milliseconds();
+        final long secondBatchTimestamp = mockTime.absoluteMilliseconds();
         produceMessages(secondBatchTimestamp);
         produceMessages(secondBatchTimestamp);
 
@@ -264,7 +264,7 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldAggregate() throws Exception {
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
         groupedStream.aggregate(
             initializer,
             aggregator,
@@ -274,7 +274,7 @@ public class KStreamAggregationIntegrationTest {
 
         startStreams();
 
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
 
         final List<KeyValue<String, Integer>> results = receiveMessages(
             new StringDeserializer(),
@@ -299,10 +299,10 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldAggregateWindowed() throws Exception {
-        final long firstTimestamp = mockTime.milliseconds();
+        final long firstTimestamp = mockTime.absoluteMilliseconds();
         mockTime.sleep(1000);
         produceMessages(firstTimestamp);
-        final long secondTimestamp = mockTime.milliseconds();
+        final long secondTimestamp = mockTime.absoluteMilliseconds();
         produceMessages(secondTimestamp);
         produceMessages(secondTimestamp);
 
@@ -376,7 +376,7 @@ public class KStreamAggregationIntegrationTest {
     private void shouldCountHelper() throws Exception {
         startStreams();
 
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
 
         final List<KeyValue<String, Long>> results = receiveMessages(
             new StringDeserializer(),
@@ -400,7 +400,7 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldCount() throws Exception {
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
 
         groupedStream.count(Materialized.as("count-by-key"))
                 .toStream()
@@ -411,7 +411,7 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldCountWithInternalStore() throws Exception {
-        produceMessages(mockTime.milliseconds());
+        produceMessages(mockTime.absoluteMilliseconds());
 
         groupedStream.count()
                 .toStream()
@@ -422,7 +422,7 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldGroupByKey() throws Exception {
-        final long timestamp = mockTime.milliseconds();
+        final long timestamp = mockTime.absoluteMilliseconds();
         produceMessages(timestamp);
         produceMessages(timestamp);
 
@@ -459,7 +459,7 @@ public class KStreamAggregationIntegrationTest {
     public void shouldCountSessionWindows() throws Exception {
         final long sessionGap = 5 * 60 * 1000L;
 
-        final long t1 = mockTime.milliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
+        final long t1 = mockTime.absoluteMilliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
         final List<KeyValue<String, String>> t1Messages = Arrays.asList(new KeyValue<>("bob", "start"),
                                                                         new KeyValue<>("penny", "start"),
                                                                         new KeyValue<>("jo", "pause"),
@@ -557,7 +557,7 @@ public class KStreamAggregationIntegrationTest {
     public void shouldReduceSessionWindows() throws Exception {
         final long sessionGap = 1000L; // something to do with time
 
-        final long t1 = mockTime.milliseconds();
+        final long t1 = mockTime.absoluteMilliseconds();
         final List<KeyValue<String, String>> t1Messages = Arrays.asList(new KeyValue<>("bob", "start"),
                                                                         new KeyValue<>("penny", "start"),
                                                                         new KeyValue<>("jo", "pause"),
@@ -650,10 +650,10 @@ public class KStreamAggregationIntegrationTest {
 
     @Test
     public void shouldCountUnlimitedWindows() throws Exception {
-        final long startTime = mockTime.milliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS) + 1;
+        final long startTime = mockTime.absoluteMilliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS) + 1;
         final long incrementTime = Duration.ofDays(1).toMillis();
 
-        final long t1 = mockTime.milliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
+        final long t1 = mockTime.absoluteMilliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
         final List<KeyValue<String, String>> t1Messages = Arrays.asList(new KeyValue<>("bob", "start"),
                                                                         new KeyValue<>("penny", "start"),
                                                                         new KeyValue<>("jo", "pause"),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
@@ -190,7 +190,7 @@ public class PurgeRepartitionTopicIntegrationTest {
                 TestUtils.producerConfig(CLUSTER.bootstrapServers(),
                         IntegerSerializer.class,
                         IntegerSerializer.class),
-                time.milliseconds());
+                time.absoluteMilliseconds());
 
         kafkaStreams.start();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -181,7 +181,7 @@ public class IntegrationTestUtils {
                 Collections.singleton(record),
                 producerConfig,
                 headers,
-                time.milliseconds(),
+                time.absoluteMilliseconds(),
                 enableTransactions);
             time.sleep(1L);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -442,7 +442,7 @@ public class StreamTaskTest {
         task = createStatelessTask(createConfig(false));
         task.initializeStateStores();
         task.initializeTopology();
-        final long now = time.milliseconds();
+        final long now = time.absoluteMilliseconds();
         time.sleep(10);
         assertTrue(task.maybePunctuateSystemTime());
         processorSystemTime.mockProcessor.scheduleCancellable.cancel();
@@ -524,32 +524,32 @@ public class StreamTaskTest {
 
         task.addRecords(partition1, Collections.singleton(new ConsumerRecord<>(topic1, 1, 0, bytes, bytes)));
 
-        assertFalse(task.isProcessable(time.milliseconds()));
+        assertFalse(task.isProcessable(time.absoluteMilliseconds()));
 
-        assertFalse(task.isProcessable(time.milliseconds() + 50L));
+        assertFalse(task.isProcessable(time.absoluteMilliseconds() + 50L));
 
-        assertTrue(task.isProcessable(time.milliseconds() + 100L));
+        assertTrue(task.isProcessable(time.absoluteMilliseconds() + 100L));
         assertEquals(1.0, metrics.metric(enforcedProcessMetric).metricValue());
 
         // once decided to enforce, continue doing that
-        assertTrue(task.isProcessable(time.milliseconds() + 101L));
+        assertTrue(task.isProcessable(time.absoluteMilliseconds() + 101L));
         assertEquals(2.0, metrics.metric(enforcedProcessMetric).metricValue());
 
         task.addRecords(partition2, Collections.singleton(new ConsumerRecord<>(topic2, 1, 0, bytes, bytes)));
 
-        assertTrue(task.isProcessable(time.milliseconds() + 130L));
+        assertTrue(task.isProcessable(time.absoluteMilliseconds() + 130L));
         assertEquals(2.0, metrics.metric(enforcedProcessMetric).metricValue());
 
         // one resumed to normal processing, the timer should be reset
         task.process();
 
-        assertFalse(task.isProcessable(time.milliseconds() + 150L));
+        assertFalse(task.isProcessable(time.absoluteMilliseconds() + 150L));
         assertEquals(2.0, metrics.metric(enforcedProcessMetric).metricValue());
 
-        assertFalse(task.isProcessable(time.milliseconds() + 249L));
+        assertFalse(task.isProcessable(time.absoluteMilliseconds() + 249L));
         assertEquals(2.0, metrics.metric(enforcedProcessMetric).metricValue());
 
-        assertTrue(task.isProcessable(time.milliseconds() + 250L));
+        assertTrue(task.isProcessable(time.absoluteMilliseconds() + 250L));
         assertEquals(3.0, metrics.metric(enforcedProcessMetric).metricValue());
     }
 
@@ -559,7 +559,7 @@ public class StreamTaskTest {
         task = createStatelessTask(createConfig(false));
         task.initializeStateStores();
         task.initializeTopology();
-        final long now = time.milliseconds();
+        final long now = time.absoluteMilliseconds();
         time.sleep(10);
         assertTrue(task.maybePunctuateSystemTime());
         time.sleep(10);
@@ -590,7 +590,7 @@ public class StreamTaskTest {
         task = createStatelessTask(createConfig(false));
         task.initializeStateStores();
         task.initializeTopology();
-        final long now = time.milliseconds();
+        final long now = time.absoluteMilliseconds();
         time.sleep(100);
         assertTrue(task.maybePunctuateSystemTime());
         assertFalse(task.maybePunctuateSystemTime());
@@ -1277,7 +1277,7 @@ public class StreamTaskTest {
         task.punctuate(processorSystemTime, 5, PunctuationType.WALL_CLOCK_TIME, new Punctuator() {
             @Override
             public void punctuate(final long timestamp) {
-                recordCollector.send("result-topic1", 3, 5, null, 0, time.milliseconds(),
+                recordCollector.send("result-topic1", 3, 5, null, 0, time.absoluteMilliseconds(),
                         new IntegerSerializer(),  new IntegerSerializer());
             }
         });

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -311,10 +311,10 @@ public class StreamThreadTest {
             new LogContext(""),
             new AtomicInteger()
         );
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
         mockTime.sleep(commitInterval - 10L);
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
 
         EasyMock.verify(taskManager);
@@ -438,10 +438,10 @@ public class StreamThreadTest {
             new LogContext(""),
             new AtomicInteger()
         );
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
         mockTime.sleep(commitInterval - 10L);
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
 
         EasyMock.verify(taskManager);
@@ -475,10 +475,10 @@ public class StreamThreadTest {
             new LogContext(""),
             new AtomicInteger()
         );
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
         mockTime.sleep(commitInterval + 1);
-        thread.setNow(mockTime.milliseconds());
+        thread.setNow(mockTime.absoluteMilliseconds());
         thread.maybeCommit();
 
         EasyMock.verify(taskManager);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
@@ -135,8 +135,8 @@ public class StreamsMetricsImplTest {
         final KafkaMetric totalMetric = metrics.metric(totalMetricName);
 
         for (int i = 0; i < 10; i++) {
-            assertEquals(i, Math.round(totalMetric.measurable().measure(config, time.milliseconds())));
-            sensor.record(latency, time.milliseconds());
+            assertEquals(i, Math.round(totalMetric.measurable().measure(config, time.absoluteMilliseconds())));
+            sensor.record(latency, time.absoluteMilliseconds());
         }
 
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -705,18 +705,18 @@ public class TopologyTestDriver implements Closeable {
         }
 
         @Override
-        public long milliseconds() {
+        public long absoluteMilliseconds() {
             return timeMs.get();
         }
 
         @Override
-        public long nanoseconds() {
+        public long relativeNanoseconds() {
             return highResTimeNs.get();
         }
 
         @Override
-        public long hiResClockMs() {
-            return TimeUnit.NANOSECONDS.toMillis(nanoseconds());
+        public long relativeMilliseconds() {
+            return TimeUnit.NANOSECONDS.toMillis(relativeNanoseconds());
         }
 
         @Override

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
@@ -25,14 +25,14 @@ public class MockTimeTest {
     @Test
     public void shouldSetStartTime() {
         final TopologyTestDriver.MockTime time = new TopologyTestDriver.MockTime(42L);
-        assertEquals(42L, time.milliseconds());
-        assertEquals(42L * 1000L * 1000L, time.nanoseconds());
+        assertEquals(42L, time.absoluteMilliseconds());
+        assertEquals(42L * 1000L * 1000L, time.relativeNanoseconds());
     }
 
     @Test
     public void shouldGetNanosAsMillis() {
         final TopologyTestDriver.MockTime time = new TopologyTestDriver.MockTime(42L);
-        assertEquals(42L, time.hiResClockMs());
+        assertEquals(42L, time.relativeMilliseconds());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -44,13 +44,13 @@ public class MockTimeTest {
     public void shouldAdvanceTimeOnSleep() {
         final TopologyTestDriver.MockTime time = new TopologyTestDriver.MockTime(42L);
 
-        assertEquals(42L, time.milliseconds());
+        assertEquals(42L, time.absoluteMilliseconds());
         time.sleep(1L);
-        assertEquals(43L, time.milliseconds());
+        assertEquals(43L, time.absoluteMilliseconds());
         time.sleep(0L);
-        assertEquals(43L, time.milliseconds());
+        assertEquals(43L, time.absoluteMilliseconds());
         time.sleep(3L);
-        assertEquals(46L, time.milliseconds());
+        assertEquals(46L, time.absoluteMilliseconds());
     }
 
 }

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -209,7 +209,7 @@ public class ClientCompatibilityTest {
 
     ClientCompatibilityTest(TestConfig testConfig) {
         this.testConfig = testConfig;
-        long curTime = Time.SYSTEM.milliseconds();
+        long curTime = Time.SYSTEM.absoluteMilliseconds();
 
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.putLong(curTime);
@@ -223,7 +223,7 @@ public class ClientCompatibilityTest {
     }
 
     void run() throws Throwable {
-        long prodTimeMs = Time.SYSTEM.milliseconds();
+        long prodTimeMs = Time.SYSTEM.absoluteMilliseconds();
         testAdminClient();
         testProduce();
         testConsume(prodTimeMs);
@@ -410,7 +410,7 @@ public class ClientCompatibilityTest {
 
                 private byte[] fetchNext() {
                     while (true) {
-                        long curTime = Time.SYSTEM.milliseconds();
+                        long curTime = Time.SYSTEM.absoluteMilliseconds();
                         if (curTime - prodTimeMs > TIMEOUT_MS)
                             throw new RuntimeException("Timed out after " + TIMEOUT_MS + " ms.");
                         if (recordIter == null) {

--- a/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PushHttpMetricsReporter.java
@@ -168,7 +168,7 @@ public class PushHttpMetricsReporter implements MetricsReporter {
     private class HttpReporter implements Runnable {
         @Override
         public void run() {
-            long now = time.milliseconds();
+            long now = time.absoluteMilliseconds();
             final List<MetricValue> samples;
             synchronized (lock) {
                 samples = new ArrayList<>(metrics.size());

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -70,7 +70,7 @@ public final class Agent {
      */
     public Agent(Platform platform, Scheduler scheduler,
                  JsonRestServer restServer, AgentRestResource resource) {
-        this.serverStartMs = scheduler.time().milliseconds();
+        this.serverStartMs = scheduler.time().absoluteMilliseconds();
         this.workerManager = new WorkerManager(platform, scheduler);
         this.restServer = restServer;
         resource.setAgent(this);

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -294,7 +294,7 @@ public final class WorkerManager {
 
         void transitionToDone() {
             state = State.DONE;
-            doneMs = time.milliseconds();
+            doneMs = time.absoluteMilliseconds();
             if (reference != null) {
                 reference.close();
                 reference = null;
@@ -310,7 +310,7 @@ public final class WorkerManager {
     public void createWorker(long workerId, String taskId, TaskSpec spec) throws Throwable {
         try (ShutdownManager.Reference ref = shutdownManager.takeReference()) {
             final Worker worker = stateChangeExecutor.
-                submit(new CreateWorker(workerId, taskId, spec, time.milliseconds())).get();
+                submit(new CreateWorker(workerId, taskId, spec, time.absoluteMilliseconds())).get();
             if (worker == null) {
                 log.info("{}: Ignoring request to create worker {}, because there is already " +
                     "a worker with that id.", nodeName, workerId);

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -193,7 +193,7 @@ public final class WorkerUtils {
      */
     private static Collection<String> createTopics(Logger log, AdminClient adminClient,
                                                    Collection<NewTopic> topics) throws Throwable {
-        long startMs = Time.SYSTEM.milliseconds();
+        long startMs = Time.SYSTEM.absoluteMilliseconds();
         int tries = 0;
         List<String> existingTopics = new ArrayList<>();
 
@@ -240,7 +240,7 @@ public final class WorkerUtils {
             if (topicsToCreate.isEmpty()) {
                 break;
             }
-            if (Time.SYSTEM.milliseconds() > startMs + CREATE_TOPICS_CALL_TIMEOUT) {
+            if (Time.SYSTEM.absoluteMilliseconds() > startMs + CREATE_TOPICS_CALL_TIMEOUT) {
                 String str = "Unable to create topic(s): " +
                              Utils.join(topicsToCreate, ", ") + "after " + tries + " attempt(s)";
                 log.warn(str);

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -76,7 +76,7 @@ public final class Coordinator {
      */
     public Coordinator(Platform platform, Scheduler scheduler, JsonRestServer restServer,
                        CoordinatorRestResource resource, long firstWorkerId) {
-        this.startTimeMs = scheduler.time().milliseconds();
+        this.startTimeMs = scheduler.time().absoluteMilliseconds();
         this.taskManager = new TaskManager(platform, scheduler, firstWorkerId);
         this.restServer = restServer;
         resource.setCoordinator(this);

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -340,14 +340,14 @@ public final class TaskManager {
                 log.info("Failed to create a new task {} with spec {}: {}",
                     id, spec, failure);
                 task = new ManagedTask(id, spec, null, TaskStateType.DONE);
-                task.doneMs = time.milliseconds();
+                task.doneMs = time.absoluteMilliseconds();
                 task.maybeSetError(failure);
                 tasks.put(id, task);
                 return null;
             }
             task = new ManagedTask(id, spec, controller, TaskStateType.PENDING);
             tasks.put(id, task);
-            long delayMs = task.startDelayMs(time.milliseconds());
+            long delayMs = task.startDelayMs(time.absoluteMilliseconds());
             task.startFuture = scheduler.schedule(executor, new RunTask(task), delayMs);
             log.info("Created a new task {} with spec {}, scheduled to start {} ms from now.",
                     id, spec, delayMs);
@@ -378,14 +378,14 @@ public final class TaskManager {
                 nodeNames = task.findNodeNames();
             } catch (Exception e) {
                 log.error("Unable to find nodes for task {}", task.id, e);
-                task.doneMs = time.milliseconds();
+                task.doneMs = time.absoluteMilliseconds();
                 task.state = TaskStateType.DONE;
                 task.maybeSetError("Unable to find nodes for task: " + e.getMessage());
                 return null;
             }
             log.info("Running task {} on node(s): {}", task.id, Utils.join(nodeNames, ", "));
             task.state = TaskStateType.RUNNING;
-            task.startedMs = time.milliseconds();
+            task.startedMs = time.absoluteMilliseconds();
             for (String workerName : nodeNames) {
                 long workerId = nextWorkerId++;
                 task.workerIds.put(workerName, workerId);
@@ -434,7 +434,7 @@ public final class TaskManager {
                 case PENDING:
                     task.cancelled = true;
                     task.clearStartFuture();
-                    task.doneMs = time.milliseconds();
+                    task.doneMs = time.absoluteMilliseconds();
                     task.state = TaskStateType.DONE;
                     log.info("Stopped pending task {}.", id);
                     break;
@@ -447,7 +447,7 @@ public final class TaskManager {
                         } else {
                             log.info("Task {} is now complete with error: {}", id, task.error);
                         }
-                        task.doneMs = time.milliseconds();
+                        task.doneMs = time.absoluteMilliseconds();
                         task.state = TaskStateType.DONE;
                     } else {
                         for (Map.Entry<String, Long> entry : activeWorkerIds.entrySet()) {
@@ -579,7 +579,7 @@ public final class TaskManager {
         }
         TreeMap<String, Long> activeWorkerIds = task.activeWorkerIds();
         if (activeWorkerIds.isEmpty()) {
-            task.doneMs = time.milliseconds();
+            task.doneMs = time.absoluteMilliseconds();
             task.state = TaskStateType.DONE;
             log.info("{}: Task {} is now complete on {} with error: {}",
                 nodeName, task.id, Utils.join(task.workerIds.keySet(), ", "),

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -101,7 +101,7 @@ public class ConnectionStressWorker implements TaskWorker {
         this.status = status;
         this.totalConnections = 0;
         this.totalFailedConnections  = 0;
-        this.startTimeMs = TIME.milliseconds();
+        this.startTimeMs = TIME.absoluteMilliseconds();
         this.throttle = new ConnectStressThrottle(WorkerUtils.
             perSecToPerPeriod(spec.targetConnectionsPerSec(), THROTTLE_PERIOD_MS));
         this.nextReportTime = 0;

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -231,7 +231,7 @@ public class ConsumeBenchWorker implements TaskWorker {
         public Void call() throws Exception {
             long messagesConsumed = 0;
             long bytesConsumed = 0;
-            long startTimeMs = Time.SYSTEM.milliseconds();
+            long startTimeMs = Time.SYSTEM.absoluteMilliseconds();
             long startBatchMs = startTimeMs;
             int maxMessages = spec.maxMessages();
             try {
@@ -240,7 +240,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                     if (records.isEmpty()) {
                         continue;
                     }
-                    long endBatchMs = Time.SYSTEM.milliseconds();
+                    long endBatchMs = Time.SYSTEM.absoluteMilliseconds();
                     long elapsedBatchMs = endBatchMs - startBatchMs;
                     for (ConsumerRecord<byte[], byte[]> record : records) {
                         messagesConsumed++;
@@ -259,7 +259,7 @@ public class ConsumeBenchWorker implements TaskWorker {
 
                         throttle.increment();
                     }
-                    startBatchMs = Time.SYSTEM.milliseconds();
+                    startBatchMs = Time.SYSTEM.absoluteMilliseconds();
                 }
             } catch (Exception e) {
                 WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
@@ -267,7 +267,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData =
                     new ConsumeStatusUpdater(latencyHistogram, messageSizeHistogram, consumer).update();
-                long curTimeMs = Time.SYSTEM.milliseconds();
+                long curTimeMs = Time.SYSTEM.absoluteMilliseconds();
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
             }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -139,7 +139,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
         @Override
         public void onCompletion(RecordMetadata metadata, Exception exception) {
-            long now = Time.SYSTEM.milliseconds();
+            long now = Time.SYSTEM.absoluteMilliseconds();
             long durationMs = now - startMs;
             sendRecords.recordDuration(durationMs);
             if (exception != null) {
@@ -162,9 +162,9 @@ public class ProduceBenchWorker implements TaskWorker {
 
         @Override
         protected synchronized void delay(long amount) throws InterruptedException {
-            long startMs = time().milliseconds();
+            long startMs = time().absoluteMilliseconds();
             producer.flush();
-            long endMs = time().milliseconds();
+            long endMs = time().absoluteMilliseconds();
             long delta = endMs - startMs;
             super.delay(amount - delta);
         }
@@ -219,7 +219,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
         @Override
         public Void call() throws Exception {
-            long startTimeMs = Time.SYSTEM.milliseconds();
+            long startTimeMs = Time.SYSTEM.absoluteMilliseconds();
             try {
                 try {
                     if (enableTransactions)
@@ -252,7 +252,7 @@ public class ProduceBenchWorker implements TaskWorker {
             } finally {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData = new StatusUpdater(histogram, transactionsCommitted).update();
-                long curTimeMs = Time.SYSTEM.milliseconds();
+                long curTimeMs = Time.SYSTEM.absoluteMilliseconds();
                 log.info("Sent {} total record(s) in {} ms.  status: {}",
                     histogram.summarize().numSamples(), curTimeMs - startTimeMs, statusData);
             }
@@ -292,7 +292,7 @@ public class ProduceBenchWorker implements TaskWorker {
             ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
                 partition.topic(), partition.partition(), keys.next(), values.next());
             sendFuture = producer.send(record,
-                new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
+                new SendRecordsCallback(this, Time.SYSTEM.absoluteMilliseconds()));
             throttle.increment();
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -334,7 +334,7 @@ public class RoundTripWorker implements TaskWorker {
             long pollInvoked = 0;
             log.debug("{}: Starting RoundTripWorker#ConsumerRunnable.", id);
             try {
-                long lastLogTimeMs = Time.SYSTEM.milliseconds();
+                long lastLogTimeMs = Time.SYSTEM.absoluteMilliseconds();
                 while (true) {
                     try {
                         pollInvoked++;
@@ -356,7 +356,7 @@ public class RoundTripWorker implements TaskWorker {
                                 }
                             }
                         }
-                        long curTimeMs = Time.SYSTEM.milliseconds();
+                        long curTimeMs = Time.SYSTEM.absoluteMilliseconds();
                         if (curTimeMs > lastLogTimeMs + LOG_INTERVAL_MS) {
                             toReceiveTracker.log();
                             lastLogTimeMs = curTimeMs;

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
@@ -41,7 +41,7 @@ public class Throttle {
                 count++;
                 return throttled;
             }
-            lastTimeMs = time().milliseconds();
+            lastTimeMs = time().absoluteMilliseconds();
             long curPeriod = lastTimeMs / periodMs;
             if (curPeriod <= prevPeriod) {
                 long nextPeriodMs = (curPeriod + 1) * periodMs;

--- a/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
@@ -325,7 +325,7 @@ public class PushHttpMetricsReporterTest {
         assertTrue(client.isObject());
         assertEquals(InetAddress.getLocalHost().getCanonicalHostName(), client.get("host").textValue());
         assertEquals("", client.get("client_id").textValue());
-        assertEquals(time.milliseconds(), client.get("time").longValue());
+        assertEquals(time.absoluteMilliseconds(), client.get("time").longValue());
     }
 
     private void expectReadResponse() throws Exception {

--- a/tools/src/test/java/org/apache/kafka/trogdor/workload/ThrottleTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/workload/ThrottleTest.java
@@ -51,20 +51,20 @@ public class ThrottleTest {
         MockTime time = new MockTime(0, 0, 0);
         ThrottleMock throttle = new ThrottleMock(time, 3);
         Assert.assertFalse(throttle.increment());
-        Assert.assertEquals(0, time.milliseconds());
+        Assert.assertEquals(0, time.absoluteMilliseconds());
         Assert.assertFalse(throttle.increment());
-        Assert.assertEquals(0, time.milliseconds());
+        Assert.assertEquals(0, time.absoluteMilliseconds());
         Assert.assertFalse(throttle.increment());
-        Assert.assertEquals(0, time.milliseconds());
+        Assert.assertEquals(0, time.absoluteMilliseconds());
         Assert.assertTrue(throttle.increment());
-        Assert.assertEquals(100, time.milliseconds());
+        Assert.assertEquals(100, time.absoluteMilliseconds());
         time.sleep(50);
         Assert.assertFalse(throttle.increment());
-        Assert.assertEquals(150, time.milliseconds());
+        Assert.assertEquals(150, time.absoluteMilliseconds());
         Assert.assertFalse(throttle.increment());
-        Assert.assertEquals(150, time.milliseconds());
+        Assert.assertEquals(150, time.absoluteMilliseconds());
         Assert.assertTrue(throttle.increment());
-        Assert.assertEquals(200, time.milliseconds());
+        Assert.assertEquals(200, time.absoluteMilliseconds());
     }
 };
 


### PR DESCRIPTION
This change renames methods in Time interface to make apparent which underlying implementation is used in each case