### PR TITLE
MINOR: Fix failing test in ConsumeBenchTest:test_multiple_consumers_specifie…

### DIFF
--- a/tests/kafkatest/tests/core/consume_bench_test.py
+++ b/tests/kafkatest/tests/core/consume_bench_test.py
@@ -177,10 +177,10 @@ class ConsumeBenchTest(Test):
 
     def test_multiple_consumers_specified_group_partitions_should_raise(self):
         """
-        Runs multiple consumers in to read messages from specific partitions.
-        Since a consumerGroup isn't specified, each consumer will get assigned a random group
-        and consume from all partitions
+        Runs multiple consumers in the same group to read messages from specific partitions.
+        It is an invalid configuration to provide a consumer group and specific partitions.
         """
+        expected_error_msg = 'You may not specify an explicit partition assignment when using multiple consumers in the same group'
         self.produce_messages(self.active_topics, max_messages=20000)
         consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                                 self.consumer_workload_service.consumer_node,
@@ -198,7 +198,7 @@ class ConsumeBenchTest(Test):
             consume_workload.wait_for_done(timeout_sec=360)
             raise Exception("Should have raised an exception due to an invalid configuration")
         except RuntimeError as e:
-            if 'Will not split partitions' not in str(e):
+            if expected_error_msg not in str(e):
                 raise RuntimeError("Unexpected Exception - " + str(e))
             self.logger.info(e)
 

--- a/tests/kafkatest/tests/core/consume_bench_test.py
+++ b/tests/kafkatest/tests/core/consume_bench_test.py
@@ -180,7 +180,7 @@ class ConsumeBenchTest(Test):
         Runs multiple consumers in the same group to read messages from specific partitions.
         It is an invalid configuration to provide a consumer group and specific partitions.
         """
-        expected_error_msg = 'You may not specify an explicit partition assignment when using multiple consumers in the same group'
+        expected_error_msg = 'explicit partition assignment'
         self.produce_messages(self.active_topics, max_messages=20000)
         consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                                 self.consumer_workload_service.consumer_node,


### PR DESCRIPTION
This is the error message we're after:
https://github.com/apache/kafka/blob/c05050346468cc27bcfb3a43bde90c47533a386c/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java#L120

We apparently changed it midway through #5810 and forgot to update the test