### PR TITLE
KAFKA-7706: Spotbugs task fails with Gradle 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For the Streams archetype project, one cannot use gradle to upload to maven; ins
     cd streams/quickstart
     mvn deploy
 
-Please note for this to work you should create/update user maven settings (typically, `${USER_HOME}/.m2/settings.xml`) to assign the following variables
+Please note for this to work you should create/update user maven settings (typically, `${M2_HOME}/conf/settings.xml` or `${USER_HOME}/.m2/settings.xml`) to assign the following variables
 
     <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For the Streams archetype project, one cannot use gradle to upload to maven; ins
     cd streams/quickstart
     mvn deploy
 
-Please note for this to work you should create/update user maven settings (typically, `${M2_HOME}/conf/settings.xml` or `${USER_HOME}/.m2/settings.xml`) to assign the following variables
+Please note for this to work you should create/update user maven settings (typically, `${USER_HOME}/.m2/settings.xml`) to assign the following variables
 
     <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,11 @@ buildscript {
     // For Apache Rat plugin to ignore non-Git files
     classpath "org.ajoberstar:grgit:1.9.3"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-    classpath 'org.scoverage:gradle-scoverage:2.3.0'
+    classpath 'org.scoverage:gradle-scoverage:2.5.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
     classpath 'org.owasp:dependency-check-gradle:3.2.1'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.3"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.5"
   }
 }
 


### PR DESCRIPTION
1. When I'm building Kafka with Gradle 5.0, the failure of Spotbugs task occurred.
    I'm running "gradle build --stacktrace".
    An interesting part of the stacktrace is:

```
Caused by: java.lang.NoClassDefFoundError: org/gradle/api/internal/ClosureBackedAction 
        at com.github.spotbugs.SpotBugsTask.reports(SpotBugsTask.java:136) 
        at com.github.spotbugs.SpotBugsTask.reports(SpotBugsTask.java:55) 
        at org.gradle.api.reporting.Reporting$reports.call(Unknown Source) 
        at build_9sk7crqolfjf8m0yenkwy63v1$_run_closure1.doCall(/Users/mchalupa/projects/others/spotbugsFailExample/build.gradle:18) 
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:70) 
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:154) 
        at org.gradle.util.ConfigureUtil.configureSelf(ConfigureUtil.java:130) 
        at org.gradle.api.internal.AbstractTask.configure(AbstractTask.java:600) 
        at org.gradle.api.internal.AbstractTask.configure(AbstractTask.java:92) 
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:103) at org.gradle.util.ConfigureUtil$WrappedConfigureAction.execute(ConfigureUtil.java:166) 
        at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:161) 
        at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:190) 
        at org.gradle.api.internal.tasks.DefaultRealizableTaskCollection.all(DefaultRealizableTaskCollection.java:229) 
        at org.gradle.api.internal.DefaultDomainObjectCollection.withType(DefaultDomainObjectCollection.java:201) 
        at org.gradle.api.DomainObjectCollection$withType.call(Unknown Source) 
        at build_9sk7crqolfjf8m0yenkwy63v1.run(/Users/mchalupa/projects/others/spotbugsFailExample/build.gradle:17) 
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:90) ... 102 more

```

2. Similar to the previous one--- ---When I'm building Kafka with Gradle 5.0, apply plugin[org.scoverage] fails
    I'm running "gradle build --stacktrace".
    An interesting part of the stacktrace is:

```
Caused by: org.gradle.api.internal.plugins.PluginApplicationException: Failed to apply plugin [id 'org.scoverage']
        at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:160)
        at org.gradle.api.internal.plugins.DefaultPluginManager.apply(DefaultPluginManager.java:130)
        ... ...
Caused by: org.gradle.api.reflect.ObjectInstantiationException: Could not create an instance of type org.scoverage.ScoverageExtension_Decorated.
        at org.gradle.internal.reflect.DirectInstantiator.newInstance(DirectInstantiator.java:53)
        at org.gradle.api.internal.ClassGeneratorBackedInstantiator.newInstance(ClassGeneratorBackedInstantiator.java:36)
        at org.gradle.api.internal.plugins.DefaultConvention.instantiate(DefaultConvention.java:242)
        at org.gradle.api.internal.plugins.DefaultConvention.create(DefaultConvention.java:142)
        at org.scoverage.ScoveragePlugin.apply(ScoveragePlugin.groovy:18)
        at org.scoverage.ScoveragePlugin.apply(ScoveragePlugin.groovy)
        at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:42)
        at org.gradle.api.internal.plugins.RuleBasedPluginTarget.applyImperative(RuleBasedPluginTarget.java:50)
        at org.gradle.api.internal.plugins.DefaultPluginManager.addPlugin(DefaultPluginManager.java:174)
        at org.gradle.api.internal.plugins.DefaultPluginManager.access$300(DefaultPluginManager.java:50)
        ... 167 more
Caused by: org.gradle.api.InvalidUserDataException: You can't map a property that does not exist: propertyName=testClassesDir
        at org.gradle.api.internal.ConventionAwareHelper.map(ConventionAwareHelper.java:56)
        at org.gradle.api.internal.ConventionAwareHelper.map(ConventionAwareHelper.java:80)
        at org.gradle.api.internal.ConventionMapping$map.call(Unknown Source)
        at org.scoverage.ScoverageExtension$_closure6.doCall(ScoverageExtension.groovy:89)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:70)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:154)
        at org.gradle.util.ConfigureUtil.configureSelf(ConfigureUtil.java:130)
        ... 186 more

```