### PR TITLE
MINOR: Bump Gradle version to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Follow instructions in http://kafka.apache.org/documentation.html#quickstart
     ./gradlew cleanTest integrationTest
 
 ### Running a particular unit/integration test ###
-    ./gradlew -Dtest.single=RequestResponseSerializationTest core:test
+    ./gradlew clients:test --tests RequestResponseTest
 
 ### Running a particular test method within a unit/integration test ###
     ./gradlew core:test --tests kafka.api.ProducerFailureHandlingTest.testCannotSendToInternalTopic
@@ -54,7 +54,7 @@ Follow instructions in http://kafka.apache.org/documentation.html#quickstart
 ### Running a particular unit/integration test with log4j output ###
 Change the log4j setting in either `clients/src/test/resources/log4j.properties` or `core/src/test/resources/log4j.properties`
 
-    ./gradlew -i -Dtest.single=RequestResponseSerializationTest core:test
+    ./gradlew clients:test --tests RequestResponseTest
 
 ### Generating test coverage reports ###
 Generate coverage reports for the whole project:

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.10.2"
+  gradleVersion = "5.0"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 

--- a/build.gradle
+++ b/build.gradle
@@ -466,10 +466,10 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
   description = 'Generates an aggregate report from all subprojects'
   dependsOn(javaProjects.test)
 
-  additionalSourceDirs.from(files(javaProjects.sourceSets.main.allSource.srcDirs))
-  sourceDirectories.from(files(javaProjects.sourceSets.main.allSource.srcDirs))
-  classDirectories.from(files(javaProjects.sourceSets.main.output))
-  executionData.from(files(javaProjects.jacocoTestReport.executionData))
+  additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
+  sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
+  classDirectories =  files(javaProjects.sourceSets.main.output)
+  executionData = files(javaProjects.jacocoTestReport.executionData)
 
   reports {
     html.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -466,10 +466,10 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
   description = 'Generates an aggregate report from all subprojects'
   dependsOn(javaProjects.test)
 
-  additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
-  sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
-  classDirectories =  files(javaProjects.sourceSets.main.output)
-  executionData = files(javaProjects.jacocoTestReport.executionData)
+  additionalSourceDirs.from(files(javaProjects.sourceSets.main.allSource.srcDirs))
+  sourceDirectories.from(files(javaProjects.sourceSets.main.allSource.srcDirs))
+  classDirectories.from(files(javaProjects.sourceSets.main.output))
+  executionData.from(files(javaProjects.jacocoTestReport.executionData))
 
   reports {
     html.enabled = true


### PR DESCRIPTION
Gradle 5.0 was released on 26 November. See the release notes for enhancements and fixes: https://docs.gradle.org/5.0/release-notes.html.

A notable bugfix ensures that Javadoc artifacts are cleaned between builds.

The upgraded wrapper was spot-checked against the commands in the README and the
README was updated not to use removed system property `-Dtest.single`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
