### PR TITLE
MINOR: Flaky Optimization test due repartition topic creation failures

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.streams.tests;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
@@ -111,6 +112,7 @@ public class StreamsOptimizedTest {
         config.setProperty(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, "0");
         config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        config.setProperty(StreamsConfig.adminClientPrefix(AdminClientConfig.RETRIES_CONFIG), "100");
 
 
         config.putAll(streamsProperties);


### PR DESCRIPTION
The topology optimization test was getting intermittent failures because of failures to create repartition topics on startup.  This PR Increased admin client retries 

I kicked off the system test with 25 repeats, all passed http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2018-12-21--001.1545436859--bbejeck--MINOR_flaky_optimization_test_create_repartition_fails--6cd55e2/report.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
