### PR TITLE
MINOR: Increase timeout in transiently failing security test

### DIFF
--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -165,6 +165,6 @@ class ReplicationTest(ProduceConsumeValidateTest):
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka, self.topic,
                                            throughput=self.producer_throughput, compression_types=compression_types,
                                            enable_idempotence=enable_idempotence)
-        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, consumer_timeout_ms=60000, message_validator=is_int)
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, message_validator=is_int)
         self.kafka.start()
         self.run_produce_consume_validate(core_test_action=lambda: failures[failure_mode](self, broker_type))

--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -57,7 +57,6 @@ class SecurityTest(ProduceConsumeValidateTest):
                                                                     "replication-factor": 1}
                                                                 })
         self.num_partitions = 2
-        self.timeout_sec = 10000
         self.producer_throughput = 1000
         self.num_producers = 1
         self.num_consumers = 1
@@ -123,5 +122,5 @@ class SecurityTest(ProduceConsumeValidateTest):
 
     def create_producer_and_consumer(self):
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka, self.topic, throughput=self.producer_throughput)
-        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, consumer_timeout_ms=10000, message_validator=is_int)
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, message_validator=is_int)
 


### PR DESCRIPTION
We have been seeing some transient failures in the security system test. The timeout passed to `ConsoleConsumer` was set inconsistently with what was being enforced in `ProduceConsumeValidateTest` and was probably a bit too low (10 seconds). This patch drops the `ConsoleConsumer` timeout override so that the test relies exclusively on the 60 second timeout set by `ProduceConsumeValidateTest`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
