### PR TITLE
KAFKA-5061 - Make default Worker Task client IDs distinct

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -489,6 +490,9 @@ public class Worker {
             OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetBackingStore, id.connector(),
                     internalKeyConverter, internalValueConverter);
             Map<String, Object> producerProps = producerConfigs(config);
+            String clientId = Objects.toString(producerProps.get(ProducerConfig.CLIENT_ID_CONFIG), "");
+            if (clientId.isEmpty())
+                producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "connect-producer-" + id);
             KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps);
 
             // Note we pass the configState as it performs dynamic transformations under the covers
@@ -502,6 +506,9 @@ public class Worker {
             retryWithToleranceOperator.reporters(sinkTaskReporters(id, sinkConfig, errorHandlingMetrics));
 
             Map<String, Object> consumerProps = consumerConfigs(id, config);
+            String clientId = Objects.toString(consumerProps.get(ConsumerConfig.CLIENT_ID_CONFIG), "");
+            if (clientId.isEmpty())
+                consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "connect-consumer-" + id);
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, configState, metrics, keyConverter,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -525,7 +525,7 @@ public class Worker {
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
         producerProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1");
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.toString(Integer.MAX_VALUE));
-        producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "connect-producer-" + id);
+        producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "connector-producer-" + id);
         // User-specified overrides
         producerProps.putAll(config.originalsWithPrefix("producer."));
         return producerProps;
@@ -538,7 +538,7 @@ public class Worker {
         Map<String, Object> consumerProps = new HashMap<>();
 
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, SinkUtils.consumerGroupId(id.connector()));
-        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "connect-consumer-" + id);
+        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "connector-consumer-" + id);
         consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
                   Utils.join(config.getList(WorkerConfig.BOOTSTRAP_SERVERS_CONFIG), ","));
         consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -488,7 +488,7 @@ public class Worker {
                     internalKeyConverter, internalValueConverter);
             OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetBackingStore, id.connector(),
                     internalKeyConverter, internalValueConverter);
-            Map<String, Object> producerProps = producerConfigs(id, config);
+            Map<String, Object> producerProps = producerConfigs("connector-producer-" + id, config);
             KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps);
 
             // Note we pass the configState as it performs dynamic transformations under the covers
@@ -513,7 +513,7 @@ public class Worker {
         }
     }
 
-    static Map<String, Object> producerConfigs(ConnectorTaskId id, WorkerConfig config) {
+    static Map<String, Object> producerConfigs(String defaultClientId, WorkerConfig config) {
         Map<String, Object> producerProps = new HashMap<>();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Utils.join(config.getList(WorkerConfig.BOOTSTRAP_SERVERS_CONFIG), ","));
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
@@ -525,7 +525,7 @@ public class Worker {
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
         producerProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1");
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.toString(Integer.MAX_VALUE));
-        producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "connector-producer-" + id);
+        producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, defaultClientId);
         // User-specified overrides
         producerProps.putAll(config.originalsWithPrefix("producer."));
         return producerProps;
