### PR TITLE
KAFKA-4850: Enable bloomfilters

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -41,7 +41,6 @@ import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
-import org.rocksdb.TableFormatConfig;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -111,13 +110,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         this.parentDir = parentDir;
     }
 
-    protected TableFormatConfig getTableConfig() {
-        final BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
-        tableConfig.setBlockCacheSize(BLOCK_CACHE_SIZE);
-        tableConfig.setBlockSize(BLOCK_SIZE);
-        tableConfig.setFilter(new BloomFilter());
-        return tableConfig;
-    }
 
     @SuppressWarnings("unchecked")
     public void openDB(final ProcessorContext context) {
@@ -125,7 +117,12 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
 
         options = new Options();
 
-        options.setTableFormatConfig(getTableConfig());
+        final BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
+        tableConfig.setBlockCacheSize(BLOCK_CACHE_SIZE);
+        tableConfig.setBlockSize(BLOCK_SIZE);
+        tableConfig.setFilter(new BloomFilter());
+
+        options.setTableFormatConfig(tableConfig);
         options.setWriteBufferSize(WRITE_BUFFER_SIZE);
         options.setCompressionType(COMPRESSION_TYPE);
         options.setCompactionStyle(COMPACTION_STYLE);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -76,8 +76,8 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
     private static final CompressionType COMPRESSION_TYPE = CompressionType.NO_COMPRESSION;
     private static final CompactionStyle COMPACTION_STYLE = CompactionStyle.UNIVERSAL;
     private static final long WRITE_BUFFER_SIZE = 16 * 1024 * 1024L;
-    protected static final long BLOCK_CACHE_SIZE = 50 * 1024 * 1024L;
-    protected static final long BLOCK_SIZE = 4096L;
+    private static final long BLOCK_CACHE_SIZE = 50 * 1024 * 1024L;
+    private static final long BLOCK_SIZE = 4096L;
     private static final int MAX_WRITE_BUFFERS = 3;
     private static final String DB_FILE_DIR = "rocksdb";
 
@@ -122,6 +122,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         tableConfig.setBlockSize(BLOCK_SIZE);
         tableConfig.setFilter(new BloomFilter());
 
+        options.optimizeFiltersForHits();
         options.setTableFormatConfig(tableConfig);
         options.setWriteBufferSize(WRITE_BUFFER_SIZE);
         options.setCompressionType(COMPRESSION_TYPE);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.CompressionType;
 import org.rocksdb.FlushOptions;
@@ -117,6 +118,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         tableConfig.setBlockSize(BLOCK_SIZE);
 
         options = new Options();
+        tableConfig.setFilter(new BloomFilter());
         options.setTableFormatConfig(tableConfig);
         options.setWriteBufferSize(WRITE_BUFFER_SIZE);
         options.setCompressionType(COMPRESSION_TYPE);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.TableFormatConfig;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -39,6 +41,13 @@ class Segment extends RocksDBStore implements Comparable<Segment> {
         return Long.compare(id, segment.id);
     }
 
+    @Override
+    protected TableFormatConfig getTableConfig() {
+        final BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
+        tableConfig.setBlockCacheSize(BLOCK_CACHE_SIZE);
+        tableConfig.setBlockSize(BLOCK_SIZE);
+        return tableConfig;
+    }
 
     @Override
     public void openDB(final ProcessorContext context) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -18,8 +18,6 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.TableFormatConfig;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -39,14 +37,6 @@ class Segment extends RocksDBStore implements Comparable<Segment> {
     @Override
     public int compareTo(final Segment segment) {
         return Long.compare(id, segment.id);
-    }
-
-    @Override
-    protected TableFormatConfig getTableConfig() {
-        final BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
-        tableConfig.setBlockCacheSize(BLOCK_CACHE_SIZE);
-        tableConfig.setBlockSize(BLOCK_SIZE);
-        return tableConfig;
     }
 
     @Override

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -31,9 +31,9 @@ if [ -z `which javac` ]; then
     if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
         find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
     fi
-    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u191-linux-x64.tar.gz" ]; then
+    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz" ]; then
       # Grab a copy of the JDK since it has moved and original downloader won't work
-      curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jdk-8u191-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u191-linux-x64.tar.gz
+      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u171-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz
     fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -31,9 +31,9 @@ if [ -z `which javac` ]; then
     if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
         find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
     fi
-    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz" ]; then
+    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u191-linux-x64.tar.gz" ]; then
       # Grab a copy of the JDK since it has moved and original downloader won't work
-      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u171-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz
+      curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jdk-8u191-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u191-linux-x64.tar.gz
     fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections


### PR DESCRIPTION
This PR enables BloomFilters for RocksDB to speed up point lookups.
The request for this has been around for some time - https://issues.apache.org/jira/browse/KAFKA-4850

For testing, I've done the following 

1. Ran the standard streams suite of unit and integration tests
2. Kicked off [the simple benchmark test with bloom filters enabled  ](https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2115/)
3. Kicked off [the simple benchmark test with bloom filters not enabled  ](https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2116/)
4. Kicked off [streams system tests](https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2114/) 



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
