### PR TITLE
KAFKA-7799; Fix flaky test RestServerTest.testCORSEnabled

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -27,6 +27,7 @@ import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
@@ -57,6 +58,12 @@ public class RestServerTest {
     @MockStrict
     private Plugins plugins;
     private RestServer server;
+
+    @Before
+    public void setUp() {
+        // To be able to set the Origin, we need to toggle this flag
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+    }
 
     @After
     public void tearDown() {
@@ -185,13 +192,10 @@ public class RestServerTest {
     }
 
     public void checkCORSRequest(String corsDomain, String origin, String expectedHeader, String method) {
-        // To be able to set the Origin, we need to toggle this flag
-
         Map<String, String> workerProps = baseWorkerProps();
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, corsDomain);
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
 
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),


### PR DESCRIPTION
The test fails 100% of the time if `testOptionsDoesNotIncludeWadlOutput` is executed before `testCORSEnabled`. It seems the problem is the use of the system property. Perhaps there is some static caching somewhere.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
