### PR TITLE
[KStream] remove topic prefix from consumer configuration to resolve unnecessary warning

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1162,6 +1162,7 @@ public class StreamsConfig extends AbstractConfig {
         props.keySet().removeAll(originalsWithPrefix(CONSUMER_PREFIX, false).keySet());
         props.keySet().removeAll(originalsWithPrefix(PRODUCER_PREFIX, false).keySet());
         props.keySet().removeAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX, false).keySet());
+        props.keySet().removeAll(originalsWithPrefix(TOPIC_PREFIX, false).keySet());
         return props;
     }
 


### PR DESCRIPTION
This warning is emitted on every stream startup when using `topic.` or `public static String topicPrefix(final String topicProp)` properties :  
```java
log.warn("The configuration '{}' was supplied but isn't a known config.", key);
```
This fix will remove the warning

