### PR TITLE
KAFKA-7704: MaxLag.Replica metric is reported incorrectly

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -272,11 +272,10 @@ abstract class AbstractFetcherThread(name: String,
                       partitionData)
 
                     logAppendInfoOpt.foreach { logAppendInfo =>
-                      val nextOffset = logAppendInfo.lastOffset + 1
-                      fetcherLagStats.getAndMaybePut(topicPartition).lag =
-                        if (nextOffset == 0) 0 else Math.max(0L, partitionData.highWatermark - nextOffset)
-
                       val validBytes = logAppendInfo.validBytes
+                      val nextOffset = if (validBytes > 0) logAppendInfo.lastOffset + 1 else currentFetchState.fetchOffset
+                      fetcherLagStats.getAndMaybePut(topicPartition).lag = Math.max(0L, partitionData.highWatermark - nextOffset)
+
                       // ReplicaDirAlterThread may have removed topicPartition from the partitionStates after processing the partition data
                       if (validBytes > 0 && partitionStates.contains(topicPartition)) {
                         // Update partitionStates only if there is no exception during processPartitionData

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -273,7 +273,8 @@ abstract class AbstractFetcherThread(name: String,
 
                     logAppendInfoOpt.foreach { logAppendInfo =>
                       val nextOffset = logAppendInfo.lastOffset + 1
-                      fetcherLagStats.getAndMaybePut(topicPartition).lag = Math.max(0L, partitionData.highWatermark - nextOffset)
+                      fetcherLagStats.getAndMaybePut(topicPartition).lag =
+                        if (nextOffset == 0) 0 else Math.max(0L, partitionData.highWatermark - nextOffset)
 
                       val validBytes = logAppendInfo.validBytes
                       // ReplicaDirAlterThread may have removed topicPartition from the partitionStates after processing the partition data


### PR DESCRIPTION
On the follower side, for the empty `LogAppendInfo` retrieved from the leader, fetcherLagStats set the wrong lag for fetcherLagStats due to `nextOffset` is zero in this case where it actually means no lagging, so the lag should be set to 0 if `nextOffset` is 0 or `logAppendInfo.lastOffset` is -1.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
