### PR TITLE
KAFKA-7687: Print batch level information in DumpLogSegments

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -292,7 +292,8 @@ object DumpLogSegments {
           }
           lastOffset = record.offset
 
-          print(s"$INDENT offset: ${record.offset} keysize: ${record.keySize} valuesize: ${record.valueSize}")
+          print(s"$INDENT offset: ${record.offset} isvalid: ${record.isValid} ${batch.timestampType}: ${record.timestamp} " +
+            s"keysize: ${record.keySize} valuesize: ${record.valueSize}")
 
           if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
             print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -37,7 +37,7 @@ import scala.collection.JavaConverters._
 object DumpLogSegments {
 
   // visible for testing
-  private[tools] val INDENT = "|"
+  private[tools] val RECORD_INDENT = "|"
 
   def main(args: Array[String]) {
     val opts = new DumpLogSegmentsOptions(args)
@@ -292,13 +292,13 @@ object DumpLogSegments {
           }
           lastOffset = record.offset
 
-          print(s"$INDENT offset: ${record.offset} isvalid: ${record.isValid} ${batch.timestampType}: ${record.timestamp} " +
+          print(s"$RECORD_INDENT offset: ${record.offset} ${batch.timestampType}: ${record.timestamp} " +
             s"keysize: ${record.keySize} valuesize: ${record.valueSize}")
 
           if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
             print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))
           } else {
-            print(" crc: " + record.checksumOrNull)
+            print(s" crc: ${record.checksumOrNull} isvalid: ${record.isValid}")
           }
 
           if (batch.isControlBatch) {
@@ -336,9 +336,8 @@ object DumpLogSegments {
       print("offset: " + batch.lastOffset)
 
     println(" position: " + accumulativeBytes + " " + batch.timestampType + ": " + batch.maxTimestamp +
-      " isvalid: " + batch.isValid +
       " size: " + batch.sizeInBytes + " magic: " + batch.magic +
-      " compresscodec: " + batch.compressionType + " crc: " + batch.checksum)
+      " compresscodec: " + batch.compressionType + " crc: " + batch.checksum + " isvalid: " + batch.isValid)
   }
 
   class TimeIndexDumpErrors {

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -36,6 +36,9 @@ import scala.collection.JavaConverters._
 
 object DumpLogSegments {
 
+  // visible for testing
+  private[tools] val INDENT = "|"
+
   def main(args: Array[String]) {
     val opts = new DumpLogSegmentsOptions(args)
     CommandLineUtils.printHelpAndExitIfNeeded(opts, "This tool helps to parse a log file and dump its contents to the console, useful for debugging a seemingly corrupt log segment.")
@@ -289,15 +292,10 @@ object DumpLogSegments {
           }
           lastOffset = record.offset
 
-          print("- offset: " + record.offset + " position: " + validBytes +
-            " " + batch.timestampType + ": " + record.timestamp + " isvalid: " + record.isValid +
-            " keysize: " + record.keySize + " valuesize: " + record.valueSize + " magic: " + batch.magic +
-            " compresscodec: " + batch.compressionType)
+          print(s"$INDENT offset: ${record.offset} keysize: ${record.keySize} valuesize: ${record.valueSize}")
 
           if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
-            print(" producerId: " + batch.producerId + " producerEpoch: " + batch.producerEpoch + " sequence: " + record.sequence +
-              " isTransactional: " + batch.isTransactional +
-              " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))
+            print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))
           } else {
             print(" crc: " + record.checksumOrNull)
           }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -67,7 +67,7 @@ class DumpLogSegmentsTest {
         if (i % 3 == 0)
           assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: ${i / 3 * 2} lastOffset: "))
         else
-          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.INDENT} offset: ${i - 1 - i / 3} isvalid:"))
+          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.RECORD_INDENT} offset: ${i - 1 - i / 3}"))
       }
     }
 

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -67,13 +67,13 @@ class DumpLogSegmentsTest {
         if (i % 3 == 0)
           assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: ${i / 3 * 2} lastOffset: "))
         else
-          assertTrue(s"Not a valid message record: $line", line.startsWith(s"- offset: ${i - 1 - i / 3} position:"))
+          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.INDENT} offset: ${i - 1 - i / 3} keysize:"))
       }
     }
 
     def verifyNoRecordsInOutput(args: Array[String]): Unit = {
       val output = runDumpLogSegments(args)
-      assertFalse(s"Data should not have been printed: $output", output.matches("(?s).*offset: [0-9]* position.*"))
+      assertFalse(s"Data should not have been printed: $output", output.matches("(?s).*offset: [0-9]* keysize.*"))
     }
 
     // Verify that records are printed with --print-data-log even if --deep-iteration is not specified

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -67,13 +67,13 @@ class DumpLogSegmentsTest {
         if (i % 3 == 0)
           assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: ${i / 3 * 2} lastOffset: "))
         else
-          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.INDENT} offset: ${i - 1 - i / 3} keysize:"))
+          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.INDENT} offset: ${i - 1 - i / 3} isvalid:"))
       }
     }
 
     def verifyNoRecordsInOutput(args: Array[String]): Unit = {
       val output = runDumpLogSegments(args)
-      assertFalse(s"Data should not have been printed: $output", output.matches("(?s).*offset: [0-9]* keysize.*"))
+      assertFalse(s"Data should not have been printed: $output", output.matches("(?s).*offset: [0-9]* isvalid.*"))
     }
 
     // Verify that records are printed with --print-data-log even if --deep-iteration is not specified


### PR DESCRIPTION

DumpLogSegment should be able to print batch level information when deep-iteration is specified

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
