### PR TITLE
MINOR: Improve exception messages in FileChannelRecordBatch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
@@ -26,11 +26,9 @@ import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Utils;
 
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -531,11 +529,10 @@ public abstract class AbstractLegacyRecordBatch extends AbstractRecordBatch impl
 
         LegacyFileChannelRecordBatch(long offset,
                                      byte magic,
-                                     File file,
-                                     FileChannel channel,
+                                     FileRecords fileRecords,
                                      int position,
                                      int batchSize) {
-            super(offset, magic, file, channel, position, batchSize);
+            super(offset, magic, fileRecords, position, batchSize);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractLegacyRecordBatch.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Utils;
 
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -530,10 +531,11 @@ public abstract class AbstractLegacyRecordBatch extends AbstractRecordBatch impl
 
         LegacyFileChannelRecordBatch(long offset,
                                      byte magic,
+                                     File file,
                                      FileChannel channel,
                                      int position,
                                      int batchSize) {
-            super(offset, magic, channel, position, batchSize);
+            super(offset, magic, file, channel, position, batchSize);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Crc32C;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -586,10 +587,11 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
         DefaultFileChannelRecordBatch(long offset,
                                       byte magic,
+                                      File file,
                                       FileChannel channel,
                                       int position,
                                       int batchSize) {
-            super(offset, magic, channel, position, batchSize);
+            super(offset, magic, file, channel, position, batchSize);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -25,11 +25,9 @@ import org.apache.kafka.common.utils.Crc32C;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -587,11 +585,10 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
 
         DefaultFileChannelRecordBatch(long offset,
                                       byte magic,
-                                      File file,
-                                      FileChannel channel,
+                                      FileRecords fileRecords,
                                       int position,
                                       int batchSize) {
-            super(offset, magic, file, channel, position, batchSize);
+            super(offset, magic, fileRecords, position, batchSize);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
@@ -235,9 +235,8 @@ public class FileLogInputStream implements LogInputStream<FileLogInputStream.Fil
 
         @Override
         public int hashCode() {
-            FileChannel channel = fileRecords.channel();
             int result = (int) (offset ^ (offset >>> 32));
-            result = 31 * result + (channel != null ? channel.hashCode() : 0);
+            result = 31 * result + (fileRecords != null ? fileRecords.hashCode() : 0);
             result = 31 * result + position;
             result = 31 * result + batchSize;
             return result;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
@@ -227,10 +227,13 @@ public class FileLogInputStream implements LogInputStream<FileLogInputStream.Fil
 
             FileChannelRecordBatch that = (FileChannelRecordBatch) o;
 
+            FileChannel channel = fileRecords == null ? null : fileRecords.channel();
+            FileChannel thatChannel = that.fileRecords == null ? null : that.fileRecords.channel();
+
             return offset == that.offset &&
                     position == that.position &&
                     batchSize == that.batchSize &&
-                    (fileRecords == null ? that.fileRecords == null : fileRecords.equals(that.fileRecords));
+                    (channel == null ? thatChannel == null : channel.equals(thatChannel));
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileLogInputStream.java
@@ -238,8 +238,10 @@ public class FileLogInputStream implements LogInputStream<FileLogInputStream.Fil
 
         @Override
         public int hashCode() {
+            FileChannel channel = fileRecords == null ? null : fileRecords.channel();
+
             int result = (int) (offset ^ (offset >>> 32));
-            result = 31 * result + (fileRecords != null ? fileRecords.hashCode() : 0);
+            result = 31 * result + (channel != null ? channel.hashCode() : 0);
             result = 31 * result + position;
             result = 31 * result + batchSize;
             return result;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -456,23 +456,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
         }
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        FileRecords that = (FileRecords) o;
-
-        return channel != null ? channel.equals(that.channel) : that.channel == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return channel != null ? channel.hashCode() : 0;
-    }
-
     public static class LogOffsetPosition {
         public final long offset;
         public final int position;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -456,6 +456,23 @@ public class FileRecords extends AbstractRecords implements Closeable {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        FileRecords that = (FileRecords) o;
+
+        return channel != null ? channel.equals(that.channel) : that.channel == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return channel != null ? channel.hashCode() : 0;
+    }
+
     public static class LogOffsetPosition {
         public final long offset;
         public final int position;


### PR DESCRIPTION
Improve exception message in `FileChannelRecordBatch.loadBatchWithSize`.
The original description was removed as part of 81f0c1e8, reuse the
description that was present before.

Replace `channel` by `fileRecords` in potentially thrown KafkaException
descriptions when loading/writing `FileChannelRecordBatch`. This makes exception
messages more readable (channel only shows an object hashcode, fileRecords shows
the path of the file being read and start/end positions in the file).

### Context

If loading a Kafka segment throws an `IOException` (from `FileChannel.read`
in [`Utils.readFully`](https://github.com/apache/kafka/blob/4616c0aaff5766b6305baeed521efdfaae0094e8/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L936)), the exception is wrapped into a `KafkaException`.
If this happens when loading/recovering a segment at start time, Kafka will shutdown
and the current exception message does not help to pinpoint the origin of the issue.

Example stacktrace: (from a broker running 1.1.0)
```
[2018-12-24 23:17:44,727] ERROR {main} There was an error in one of the threads during logs loading: org.apache.kafka.common.KafkaException: java.io.IOException: Input/output error (kafka.log.LogManager)
[2018-12-24 23:17:44,732] ERROR {main} [KafkaServer id=172329974] Fatal error during KafkaServer startup. Prepare to shutdown (kafka.server.KafkaServer)
org.apache.kafka.common.KafkaException: java.io.IOException: Input/output error
        at org.apache.kafka.common.record.FileLogInputStream$FileChannelRecordBatch.loadBatchWithSize(FileLogInputStream.java:214)
        ...
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Input/output error
        at sun.nio.ch.FileDispatcherImpl.pread0(Native Method)
        at sun.nio.ch.FileDispatcherImpl.pread(FileDispatcherImpl.java:52)
        at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:220)
        at sun.nio.ch.IOUtil.read(IOUtil.java:197)
        at sun.nio.ch.FileChannelImpl.readInternal(FileChannelImpl.java:741)
        at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:727)
        at org.apache.kafka.common.utils.Utils.readFully(Utils.java:831)
        at org.apache.kafka.common.utils.Utils.readFullyOrFail(Utils.java:804)
        at org.apache.kafka.common.record.FileLogInputStream$FileChannelRecordBatch.loadBatchWithSize(FileLogInputStream.java:210)
        ... 28 more
```

After applying the proposed changes:
```
org.apache.kafka.common.KafkaException: Failed to load record batch at position 12868 from FileRecords(file= /usr/local/var/lib/kafka-logs/__consumer_offsets-9/00000000000000000000.log, start=0, end=2147483647)
	at org.apache.kafka.common.record.FileLogInputStream$FileChannelRecordBatch.loadBatchWithSize(FileLogInputStream.java:218)
	...
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: Input/output error
        at sun.nio.ch.FileDispatcherImpl.pread0(Native Method)
        at sun.nio.ch.FileDispatcherImpl.pread(FileDispatcherImpl.java:52)
        at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:220)
        at sun.nio.ch.IOUtil.read(IOUtil.java:197)
        at sun.nio.ch.FileChannelImpl.readInternal(FileChannelImpl.java:741)
        at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:727)
        at org.apache.kafka.common.utils.Utils.readFully(Utils.java:831)
        at org.apache.kafka.common.utils.Utils.readFullyOrFail(Utils.java:804)
        at org.apache.kafka.common.record.FileLogInputStream$FileChannelRecordBatch.loadBatchWithSize(FileLogInputStream.java:213)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
