### PR TITLE
KAFKA-7759: Disable WADL output on OPTIONS method in Connect REST.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,6 +172,7 @@ public class RestServer {
         resourceConfig.register(new ConnectorPluginsResource(herder));
 
         resourceConfig.register(ConnectExceptionMapper.class);
+        resourceConfig.property(ServerProperties.WADL_FEATURE_DISABLE, true);
 
         registerRestExtensions(herder, resourceConfig);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -177,8 +177,8 @@ public class RestServerTest {
         Response response = request("/connectors")
             .accept(MediaType.WILDCARD)
             .options();
-        MediaType.TEXT_PLAIN.equals(response.getMediaType());
-        METHODS_LIST.equals(response.readEntity(String.class));
+        Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getMediaType());
+        Assert.assertEquals(METHODS_LIST, response.readEntity(String.class));
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -52,8 +52,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(PowerMockRunner.class)
 public class RestServerTest {
 
-    private static final String METHODS_LIST = "HEAD, POST, GET, OPTIONS";
-
     @MockStrict
     private Herder herder;
     @MockStrict
@@ -178,7 +176,10 @@ public class RestServerTest {
             .accept(MediaType.WILDCARD)
             .options();
         Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getMediaType());
-        Assert.assertEquals(METHODS_LIST, response.readEntity(String.class));
+        Assert.assertArrayEquals(
+            response.getAllowedMethods().toArray(new String[0]),
+            response.readEntity(String.class).split(", ")
+        );
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.util.Callback;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,17 +40,19 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
 public class RestServerTest {
+
+    private static final String METHODS_LIST = "HEAD, POST, GET, OPTIONS";
 
     @MockStrict
     private Herder herder;
@@ -158,6 +159,30 @@ public class RestServerTest {
         Assert.assertEquals("http://my-hostname:8080/", server.advertisedUrl().toString());
     }
 
+    @Test
+    public void testWadlOutput() {
+        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
+        DistributedConfig workerConfig = new DistributedConfig(configMap);
+
+        EasyMock.expect(herder.plugins()).andStubReturn(plugins);
+        EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
+            workerConfig,
+            ConnectRestExtension.class))
+            .andStubReturn(Collections.emptyList());
+        PowerMock.replayAll();
+
+        server = new RestServer(workerConfig);
+        server.start(herder);
+
+        Response response = request("/connectors")
+            .accept(MediaType.WILDCARD)
+            .options();
+        MediaType.TEXT_PLAIN.equals(response.getMediaType());
+        METHODS_LIST.equals(response.readEntity(String.class));
+
+        PowerMock.verifyAll();
+    }
+
     public void checkCORSRequest(String corsDomain, String origin, String expectedHeader, String method) {
         // To be able to set the Origin, we need to toggle this flag
 
@@ -175,12 +200,9 @@ public class RestServerTest {
 
         final Capture<Callback<Collection<String>>> connectorsCallback = EasyMock.newCapture();
         herder.connectors(EasyMock.capture(connectorsCallback));
-        PowerMock.expectLastCall().andAnswer(new IAnswer<Object>() {
-            @Override
-            public Object answer() throws Throwable {
-                connectorsCallback.getValue().onCompletion(null, Arrays.asList("a", "b"));
-                return null;
-            }
+        PowerMock.expectLastCall().andAnswer(() -> {
+            connectorsCallback.getValue().onCompletion(null, Arrays.asList("a", "b"));
+            return null;
         });
 
         PowerMock.replayAll();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -158,7 +158,7 @@ public class RestServerTest {
     }
 
     @Test
-    public void testWadlOutput() {
+    public void testOptionsDoesNotIncludeWadlOutput() {
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 


### PR DESCRIPTION
Currently, Connect REST endpoint replies to OPTIONS request with verbose WADL information, which could be used for an attack. This was never documented or intended to expose. More discussion is [here] 
(https://lists.apache.org/thread.html/84eb4538397ae4544d20c072c936d9a31f22f429a0891cbb7d8e2296@%3Cdev.kafka.apache.org%3E)

Added unit tests in RestServerTest, which asserts that calling `OPTIONS` on `/connectors` replies with a list of supported HTTP methods, with no WADL information.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
