### PR TITLE
KAFKA-7789: Increase size of RSA keys used by TestSslUtils

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -89,7 +89,7 @@ public class TestSslUtils {
 
     public static KeyPair generateKeyPair(String algorithm) throws NoSuchAlgorithmException {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm);
-        keyGen.initialize(1024);
+        keyGen.initialize(2048);
         return keyGen.genKeyPair();
     }
 


### PR DESCRIPTION
Fix [KAFKA-7789](https://issues.apache.org/jira/browse/KAFKA-7789) by increasing the key size for the RSA keys generated for the tests. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
