### PR TITLE
MINOR: Fix some logging statements which can not correctly record the behaviors 

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -318,7 +318,7 @@ public class StandaloneHerder extends AbstractHerder {
 
     private void updateConnectorTasks(String connName) {
         if (!worker.isRunning(connName)) {
-            log.info("Skipping reconfiguration of connector {} since it is not running", connName);
+            log.info("Skipping update of connector {} since it is not running", connName);
             return;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -340,7 +340,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         try {
             SchemaAndValue schemaAndValue = converter.toConnectData(topic, data);
             if (!(schemaAndValue.value() instanceof Map)) {
-                log.error("Invalid connector status type {}", schemaAndValue.value().getClass());
+                log.error("Invalid task status type {}", schemaAndValue.value().getClass());
                 return null;
             }
             @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -258,7 +258,7 @@ public class GlobalStreamThread extends Thread {
             } catch (final RuntimeException e) {
                 // just log an error if the consumer throws an exception during close
                 // so we can always attempt to close the state stores.
-                log.error("Failed to close consumer due to the following error:", e);
+                log.error("Failed to close global consumer due to the following error:", e);
             }
 
             stateMaintainer.close();


### PR DESCRIPTION
There are some possible copy and paste errors in the log messages (The logging statement was copied from an old place to a new place, but the message wasn't changed to adapt to the function of the new place).
So I modified some logging statements to make them record the run-time behaviors more accurately.