### PR TITLE
MINOR: Streams broker down flaky test

### DIFF
--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -45,6 +45,7 @@ class BaseStreamsTest(KafkaTest):
                                   topic,
                                   max_messages=num_messages,
                                   acks=1,
+                                  throughput=1000,
                                   repeating_keys=repeating_keys)
 
     def assert_produce_consume(self,

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -62,6 +62,13 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
 
         self.kafka.start_node(node)
 
+        connected = 'Discovered group coordinator'
+
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            monitor.wait_until(connected,
+                               timeout_sec=120,
+                               err_msg=("Never saw output '%s' on " % connected) + str(processor.node.account))
+
         self.assert_produce_consume(self.inputTopic,
                                     self.outputTopic,
                                     self.client_id,

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -27,7 +27,8 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
     inputTopic = "streamsResilienceSource"
     outputTopic = "streamsResilienceSink"
     client_id = "streams-broker-resilience-verify-consumer"
-    num_messages = 5
+    num_messages = 10000
+    message = "processed[0-9]*messages"
 
     def __init__(self, test_context):
         super(StreamsBrokerDownResilience, self).__init__(test_context,
@@ -48,8 +49,6 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         processor = StreamsBrokerDownResilienceService(self.test_context, self.kafka, self.get_configs())
         processor.start()
 
-        # until KIP-91 is merged we'll only send 5 messages to assert Kafka Streams is running before taking the broker down
-        # After KIP-91 is merged we'll continue to send messages the duration of the test
         self.assert_produce_consume(self.inputTopic,
                                     self.outputTopic,
                                     self.client_id,
@@ -103,14 +102,13 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                     self.outputTopic,
                                     self.client_id,
                                     "running_with_broker_down_initially",
-                                    num_messages=9,
+                                    num_messages=self.num_messages,
                                     timeout_sec=120)
 
-        message = "processed3messages"
         # need to show all 3 instances processed messages
-        self.wait_for_verification(processor, message, processor.STDOUT_FILE)
-        self.wait_for_verification(processor_2, message, processor_2.STDOUT_FILE)
-        self.wait_for_verification(processor_3, message, processor_3.STDOUT_FILE)
+        self.wait_for_verification(processor, self.message, processor.STDOUT_FILE)
+        self.wait_for_verification(processor_2, self.message, processor_2.STDOUT_FILE)
+        self.wait_for_verification(processor_3, self.message, processor_3.STDOUT_FILE)
 
         self.kafka.stop()
 
@@ -136,14 +134,12 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                     self.outputTopic,
                                     self.client_id,
                                     "waiting for rebalance to complete",
-                                    num_messages=9,
+                                    num_messages=self.num_messages,
                                     timeout_sec=120)
 
-        message = "processed3messages"
-
-        self.wait_for_verification(processor, message, processor.STDOUT_FILE)
-        self.wait_for_verification(processor_2, message, processor_2.STDOUT_FILE)
-        self.wait_for_verification(processor_3, message, processor_3.STDOUT_FILE)
+        self.wait_for_verification(processor, self.message, processor.STDOUT_FILE)
+        self.wait_for_verification(processor_2, self.message, processor_2.STDOUT_FILE)
+        self.wait_for_verification(processor_3, self.message, processor_3.STDOUT_FILE)
 
         node = self.kafka.leader(self.inputTopic)
         self.kafka.stop_node(node)
@@ -161,10 +157,10 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                     self.outputTopic,
                                     self.client_id,
                                     "sending_message_after_stopping_streams_instance_bouncing_broker",
-                                    num_messages=9,
+                                    num_messages=self.num_messages,
                                     timeout_sec=120)
 
-        self.wait_for_verification(processor_3, "processed9messages", processor_3.STDOUT_FILE)
+        self.wait_for_verification(processor_3, self.message, processor_3.STDOUT_FILE)
 
         self.kafka.stop()
 
@@ -190,14 +186,12 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                     self.outputTopic,
                                     self.client_id,
                                     "waiting for rebalance to complete",
-                                    num_messages=9,
+                                    num_messages=self.num_messages,
                                     timeout_sec=120)
 
-        message = "processed3messages"
-
-        self.wait_for_verification(processor, message, processor.STDOUT_FILE)
-        self.wait_for_verification(processor_2, message, processor_2.STDOUT_FILE)
-        self.wait_for_verification(processor_3, message, processor_3.STDOUT_FILE)
+        self.wait_for_verification(processor, self.message, processor.STDOUT_FILE)
+        self.wait_for_verification(processor_2, self.message, processor_2.STDOUT_FILE)
+        self.wait_for_verification(processor_3, self.message, processor_3.STDOUT_FILE)
 
         node = self.kafka.leader(self.inputTopic)
         self.kafka.stop_node(node)
@@ -212,7 +206,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                     self.outputTopic,
                                     self.client_id,
                                     "sending_message_after_hard_bouncing_streams_instance_bouncing_broker",
-                                    num_messages=9,
+                                    num_messages=self.num_messages,
                                     timeout_sec=120)
 
         self.kafka.stop()

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -29,7 +29,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
     client_id = "streams-broker-resilience-verify-consumer"
     num_messages = 10000
     message = "processed[0-9]*messages"
