### PR TITLE
KAFKA-7790: Fix Bugs in Trogdor Task Expiration

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
@@ -49,10 +49,12 @@ import org.apache.kafka.trogdor.common.ThreadUtils;
 import org.apache.kafka.trogdor.rest.AgentStatusResponse;
 import org.apache.kafka.trogdor.rest.CreateWorkerRequest;
 import org.apache.kafka.trogdor.rest.StopWorkerRequest;
+import org.apache.kafka.trogdor.rest.WorkerDone;
 import org.apache.kafka.trogdor.rest.WorkerReceiving;
 import org.apache.kafka.trogdor.rest.WorkerRunning;
 import org.apache.kafka.trogdor.rest.WorkerStarting;
 import org.apache.kafka.trogdor.rest.WorkerState;
+import org.apache.kafka.trogdor.rest.WorkerStopping;
 import org.apache.kafka.trogdor.task.TaskSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -235,6 +237,8 @@ public final class NodeManager {
                             log.debug("{}: worker state is still {}", node.name(), worker.state);
                         } else {
                             log.info("{}: worker state changed from {} to {}", node.name(), worker.state, state);
+                            if (state instanceof WorkerDone || state instanceof WorkerStopping)
+                                worker.shouldRun = false;
                             worker.state = state;
                             taskManager.updateWorkerState(node.name(), worker.workerId, state);
                         }

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
@@ -204,48 +204,58 @@ public final class NodeManager {
                 if (log.isTraceEnabled()) {
                     log.trace("{}: got heartbeat status {}", node.name(), agentStatus);
                 }
-                // Identify workers which we think should be running, but which do not appear
-                // in the agent's response.  We need to send startWorker requests for these.
-                for (Map.Entry<Long, ManagedWorker> entry : workers.entrySet()) {
-                    Long workerId = entry.getKey();
-                    if (!agentStatus.workers().containsKey(workerId)) {
-                        ManagedWorker worker = entry.getValue();
-                        if (worker.shouldRun) {
-                            worker.tryCreate();
-                        }
-                    }
-                }
-                for (Map.Entry<Long, WorkerState> entry : agentStatus.workers().entrySet()) {
-                    long workerId = entry.getKey();
-                    WorkerState state = entry.getValue();
-                    ManagedWorker worker = workers.get(workerId);
-                    if (worker == null) {
-                        // Identify tasks which are running, but which we don't know about.
-                        // Add these to the NodeManager as tasks that should not be running.
-                        log.warn("{}: scheduling unknown worker with ID {} for stopping.", node.name(), workerId);
-                        workers.put(workerId, new ManagedWorker(workerId, state.taskId(),
-                            state.spec(), false, state));
-                    } else {
-                        // Handle workers which need to be stopped.
-                        if (state instanceof WorkerStarting || state instanceof WorkerRunning) {
-                            if (!worker.shouldRun) {
-                                worker.tryStop();
-                            }
-                        }
-                        // Notify the TaskManager if the worker state has changed.
-                        if (worker.state.equals(state)) {
-                            log.debug("{}: worker state is still {}", node.name(), worker.state);
-                        } else {
-                            log.info("{}: worker state changed from {} to {}", node.name(), worker.state, state);
-                            if (state instanceof WorkerDone || state instanceof WorkerStopping)
-                                worker.shouldRun = false;
-                            worker.state = state;
-                            taskManager.updateWorkerState(node.name(), worker.workerId, state);
-                        }
-                    }
-                }
+                handleMissingWorkers(agentStatus);
+                handlePresentWorkers(agentStatus);
             } catch (Throwable e) {
                 log.error("{}: Unhandled exception in NodeHeartbeatRunnable", node.name(), e);
+            }
+        }
+
+        /**
+         * Identify workers which we think should be running but do not appear in the agent's response.
+         * We need to send startWorker requests for those
+         */
+        private void handleMissingWorkers(AgentStatusResponse agentStatus) {
+            for (Map.Entry<Long, ManagedWorker> entry : workers.entrySet()) {
+                Long workerId = entry.getKey();
+                if (!agentStatus.workers().containsKey(workerId)) {
+                    ManagedWorker worker = entry.getValue();
+                    if (worker.shouldRun) {
+                        worker.tryCreate();
+                    }
+                }
+            }
+        }
+
+        private void handlePresentWorkers(AgentStatusResponse agentStatus) {
+            for (Map.Entry<Long, WorkerState> entry : agentStatus.workers().entrySet()) {
+                long workerId = entry.getKey();
+                WorkerState state = entry.getValue();
+                ManagedWorker worker = workers.get(workerId);
+                if (worker == null) {
+                    // Identify tasks which are running, but which we don't know about.
+                    // Add these to the NodeManager as tasks that should not be running.
+                    log.warn("{}: scheduling unknown worker with ID {} for stopping.", node.name(), workerId);
+                    workers.put(workerId, new ManagedWorker(workerId, state.taskId(),
+                        state.spec(), false, state));
+                } else {
+                    // Handle workers which need to be stopped.
+                    if (state instanceof WorkerStarting || state instanceof WorkerRunning) {
+                        if (!worker.shouldRun) {
+                            worker.tryStop();
+                        }
+                    }
+                    // Notify the TaskManager if the worker state has changed.
+                    if (worker.state.equals(state)) {
+                        log.debug("{}: worker state is still {}", node.name(), worker.state);
+                    } else {
+                        log.info("{}: worker state changed from {} to {}", node.name(), worker.state, state);
+                        if (state instanceof WorkerDone || state instanceof WorkerStopping)
+                            worker.shouldRun = false;
+                        worker.state = state;
+                        taskManager.updateWorkerState(node.name(), worker.workerId, state);
+                    }
+                }
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -136,7 +136,7 @@ public final class TaskManager {
         this.nextWorkerId = firstWorkerId;
         for (Node node : platform.topology().nodes().values()) {
             if (Node.Util.getTrogdorAgentPort(node) > 0) {
-                this.nodeManagers.put(node.name(), new NodeManager(node, this));
+                this.nodeManagers.put(node.name(), new NodeManager(node, this, this.time));
             }
         }
         log.info("Created TaskManager for agent(s) on: {}",
@@ -336,6 +336,9 @@ public final class TaskManager {
             } catch (Throwable t) {
                 failure = "Failed to create TaskController: " + t.getMessage();
             }
+            if (spec.hasExpired(time, -1))
+                failure = "worker expired";
+
             if (failure != null) {
                 log.info("Failed to create a new task {} with spec {}: {}",
                     id, spec, failure);

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -17,8 +17,10 @@
 
 package org.apache.kafka.trogdor.coordinator;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -136,7 +138,7 @@ public final class TaskManager {
         this.nextWorkerId = firstWorkerId;
         for (Node node : platform.topology().nodes().values()) {
             if (Node.Util.getTrogdorAgentPort(node) > 0) {
-                this.nodeManagers.put(node.name(), new NodeManager(node, this, this.time));
+                this.nodeManagers.put(node.name(), new NodeManager(node, this));
             }
         }
         log.info("Created TaskManager for agent(s) on: {}",
@@ -150,7 +152,13 @@ public final class TaskManager {
         final private String id;
 
         /**
-         * The task specification.
+         * The original task specification as submitted when the task was created.
+         */
+        final private TaskSpec originalSpec;
+
+        /**
+         * The effective task specification.
+         * The start time will be adjusted to reflect the time when the task was submitted.
          */
         final private TaskSpec spec;
 
@@ -195,8 +203,10 @@ public final class TaskManager {
          */
         private String error = "";
 
-        ManagedTask(String id, TaskSpec spec, TaskController controller, TaskStateType state) {
+        ManagedTask(String id, TaskSpec originalSpec, TaskSpec spec,
+                    TaskController controller, TaskStateType state) {
             this.id = id;
+            this.originalSpec = originalSpec;
             this.spec = spec;
             this.controller = controller;
             this.state = state;
@@ -297,7 +307,7 @@ public final class TaskManager {
             throws Throwable {
         try {
             executor.submit(new CreateTask(id, spec)).get();
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | JsonProcessingException e) {
             log.info("createTask(id={}, spec={}) error", id, spec, e);
             throw e.getCause();
         }
@@ -308,11 +318,15 @@ public final class TaskManager {
      */
     class CreateTask implements Callable<Void> {
         private final String id;
+        private final TaskSpec originalSpec;
         private final TaskSpec spec;
 
-        CreateTask(String id, TaskSpec spec) {
+        CreateTask(String id, TaskSpec spec) throws JsonProcessingException {
             this.id = id;
-            this.spec = spec;
+            this.originalSpec = spec;
+            ObjectNode node = JsonUtil.JSON_SERDE.valueToTree(originalSpec);
+            node.set("startMs", new LongNode(Math.max(time.milliseconds(), originalSpec.startMs())));
+            this.spec = JsonUtil.JSON_SERDE.treeToValue(node, TaskSpec.class);
         }
 
         @Override
@@ -322,11 +336,11 @@ public final class TaskManager {
             }
             ManagedTask task = tasks.get(id);
             if (task != null) {
-                if (!task.spec.equals(spec)) {
+                if (!task.originalSpec.equals(originalSpec)) {
                     throw new RequestConflictException("Task ID " + id + " already " +
-                        "exists, and has a different spec " + task.spec);
+                        "exists, and has a different spec " + task.originalSpec);
                 }
-                log.info("Task {} already exists with spec {}", id, spec);
+                log.info("Task {} already exists with spec {}", id, originalSpec);
                 return null;
             }
             TaskController controller = null;
@@ -336,19 +350,16 @@ public final class TaskManager {
             } catch (Throwable t) {
                 failure = "Failed to create TaskController: " + t.getMessage();
             }
-            if (spec.hasExpired(time, -1))
-                failure = "worker expired";
-
             if (failure != null) {
                 log.info("Failed to create a new task {} with spec {}: {}",
                     id, spec, failure);
-                task = new ManagedTask(id, spec, null, TaskStateType.DONE);
+                task = new ManagedTask(id, originalSpec, spec, null, TaskStateType.DONE);
                 task.doneMs = time.milliseconds();
                 task.maybeSetError(failure);
                 tasks.put(id, task);
                 return null;
             }
-            task = new ManagedTask(id, spec, controller, TaskStateType.PENDING);
+            task = new ManagedTask(id, originalSpec, spec, controller, TaskStateType.PENDING);
             tasks.put(id, task);
             long delayMs = task.startDelayMs(time.milliseconds());
             task.startFuture = scheduler.schedule(executor, new RunTask(task), delayMs);

--- a/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
@@ -19,6 +19,7 @@ package org.apache.kafka.trogdor.task;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.trogdor.common.JsonUtil;
 
 import java.util.Collections;
@@ -72,6 +73,18 @@ public abstract class TaskSpec {
     @JsonProperty
     public final long durationMs() {
         return durationMs;
+    }
+
+    /**
+     * Whether the task is considered expired
+     * @param startedMs the actual time that this task started on
+     */
+    public boolean hasExpired(Time time, long startedMs) {
+        long startMs = this.startMs > 0 ? this.startMs : startedMs;
+        if (startMs <= 0) // task doesn't have a start time yet
+            return false;
+
+        return startMs + durationMs < time.milliseconds();
     }
 
     /**

--- a/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
@@ -19,7 +19,6 @@ package org.apache.kafka.trogdor.task;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.trogdor.common.JsonUtil;
 
 import java.util.Collections;
@@ -68,23 +67,18 @@ public abstract class TaskSpec {
     }
 
     /**
+     * Get the deadline time of this task in ms
+     */
+    public final long endMs() {
+        return startMs + durationMs;
+    }
+
+    /**
      * Get the duration of this task in ms.
      */
     @JsonProperty
     public final long durationMs() {
         return durationMs;
-    }
-
-    /**
-     * Whether the task is considered expired
-     * @param startedMs the actual time that this task started on
-     */
-    public boolean hasExpired(Time time, long startedMs) {
-        long startMs = this.startMs > 0 ? this.startMs : startedMs;
-        if (startMs <= 0) // task doesn't have a start time yet
-            return false;
-
-        return startMs + durationMs < time.milliseconds();
     }
 
     /**

--- a/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.trogdor.rest.DestroyWorkerRequest;
 import org.apache.kafka.trogdor.rest.JsonRestServer;
 import org.apache.kafka.trogdor.rest.RequestConflictException;
 import org.apache.kafka.trogdor.rest.StopWorkerRequest;
+import org.apache.kafka.trogdor.rest.TaskDone;
 import org.apache.kafka.trogdor.rest.WorkerDone;
 import org.apache.kafka.trogdor.rest.WorkerRunning;
 import org.apache.kafka.trogdor.task.NoOpTaskSpec;
@@ -111,10 +112,12 @@ public class AgentTest {
 
     @Test
     public void testCreateExpiredWorkerIsNotScheduled() throws Exception {
+        long initialTimeMs = 100;
+        long tickMs = 15;
         final boolean[] toSleep = {true};
-        MockTime time = new MockTime(15, 100, 0) {
+        MockTime time = new MockTime(tickMs, initialTimeMs, 0) {
             /**
-             * Modify sleep() to call super.sleep() only some times
+             * Modify sleep() to call super.sleep() every second call
              * in order to avoid the endless loop in the tick() calls to the MockScheduler listener
              */
             @Override
@@ -134,8 +137,12 @@ public class AgentTest {
 
         final NoOpTaskSpec fooSpec = new NoOpTaskSpec(10, 10);
         client.createWorker(new CreateWorkerRequest(0, "foo", fooSpec));
+        long actualStartTimeMs = initialTimeMs + tickMs;
+        long doneMs = actualStartTimeMs + 2 * tickMs;
         new ExpectedTasks().addTask(new ExpectedTaskBuilder("foo").
-            workerState(new WorkerDone("foo", fooSpec, 115, 145, null, "worker expired")).
+            workerState(new WorkerDone("foo", fooSpec, actualStartTimeMs,
+                doneMs, null, "worker expired")).
+            taskState(new TaskDone(fooSpec, actualStartTimeMs, doneMs, "worker expired", false, null)).
             build()).
             waitFor(client);
     }
@@ -202,53 +209,58 @@ public class AgentTest {
 
     @Test
     public void testAgentFinishesTasks() throws Exception {
-        MockTime time = new MockTime(0, 0, 0);
+        long startTimeMs = 2000;
+        MockTime time = new MockTime(0, startTimeMs, 0);
         MockScheduler scheduler = new MockScheduler(time);
         Agent agent = createAgent(scheduler);
         AgentClient client = new AgentClient.Builder().
             maxTries(10).target("localhost", agent.port()).build();
         new ExpectedTasks().waitFor(client);
 
-        final NoOpTaskSpec fooSpec = new NoOpTaskSpec(10, 2);
+        final NoOpTaskSpec fooSpec = new NoOpTaskSpec(startTimeMs, 2);
+        long fooSpecStartTimeMs = startTimeMs;
         client.createWorker(new CreateWorkerRequest(0, "foo", fooSpec));
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").
-                workerState(new WorkerRunning("foo", fooSpec, 0, new TextNode("active"))).
+                workerState(new WorkerRunning("foo", fooSpec, startTimeMs, new TextNode("active"))).
                 build()).
             waitFor(client);
 
         time.sleep(1);
 
-        final NoOpTaskSpec barSpec = new NoOpTaskSpec(2000, 900000);
-        client.createWorker(new CreateWorkerRequest(1, "bar", barSpec));
+        long barSpecWorkerId = 1;
+        long barSpecStartTimeMs = startTimeMs + 1;
+        final NoOpTaskSpec barSpec = new NoOpTaskSpec(startTimeMs, 900000);
+        client.createWorker(new CreateWorkerRequest(barSpecWorkerId, "bar", barSpec));
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").
-                workerState(new WorkerRunning("foo", fooSpec, 0, new TextNode("active"))).
+                workerState(new WorkerRunning("foo", fooSpec, fooSpecStartTimeMs, new TextNode("active"))).
                 build()).
             addTask(new ExpectedTaskBuilder("bar").
-                workerState(new WorkerRunning("bar", barSpec, 1, new TextNode("active"))).
+                workerState(new WorkerRunning("bar", barSpec, barSpecStartTimeMs, new TextNode("active"))).
                 build()).
             waitFor(client);
 
         time.sleep(1);
 
+        // foo task expired
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").
-                workerState(new WorkerDone("foo", fooSpec, 0, 2, new TextNode("done"), "")).
+                workerState(new WorkerDone("foo", fooSpec, fooSpecStartTimeMs, fooSpecStartTimeMs + 2, new TextNode("done"), "")).
                 build()).
             addTask(new ExpectedTaskBuilder("bar").
-                workerState(new WorkerRunning("bar", barSpec, 1, new TextNode("active"))).
+                workerState(new WorkerRunning("bar", barSpec, barSpecStartTimeMs, new TextNode("active"))).
                 build()).
             waitFor(client);
 
         time.sleep(5);
-        client.stopWorker(new StopWorkerRequest(1));
+        client.stopWorker(new StopWorkerRequest(barSpecWorkerId));
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").
-                workerState(new WorkerDone("foo", fooSpec, 0, 2, new TextNode("done"), "")).
+                workerState(new WorkerDone("foo", fooSpec, fooSpecStartTimeMs, fooSpecStartTimeMs + 2, new TextNode("done"), "")).
                 build()).
             addTask(new ExpectedTaskBuilder("bar").
-                workerState(new WorkerDone("bar", barSpec, 1, 7, new TextNode("done"), "")).
+                workerState(new WorkerDone("bar", barSpec, barSpecStartTimeMs, startTimeMs + 7, new TextNode("done"), "")).
                 build()).
             waitFor(client);
 
@@ -379,7 +391,7 @@ public class AgentTest {
             maxTries(10).target("localhost", agent.port()).build();
         new ExpectedTasks().waitFor(client);
 
-        final NoOpTaskSpec fooSpec = new NoOpTaskSpec(10, 5);
+        final NoOpTaskSpec fooSpec = new NoOpTaskSpec(0, 5);
         client.createWorker(new CreateWorkerRequest(0, "foo", fooSpec));
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").
@@ -394,7 +406,7 @@ public class AgentTest {
         new ExpectedTasks().waitFor(client);
         time.sleep(1);
 
-        final NoOpTaskSpec fooSpec2 = new NoOpTaskSpec(100, 1);
+        final NoOpTaskSpec fooSpec2 = new NoOpTaskSpec(2, 1);
         client.createWorker(new CreateWorkerRequest(1, "foo", fooSpec2));
         new ExpectedTasks().
             addTask(new ExpectedTaskBuilder("foo").


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7790

### Changes:
* The Trogdor Coordinator now overwrites a task's `startMs` to the time it received it if `startMs` is in the past.
* The Trogdor Agent now correctly expires a task after the expiry time (`startMs + durationMs`) passes. Previously, it would ignore `startMs` and expire after `durationMs` milliseconds of local start of the task.


