### PR TITLE
KAFKA-7766: Fail fast PR builds

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -254,7 +254,7 @@ public class Metadata implements Closeable {
      */
     public synchronized void update(MetadataResponse metadataResponse, long now) {
         Objects.requireNonNull(metadataResponse, "Metadata response cannot be null");
-        if(isClosed())
+        if (isClosed())
             throw new IllegalStateException("Update requested after metadata close");
 
         this.needUpdate = false;

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -254,7 +254,7 @@ public class Metadata implements Closeable {
      */
     public synchronized void update(MetadataResponse metadataResponse, long now) {
         Objects.requireNonNull(metadataResponse, "Metadata response cannot be null");
-        if (isClosed())
+        if(isClosed())
             throw new IllegalStateException("Update requested after metadata close");
 
         this.needUpdate = false;

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -17,4 +17,14 @@
 # This script is used for verifying changes in Jenkins. In order to provide faster feedback, the tasks are ordered so
 # that faster tasks are executed in every module before slower tasks (if possible). For example, the unit tests for all
 # the modules are executed before the integration tests.
-./gradlew clean compileJava compileScala compileTestJava compileTestScala spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain unitTest rat integrationTest --no-daemon --continue -PxmlSpotBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed "$@"
+
+# Run validation checks (compilation and static analysis)
+./gradlew clean compileJava compileScala compileTestJava compileTestScala \
+    spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain \
+    --no-daemon --continue -PxmlSpotBugsReport=true "$@" \
+    || { echo 'Validation steps failed'; exit 1; }
+
+# Run tests
+./gradlew unitTest rat integrationTest \
+    --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+    || { echo 'Test steps failed'; exit 1; }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -21,10 +21,10 @@
 # Run validation checks (compilation and static analysis)
 ./gradlew clean compileJava compileScala compileTestJava compileTestScala \
     spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-    --no-daemon --continue -PxmlSpotBugsReport=true "$@" \
+    --profile --no-daemon --continue -PxmlSpotBugsReport=true "$@" \
     || { echo 'Validation steps failed'; exit 1; }
 
 # Run tests
 ./gradlew unitTest integrationTest \
-    --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
     || { echo 'Test steps failed'; exit 1; }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -20,11 +20,11 @@
 
 # Run validation checks (compilation and static analysis)
 ./gradlew clean compileJava compileScala compileTestJava compileTestScala \
-    spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain \
+    spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
     --no-daemon --continue -PxmlSpotBugsReport=true "$@" \
     || { echo 'Validation steps failed'; exit 1; }
 
 # Run tests
-./gradlew unitTest rat integrationTest \
+./gradlew unitTest integrationTest \
     --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
     || { echo 'Test steps failed'; exit 1; }


### PR DESCRIPTION
Split the Gradle invocation in the jenkins.sh script into two commands so we can fail fast for validation checks such as compile errors and checkstyle errors.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
