### PR TITLE
[KAFKA-6989] Add asynchronous processing to Processor API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -382,6 +382,11 @@ public class StreamsConfig extends AbstractConfig {
     public static final String NUM_STREAM_THREADS_CONFIG = "num.stream.threads";
     private static final String NUM_STREAM_THREADS_DOC = "The number of threads to execute stream processing.";
 
+    /** {@code num.threads.per.task} */ 
+    @SuppressWarnings("WeakerAccess")
+    public static final String NUM_THREADS_PER_TASK_CONFIG = "num.threads.per.task";
+    private static final String NUM_THREADS_PER_TASK_DOC = "The number of threads per task that a user allows Kafka Streams to process.";
+    
     /** {@code partition.grouper} */
     @SuppressWarnings("WeakerAccess")
     public static final String PARTITION_GROUPER_CLASS_CONFIG = "partition.grouper";
@@ -544,6 +549,11 @@ public class StreamsConfig extends AbstractConfig {
                     1,
                     Importance.MEDIUM,
                     NUM_STREAM_THREADS_DOC)
+            .define(NUM_THREADS_PER_TASK_CONFIG,
+            		Type.INT,
+            		1,
+            		Importance.MEDIUM,
+            		NUM_THREADS_PER_TASK_DOC)
             .define(MAX_TASK_IDLE_MS_CONFIG,
                     Type.LONG,
                     0L,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -157,6 +157,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         try {
             try {
                 Files.createDirectories(dbDir.getParentFile().toPath());
+                Files.createDirectories(new File(dbDir.getAbsolutePath()).toPath());
                 db = RocksDB.open(options, dbDir.getAbsolutePath());
             } catch (final RocksDBException e) {
                 throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir.toString(), e);


### PR DESCRIPTION
Here is the design doc for KAFKA-6989:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-408%3A+Add+Asynchronous+Processing+To+Kafka+Streams

The implementation details and changes can be found here.

