### PR TITLE
MINOR: Safe string conversion to avoid NPEs

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectRecord.java
@@ -140,9 +140,9 @@ public abstract class ConnectRecord<R extends ConnectRecord<R>> {
                 "topic='" + topic + '\'' +
                 ", kafkaPartition=" + kafkaPartition +
                 ", key=" + key +
-                ", keySchema=" + keySchema.toString() +
+                ", keySchema=" + keySchema +
                 ", value=" + value +
-                ", valueSchema=" + valueSchema.toString() +
+                ", valueSchema=" + valueSchema +
                 ", timestamp=" + timestamp +
                 ", headers=" + headers +
                 '}';


### PR DESCRIPTION
Should be ported back to 2.0

