### PR TITLE
MINOR: Rejoin split ssl principal mapping rules

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
@@ -17,7 +17,10 @@
 package org.apache.kafka.common.security.ssl;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,12 +41,12 @@ public class SslPrincipalMapper {
 
     private static List<String> joinSplitRules(List<String> rules) {
         String rule = "RULE:";
-        String _default = "DEFAULT";
+        String defaultRule = "DEFAULT";
         List<String> retVal = new ArrayList<String>();
         StringBuilder currentRule = new StringBuilder();
-        for(String r : rules) {
-            if(currentRule.length() > 0) {
-                if(r.toUpperCase().startsWith(rule) || r.equalsIgnoreCase(_default)) {
+        for (String r : rules) {
+            if (currentRule.length() > 0) {
+                if (r.startsWith(rule) || r.equalsIgnoreCase(defaultRule)) {
                     retVal.add(currentRule.toString());
                     currentRule.setLength(0);
                     currentRule.append(r);
@@ -54,7 +57,7 @@ public class SslPrincipalMapper {
                 currentRule.append(r);
             }
         }
-        if(currentRule.length() > 0) {
+        if (currentRule.length() > 0) {
             retVal.add(currentRule.toString());
         }
         return retVal;

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
@@ -17,10 +17,7 @@
 package org.apache.kafka.common.security.ssl;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,7 +36,32 @@ public class SslPrincipalMapper {
         return new SslPrincipalMapper(parseRules(rules));
     }
 
+    private static List<String> joinSplitRules(List<String> rules) {
+        String rule = "RULE:";
+        String _default = "DEFAULT";
+        List<String> retVal = new ArrayList<String>();
+        StringBuilder currentRule = new StringBuilder();
+        for(String r : rules) {
+            if(currentRule.length() > 0) {
+                if(r.toUpperCase().startsWith(rule) || r.equalsIgnoreCase(_default)) {
+                    retVal.add(currentRule.toString());
+                    currentRule.setLength(0);
+                    currentRule.append(r);
+                } else {
+                    currentRule.append(String.format(",%s", r));
+                }
+            } else {
+                currentRule.append(r);
+            }
+        }
+        if(currentRule.length() > 0) {
+            retVal.add(currentRule.toString());
+        }
+        return retVal;
+    }
+
     private static List<Rule> parseRules(List<String> rules) {
+        rules = joinSplitRules(rules);
         List<Rule> result = new ArrayList<>();
         for (String rule : rules) {
             Matcher matcher = RULE_PARSER.matcher(rule);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
@@ -46,7 +46,7 @@ public class SslPrincipalMapper {
         StringBuilder currentRule = new StringBuilder();
         for (String r : rules) {
             if (currentRule.length() > 0) {
-                if (r.startsWith(rule) || r.equalsIgnoreCase(defaultRule)) {
+                if (r.startsWith(rule) || r.equals(defaultRule)) {
                     retVal.add(currentRule.toString());
                     currentRule.setLength(0);
                     currentRule.append(r);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslPrincipalMapper.java
@@ -42,7 +42,7 @@ public class SslPrincipalMapper {
     private static List<String> joinSplitRules(List<String> rules) {
         String rule = "RULE:";
         String defaultRule = "DEFAULT";
-        List<String> retVal = new ArrayList<String>();
+        List<String> retVal = new ArrayList<>();
         StringBuilder currentRule = new StringBuilder();
         for (String r : rules) {
             if (currentRule.length() > 0) {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
@@ -36,6 +36,16 @@ public class SslPrincipalMapperTest {
         testValidRule(Arrays.asList("RULE:^cn=(.?),ou=(.?),dc=(.?),dc=(.?)$/$1@$2/U"));
     }
 
+    @Test
+    public void testValidSplitRules() {
+        testValidRule(Arrays.asList("DEFAULT"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/L", "DEFAULT"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=(.*?),O=(.*?),L=(.*?)","ST=(.*?),C=(.*?)$/$1@$2/"));
+        testValidRule(Arrays.asList("RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L"));
+        testValidRule(Arrays.asList("RULE:^cn=(.?)","ou=(.?)","dc=(.?)","dc=(.?)$/$1@$2/U"));
+    }
+
     private void testValidRule(List<String> rules) {
         SslPrincipalMapper.fromRules(rules);
     }
@@ -53,6 +63,21 @@ public class SslPrincipalMapperTest {
         testInvalidRule(Arrays.asList("RULE:^CN=(.*?),OU=ServiceUsers.*$/L"));
         testInvalidRule(Arrays.asList("RULE:^CN=(.*?),OU=ServiceUsers.*$/U"));
         testInvalidRule(Arrays.asList("RULE:^CN=(.*?),OU=ServiceUsers.*$/LU"));
+    }
+
+    @Test
+    public void testInvalidSplitRules() {
+        testInvalidRule(Arrays.asList("default"));
+        testInvalidRule(Arrays.asList("DEFAUL"));
+        testInvalidRule(Arrays.asList("DEFAULT/L"));
+        testInvalidRule(Arrays.asList("DEFAULT/U"));
+
+        testInvalidRule(Arrays.asList("RULE:CN=(.*?)","OU=ServiceUsers.*/$1"));
+        testInvalidRule(Arrays.asList("rule:^CN=(.*?)","OU=ServiceUsers.*$/$1/"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/L/U"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/L"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/U"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/LU"));
     }
 
     private void testInvalidRule(List<String> rules) {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
@@ -39,11 +39,11 @@ public class SslPrincipalMapperTest {
     @Test
     public void testValidSplitRules() {
         testValidRule(Arrays.asList("DEFAULT"));
-        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/"));
-        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/L", "DEFAULT"));
-        testValidRule(Arrays.asList("RULE:^CN=(.*?)","OU=(.*?),O=(.*?),L=(.*?)","ST=(.*?),C=(.*?)$/$1@$2/"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/$1/"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/$1/L", "DEFAULT"));
+        testValidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=(.*?),O=(.*?),L=(.*?)", "ST=(.*?)", "C=(.*?)$/$1@$2/"));
         testValidRule(Arrays.asList("RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L"));
-        testValidRule(Arrays.asList("RULE:^cn=(.?)","ou=(.?)","dc=(.?)","dc=(.?)$/$1@$2/U"));
+        testValidRule(Arrays.asList("RULE:^cn=(.?)", "ou=(.?)", "dc=(.?)", "dc=(.?)$/$1@$2/U"));
     }
 
     private void testValidRule(List<String> rules) {
@@ -72,12 +72,12 @@ public class SslPrincipalMapperTest {
         testInvalidRule(Arrays.asList("DEFAULT/L"));
         testInvalidRule(Arrays.asList("DEFAULT/U"));
 
-        testInvalidRule(Arrays.asList("RULE:CN=(.*?)","OU=ServiceUsers.*/$1"));
-        testInvalidRule(Arrays.asList("rule:^CN=(.*?)","OU=ServiceUsers.*$/$1/"));
-        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/$1/L/U"));
-        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/L"));
-        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/U"));
-        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)","OU=ServiceUsers.*$/LU"));
+        testInvalidRule(Arrays.asList("RULE:CN=(.*?)", "OU=ServiceUsers.*/$1"));
+        testInvalidRule(Arrays.asList("rule:^CN=(.*?)", "OU=ServiceUsers.*$/$1/"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/$1/L/U"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/L"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/U"));
+        testInvalidRule(Arrays.asList("RULE:^CN=(.*?)", "OU=ServiceUsers.*$/LU"));
     }
 
     private void testInvalidRule(List<String> rules) {


### PR DESCRIPTION
The string in the properties file is split on commas such that `ssl.principal.mapping.rules=RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/` will create an array of `["RULE:^CN=(.*?)", "OU=ServiceUsers.*$/$1/"]`. The Kafka broker then throws an illegal argument exception on startup because these rules are invalid. This pull request merges strings back together such that all rules either begin with `RULE:` or `DEFAULT`.

The new code was tested by adding two new functions to `SslPrincipalMapperTest` that mimic the existing tests, but with string lists as they would be read from the properties file as mentioned above. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)