### PR TITLE
KAFKA-2334 Guard against non-monotonic offsets in the client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -811,7 +811,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                         "is before 0.10.0", topicPartition);
             } else if (error == Errors.NOT_LEADER_FOR_PARTITION ||
                        error == Errors.REPLICA_NOT_AVAILABLE ||
-                       error == Errors.KAFKA_STORAGE_ERROR) {
+                       error == Errors.KAFKA_STORAGE_ERROR ||
+                       error == Errors.OFFSET_NOT_AVAILABLE ||
+                       error == Errors.LEADER_NOT_AVAILABLE) {
                 log.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
                         topicPartition, error);
                 partitionsToRetry.add(topicPartition);

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.errors;
 
 /**

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
@@ -18,16 +18,12 @@ package org.apache.kafka.common.errors;
 
 /**
  * Indicates that the leader is not able to guarantee monotonically increasing offsets
- * due to a recent leader election and high-water mark lag
+ * due to the high watermark lagging behind the epoch start offset after a recent leader election
  */
 public class OffsetNotAvailableException extends RetriableException {
     private static final long serialVersionUID = 1L;
 
     public OffsetNotAvailableException(String message) {
         super(message);
-    }
-
-    public OffsetNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetNotAvailableException.java
@@ -1,0 +1,17 @@
+package org.apache.kafka.common.errors;
+
+/**
+ * Indicates that the leader is not able to guarantee monotonically increasing offsets
+ * due to a recent leader election and high-water mark lag
+ */
+public class OffsetNotAvailableException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public OffsetNotAvailableException(String message) {
+        super(message);
+    }
+
+    public OffsetNotAvailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -292,7 +292,7 @@ public enum Errors {
             UnsupportedCompressionTypeException::new),
     STALE_BROKER_EPOCH(77, "Broker epoch has changed",
             StaleBrokerEpochException::new),
-    OFFSET_NOT_AVAILABLE(78, "The leader high-water mark has not caught up from a recent leader " +
+    OFFSET_NOT_AVAILABLE(78, "The leader high watermark has not caught up from a recent leader " +
             "election so the offsets cannot be guaranteed to be monotonically increasing",
             OffsetNotAvailableException::new);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -66,6 +66,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasAfterAppendException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.OffsetMetadataTooLarge;
+import org.apache.kafka.common.errors.OffsetNotAvailableException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
@@ -287,7 +288,10 @@ public enum Errors {
     UNKNOWN_LEADER_EPOCH(75, "The leader epoch in the request is newer than the epoch on the broker",
             UnknownLeaderEpochException::new),
     UNSUPPORTED_COMPRESSION_TYPE(76, "The requesting client does not support the compression type of given partition.",
-            UnsupportedCompressionTypeException::new);
+            UnsupportedCompressionTypeException::new),
+    OFFSET_NOT_AVAILABLE(77, "The leader high-water mark has not caught up from a recent leader " +
+            "election so the offsets cannot be guaranteed to be monotonically increasing",
+            OffsetNotAvailableException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
@@ -118,7 +118,7 @@ public class ListOffsetRequest extends AbstractRequest {
             ISOLATION_LEVEL,
             TOPICS_V4);
 
-    // V5 bump to include new possible error code
+    // V5 bump to include new possible error code (OFFSET_NOT_AVAILABLE)
     private static final Schema LIST_OFFSET_REQUEST_V5 = LIST_OFFSET_REQUEST_V4;
 
     public static Schema[] schemaVersions() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
@@ -118,9 +118,12 @@ public class ListOffsetRequest extends AbstractRequest {
             ISOLATION_LEVEL,
             TOPICS_V4);
 
+    // V5 bump to include new possible error code
+    private static final Schema LIST_OFFSET_REQUEST_V5 = LIST_OFFSET_REQUEST_V4;
+
     public static Schema[] schemaVersions() {
         return new Schema[] {LIST_OFFSET_REQUEST_V0, LIST_OFFSET_REQUEST_V1, LIST_OFFSET_REQUEST_V2,
-            LIST_OFFSET_REQUEST_V3, LIST_OFFSET_REQUEST_V4};
+            LIST_OFFSET_REQUEST_V3, LIST_OFFSET_REQUEST_V4, LIST_OFFSET_REQUEST_V5};
     }
 
     private final int replicaId;

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -52,6 +52,8 @@ import static org.apache.kafka.common.protocol.types.Type.INT64;
  * - {@link Errors#UNKNOWN_TOPIC_OR_PARTITION} If the broker does not have metadata for a topic or partition
  * - {@link Errors#KAFKA_STORAGE_ERROR} If the log directory for one of the requested partitions is offline
  * - {@link Errors#UNKNOWN_SERVER_ERROR} For any unexpected errors
+ * - {@link Errors#LEADER_NOT_AVAILABLE} The leader's HW has not caught up after recent election (v4 protocol)
+ * - {@link Errors#OFFSET_NOT_AVAILABLE} The leader's HW has not caught up after recent election (v5+ protocol)
  */
 public class ListOffsetResponse extends AbstractResponse {
     public static final long UNKNOWN_TIMESTAMP = -1L;
@@ -125,9 +127,11 @@ public class ListOffsetResponse extends AbstractResponse {
             THROTTLE_TIME_MS,
             TOPICS_V4);
 
+    private static final Schema LIST_OFFSET_RESPONSE_V5 = LIST_OFFSET_RESPONSE_V4;
+
     public static Schema[] schemaVersions() {
         return new Schema[] {LIST_OFFSET_RESPONSE_V0, LIST_OFFSET_RESPONSE_V1, LIST_OFFSET_RESPONSE_V2,
-            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4};
+            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4, LIST_OFFSET_RESPONSE_V5};
     }
 
     public static final class PartitionData {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1126,6 +1126,45 @@ public class FetcherTest {
         assertEquals(5, subscriptions.position(tp0).longValue());
     }
 
+    /**
+     * Make sure the client behaves appropriately when receiving an exception for unavailable offsets
+     */
+    @Test
+    public void testFetchOffsetErrors() {
+        subscriptions.assignFromUser(singleton(tp0));
+        subscriptions.requestOffsetReset(tp0, OffsetResetStrategy.LATEST);
+
+        // Fail with OFFSET_NOT_AVAILABLE
+        client.prepareResponse(listOffsetRequestMatcher(ListOffsetRequest.LATEST_TIMESTAMP),
+                listOffsetResponse(Errors.OFFSET_NOT_AVAILABLE, 1L, 5L), false);
+        fetcher.resetOffsetsIfNeeded();
+        consumerClient.pollNoWakeup();
+        assertFalse(subscriptions.hasValidPosition(tp0));
+        assertTrue(subscriptions.isOffsetResetNeeded(tp0));
+        assertFalse(subscriptions.isFetchable(tp0));
+
+        // Fail with LEADER_NOT_AVAILABLE
+        time.sleep(retryBackoffMs);
+        client.prepareResponse(listOffsetRequestMatcher(ListOffsetRequest.LATEST_TIMESTAMP),
+                listOffsetResponse(Errors.OFFSET_NOT_AVAILABLE, 1L, 5L), false);
+        fetcher.resetOffsetsIfNeeded();
+        consumerClient.pollNoWakeup();
+        assertFalse(subscriptions.hasValidPosition(tp0));
+        assertTrue(subscriptions.isOffsetResetNeeded(tp0));
+        assertFalse(subscriptions.isFetchable(tp0));
+
+        // Back to normal
+        time.sleep(retryBackoffMs);
+        client.prepareResponse(listOffsetRequestMatcher(ListOffsetRequest.LATEST_TIMESTAMP),
+                listOffsetResponse(Errors.NONE, 1L, 5L), false);
+        fetcher.resetOffsetsIfNeeded();
+        consumerClient.pollNoWakeup();
+        assertTrue(subscriptions.hasValidPosition(tp0));
+        assertFalse(subscriptions.isOffsetResetNeeded(tp0));
+        assertTrue(subscriptions.isFetchable(tp0));
+        assertEquals(subscriptions.position(tp0).longValue(), 5L);
+    }
+
     @Test
     public void testListOffsetsSendsIsolationLevel() {
         for (final IsolationLevel isolationLevel : IsolationLevel.values()) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1146,7 +1146,7 @@ public class FetcherTest {
         // Fail with LEADER_NOT_AVAILABLE
         time.sleep(retryBackoffMs);
         client.prepareResponse(listOffsetRequestMatcher(ListOffsetRequest.LATEST_TIMESTAMP),
-                listOffsetResponse(Errors.OFFSET_NOT_AVAILABLE, 1L, 5L), false);
+                listOffsetResponse(Errors.LEADER_NOT_AVAILABLE, 1L, 5L), false);
         fetcher.resetOffsetsIfNeeded();
         consumerClient.pollNoWakeup();
         assertFalse(subscriptions.hasValidPosition(tp0));

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -295,8 +295,9 @@ case object KAFKA_2_2_IV1 extends DefaultApiVersion {
   val shortVersion: String = "2.2"
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
-  val id: Int = 20
+  val id: Int = 21
 }
+
 object ApiVersionValidator extends Validator {
 
   override def ensureValid(name: String, value: Any): Unit = {

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -84,7 +84,9 @@ object ApiVersion {
     KAFKA_2_1_IV2,
     // Introduced broker generation (KIP-380), and
     // LeaderAdnIsrRequest V2, UpdateMetadataRequest V5, StopReplicaRequest V1
-    KAFKA_2_2_IV0
+    KAFKA_2_2_IV0,
+    // New error code for ListOffsets when a new leader is lagging behind former HW (KIP-207)
+    KAFKA_2_2_IV1,
   )
 
   // Map keys are the union of the short and full versions
@@ -289,6 +291,12 @@ case object KAFKA_2_2_IV0 extends DefaultApiVersion {
   val id: Int = 20
 }
 
+case object KAFKA_2_2_IV1 extends DefaultApiVersion {
+  val shortVersion: String = "2.2"
+  val subVersion = "IV1"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 20
+}
 object ApiVersionValidator extends Validator {
 
   override def ensureValid(name: String, value: Any): Unit = {

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -86,7 +86,7 @@ object ApiVersion {
     // LeaderAdnIsrRequest V2, UpdateMetadataRequest V5, StopReplicaRequest V1
     KAFKA_2_2_IV0,
     // New error code for ListOffsets when a new leader is lagging behind former HW (KIP-207)
-    KAFKA_2_2_IV1,
+    KAFKA_2_2_IV1
   )
 
   // Map keys are the union of the short and full versions

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -817,7 +817,7 @@ class Partition(val topicPartition: TopicPartition,
       case None => localReplica.logEndOffset.messageOffset
     }
 
-    // Only actually check the HW if this is a client request (isolation level is null)
+    // Only actually check the HW if this is a client request (isolation level is non-null)
     if (isolationLevel.isDefined && leaderEpochStartOffsetOpt.isDefined) {
       // Wait until the HW has caught up with the start offset from this epoch
       if (leaderEpochStartOffsetOpt.get > localReplica.highWatermark.messageOffset) {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -819,7 +819,7 @@ class Partition(val topicPartition: TopicPartition,
     // Only actually check the HW if this is a client request and _not_ while unclean leader
     // election is enabled
     val shouldCheckHW = {
-      !replicaManager.config.uncleanLeaderElectionEnable &&
+      !logManager.currentDefaultConfig.uncleanLeaderElectionEnable &&
         isFromClient &&
         leaderEpochStartOffsetOpt.isDefined
     }
@@ -827,7 +827,7 @@ class Partition(val topicPartition: TopicPartition,
     if(shouldCheckHW) {
       // Wait until the HW has caught up with the start offset from this epoch
       if(leaderEpochStartOffsetOpt.get > localReplica.highWatermark.messageOffset) {
-        throw Errors.LEADER_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
+        throw Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
           s"partition $topicPartition with leader epoch ${currentLeaderEpoch.get} as this partition's " +
           s"high-water mark (${localReplica.highWatermark.messageOffset}) is lagging behind its " +
           s"LEO (${leaderEpochStartOffsetOpt.get}).")

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -826,11 +826,11 @@ class Partition(val topicPartition: TopicPartition,
     // Only consider throwing an error if we get a client request (isolationLevel is defined) and the start offset
     // is lagging behind the high watermark
     val maybeOffsetsError: Option[ApiException] = leaderEpochStartOffsetOpt
-      .filter(epochLSO => isolationLevel.isDefined && epochLSO > localReplica.highWatermark.messageOffset)
-      .map(epochLSO => Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
+      .filter(epochStart => isolationLevel.isDefined && epochStart > localReplica.highWatermark.messageOffset)
+      .map(epochStart => Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
         s"partition $topicPartition with leader $epochLogString as this partition's " +
         s"high watermark (${localReplica.highWatermark.messageOffset}) is lagging behind the " +
-        s"start offset from the beginning of this epoch ($epochLSO)."))
+        s"start offset from the beginning of this epoch ($epochStart)."))
 
     def getOffsetByTimestamp: Option[TimestampAndOffset] = {
       logManager.getLog(topicPartition).flatMap(log => log.fetchOffsetByTimestamp(timestamp))

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -820,7 +820,7 @@ class Partition(val topicPartition: TopicPartition,
     // election is enabled
     val shouldCheckHW = {
       !logManager.currentDefaultConfig.uncleanLeaderElectionEnable &&
-        //isFromClient &&
+        isFromClient &&
         leaderEpochStartOffsetOpt.isDefined
     }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -818,7 +818,7 @@ class Partition(val topicPartition: TopicPartition,
     }
 
     // Only actually check the HW if this is a client request (isolation level is null)
-    if (isolationLevel.isEmpty && leaderEpochStartOffsetOpt.isDefined) {
+    if (isolationLevel.isDefined && leaderEpochStartOffsetOpt.isDefined) {
       // Wait until the HW has caught up with the start offset from this epoch
       if (leaderEpochStartOffsetOpt.get > localReplica.highWatermark.messageOffset) {
         throw Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -820,7 +820,7 @@ class Partition(val topicPartition: TopicPartition,
     // election is enabled
     val shouldCheckHW = {
       !logManager.currentDefaultConfig.uncleanLeaderElectionEnable &&
-        isFromClient &&
+        //isFromClient &&
         leaderEpochStartOffsetOpt.isDefined
     }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -823,7 +823,7 @@ class Partition(val topicPartition: TopicPartition,
       if (leaderEpochStartOffsetOpt.get > localReplica.highWatermark.messageOffset) {
         throw Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
           s"partition $topicPartition with leader epoch ${currentLeaderEpoch.get} as this partition's " +
-          s"high-water mark (${localReplica.highWatermark.messageOffset}) is lagging behind its " +
+          s"high watermark (${localReplica.highWatermark.messageOffset}) is lagging behind its " +
           s"LEO (${leaderEpochStartOffsetOpt.get}).")
       }
     }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -830,7 +830,7 @@ class Partition(val topicPartition: TopicPartition,
       .map(epochLSO => Errors.OFFSET_NOT_AVAILABLE.exception(s"Failed to fetch offsets for " +
         s"partition $topicPartition with leader $epochLogString as this partition's " +
         s"high watermark (${localReplica.highWatermark.messageOffset}) is lagging behind the " +
-        s"LSO at the beginning of this epoch ($epochLSO)."))
+        s"start offset from the beginning of this epoch ($epochLSO)."))
 
     def getOffsetByTimestamp: Option[TimestampAndOffset] = {
       logManager.getLog(topicPartition).flatMap(log => log.fetchOffsetByTimestamp(timestamp))

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -849,8 +849,7 @@ class KafkaApis(val requestChannel: RequestChannel,
             partitionData.timestamp,
             isolationLevelOpt,
             partitionData.currentLeaderEpoch,
-            fetchOnlyFromLeader,
-            isFromClient = isClientRequest)
+            fetchOnlyFromLeader)
 
           val response = foundOpt match {
             case Some(found) =>

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -812,7 +812,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       } else {
         try {
           val fetchOnlyFromLeader = offsetRequest.replicaId != ListOffsetRequest.DEBUGGING_REPLICA_ID
-          val isolationLevelOpt = if (offsetRequest.replicaId == ListOffsetRequest.CONSUMER_REPLICA_ID)
+          val isClientRequest = offsetRequest.replicaId == ListOffsetRequest.CONSUMER_REPLICA_ID
+          val isolationLevelOpt = if (isClientRequest)
             Some(offsetRequest.isolationLevel)
           else
             None
@@ -821,7 +822,8 @@ class KafkaApis(val requestChannel: RequestChannel,
             partitionData.timestamp,
             isolationLevelOpt,
             partitionData.currentLeaderEpoch,
-            fetchOnlyFromLeader)
+            fetchOnlyFromLeader,
+            isFromClient = isClientRequest)
 
           val response = foundOpt match {
             case Some(found) =>

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -806,7 +806,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     val correlationId = request.header.correlationId
     val clientId = request.header.clientId
     val offsetRequest = request.body[ListOffsetRequest]
-    val isV5Schema = request.header.apiVersion() >= 5
 
     val (authorizedRequestInfo, unauthorizedRequestInfo) = offsetRequest.partitionTimestamps.asScala.partition {
       case (topicPartition, _) => authorize(request.session, Describe, Resource(Topic, topicPartition.topic, LITERAL))
@@ -874,7 +873,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
           // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
           case e: OffsetNotAvailableException =>
-            if(isV5Schema) {
+            if(request.header.apiVersion >= 5) {
               buildErrorResponse(Errors.forException(e))
             } else {
               buildErrorResponse(Errors.LEADER_NOT_AVAILABLE)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util.Optional
 
+import kafka.api
 import kafka.api._
 import kafka.cluster.BrokerEndPoint
 import kafka.log.LogAppendInfo
@@ -80,7 +81,7 @@ class ReplicaFetcherThread(name: String,
 
   // Visible for testing
   private[server] val listOffsetRequestVersion: Short =
-    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 4
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 5
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_0_IV1) 3
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_11_0_IV0) 2
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_10_1_IV2) 1

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -81,7 +81,8 @@ class ReplicaFetcherThread(name: String,
 
   // Visible for testing
   private[server] val listOffsetRequestVersion: Short =
-    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 5
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_2_IV1) 5
+    else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 4
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_0_IV1) 3
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_11_0_IV0) 2
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_10_1_IV2) 1

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -776,10 +776,9 @@ class ReplicaManager(val config: KafkaConfig,
                               timestamp: Long,
                               isolationLevel: Option[IsolationLevel],
                               currentLeaderEpoch: Optional[Integer],
-                              fetchOnlyFromLeader: Boolean,
-                              isFromClient: Boolean): Option[TimestampAndOffset] = {
+                              fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition, expectLeader = fetchOnlyFromLeader)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader, isFromClient)
+    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -776,9 +776,10 @@ class ReplicaManager(val config: KafkaConfig,
                               timestamp: Long,
                               isolationLevel: Option[IsolationLevel],
                               currentLeaderEpoch: Optional[Integer],
-                              fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
+                              fetchOnlyFromLeader: Boolean,
+                              isFromClient: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition, expectLeader = fetchOnlyFromLeader)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
+    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader, isFromClient)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -17,9 +17,12 @@
 
 package kafka.api
 
+import org.apache.commons.collections.CollectionUtils
 import org.apache.kafka.common.record.RecordVersion
 import org.junit.Test
 import org.junit.Assert._
+
+import scala.collection.JavaConverters
 
 class ApiVersionTest {
 
@@ -84,6 +87,22 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_1_IV0, ApiVersion("2.1-IV0"))
     assertEquals(KAFKA_2_1_IV1, ApiVersion("2.1-IV1"))
     assertEquals(KAFKA_2_1_IV2, ApiVersion("2.1-IV2"))
+
+    assertEquals(KAFKA_2_2_IV1, ApiVersion("2.2"))
+    assertEquals(KAFKA_2_2_IV0, ApiVersion("2.2-IV0"))
+    assertEquals(KAFKA_2_2_IV1, ApiVersion("2.2-IV1"))
+  }
+
+  @Test
+  def testApiVersionUniqueIds(): Unit = {
+    val allIds: Seq[Int] = ApiVersion.allVersions.map(apiVersion => {
+      apiVersion.id
+    })
+
+    val uniqueIds: Set[Int] = allIds.toSet
+    assertTrue(CollectionUtils.isEqualCollection(
+      JavaConverters.seqAsJavaList(allIds),
+      JavaConverters.setAsJavaSet(uniqueIds)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -100,9 +100,8 @@ class ApiVersionTest {
     })
 
     val uniqueIds: Set[Int] = allIds.toSet
-    assertTrue(CollectionUtils.isEqualCollection(
-      JavaConverters.seqAsJavaList(allIds),
-      JavaConverters.setAsJavaSet(uniqueIds)))
+
+    assertEquals(allIds.size, uniqueIds.size)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -399,13 +399,15 @@ class PartitionTest {
     val replicas = List[Integer](leader, follower1, follower2).asJava
     val isr = List[Integer](leader, follower2).asJava
     val leaderEpoch = 8
-    val batch1 = TestUtils.records(records = List(new SimpleRecord("k1".getBytes, "v1".getBytes),
-      new SimpleRecord("k2".getBytes, "v2".getBytes)))
+    val batch1 = TestUtils.records(records = List(
+      new SimpleRecord(10, "k1".getBytes, "v1".getBytes),
+      new SimpleRecord(11,"k2".getBytes, "v2".getBytes)))
     val batch2 = TestUtils.records(records = List(new SimpleRecord("k3".getBytes, "v1".getBytes),
-      new SimpleRecord("k4".getBytes, "v2".getBytes),
-      new SimpleRecord("k5".getBytes, "v3".getBytes)))
-    val batch3 = TestUtils.records(records = List(new SimpleRecord("k6".getBytes, "v1".getBytes),
-      new SimpleRecord("k7".getBytes, "v2".getBytes)))
+      new SimpleRecord(20,"k4".getBytes, "v2".getBytes),
+      new SimpleRecord(21,"k5".getBytes, "v3".getBytes)))
+    val batch3 = TestUtils.records(records = List(
+      new SimpleRecord(30,"k6".getBytes, "v1".getBytes),
+      new SimpleRecord(31,"k7".getBytes, "v2".getBytes)))
 
     val partition = Partition(topicPartition, time, replicaManager)
     assertTrue("Expected first makeLeader() to return 'leader changed'",
@@ -434,6 +436,20 @@ class PartitionTest {
         readSize = 10240,
         lastStableOffset = None)
     }
+
+    def fetchOffsetsForTimestamp(timestamp: Long, isolation: Option[IsolationLevel]): Either[ApiException, Option[TimestampAndOffset]] = {
+      try {
+        Right(partition.fetchOffsetForTimestamp(
+          timestamp = timestamp,
+          isolationLevel = isolation,
+          currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
+          fetchOnlyFromLeader = true
+        ))
+      } catch {
+        case e: ApiException => Left(e)
+      }
+    }
+
     // Update follower 1
     partition.updateReplicaLogReadResult(
       follower1Replica, readResult(FetchDataInfo(LogOffsetMetadata(0), batch1), leaderReplica))
@@ -447,59 +463,72 @@ class PartitionTest {
       follower2Replica, readResult(FetchDataInfo(LogOffsetMetadata(2), batch2), leaderReplica))
 
     // At this point, the leader has gotten 5 writes, but followers have only fetched two
+    assertEquals(2, partition.localReplica.get.highWatermark.messageOffset)
 
-    // Get offsets
-    var offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
-      isolationLevel = None,
-      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-      fetchOnlyFromLeader = true
-    )
+    // Get the LEO
+    fetchOffsetsForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP, None) match {
+      case Right(Some(offsetAndTimestamp)) => assertEquals(5, offsetAndTimestamp.offset)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e) => fail("Should not have seen an error")
+    }
 
-    assertTrue(offsetAndTimestamp.isDefined)
-    assertEquals(offsetAndTimestamp.get.offset, 5) // Leader LEO is 5
-    assertEquals(partition.localReplica.get.highWatermark.messageOffset, 2) // Leader HW is 2
+    // Get the HW
+    fetchOffsetsForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) => assertEquals(2, offsetAndTimestamp.offset)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e) => fail("Should not have seen an error")
+    }
+
+    // Get a offset beyond the HW by timestamp, get a None
+    assertEquals(Right(None), fetchOffsetsForTimestamp(30, Some(IsolationLevel.READ_UNCOMMITTED)))
 
     // Make into a follower
     assertTrue(partition.makeFollower(controllerId,
       new LeaderAndIsrRequest.PartitionState(controllerEpoch, follower2, leaderEpoch + 1, isr, 1, replicas, false), 1))
 
-    // Back to leader, this resets the startLogOffset for this epoch
+    // Back to leader, this resets the startLogOffset for this epoch (to 2), we're now in the fault condition
     assertTrue(partition.makeLeader(controllerId,
       new LeaderAndIsrRequest.PartitionState(controllerEpoch, leader, leaderEpoch + 2, isr, 1, replicas, false), 2))
 
-    try {
-      // Try to get offsets as a client
-      partition.fetchOffsetForTimestamp(
-        timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
-        isolationLevel = Some(IsolationLevel.READ_COMMITTED),
-        currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-        fetchOnlyFromLeader = true
-      )
-    } catch {
-      case e: OffsetNotAvailableException => // expected
-      case e: ApiException => fail(s"Expected LeaderNotAvailableException, got ${e}")
+    // Try to get offsets as a client
+    fetchOffsetsForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) => fail("Should have failed with OffsetNotAvailable")
+      case Right(None) => fail("Should have seen an error")
+      case Left(e: OffsetNotAvailableException) => // ok
+      case Left(e: ApiException) => fail(s"Expected OffsetNotAvailableException, got $e")
     }
 
     // If request is not from a client, we skip the check
-    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
-      isolationLevel = None,
-      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-      fetchOnlyFromLeader = true
-    )
-    assertTrue(offsetAndTimestamp.isDefined)
-    assertEquals(offsetAndTimestamp.get.offset, 5)
+    fetchOffsetsForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP, None) match {
+      case Right(Some(offsetAndTimestamp)) => assertEquals(5, offsetAndTimestamp.offset)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e: ApiException) => fail(s"Got ApiException $e")
+    }
 
-    // Or if we request the earliest timestamp, we skip the check
-    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = ListOffsetRequest.EARLIEST_TIMESTAMP,
-      isolationLevel = None,
-      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-      fetchOnlyFromLeader = true
-    )
-    assertTrue(offsetAndTimestamp.isDefined)
-    assertEquals(offsetAndTimestamp.get.offset, 0)
+    // If we request the earliest timestamp, we skip the check
+    fetchOffsetsForTimestamp(ListOffsetRequest.EARLIEST_TIMESTAMP, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) => assertEquals(0, offsetAndTimestamp.offset)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e: ApiException) => fail(s"Got ApiException $e")
+    }
+
+    // If we request an offset by timestamp earlier than the HW, we are ok
+    fetchOffsetsForTimestamp(11, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) =>
+        assertEquals(1, offsetAndTimestamp.offset)
+        assertEquals(11, offsetAndTimestamp.timestamp)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e: ApiException) => fail(s"Got ApiException $e")
+    }
+
+    // Request an offset by timestamp beyond the HW, get an error now since we're in a bad state
+    fetchOffsetsForTimestamp(100, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) => fail("Should have failed")
+      case Right(None) => fail("Should have failed")
+      case Left(e: OffsetNotAvailableException) => // ok
+      case Left(e: ApiException) => fail("Should have seen OffsetNotAvailableException, saw $e")
+    }
+
 
     // Next fetch from replicas, HW is moved up to 5 (ahead of the LEO)
     partition.updateReplicaLogReadResult(
@@ -508,14 +537,14 @@ class PartitionTest {
       follower2Replica, readResult(FetchDataInfo(LogOffsetMetadata(5), MemoryRecords.EMPTY), leaderReplica))
 
     // Error goes away
-    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
-      isolationLevel = Some(IsolationLevel.READ_COMMITTED),
-      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-      fetchOnlyFromLeader = true
-    )
-    assertTrue(offsetAndTimestamp.isDefined)
-    assertEquals(offsetAndTimestamp.get.offset, 5)
+    fetchOffsetsForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP, Some(IsolationLevel.READ_UNCOMMITTED)) match {
+      case Right(Some(offsetAndTimestamp)) => assertEquals(5, offsetAndTimestamp.offset)
+      case Right(None) => fail("Should have seen some offsets")
+      case Left(e: ApiException) => fail(s"Got ApiException $e")
+    }
+
+    // Now we see None instead of an error for out of range timestamp
+    assertEquals(Right(None), fetchOffsetsForTimestamp(100, Some(IsolationLevel.READ_UNCOMMITTED)))
   }
 
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -484,17 +484,6 @@ class PartitionTest {
       case e: ApiException => fail(s"Expected LeaderNotAvailableException, got ${e}")
     }
 
-    // If request is not from a client, we skip the check
-    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = -1L,
-      isolationLevel = None,
-      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
-      fetchOnlyFromLeader = true,
-      isFromClient = false
-    )
-    assertTrue(offsetAndTimestamp.isDefined)
-    assertEquals(offsetAndTimestamp.get.offset, 5)
-
     // Next fetch from replicas
     partition.updateReplicaLogReadResult(
       follower1Replica, readResult(FetchDataInfo(LogOffsetMetadata(5), MemoryRecords.EMPTY), leaderReplica))

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -484,6 +484,17 @@ class PartitionTest {
       case e: ApiException => fail(s"Expected LeaderNotAvailableException, got ${e}")
     }
 
