### PR TITLE
KAFKA-7779: Avoid unnecessary loop iteration in leastLoadedNode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -652,7 +652,8 @@ public class NetworkClient implements KafkaClient {
             int idx = (offset + i) % nodes.size();
             Node node = nodes.get(idx);
             int currInflight = this.inFlightRequests.count(node.idString());
-            if (currInflight == 0 && isReady(node, now)) {
+            if (currInflight == 0 &&
+                    (this.metadataUpdater.isUpdateDue(now) ? canSendRequest(node.idString(), now) : isReady(node, now))) {
                 // if we find an established connection with no in-flight requests we can stop right away
                 log.trace("Found least loaded node {} connected with no in-flight requests", node);
                 return node;

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -652,8 +652,7 @@ public class NetworkClient implements KafkaClient {
             int idx = (offset + i) % nodes.size();
             Node node = nodes.get(idx);
             int currInflight = this.inFlightRequests.count(node.idString());
-            if (currInflight == 0 &&
-                    (this.metadataUpdater.isUpdateDue(now) ? canSendRequest(node.idString(), now) : isReady(node, now))) {
+            if (currInflight == 0 && canSendRequest(node.idString(), now)) {
                 // if we find an established connection with no in-flight requests we can stop right away
                 log.trace("Found least loaded node {} connected with no in-flight requests", node);
                 return node;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7779

In NetworkClient.leastLoadedNode, it invokes `isReady` to  check if an established connection exists for the given node. `isReady` checks whether metadata needs to be updated also which wants to make metadata request first priority. However, if the to-be-sent request is metadata request, then we do not have to check this otherwise the loop in `leastLoadedNode` will do a complete iteration until the final node is selected. That's not performance efficient for a large cluster.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