@@ -563,7 +563,7 @@ public class Worker {
         // check if topic for dead letter queue exists
         String topic = connConfig.dlqTopicName();
         if (topic != null && !topic.isEmpty()) {
-            Map<String, Object> producerProps = producerConfigs(id, config);
+            Map<String, Object> producerProps = producerConfigs("connector-dlq-producer-" + id, config);
             DeadLetterQueueReporter reporter = DeadLetterQueueReporter.createAndSetup(config, id, connConfig, producerProps, errorHandlingMetrics);
             reporters.add(reporter);
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -829,7 +829,9 @@ public class WorkerTest extends ThreadedTest {
 
     @Test
     public void testProducerConfigsWithoutOverrides() {
-        assertEquals(defaultProducerConfigs, Worker.producerConfigs(config));
+        Map<String, String> expectedConfigs = new HashMap<>(defaultProducerConfigs);
+        expectedConfigs.put("client.id", "connect-producer-job-0");
+        assertEquals(expectedConfigs, Worker.producerConfigs(TASK_ID, config));
     }
 
     @Test
@@ -837,18 +839,21 @@ public class WorkerTest extends ThreadedTest {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("producer.acks", "-1");
         props.put("producer.linger.ms", "1000");
+        props.put("producer.client.id", "producer-test-id");
         WorkerConfig configWithOverrides = new StandaloneConfig(props);
 
         Map<String, String> expectedConfigs = new HashMap<>(defaultProducerConfigs);
         expectedConfigs.put("acks", "-1");
         expectedConfigs.put("linger.ms", "1000");
-        assertEquals(expectedConfigs, Worker.producerConfigs(configWithOverrides));
+        expectedConfigs.put("client.id", "producer-test-id");
+        assertEquals(expectedConfigs, Worker.producerConfigs(TASK_ID, configWithOverrides));
     }
 
     @Test
     public void testConsumerConfigsWithoutOverrides() {
         Map<String, String> expectedConfigs = new HashMap<>(defaultConsumerConfigs);
         expectedConfigs.put("group.id", "connect-test");
+        expectedConfigs.put("client.id", "connect-consumer-test-1");
         assertEquals(expectedConfigs, Worker.consumerConfigs(new ConnectorTaskId("test", 1), config));
     }
 
@@ -857,12 +862,14 @@ public class WorkerTest extends ThreadedTest {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("consumer.auto.offset.reset", "latest");
         props.put("consumer.max.poll.records", "1000");
+        props.put("consumer.client.id", "consumer-test-id");
         WorkerConfig configWithOverrides = new StandaloneConfig(props);
 
         Map<String, String> expectedConfigs = new HashMap<>(defaultConsumerConfigs);
         expectedConfigs.put("group.id", "connect-test");
         expectedConfigs.put("auto.offset.reset", "latest");
         expectedConfigs.put("max.poll.records", "1000");
+        expectedConfigs.put("client.id", "consumer-test-id");
         assertEquals(expectedConfigs, Worker.consumerConfigs(new ConnectorTaskId("test", 1), configWithOverrides));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -830,7 +830,7 @@ public class WorkerTest extends ThreadedTest {
     @Test
     public void testProducerConfigsWithoutOverrides() {
         Map<String, String> expectedConfigs = new HashMap<>(defaultProducerConfigs);
-        expectedConfigs.put("client.id", "connect-producer-job-0");
+        expectedConfigs.put("client.id", "connector-producer-job-0");
         assertEquals(expectedConfigs, Worker.producerConfigs(TASK_ID, config));
     }
 
@@ -853,7 +853,7 @@ public class WorkerTest extends ThreadedTest {
     public void testConsumerConfigsWithoutOverrides() {
         Map<String, String> expectedConfigs = new HashMap<>(defaultConsumerConfigs);
         expectedConfigs.put("group.id", "connect-test");
-        expectedConfigs.put("client.id", "connect-consumer-test-1");
+        expectedConfigs.put("client.id", "connector-consumer-test-1");
         assertEquals(expectedConfigs, Worker.consumerConfigs(new ConnectorTaskId("test", 1), config));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -831,7 +831,7 @@ public class WorkerTest extends ThreadedTest {
     public void testProducerConfigsWithoutOverrides() {
         Map<String, String> expectedConfigs = new HashMap<>(defaultProducerConfigs);
         expectedConfigs.put("client.id", "connector-producer-job-0");
-        assertEquals(expectedConfigs, Worker.producerConfigs(TASK_ID, config));
+        assertEquals(expectedConfigs, Worker.producerConfigs("connector-producer-" + TASK_ID, config));
     }
 
     @Test
@@ -846,7 +846,7 @@ public class WorkerTest extends ThreadedTest {
         expectedConfigs.put("acks", "-1");
         expectedConfigs.put("linger.ms", "1000");
         expectedConfigs.put("client.id", "producer-test-id");
-        assertEquals(expectedConfigs, Worker.producerConfigs(TASK_ID, configWithOverrides));
+        assertEquals(expectedConfigs, Worker.producerConfigs("connector-producer-" + TASK_ID, configWithOverrides));
     }
 
     @Test


### PR DESCRIPTION
Use the task ID to make the default client IDs used by Worker Tasks
distinct and stable. This is avoids name conflicts on JMX MBeans and
enables useful monitoring.

This implements [KIP-411](https://cwiki.apache.org/confluence/display/KAFKA/KIP-411%3A+Make+default+Kafka+Connect+worker+task+client+IDs+distinct), and so it should be merged only after that KIP is approved.

See: https://issues.apache.org/jira/browse/KAFKA-5061

This PR is an alternative to https://github.com/apache/kafka/pull/5775, avoiding the need for a new  configuration option. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
