### PR TITLE
MINOR: Increase throughput too slow for consumer to read within timeout

### DIFF
--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -38,14 +38,14 @@ class BaseStreamsTest(KafkaTest):
                                   client_id,
                                   max_messages=num_messages)
 
-    def get_producer(self, topic, num_messages, repeating_keys=None):
+    def get_producer(self, topic, num_messages, throughput=1000, repeating_keys=None):
         return VerifiableProducer(self.test_context,
                                   1,
                                   self.kafka,
                                   topic,
                                   max_messages=num_messages,
                                   acks=1,
-                                  throughput=1000,
+                                  throughput=throughput,
                                   repeating_keys=repeating_keys)
 
     def assert_produce_consume(self,

--- a/tests/kafkatest/tests/streams/streams_standby_replica_test.py
+++ b/tests/kafkatest/tests/streams/streams_standby_replica_test.py
@@ -46,7 +46,7 @@ class StreamsStandbyTask(BaseStreamsTest):
                                                                                     self.streams_sink_topic_1,
                                                                                     self.streams_sink_topic_2))
 
-        producer = self.get_producer(self.streams_source_topic, self.num_messages, repeating_keys=6)
+        producer = self.get_producer(self.streams_source_topic, self.num_messages, throughput=15000, repeating_keys=6)
         producer.start()
 
         processor_1 = StreamsStandbyTaskService(self.test_context, self.kafka, configs)


### PR DESCRIPTION
Previous PR #6043 reduced throughput for VerifiableProducer in base class, but the streams_standby_replica_test needs higher throughput for consumer to complete verification in 60 seconds. Same update as #6060

For testing kicked off branch builder with 25 repeats https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2202/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
