### PR TITLE
KAFKA-7752

### DIFF
--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -532,9 +532,13 @@ class ExtendedAclStore(val patternType: PatternType) extends ZkAclStore {
   if (patternType == PatternType.LITERAL)
     throw new IllegalArgumentException("Literal pattern types are not supported")
 
-  val aclPath: String = s"/kafka-acl-extended/${patternType.name.toLowerCase}"
+  val aclPath: String = s"${ExtendedAclZNode.path}/${patternType.name.toLowerCase}"
 
   def changeStore: ZkAclChangeStore = ExtendedAclChangeStore
+}
+
+object ExtendedAclZNode {
+  def path = "/kafka-acl-extended"
 }
 
 trait AclChangeNotificationHandler {
@@ -720,7 +724,8 @@ object ZkData {
     IsrChangeNotificationZNode.path,
     ProducerIdBlockZNode.path,
     LogDirEventNotificationZNode.path,
-    DelegationTokenAuthZNode.path) ++ ZkAclStore.securePaths
+    DelegationTokenAuthZNode.path,
+    ExtendedAclZNode.path) ++ ZkAclStore.securePaths
 
   // These are persistent ZK paths that should exist on kafka broker startup.
   val PersistentZkPaths = Seq(

--- a/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
@@ -30,7 +30,6 @@ import org.junit.{After, Before, Test}
 
 import scala.util.{Failure, Success, Try}
 import javax.security.auth.login.Configuration
-
 import kafka.api.ApiVersion
 import kafka.cluster.{Broker, EndPoint}
 import org.apache.kafka.common.network.ListenerName
@@ -250,6 +249,8 @@ class ZkAuthorizationTest extends ZooKeeperTestHarness with Logging {
     // Check consumers path.
     val consumersAcl = firstZk.getAcl(ConsumerPathZNode.path)
     assertTrue(ConsumerPathZNode.path, isAclCorrect(consumersAcl, false, false))
+    assertTrue("/kafka-acl-extended", isAclCorrect(firstZk.getAcl("/kafka-acl-extended"), secondZk.secure,
+      ZkData.sensitivePath(ExtendedAclZNode.path)))
   }
 
   /**


### PR DESCRIPTION
- This commits sets ACL on /kafka-acl-extended 
- Extended ZkAuthorizationTest to check ACL on /kafka-acl-extended
- Using zookeeper-security-migration.sh tool on a Kerberized test cluster, I verified the changes: secured and unsecured Kafka znodes and examined ACL on /kafka-acl-extended with zookeeper client

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
