### PR TITLE
 FailoverAssignor: All partitions will be assigned to one consumer, while others consumer are failover.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
@@ -1,10 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 
 /**
  * All partitions will be assigned to one consumer, while others consumer are failover.
@@ -42,7 +64,6 @@ public class FailoverAssignor extends AbstractPartitionAssignor {
     @Override
     public String name() {
         return "failover";
-
     }
 
     public List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
@@ -7,8 +7,6 @@ import org.apache.kafka.common.utils.Utils;
 import java.util.*;
 
 /**
- * 冷备模式: 单个 consumer 消费所有 partition 数据, 宕机后重新分配到另外一个 consumer 消费所有数据
- * 
  * All partitions will be assigned to one consumer, while others consumer are failover.
  *
  * For example, suppose there are two consumers C0 and C1, two topics t0 and t1, and each topic has 3 partitions,
@@ -21,6 +19,7 @@ import java.util.*;
  * When C0 crashes , the result of the assignment will be
  * C1: [t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2]
  *
+ * 冷备模式: 单个 consumer 消费所有 partition 数据, 宕机后重新分配到另外一个 consumer 消费所有数据
  * User: FengHong
  * Date: 2018/11/2811:02
  */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/FailoverAssignor.java
@@ -1,0 +1,64 @@
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.*;
+
+/**
+ * 冷备模式: 单个 consumer 消费所有 partition 数据, 宕机后重新分配到另外一个 consumer 消费所有数据
+ * 
+ * All partitions will be assigned to one consumer, while others consumer are failover.
+ *
+ * For example, suppose there are two consumers C0 and C1, two topics t0 and t1, and each topic has 3 partitions,
+ * resulting in partitions t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2.
+ *
+ * The assignment will be:
+ * C0: [t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2]
+ * C1: []
+ *
+ * When C0 crashes , the result of the assignment will be
+ * C1: [t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2]
+ *
+ * User: FengHong
+ * Date: 2018/11/2811:02
+ */
+public class FailoverAssignor extends AbstractPartitionAssignor {
+    @Override
+    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+                                                    Map<String, Subscription> subscriptions) {
+        Map<String, List<TopicPartition>> assignment = new HashMap<>();
+        for (String memberId : subscriptions.keySet())
+            assignment.put(memberId, new ArrayList<>());
+
+        List<String> subscriptionsKeySet = Utils.sorted(subscriptions.keySet());
+        List<TopicPartition> allPartitionsSorted = allPartitionsSorted(partitionsPerTopic, subscriptions);
+
+        assignment.get(subscriptionsKeySet.get(0)).addAll(allPartitionsSorted);
+        return assignment;
+    }
+
+
+    @Override
+    public String name() {
+        return "failover";
+
+    }
+
+    public List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,
+                                                    Map<String, Subscription> subscriptions) {
+        SortedSet<String> topics = new TreeSet<>();
+        for (Subscription subscription : subscriptions.values())
+            topics.addAll(subscription.topics());
+
+        List<TopicPartition> allPartitions = new ArrayList<>();
+        for (String topic : topics) {
+            Integer numPartitionsForTopic = partitionsPerTopic.get(topic);
+            if (numPartitionsForTopic != null) allPartitions.addAll(AbstractPartitionAssignor.partitions(topic, numPartitionsForTopic));
+        }
+        return allPartitions;
+    }
+
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/FailoverAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/FailoverAssignorTest.java
@@ -1,0 +1,198 @@
+package org.apache.kafka.clients.consumer;
+import org.apache.kafka.clients.consumer.internals.PartitionAssignor.Subscription;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * User: fenghong
+ * Date: 2018/11/29 17:22
+ */
+public class FailoverAssignorTest {
+
+    private FailoverAssignor assignor = new FailoverAssignor();
+
+
+    @Test
+    public void testOneConsumerNoTopic() {
+        String consumerId = "consumer";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
+                Collections.singletonMap(consumerId, new Subscription(Collections.<String>emptyList())));
+
+        assertEquals(Collections.singleton(consumerId), assignment.keySet());
+        assertTrue(assignment.get(consumerId).isEmpty());
+    }
+
+    @Test
+    public void testOneConsumerNonexistentTopic() {
+        String topic = "topic";
+        String consumerId = "consumer";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
+                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
+        assertEquals(Collections.singleton(consumerId), assignment.keySet());
+        assertTrue(assignment.get(consumerId).isEmpty());
+    }
+
+    @Test
+    public void testOneConsumerOneTopic() {
+        String topic = "topic";
+        String consumerId = "consumer";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 3);
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
+                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
+
+        assertEquals(Collections.singleton(consumerId), assignment.keySet());
+        assertAssignment(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
+    }
+
+    @Test
+    public void testOnlyAssignsPartitionsFromSubscribedTopics() {
+        String topic = "topic";
+        String otherTopic = "other";
+        String consumerId = "consumer";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 3);
+        partitionsPerTopic.put(otherTopic, 3);
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
+                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
+        assertEquals(Collections.singleton(consumerId), assignment.keySet());
+        assertAssignment(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
+    }
+
+    @Test
+    public void testOneConsumerMultipleTopics() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumerId = "consumer";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 1);
+        partitionsPerTopic.put(topic2, 2);
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
+                Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2))));
+
+        assertEquals(Collections.singleton(consumerId), assignment.keySet());
+        assertAssignment(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerId));
+    }
+
+    @Test
+    public void testTwoConsumersOneTopicOnePartition() {
+        String topic = "topic";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 1);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic)));
+        consumers.put(consumer2, new Subscription(topics(topic)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic, 0)), assignment.get(consumer1));
+        assertAssignment(Collections.<TopicPartition>emptyList(), assignment.get(consumer2));
+    }
+
+
+    @Test
+    public void testTwoConsumersOneTopicTwoPartitions() {
+        String topic = "topic";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 2);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic)));
+        consumers.put(consumer2, new Subscription(topics(topic)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic, 0), tp(topic, 1)),
+                assignment.get(consumer1));
+        assertTrue( assignment.get(consumer2).isEmpty());
+    }
+
+    @Test
+    public void testMultipleConsumersMixedTopics() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+        String consumer3 = "consumer3";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 3);
+        partitionsPerTopic.put(topic2, 2);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic1)));
+        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer3, new Subscription(topics(topic1)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0),
+                tp(topic2, 1), tp(topic1, 2)), assignment.get(consumer1));
+        assertTrue( assignment.get(consumer2).isEmpty());
+        assertTrue( assignment.get(consumer3).isEmpty());
+    }
+
+    @Test
+    public void testTwoConsumersTwoTopicsSixPartitions() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 3);
+        partitionsPerTopic.put(topic2, 3);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2),
+                tp(topic2, 0), tp(topic2, 1), tp(topic2, 2)),
+                assignment.get(consumer1));
+        assertTrue( assignment.get(consumer2).isEmpty());
+    }
+
+    private void assertAssignment(List<TopicPartition> expected, List<TopicPartition> actual) {
+        // order doesn't matter for assignment, so convert to a set
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    private static List<String> topics(String... topics) {
+        return Arrays.asList(topics);
+    }
+
+    private static List<TopicPartition> partitions(TopicPartition... partitions) {
+        return Arrays.asList(partitions);
+    }
+
+    private static TopicPartition tp(String topic, int partition) {
+        return new TopicPartition(topic, partition);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/FailoverAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/FailoverAssignorTest.java
@@ -1,4 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.clients.consumer;
+
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor.Subscription;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
@@ -130,7 +147,7 @@ public class FailoverAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic, 0), tp(topic, 1)),
                 assignment.get(consumer1));
