### PR TITLE
MINOR: fix checkpoint write failure warning log

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -292,7 +292,9 @@ public class ProcessorStateManager extends AbstractStateManager {
         try {
             checkpoint.write(this.checkpointableOffsets);
         } catch (final IOException e) {
-            log.warn("Failed to write offset checkpoint file to {}: {}", checkpoint, e);
+            if (log.isWarnEnabled()) {
+                log.warn("Failed to write offset checkpoint file to [" + checkpoint + "]", e);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -292,9 +292,7 @@ public class ProcessorStateManager extends AbstractStateManager {
         try {
             checkpoint.write(this.checkpointableOffsets);
         } catch (final IOException e) {
-            if (log.isWarnEnabled()) {
-                log.warn("Failed to write offset checkpoint file to [" + checkpoint + "]", e);
-            }
+            log.warn("Failed to write offset checkpoint file to [{}]", checkpoint, e);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -52,10 +52,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -569,6 +567,7 @@ public class ProcessorStateManagerTest {
         }
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void shouldLogAWarningIfCheckpointThrowsAnIOException() {
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -584,7 +584,7 @@ public class ProcessorStateManagerTest {
                 changelogReader,
                 false,
                 logContext);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
             throw new AssertionError(e);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -567,6 +567,7 @@ public class ProcessorStateManagerTest {
         }
     }
 
+    // if the optional is absent, it'll throw an exception and fail the test.
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void shouldLogAWarningIfCheckpointThrowsAnIOException() {
@@ -598,8 +599,8 @@ public class ProcessorStateManagerTest {
         final LogCaptureAppender.Event lastEvent = messages.get(messages.size() - 1);
 
         assertThat(lastEvent.getLevel(), is("WARN"));
-        assertThat(lastEvent.getMessage(), startsWith("process-state-manager-test Failed to write offset checkpoint file to [/tmp/"));
-        assertThat(lastEvent.getMessage(), endsWith("test-application/0_1/.checkpoint]"));
+        assertThat(lastEvent.getMessage(), startsWith("process-state-manager-test Failed to write offset checkpoint file to ["));
+        assertThat(lastEvent.getMessage(), endsWith(".checkpoint]"));
         assertThat(lastEvent.getThrowableInfo().get(), startsWith("java.io.FileNotFoundException: "));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
@@ -29,12 +29,13 @@ import java.util.Optional;
 public class LogCaptureAppender extends AppenderSkeleton {
     private final LinkedList<LoggingEvent> events = new LinkedList<>();
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static class Event {
         private String level;
         private String message;
         private Optional<String> throwableInfo;
 
-        public Event(final String level, final String message, final Optional<String> throwableInfo) {
+        Event(final String level, final String message, final Optional<String> throwableInfo) {
             this.level = level;
             this.message = message;
             this.throwableInfo = throwableInfo;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
@@ -24,9 +24,34 @@ import org.apache.log4j.spi.LoggingEvent;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 public class LogCaptureAppender extends AppenderSkeleton {
     private final LinkedList<LoggingEvent> events = new LinkedList<>();
+
+    public static class Event {
+        private String level;
+        private String message;
+        private Optional<String> throwableInfo;
+
+        public Event(final String level, final String message, final Optional<String> throwableInfo) {
+            this.level = level;
+            this.message = message;
+            this.throwableInfo = throwableInfo;
+        }
+
+        public String getLevel() {
+            return level;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Optional<String> getThrowableInfo() {
+            return throwableInfo;
+        }
+    }
 
     public static LogCaptureAppender createAndRegister() {
         final LogCaptureAppender logCaptureAppender = new LogCaptureAppender();
@@ -54,6 +79,30 @@ public class LogCaptureAppender extends AppenderSkeleton {
         synchronized (events) {
             for (final LoggingEvent event : events) {
                 result.add(event.getRenderedMessage());
+            }
+        }
+        return result;
+    }
+
+    public List<Event> getEvents() {
+        final LinkedList<Event> result = new LinkedList<>();
+        synchronized (events) {
+            for (final LoggingEvent event : events) {
+                final String[] throwableStrRep = event.getThrowableStrRep();
+                final Optional<String> throwableString;
+                if (throwableStrRep == null) {
+                    throwableString = Optional.empty();
+                } else {
+                    final StringBuilder throwableStringBuilder = new StringBuilder();
+
+                    for (final String s : throwableStrRep) {
+                        throwableStringBuilder.append(s);
+                    }
+
+                    throwableString = Optional.of(throwableStringBuilder.toString());
+                }
+
+                result.add(new Event(event.getLevel().toString(), event.getRenderedMessage(), throwableString));
             }
         }
         return result;


### PR DESCRIPTION
We saw a log statement in which the cause of the failure to write a checkpoint was not properly logged.
This change logs the exception properly and also verifies the log message.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
