### PR TITLE
MINOR: Put states in proper order, increase timeout for starting

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -121,7 +121,7 @@ public class StreamsOptimizedTest {
         final KafkaStreams streams = new KafkaStreams(topology, config);
 
 
-        streams.setStateListener((oldState, newState) -> {
+        streams.setStateListener((newState, oldState) -> {
             if (oldState == State.REBALANCING && newState == State.RUNNING) {
                 final int repartitionTopicCount = getCountOfRepartitionTopicsFound(topology.describe().toString(), repartitionTopicPattern);
                 System.out.println(String.format("REBALANCING -> RUNNING with REPARTITION TOPIC COUNT=%d", repartitionTopicCount));

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -96,7 +96,7 @@ class StreamsOptimizedTest(Test):
         with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
             processor.start()
             monitor.wait_until('REBALANCING -> RUNNING with REPARTITION TOPIC COUNT=%s' % repartition_topic_count,
-                               timeout_sec=60,
+                               timeout_sec=120,
                                err_msg="Never saw 'REBALANCING -> RUNNING with REPARTITION TOPIC COUNT=%s' message "
                                        % repartition_topic_count + str(processor.node.account))
 


### PR DESCRIPTION
This PR puts the states in the `stateListener.onChange` method in the correct order `newState, oldState`.  Updates to the new `KafkaStreams` states has exposed this bug.

Updated code for system test and ran [successfully](https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2242/), and [test report](http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2019-01-08--001.1546979269--bbejeck--MINOR_change_order_of_states_optimizable_test--2bf426a/report.html)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
