### PR TITLE
KAFKA-7698: Kafka Broker fail to start: ProducerFencedException throw…

### DIFF
--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -299,7 +299,9 @@ private[log] class ProducerAppendInfo(val producerId: Long,
                          producerEpoch: Short,
                          offset: Long,
                          timestamp: Long): CompletedTxn = {
-    checkProducerEpoch(producerEpoch)
+    // Similar to maybeValidateAppend(), we should skip check if validationType is None
+    if (validationType != ValidationType.None)
+      checkProducerEpoch(producerEpoch)
 
     if (updatedEntry.coordinatorEpoch > endTxnMarker.coordinatorEpoch)
       throw new TransactionCoordinatorFencedException(s"Invalid coordinator epoch: ${endTxnMarker.coordinatorEpoch} " +


### PR DESCRIPTION
If ValidationType is None, also skip the check in appendEndTxnMarker (similar to append).

Verified with existing unitest and our daily operation.
