### PR TITLE
KAFKA-7715: Added a configuration parameter to Connect which disables WADL output for OPTIONS method.

### DIFF
--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -75,6 +75,9 @@ offset.flush.interval.ms=10000
 #rest.advertised.host.name=
 #rest.advertised.port=
 
+# Controls presence of WADL information in a response to OPTIONS request
+#rest.wadl.enable=false
+
 # Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
 # (connectors, converters, transformations). The list should consist of top level directories that include 
 # any combination of: 

--- a/config/connect-standalone.properties
+++ b/config/connect-standalone.properties
@@ -29,6 +29,9 @@ offset.storage.file.filename=/tmp/connect.offsets
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000
 
+# Controls presence of WADL information in a response to OPTIONS request
+#rest.wadl.enable=false
+
 # Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
 # (connectors, converters, transformations). The list should consist of top level directories that include 
 # any combination of: 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -171,6 +171,11 @@ public class WorkerConfig extends AbstractConfig {
     public static final String REST_ADVERTISED_LISTENER_CONFIG = "rest.advertised.listener";
     private static final String REST_ADVERTISED_LISTENER_DOC
             = "Sets the advertised listener (HTTP or HTTPS) which will be given to other workers to use.";
+    public static final String REST_ENABLE_WADL_CONFIG = "rest.wadl.enable";
+    private static final String REST_ENABLE_WADL_DOC =
+        "If true, OPTIONS request to Connect REST replies with WADL information. "
+        + "It's recommended to disable it, since exposing WADL information can pose a security risk.";
+    private static final Boolean REST_ENABLE_WADL_DEFAULT = true;
 
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG = "access.control.allow.origin";
     protected static final String ACCESS_CONTROL_ALLOW_ORIGIN_DOC =
@@ -255,6 +260,7 @@ public class WorkerConfig extends AbstractConfig {
                 .define(REST_ADVERTISED_HOST_NAME_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_HOST_NAME_DOC)
                 .define(REST_ADVERTISED_PORT_CONFIG, Type.INT,  null, Importance.LOW, REST_ADVERTISED_PORT_DOC)
                 .define(REST_ADVERTISED_LISTENER_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_LISTENER_DOC)
+                .define(REST_ENABLE_WADL_CONFIG, Type.BOOLEAN, REST_ENABLE_WADL_DEFAULT, Importance.LOW, REST_ENABLE_WADL_DOC)
                 .define(ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, Type.STRING,
                         ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT, Importance.LOW,
                         ACCESS_CONTROL_ALLOW_ORIGIN_DOC)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,6 +172,7 @@ public class RestServer {
         resourceConfig.register(new ConnectorPluginsResource(herder));
 
         resourceConfig.register(ConnectExceptionMapper.class);
+        resourceConfig.property(ServerProperties.WADL_FEATURE_DISABLE, !config.getBoolean(WorkerConfig.REST_ENABLE_WADL_CONFIG));
 
         registerRestExtensions(herder, resourceConfig);
 


### PR DESCRIPTION
Currently, Connect REST endpoint replies to `OPTIONS` request with verbose WADL information, which could be used for an attack.
It's not recommended for the production system to expose that information, but for the backward-compatibility reasons, it may still be available by default, with a possibility to turn it off by setting `rest.wadl.enable=false`.

Added unit tests in `RestServerTest`, which asserts that `Content-type` is either `application/vnd.sun.wadl+xml` if `rest.wadl.enable=true` or `rest.wadl.enable` is not set;  or `text/plain` otherwise.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
