### PR TITLE
MINOR: Use functional patterns in PartitionStates

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * This class is a useful building block for doing fetch requests where topic partitions have to be rotated via
@@ -93,6 +94,10 @@ public class PartitionStates<S> {
             result.add(new PartitionState<>(entry.getKey(), entry.getValue()));
         }
         return result;
+    }
+
+    public Stream<PartitionState<S>> stream() {
+        return map.entrySet().stream().map(entry -> new PartitionState<>(entry.getKey(), entry.getValue()));
     }
 
     public LinkedHashMap<TopicPartition, S> partitionStateMap() {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -145,7 +145,7 @@ abstract class AbstractFetcherThread(name: String,
     val partitionsWithoutEpochs = mutable.Set.empty[TopicPartition]
     val partitionsWithEpochs = mutable.Map.empty[TopicPartition, EpochData]
 
-    partitionStates.partitionStates.asScala.foreach { state =>
+    partitionStates.stream().forEach { state =>
       val tp = state.topicPartition
       if (state.value.isTruncating) {
         latestEpoch(tp) match {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -35,6 +35,7 @@ import scala.collection.{Map, Set, mutable}
 import scala.collection.JavaConverters._
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import java.util.function.Consumer
 
 import com.yammer.metrics.core.Gauge
 import kafka.log.LogAppendInfo
@@ -42,7 +43,6 @@ import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.internals.PartitionStates
 import org.apache.kafka.common.record.{FileRecords, MemoryRecords, Records}
 import org.apache.kafka.common.requests._
-
 
 import scala.math._
 
@@ -145,18 +145,20 @@ abstract class AbstractFetcherThread(name: String,
     val partitionsWithoutEpochs = mutable.Set.empty[TopicPartition]
     val partitionsWithEpochs = mutable.Map.empty[TopicPartition, EpochData]
 
-    partitionStates.stream().forEach { state =>
-      val tp = state.topicPartition
-      if (state.value.isTruncating) {
-        latestEpoch(tp) match {
-          case Some(latestEpoch) =>
-            val partitionData = new EpochData(Optional.of(state.value.currentLeaderEpoch), latestEpoch)
-            partitionsWithEpochs += tp -> partitionData
-          case None =>
-            partitionsWithoutEpochs += tp
+    partitionStates.stream().forEach(new Consumer[PartitionStates.PartitionState[PartitionFetchState]] {
+      override def accept(state: PartitionStates.PartitionState[PartitionFetchState]): Unit = {
+        val tp = state.topicPartition
+        if (state.value.isTruncating) {
+          latestEpoch(tp) match {
+            case Some(latestEpoch) =>
+              val partitionData = new EpochData(Optional.of(state.value.currentLeaderEpoch), latestEpoch)
+              partitionsWithEpochs += tp -> partitionData
+            case None =>
+              partitionsWithoutEpochs += tp
+          }
         }
       }
-    }
+    })
 
     debug(s"Build leaderEpoch request $partitionsWithEpochs")
     ResultWithPartitions(partitionsWithEpochs, partitionsWithoutEpochs)


### PR DESCRIPTION
By introducing some functional apis, we can eliminate some filtering and collection boilerplate. This also removes the often unnecessary copy in `PartitionStates.partitionStates()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