-        assertTrue( assignment.get(consumer2).isEmpty());
+        assertTrue(assignment.get(consumer2).isEmpty());
     }
 
     @Test
@@ -153,8 +170,8 @@ public class FailoverAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0),
                 tp(topic2, 1), tp(topic1, 2)), assignment.get(consumer1));
-        assertTrue( assignment.get(consumer2).isEmpty());
-        assertTrue( assignment.get(consumer3).isEmpty());
+        assertTrue(assignment.get(consumer2).isEmpty());
+        assertTrue(assignment.get(consumer3).isEmpty());
     }
 
     @Test
@@ -176,7 +193,7 @@ public class FailoverAssignorTest {
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2),
                 tp(topic2, 0), tp(topic2, 1), tp(topic2, 2)),
                 assignment.get(consumer1));
-        assertTrue( assignment.get(consumer2).isEmpty());
+        assertTrue(assignment.get(consumer2).isEmpty());
     }
 
     private void assertAssignment(List<TopicPartition> expected, List<TopicPartition> actual) {


### PR DESCRIPTION
  All partitions will be assigned to one consumer, while others consumer are failover.
 
  For example, suppose there are two consumers C0 and C1, two topics t0 and t1, and each topic has 3 partitions,
  resulting in partitions t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2.
 
  The assignment will be:
  C0: [t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2]
  C1: []
 
  When C0 crashes , the result of the assignment will be
  C1: [t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2]

 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)