### PR TITLE
KAFKA-7786: Ignore OffsetsForLeaderEpoch response if leader epoch changed while request in flight

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -180,5 +180,13 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
             this.leaderEpoch = leaderEpoch;
         }
 
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            bld.append("(currentLeaderEpoch=").append(currentLeaderEpoch).
+                append(", leaderEpoch=").append(leaderEpoch).
+                append(")");
+            return bld.toString();
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -166,4 +166,14 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         responseStruct.set(TOPICS, topics.toArray());
         return responseStruct;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder bld = new StringBuilder();
+        bld.append("(type=OffsetsForLeaderEpochResponse, ")
+            .append(", throttleTimeMs=").append(throttleTimeMs)
+            .append(", epochEndOffsetsByPartition=").append(epochEndOffsetsByPartition)
+            .append(")");
+        return bld.toString();
+    }
 }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -184,12 +184,11 @@ abstract class AbstractFetcherThread(name: String,
         //Check no leadership and no leader epoch changes happened whilst we were unlocked, fetching epochs
         val leaderEpochs = fetchedEpochs.filter { case (tp, _) =>
           val curPartitionState = partitionStates.stateValue(tp)
-          val leaderEpochInRequest = epochRequests.get(tp) match {
-            case Some(request) => request.currentLeaderEpoch.get
-            case _ =>
-              throw new IllegalStateException(
-                s"Leader replied with partition $tp not requested in OffsetsForLeaderEpoch request")
+          val partitionEpochRequest = epochRequests.get(tp).getOrElse {
+            throw new IllegalStateException(
+              s"Leader replied with partition $tp not requested in OffsetsForLeaderEpoch request")
           }
+          val leaderEpochInRequest = partitionEpochRequest.currentLeaderEpoch.get
           curPartitionState != null && leaderEpochInRequest == curPartitionState.currentLeaderEpoch
         }
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -184,7 +184,12 @@ abstract class AbstractFetcherThread(name: String,
         //Check no leadership and no leader epoch changes happened whilst we were unlocked, fetching epochs
         val leaderEpochs = fetchedEpochs.filter { case (tp, _) =>
           val curPartitionState = partitionStates.stateValue(tp)
-          val leaderEpochInRequest = epochRequests.get(tp).get.currentLeaderEpoch.get
+          val leaderEpochInRequest = epochRequests.get(tp) match {
+            case Some(request) => request.currentLeaderEpoch.get
+            case _ =>
+              throw new IllegalStateException(
+                s"Leader replied with partition $tp not requested in OffsetsForLeaderEpoch request")
+          }
           curPartitionState != null && leaderEpochInRequest == curPartitionState.currentLeaderEpoch
         }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -669,7 +669,7 @@ class ReplicaFetcherThreadTest {
     //Create the thread
     val mockNetwork = new ReplicaFetcherMockBlockingSend(offsetsReply, brokerEndPoint, new SystemTime())
     val thread = new ReplicaFetcherThread("bob", 0, brokerEndPoint, configs(0), replicaManager, new Metrics(), new SystemTime(), quota, Some(mockNetwork))
-    thread.addPartitions(Map(t1p0 -> offsetAndEpoch(0L), t2p1 -> offsetAndEpoch(0L)))
+    thread.addPartitions(Map(t1p0 -> offsetAndEpoch(0L), t1p1 -> offsetAndEpoch(0L)))
 
     //Run thread 3 times
     (0 to 3).foreach { _ =>


### PR DESCRIPTION
There is a race condition in ReplicaFetcherThread, where we can update PartitionFetchState with the new leader epoch (same leader) before handling the OffsetsForLeaderEpoch response with FENCED_LEADER_EPOCH error which causes removing partition from partitionStates, which in turn causes no fetching until the next LeaderAndIsr. 

Our system test kafkatest.tests.core.reassign_partitions_test.ReassignPartitionsTest.test_reassign_partitions.bounce_brokers=True.reassign_from_offset_zero=True failed 3 times due to this error in the last couple of months. Since this test is already able to test this condition, not adding any more tests.

Also added toString() implementation to PartitionData, because some log messages did not show useful info which I found while investigating the above system test failure.

cc @hachikuji who suggested the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
