### PR TITLE
MINOR: Improve ducker-ak script

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -83,7 +83,7 @@ ssh [node-name|user-name@node-name] [command]
     is specified, we will run that command.  Otherwise, we will provide a login
     shell.
 
-down [-q|--quiet]
+down [-q|--quiet] [-f|--force]
     Tear down all the currently active ducker-ak nodes.  If --quiet is specified,
     only error messages are printed.
 
@@ -476,9 +476,11 @@ echo_running_container_names() {
 ducker_down() {
     require_commands docker
     local verbose=1
+    local force_str=""
     while [[ $# -ge 1 ]]; do
         case "${1}" in
             -q|--quiet) verbose=0; shift;;
+            -f|--force) force_str="-f"; shift;;
             *) die "ducker_down: unexpected command-line argument ${1}";;
         esac
     done
@@ -499,7 +501,7 @@ ducker_down() {
     if [[ -n "${running_containers}" ]]; then
         must_do ${verbose_flag} docker kill "${running_containers}"
     fi
-    must_do ${verbose_flag} docker rm "${all_containers}"
+    must_do ${verbose_flag} docker rm ${force_str} "${all_containers}"
     must_do ${verbose_flag} -o rm -f -- "${ducker_dir}/build/node_hosts" "${ducker_dir}/build/cluster.json"
     if docker network inspect ducknet &>/dev/null; then
         must_do -v docker network rm ducknet

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -421,8 +421,8 @@ ducker_test() {
     (test -f ./gradlew || gradle) && ./gradlew systemTestLibs
     must_popd
     cmd="cd /opt/kafka-dev && ducktape --cluster-file /opt/kafka-dev/tests/docker/build/cluster.json $args"
-    echo "docker exec -it ducker01 bash -c \"${cmd}\""
-    exec docker exec --user=ducker -it ducker01 bash -c "${cmd}"
+    echo "docker exec ducker01 bash -c \"${cmd}\""
+    exec docker exec --user=ducker ducker01 bash -c "${cmd}"
 }
 
 ducker_ssh() {

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -85,7 +85,8 @@ ssh [node-name|user-name@node-name] [command]
 
 down [-q|--quiet] [-f|--force]
     Tear down all the currently active ducker-ak nodes.  If --quiet is specified,
-    only error messages are printed.
+    only error messages are printed. If --force or -f is specified, "docker rm -f"
+    will be used to remove the nodes, which kills currently running ducker-ak test.
 
 purge [--f|--force]
     Purge Docker images created by ducker-ak.  This will free disk space.


### PR DESCRIPTION
- Remove -it from docker exec commands. When running integration tests on some CI systems the script fails and complains that there is no TTY. TTY is not needed to run ducktape so it is OK to remove them.
- Add -f/--force option to "ducker-ak down" to forcefully cleanup existing docker instances.

The contribution is my original work and I license the work to the project under the project's open source license.

Signed-off-by: Kan Li likan@uber.com

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Runs the script in jenkins, without the commit the script fails, while with the commit the script runs successfully.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