-    connected = "Discovered group coordinator"
+    connected_message = "Discovered group coordinator"
 
     def __init__(self, test_context):
         super(StreamsBrokerDownResilience, self).__init__(test_context,
@@ -63,9 +63,9 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
 
         with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
             self.kafka.start_node(node)
-            monitor.wait_until(self.connected,
+            monitor.wait_until(self.connected_message,
                                timeout_sec=120,
-                               err_msg=("Never saw output '%s' on " % self.connected) + str(processor.node.account))
+                               err_msg=("Never saw output '%s' on " % self.connected_message) + str(processor.node.account))
 
         self.assert_produce_consume(self.inputTopic,
                                     self.outputTopic,
@@ -104,22 +104,22 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                 with processor_3.node.account.monitor_log(processor_3.LOG_FILE) as monitor_3:
                     self.kafka.start_node(node)
 
-                    monitor_1.wait_until(self.connected,
+                    monitor_1.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor.node.account))
-                    monitor_2.wait_until(self.connected,
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor.node.account))
+                    monitor_2.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor_2.node.account))
-                    monitor_3.wait_until(self.connected,
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor_2.node.account))
+                    monitor_3.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor_3.node.account))
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor_3.node.account))
 
         with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor_1:
             with processor_2.node.account.monitor_log(processor_2.STDOUT_FILE) as monitor_2:
                 with processor_3.node.account.monitor_log(processor_3.STDOUT_FILE) as monitor_3:
 
                     self.assert_produce(self.inputTopic,
-                                        "sending_message_after_hard_bouncing_streams_instance_bouncing_broker",
+                                        "sending_message_after_broker_down_initially",
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
 
@@ -134,7 +134,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                          err_msg=("Never saw '%s' on " % self.message) + str(processor_3.node.account))
 
                     self.assert_consume(self.client_id,
-                                        "sending_message_after_stopping_streams_instance_bouncing_broker",
+                                        "consuming_message_after_broker_down_initially",
                                         self.outputTopic,
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
@@ -168,7 +168,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                 with processor_3.node.account.monitor_log(processor_3.STDOUT_FILE) as monitor_3:
 
                     self.assert_produce(self.inputTopic,
-                                        "sending_message_after_hard_bouncing_streams_instance_bouncing_broker",
+                                        "sending_message_normal_broker_start",
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
 
@@ -183,7 +183,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                          err_msg=("Never saw '%s' on " % self.message) + str(processor_3.node.account))
 
                     self.assert_consume(self.client_id,
-                                        "sending_message_after_stopping_streams_instance_bouncing_broker",
+                                        "consuming_message_normal_broker_start",
                                         self.outputTopic,
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
@@ -201,9 +201,9 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         with processor_3.node.account.monitor_log(processor_3.LOG_FILE) as monitor_3:
             self.kafka.start_node(node)
 
-            monitor_3.wait_until(self.connected,
+            monitor_3.wait_until(self.connected_message,
                                  timeout_sec=120,
-                                 err_msg=("Never saw '%s' on " % self.connected) + str(processor_3.node.account))
+                                 err_msg=("Never saw '%s' on " % self.connected_message) + str(processor_3.node.account))
 
         self.assert_produce_consume(self.inputTopic,
                                     self.outputTopic,
@@ -241,7 +241,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                 with processor_3.node.account.monitor_log(processor_3.STDOUT_FILE) as monitor_3:
 
                     self.assert_produce(self.inputTopic,
-                                        "sending_message_after_hard_bouncing_streams_instance_bouncing_broker",
+                                        "sending_message_after_normal_broker_start",
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
 
@@ -256,7 +256,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                          err_msg=("Never saw '%s' on " % self.message) + str(processor_3.node.account))
 
                     self.assert_consume(self.client_id,
-                                        "sending_message_after_stopping_streams_instance_bouncing_broker",
+                                        "consuming_message_after_normal_broker_start",
                                         self.outputTopic,
                                         num_messages=self.num_messages,
                                         timeout_sec=120)
@@ -273,15 +273,15 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                 with processor_3.node.account.monitor_log(processor_3.LOG_FILE) as monitor_3:
                     self.kafka.start_node(node)
 
-                    monitor_1.wait_until(self.connected,
+                    monitor_1.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor.node.account))
-                    monitor_2.wait_until(self.connected,
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor.node.account))
+                    monitor_2.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor_2.node.account))
-                    monitor_3.wait_until(self.connected,
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor_2.node.account))
+                    monitor_3.wait_until(self.connected_message,
                                          timeout_sec=120,
-                                         err_msg=("Never saw '%s' on " % self.connected) + str(processor_3.node.account))
+                                         err_msg=("Never saw '%s' on " % self.connected_message) + str(processor_3.node.account))
 
         with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor_1:
             with processor_2.node.account.monitor_log(processor_2.STDOUT_FILE) as monitor_2:
@@ -303,7 +303,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
                                          err_msg=("Never saw '%s' on " % self.message) + str(processor_3.node.account))
 
                     self.assert_consume(self.client_id,
-                                        "sending_message_after_stopping_streams_instance_bouncing_broker",
+                                        "consuming_message_after_stopping_streams_instance_bouncing_broker",
                                         self.outputTopic,
                                         num_messages=self.num_messages,
                                         timeout_sec=120)

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -60,13 +60,12 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
 
         time.sleep(broker_down_time_in_seconds)
 
-        self.kafka.start_node(node)
-
         connected = 'Discovered group coordinator'
 
         with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            self.kafka.start_node(node)
             monitor.wait_until(connected,
-                               timeout_sec=120,
+                               timeout_sec=180,
                                err_msg=("Never saw output '%s' on " % connected) + str(processor.node.account))
 
         self.assert_produce_consume(self.inputTopic,


### PR DESCRIPTION
This PR addresses a few issues with this system test flakiness. I'll issue similar PRs for `2.1` and `trunk` as well.

1. Need to grab the monitor before a given operation to observe logs for signal
2. Relied too much on a timely rebalance and only sent a handful of messages. 

I've updated the test and ran it here https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2141/ parameterized for 15 repeats all passed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