+    // If request is not from a client, we skip the check
+    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
+      timestamp = -1L,
+      isolationLevel = None,
+      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
+      fetchOnlyFromLeader = true,
+      isFromClient = false
+    )
+    assertTrue(offsetAndTimestamp.isDefined)
+    assertEquals(offsetAndTimestamp.get.offset, 5)
+
     // Next fetch from replicas
     partition.updateReplicaLogReadResult(
       follower1Replica, readResult(FetchDataInfo(LogOffsetMetadata(5), MemoryRecords.EMPTY), leaderReplica))

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -29,7 +29,7 @@ import kafka.server._
 import kafka.utils.{MockScheduler, MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{ApiException, LeaderNotAvailableException, ReplicaNotAvailableException}
+import org.apache.kafka.common.errors.{ApiException, LeaderNotAvailableException, OffsetNotAvailableException, ReplicaNotAvailableException}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
@@ -480,8 +480,8 @@ class PartitionTest {
         isFromClient = true
       )
     } catch {
-      case e: LeaderNotAvailableException => // expected
-      case e: ApiException => fail(s"Expected LeaderNotAvailableException, got different API exception ${e.getMessage}")
+      case e: OffsetNotAvailableException => // expected
+      case e: ApiException => fail(s"Expected LeaderNotAvailableException, got ${e}")
     }
 
     // If request is not from a client, we skip the check

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -450,7 +450,7 @@ class PartitionTest {
 
     // Get offsets
     var offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = -1L,
+      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
       isolationLevel = None,
       currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
       fetchOnlyFromLeader = true
@@ -471,7 +471,7 @@ class PartitionTest {
     try {
       // Try to get offsets as a client
       partition.fetchOffsetForTimestamp(
-        timestamp = -1L,
+        timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
         isolationLevel = Some(IsolationLevel.READ_COMMITTED),
         currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
         fetchOnlyFromLeader = true
@@ -483,13 +483,23 @@ class PartitionTest {
 
     // If request is not from a client, we skip the check
     offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = -1L,
+      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
       isolationLevel = None,
       currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
       fetchOnlyFromLeader = true
     )
     assertTrue(offsetAndTimestamp.isDefined)
     assertEquals(offsetAndTimestamp.get.offset, 5)
+
+    // Or if we request the earliest timestamp, we skip the check
+    offsetAndTimestamp = partition.fetchOffsetForTimestamp(
+      timestamp = ListOffsetRequest.EARLIEST_TIMESTAMP,
+      isolationLevel = None,
+      currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
+      fetchOnlyFromLeader = true
+    )
+    assertTrue(offsetAndTimestamp.isDefined)
+    assertEquals(offsetAndTimestamp.get.offset, 0)
 
     // Next fetch from replicas, HW is moved up to 5 (ahead of the LEO)
     partition.updateReplicaLogReadResult(
@@ -499,7 +509,7 @@ class PartitionTest {
 
     // Error goes away
     offsetAndTimestamp = partition.fetchOffsetForTimestamp(
-      timestamp = -1L,
+      timestamp = ListOffsetRequest.LATEST_TIMESTAMP,
       isolationLevel = Some(IsolationLevel.READ_COMMITTED),
       currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
       fetchOnlyFromLeader = true

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -374,7 +374,7 @@ class KafkaApisTest {
     val currentLeaderEpoch = Optional.of[Integer](15)
 
     EasyMock.expect(replicaManager.fetchOffsetForTimestamp(tp, ListOffsetRequest.EARLIEST_TIMESTAMP,
-      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true))
+      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true, isFromClient = false))
       .andThrow(error.exception)
 
     val capturedResponse = expectNoThrottling()
@@ -463,7 +463,7 @@ class KafkaApisTest {
     val currentLeaderEpoch = Optional.empty[Integer]()
 
     EasyMock.expect(replicaManager.fetchOffsetForTimestamp(tp, ListOffsetRequest.LATEST_TIMESTAMP,
-      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true))
+      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true, isFromClient = false))
       .andReturn(Some(new TimestampAndOffset(ListOffsetResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
 
     val capturedResponse = expectNoThrottling()

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -373,9 +373,14 @@ class KafkaApisTest {
     val isolationLevel = IsolationLevel.READ_UNCOMMITTED
     val currentLeaderEpoch = Optional.of[Integer](15)
 
-    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(tp, ListOffsetRequest.EARLIEST_TIMESTAMP,
-      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true, isFromClient = false))
-      .andThrow(error.exception)
+    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(
+      EasyMock.eq(tp),
+      EasyMock.eq(ListOffsetRequest.EARLIEST_TIMESTAMP),
+      EasyMock.eq(Some(isolationLevel)),
+      EasyMock.eq(currentLeaderEpoch),
+      fetchOnlyFromLeader = EasyMock.eq(true),
+      isFromClient = EasyMock.anyBoolean())
+    ).andThrow(error.exception)
 
     val capturedResponse = expectNoThrottling()
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)
@@ -462,9 +467,14 @@ class KafkaApisTest {
     val latestOffset = 15L
     val currentLeaderEpoch = Optional.empty[Integer]()
 
-    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(tp, ListOffsetRequest.LATEST_TIMESTAMP,
-      Some(isolationLevel), currentLeaderEpoch, fetchOnlyFromLeader = true, isFromClient = false))
-      .andReturn(Some(new TimestampAndOffset(ListOffsetResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
+    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(
+      EasyMock.eq(tp),
+      EasyMock.eq(ListOffsetRequest.LATEST_TIMESTAMP),
+      EasyMock.eq(Some(isolationLevel)),
+      EasyMock.eq(currentLeaderEpoch),
+      fetchOnlyFromLeader = EasyMock.eq(true),
+      isFromClient = EasyMock.anyBoolean())
+    ).andReturn(Some(new TimestampAndOffset(ListOffsetResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
 
     val capturedResponse = expectNoThrottling()
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -378,8 +378,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetRequest.EARLIEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
-      fetchOnlyFromLeader = EasyMock.eq(true),
-      isFromClient = EasyMock.anyBoolean())
+      fetchOnlyFromLeader = EasyMock.eq(true))
     ).andThrow(error.exception)
 
     val capturedResponse = expectNoThrottling()
@@ -472,8 +471,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetRequest.LATEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
-      fetchOnlyFromLeader = EasyMock.eq(true),
-      isFromClient = EasyMock.anyBoolean())
+      fetchOnlyFromLeader = EasyMock.eq(true))
     ).andReturn(Some(new TimestampAndOffset(ListOffsetResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
 
     val capturedResponse = expectNoThrottling()


### PR DESCRIPTION
After a recent leader election, the leaders high-water mark might lag behind the offset at the beginning of the new epoch (as well as the previous leader's HW). This can lead to offsets going backwards from a client perspective, which is confusing and leads to strange behavior in some clients.

This change causes Partition#fetchOffsetForTimestamp to throw an exception to indicate the offsets are not yet available from the leader. For new clients, a new OFFSET_NOT_AVAILABLE error is added. For existing clients, a LEADER_NOT_AVAILABLE is thrown.

This is an implementation of [KIP-207](https://cwiki.apache.org/confluence/display/KAFKA/KIP-207%3A+Offsets+returned+by+ListOffsetsResponse+should+be+monotonically+increasing+even+during+a+partition+leader+change)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
