### PR TITLE
MINOR: Gracefully close the consumer in ConsumeBenchWorker

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -60,7 +60,7 @@ public final class WorkerUtils {
      * @throws KafkaException   A wrapped version of the exception.
      */
     public static void abortAndThrow(Logger log, String what, Throwable exception,
-                                     KafkaFutureImpl<String> doneFuture) throws KafkaException {
+            KafkaFutureImpl<String> doneFuture) throws KafkaException {
         log.warn("{} caught an exception: ", what, exception);
         doneFuture.complete(exception.getMessage());
         throw new KafkaException(exception);

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -59,8 +59,8 @@ public final class WorkerUtils {
      * @param doneFuture        The TaskWorker's doneFuture
      * @throws KafkaException   A wrapped version of the exception.
      */
-    public static void abort(Logger log, String what, Throwable exception,
-            KafkaFutureImpl<String> doneFuture) throws KafkaException {
+    public static void abortAndThrow(Logger log, String what, Throwable exception,
+                                     KafkaFutureImpl<String> doneFuture) throws KafkaException {
         log.warn("{} caught an exception: ", what, exception);
         doneFuture.complete(exception.getMessage());
         throw new KafkaException(exception);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -160,7 +160,7 @@ public class ConnectionStressWorker implements TaskWorker {
                     }
                 }
             } catch (Exception e) {
-                WorkerUtils.abort(log, "ConnectionStressRunnable", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ConnectionStressRunnable", e, doneFuture);
             }
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -105,7 +105,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                 }
                 executor.submit(new CloseStatusUpdater(consumeTasks));
             } catch (Throwable e) {
-                WorkerUtils.abort(log, "Prepare", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "Prepare", e, doneFuture);
             }
         }
 
@@ -263,7 +263,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                 }
             } catch (Exception e) {
                 consumer.close();
-                WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ConsumeRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData =
@@ -312,7 +312,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             try {
                 update();
             } catch (Exception e) {
-                WorkerUtils.abort(log, "ConsumeStatusUpdater", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ConsumeStatusUpdater", e, doneFuture);
             }
         }
 
@@ -344,7 +344,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             try {
                 update();
             } catch (Exception e) {
-                WorkerUtils.abort(log, "ConsumeStatusUpdater", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ConsumeStatusUpdater", e, doneFuture);
             }
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -270,9 +270,9 @@ public class ConsumeBenchWorker implements TaskWorker {
                 long curTimeMs = Time.SYSTEM.milliseconds();
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
-                doneFuture.complete("");
                 consumer.close();
             }
+            doneFuture.complete("");
             return null;
         }
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -262,6 +262,7 @@ public class ConsumeBenchWorker implements TaskWorker {
                     startBatchMs = Time.SYSTEM.milliseconds();
                 }
             } catch (Exception e) {
+                consumer.close();
                 WorkerUtils.abort(log, "ConsumeRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);
@@ -270,8 +271,8 @@ public class ConsumeBenchWorker implements TaskWorker {
                 long curTimeMs = Time.SYSTEM.milliseconds();
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
-                consumer.close();
             }
+            consumer.close();
             doneFuture.complete("");
             return null;
         }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -270,9 +270,9 @@ public class ConsumeBenchWorker implements TaskWorker {
                 long curTimeMs = Time.SYSTEM.milliseconds();
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
+                doneFuture.complete("");
+                consumer.close();
             }
-            doneFuture.complete("");
-            consumer.close();
             return null;
         }
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -123,7 +123,7 @@ public class ProduceBenchWorker implements TaskWorker {
                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
                 executor.submit(new SendRecords(active));
             } catch (Throwable e) {
-                WorkerUtils.abort(log, "Prepare", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "Prepare", e, doneFuture);
             }
         }
     }
@@ -248,7 +248,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     producer.close();
                 }
             } catch (Exception e) {
-                WorkerUtils.abort(log, "SendRecords", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "SendRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);
                 StatusData statusData = new StatusUpdater(histogram, transactionsCommitted).update();
@@ -315,7 +315,7 @@ public class ProduceBenchWorker implements TaskWorker {
             try {
                 update();
             } catch (Exception e) {
-                WorkerUtils.abort(log, "StatusUpdater", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "StatusUpdater", e, doneFuture);
             }
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -153,7 +153,7 @@ public class RoundTripWorker implements TaskWorker {
                 executor.scheduleWithFixedDelay(
                     new StatusUpdater(), 30, 30, TimeUnit.SECONDS);
             } catch (Throwable e) {
-                WorkerUtils.abort(log, "Prepare", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "Prepare", e, doneFuture);
             }
         }
     }
@@ -262,7 +262,7 @@ public class RoundTripWorker implements TaskWorker {
                     });
                 }
             } catch (Throwable e) {
-                WorkerUtils.abort(log, "ProducerRunnable", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ProducerRunnable", e, doneFuture);
             } finally {
                 log.info("{}: ProducerRunnable is exiting.  messagesSent={}; uniqueMessagesSent={}; " +
                         "ackedSends={}.", id, messagesSent, uniqueMessagesSent,
@@ -368,7 +368,7 @@ public class RoundTripWorker implements TaskWorker {
                     }
                 }
             } catch (Throwable e) {
-                WorkerUtils.abort(log, "ConsumerRunnable", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "ConsumerRunnable", e, doneFuture);
             } finally {
                 log.info("{}: ConsumerRunnable is exiting.  Invoked poll {} time(s).  " +
                     "messagesReceived = {}; uniqueMessagesReceived = {}.",
@@ -383,7 +383,7 @@ public class RoundTripWorker implements TaskWorker {
             try {
                 update();
             } catch (Exception e) {
-                WorkerUtils.abort(log, "StatusUpdater", e, doneFuture);
+                WorkerUtils.abortAndThrow(log, "StatusUpdater", e, doneFuture);
             }
         }
 


### PR DESCRIPTION
Since WorkerUtils.abort propagates the exception after handling it, any exceptions raised will not close the consumer properly
