### PR TITLE
 KAFKA-7672 : force write checkpoint during StreamTask #suspend

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractStateManager.java
@@ -41,7 +41,7 @@ abstract class AbstractStateManager implements StateManager {
     static final String CHECKPOINT_FILE_NAME = ".checkpoint";
 
     final File baseDir;
-    private final boolean eosEnabled;
+    final boolean eosEnabled;
     OffsetCheckpoint checkpoint;
 
     final Map<TopicPartition, Long> checkpointableOffsets = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -240,14 +240,14 @@ public abstract class AbstractTask implements Task {
     }
 
     /**
-     * @param writeCheckpoint boolean indicating if a checkpoint file should be written
      * @throws ProcessorStateException if there is an error while closing the state manager
      */
-    void closeStateManager(final boolean writeCheckpoint) throws ProcessorStateException {
+    // visible for testing
+    void closeStateManager() throws ProcessorStateException {
         ProcessorStateException exception = null;
         log.trace("Closing state manager");
         try {
-            stateMgr.close(writeCheckpoint ? activeTaskCheckpointableOffsets() : null);
+            stateMgr.close();
         } catch (final ProcessorStateException e) {
             exception = e;
         } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -242,11 +242,11 @@ public abstract class AbstractTask implements Task {
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
      */
-    void closeStateManager() throws ProcessorStateException {
+    void closeStateManager(final boolean clean) throws ProcessorStateException {
         ProcessorStateException exception = null;
         log.trace("Closing state manager");
         try {
-            stateMgr.close();
+            stateMgr.close(clean);
         } catch (final ProcessorStateException e) {
             exception = e;
         } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -242,7 +242,6 @@ public abstract class AbstractTask implements Task {
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
      */
-    // visible for testing
     void closeStateManager() throws ProcessorStateException {
         ProcessorStateException exception = null;
         log.trace("Closing state manager");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -318,7 +318,7 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
 
 
     @Override
-    public void close() throws IOException {
+    public void close(final boolean clean) throws IOException {
         try {
             if (globalStores.isEmpty()) {
                 return;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -318,7 +318,7 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
 
 
     @Override
-    public void close(final Map<TopicPartition, Long> offsets) throws IOException {
+    public void close() throws IOException {
         try {
             if (globalStores.isEmpty()) {
                 return;
@@ -341,7 +341,6 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
             if (closeFailed.length() > 0) {
                 throw new ProcessorStateException("Exceptions caught during close of 1 or more global state globalStores\n" + closeFailed);
             }
-            checkpoint(offsets);
         } finally {
             stateDirectory.unlockGlobalState();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -105,7 +105,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void close() throws IOException {
-        stateMgr.close(offsets);
+        stateMgr.close();
     }
 
     private void initTopology() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -105,7 +105,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void close() throws IOException {
-        stateMgr.close();
+        stateMgr.close(true);
     }
 
     private void initTopology() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -277,8 +277,7 @@ public class ProcessorStateManager extends AbstractStateManager {
             stores.clear();
         }
 
-        /*
-        if (!clean && this.eosEnabled && checkpoint != null) {
+        if (!clean && eosEnabled && checkpoint != null) {
             // delete the checkpoint file if this is an unclean close
             try {
                 checkpoint.delete();
@@ -287,7 +286,6 @@ public class ProcessorStateManager extends AbstractStateManager {
                 throw new ProcessorStateException(String.format("%sError while deleting the checkpoint file", logPrefix), e);
             }
         }
-        */
 
         if (firstException != null) {
             throw firstException;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -89,6 +89,9 @@ public class ProcessorStateManager extends AbstractStateManager {
 
         // load the checkpoint information
         checkpointableOffsets.putAll(checkpoint.read());
+
+        log.trace("Checkpointable offsets read from checkpoint: {}", checkpointableOffsets);
+
         if (eosEnabled) {
             // delete the checkpoint file after finish loading its stored offsets
             checkpoint.delete();
@@ -140,7 +143,7 @@ public class ProcessorStateManager extends AbstractStateManager {
             restoreCallbacks.put(topic, stateRestoreCallback);
             recordConverters.put(topic, recordConverter);
         } else {
-            log.trace("Restoring state store {} from changelog topic {}", storeName, topic);
+            log.trace("Restoring state store {} from changelog topic {} at checkpoint {}", storeName, topic, checkpointableOffsets.get(storePartition));
 
             final StateRestorer restorer = new StateRestorer(
                 storePartition,
@@ -254,7 +257,7 @@ public class ProcessorStateManager extends AbstractStateManager {
      * @throws ProcessorStateException if any error happens when closing the state stores
      */
     @Override
-    public void close() throws ProcessorStateException {
+    public void close(final boolean clean) throws ProcessorStateException {
         ProcessorStateException firstException = null;
         // attempting to close the stores, just in case they
         // are not closed by a ProcessorNode yet
@@ -274,6 +277,16 @@ public class ProcessorStateManager extends AbstractStateManager {
             stores.clear();
         }
 
+        if (!clean && this.eosEnabled && checkpoint != null) {
+            // delete the checkpoint file if this is an unclean close
+            try {
+                checkpoint.delete();
+                checkpoint = null;
+            } catch (final IOException e) {
+                throw new ProcessorStateException(String.format("%sError while deleting the checkpoint file", logPrefix), e);
+            }
+        }
+
         if (firstException != null) {
             throw firstException;
         }
@@ -283,6 +296,7 @@ public class ProcessorStateManager extends AbstractStateManager {
     @Override
     public void checkpoint(final Map<TopicPartition, Long> checkpointableOffsets) {
         this.checkpointableOffsets.putAll(changelogReader.restoredOffsets());
+        log.trace("Checkpointable offsets updated with restored offsets: {}", this.checkpointableOffsets);
         for (final StateStore store : stores.values()) {
             final String storeName = store.name();
             // only checkpoint the offset to the offsets file if
@@ -298,6 +312,9 @@ public class ProcessorStateManager extends AbstractStateManager {
                 }
             }
         }
+
+        log.trace("Checkpointable offsets updated with active acked offsets: {}", this.checkpointableOffsets);
+
         // write the checkpoint file before closing
         if (checkpoint == null) {
             checkpoint = new OffsetCheckpoint(new File(baseDir, CHECKPOINT_FILE_NAME));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -271,10 +271,6 @@ public class ProcessorStateManager extends AbstractStateManager {
                     log.error("Failed to close state store {}: ", store.name(), e);
                 }
             }
-
-            if (ackedOffsets != null) {
-                checkpoint(ackedOffsets);
-            }
             stores.clear();
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -254,7 +254,7 @@ public class ProcessorStateManager extends AbstractStateManager {
      * @throws ProcessorStateException if any error happens when closing the state stores
      */
     @Override
-    public void close(final Map<TopicPartition, Long> ackedOffsets) throws ProcessorStateException {
+    public void close() throws ProcessorStateException {
         ProcessorStateException firstException = null;
         // attempting to close the stores, just in case they
         // are not closed by a ProcessorNode yet

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -277,6 +277,7 @@ public class ProcessorStateManager extends AbstractStateManager {
             stores.clear();
         }
 
+        /*
         if (!clean && this.eosEnabled && checkpoint != null) {
             // delete the checkpoint file if this is an unclean close
             try {
@@ -286,6 +287,7 @@ public class ProcessorStateManager extends AbstractStateManager {
                 throw new ProcessorStateException(String.format("%sError while deleting the checkpoint file", logPrefix), e);
             }
         }
+        */
 
         if (firstException != null) {
             throw firstException;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -127,8 +127,6 @@ public class StandbyTask extends AbstractTask {
      * - {@link #commit()}
      * - close state
      * <pre>
-     * @param clean ignored by {@code StandbyTask} as it can always try to close cleanly
-     *              (ie, commit, flush, and write checkpoint file)
      * @param isZombie ignored by {@code StandbyTask} as it can never be a zombie
      */
     @Override
@@ -138,14 +136,10 @@ public class StandbyTask extends AbstractTask {
             return;
         }
         log.debug("Closing");
-        boolean committedSuccessfully = false;
         try {
-            if (clean) {
-                commit();
-                committedSuccessfully = true;
-            }
+            commit();
         } finally {
-            closeStateManager(committedSuccessfully);
+            closeStateManager();
         }
 
         taskClosed = true;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -136,7 +136,6 @@ public class StandbyTask extends AbstractTask {
             return;
         }
         log.debug("Closing");
-        boolean committed = false;
         try {
             if (clean) {
                 commit();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -136,10 +136,14 @@ public class StandbyTask extends AbstractTask {
             return;
         }
         log.debug("Closing");
+        boolean committed = false;
         try {
-            commit();
+            if (clean) {
+                commit();
+                committed = true;
+            }
         } finally {
-            closeStateManager();
+            closeStateManager(clean && committed);
         }
 
         taskClosed = true;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -140,10 +140,9 @@ public class StandbyTask extends AbstractTask {
         try {
             if (clean) {
                 commit();
-                committed = true;
             }
         } finally {
-            closeStateManager(clean && committed);
+            closeStateManager(true);
         }
 
         taskClosed = true;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
 
 interface StateManager extends Checkpointable {
     File baseDir();
@@ -41,7 +40,7 @@ interface StateManager extends Checkpointable {
     void reinitializeStateStoresForPartitions(final Collection<TopicPartition> partitions,
                                               final InternalProcessorContext processorContext);
 
-    void close(final Map<TopicPartition, Long> offsets) throws IOException;
+    void close() throws IOException;
 
     StateStore getGlobalStore(final String name);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
@@ -40,7 +40,7 @@ interface StateManager extends Checkpointable {
     void reinitializeStateStoresForPartitions(final Collection<TopicPartition> partitions,
                                               final InternalProcessorContext processorContext);
 
-    void close() throws IOException;
+    void close(final boolean clean) throws IOException;
 
     StateStore getGlobalStore(final String name);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -195,7 +195,7 @@ public class StoreChangelogReader implements ChangelogReader {
         for (final TopicPartition partition : initialized) {
             final StateRestorer restorer = stateRestorers.get(partition);
             if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
-                log.warn("Found checkpoint {} from changelog {} for store {}.", restorer.checkpoint(), partition, restorer.storeName());
+                log.trace("Found checkpoint {} from changelog {} for store {}.", restorer.checkpoint(), partition, restorer.storeName());
 
                 restoreConsumer.seek(partition, restorer.checkpoint());
                 logRestoreOffsets(partition,
@@ -204,7 +204,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 restorer.setStartingOffset(restoreConsumer.position(partition));
                 restorer.restoreStarted();
             } else {
-                log.warn("NOT Found checkpoint from changelog {} for store {}.", partition, restorer.storeName());
+                log.trace("Did not find checkpoint from changelog {} for store {}, rewinding to beginning.", partition, restorer.storeName());
 
                 restoreConsumer.seekToBeginning(Collections.singletonList(partition));
                 needsPositionUpdate.add(restorer);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -195,6 +195,8 @@ public class StoreChangelogReader implements ChangelogReader {
         for (final TopicPartition partition : initialized) {
             final StateRestorer restorer = stateRestorers.get(partition);
             if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
+                log.warn("Found checkpoint {} from changelog {} for store {}.", restorer.checkpoint(), partition, restorer.storeName());
+
                 restoreConsumer.seek(partition, restorer.checkpoint());
                 logRestoreOffsets(partition,
                         restorer.checkpoint(),
@@ -202,6 +204,8 @@ public class StoreChangelogReader implements ChangelogReader {
                 restorer.setStartingOffset(restoreConsumer.position(partition));
                 restorer.restoreStarted();
             } else {
+                log.warn("NOT Found checkpoint from changelog {} for store {}.", partition, restorer.storeName());
+
                 restoreConsumer.seekToBeginning(Collections.singletonList(partition));
                 needsPositionUpdate.add(restorer);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -648,7 +648,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
     // helper to avoid calling suspend() twice if a suspended task is not reassigned and closed
     @Override
-    public void closeSuspended(final boolean clean, final boolean isZombie,
+    public void closeSuspended(final boolean clean,
+                               final boolean isZombie,
                                RuntimeException firstException) {
         try {
             closeStateManager();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -452,7 +452,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
         flushState();
 
-        stateMgr.checkpoint(activeTaskCheckpointableOffsets());
+        if (!eosEnabled) {
+            stateMgr.checkpoint(activeTaskCheckpointableOffsets());
+        }
 
         final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
         for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
@@ -576,6 +578,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 commit(false);
             } finally {
                 if (eosEnabled) {
+
+                    stateMgr.checkpoint(activeTaskCheckpointableOffsets());
+
                     try {
                         recordCollector.close();
                     } catch (final ProducerFencedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -688,7 +688,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
      *                               or if the task producer got fenced (EOS)
      */
     @Override
-    public void close(final boolean clean,
+    public void close(boolean clean,
                       final boolean isZombie) {
         log.debug("Closing");
 
@@ -696,6 +696,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         try {
             suspend(clean, isZombie);
         } catch (final RuntimeException e) {
+            clean = false;
             firstException = e;
             log.error("Could not close task due to the following error:", e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -567,6 +567,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 commit(false);
             } finally {
                 if (eosEnabled) {
+                    // In #commit, we don't do checkpoint file writing when eos is turned on. To avoid race condition when writing checkpoint file
+                    // through StateManager #closeSuspendedwe, we decide to always checkpoint offsets after commit for EOS.
+                    // The check here is to avoid double checkpoint file write through #commit and #suspend.
+                    stateMgr.checkpoint(activeTaskCheckpointableOffsets());
                     try {
                         recordCollector.close();
                     } catch (final ProducerFencedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -44,8 +44,7 @@ public interface Task {
 
     void resume();
 
-    void closeSuspended(final boolean clean,
-                        final boolean isZombie,
+    void closeSuspended(boolean clean, final boolean isZombie,
                         final RuntimeException e);
 
     void close(final boolean clean,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -44,7 +44,8 @@ public interface Task {
 
     void resume();
 
-    void closeSuspended(boolean clean, final boolean isZombie,
+    void closeSuspended(final boolean clean,
+                        final boolean isZombie,
                         final RuntimeException e);
 
     void close(final boolean clean,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -371,7 +371,7 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(1, 0, t2);
         stateManager.register(store2, stateRestoreCallback);
 
-        stateManager.close();
+        stateManager.close(true);
         assertFalse(store1.isOpen());
         assertFalse(store2.isOpen());
     }
@@ -382,7 +382,7 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(1, 0, t1);
         stateManager.register(store1, stateRestoreCallback);
         final Map<TopicPartition, Long> expected = Collections.singletonMap(t1, 25L);
-        stateManager.close();
+        stateManager.close(true);
         final Map<TopicPartition, Long> result = readOffsetsCheckpoint();
         assertEquals(expected, result);
     }
@@ -398,7 +398,7 @@ public class GlobalStateManagerImplTest {
             }
         }, stateRestoreCallback);
 
-        stateManager.close();
+        stateManager.close(true);
     }
 
     @Test
@@ -415,7 +415,7 @@ public class GlobalStateManagerImplTest {
     @Test
     public void shouldUnlockGlobalStateDirectoryOnClose() throws IOException {
         stateManager.initialize();
-        stateManager.close();
+        stateManager.close(true);
         final StateDirectory stateDir = new StateDirectory(streamsConfig, new MockTime(), true);
         try {
             // should be able to get the lock now as it should've been released in close
@@ -438,9 +438,9 @@ public class GlobalStateManagerImplTest {
                 super.close();
             }
         }, stateRestoreCallback);
-        stateManager.close();
+        stateManager.close(true);
 
-        stateManager.close();
+        stateManager.close(true);
     }
 
     @Test
@@ -460,7 +460,7 @@ public class GlobalStateManagerImplTest {
         stateManager.register(store2, stateRestoreCallback);
 
         try {
-            stateManager.close();
+            stateManager.close(true);
         } catch (final ProcessorStateException e) {
             // expected
         }
@@ -539,7 +539,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(10, 0, t1);
         stateManager.register(store1, stateRestoreCallback);
-        stateManager.close();
+        stateManager.close(true);
 
         final Map<TopicPartition, Long> checkpointMap = stateManager.checkpointed();
         assertThat(checkpointMap, equalTo(Collections.singletonMap(t1, 10L)));
@@ -551,7 +551,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(10, 0, t3);
         stateManager.register(store3, stateRestoreCallback);
-        stateManager.close();
+        stateManager.close(true);
 
         assertThat(readOffsetsCheckpoint(), equalTo(Collections.emptyMap()));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -376,17 +376,6 @@ public class GlobalStateManagerImplTest {
         assertFalse(store2.isOpen());
     }
 
-    @Test
-    public void shouldWriteCheckpointsOnClose() throws IOException {
-        stateManager.initialize();
-        initializeConsumer(1, 0, t1);
-        stateManager.register(store1, stateRestoreCallback);
-        final Map<TopicPartition, Long> expected = Collections.singletonMap(t1, 25L);
-        stateManager.close(true);
-        final Map<TopicPartition, Long> result = readOffsetsCheckpoint();
-        assertEquals(expected, result);
-    }
-
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateStoreExceptionIfStoreCloseFailed() throws IOException {
         stateManager.initialize();
@@ -539,6 +528,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(10, 0, t1);
         stateManager.register(store1, stateRestoreCallback);
+        stateManager.checkpoint(Collections.emptyMap());
         stateManager.close(true);
 
         final Map<TopicPartition, Long> checkpointMap = stateManager.checkpointed();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -371,7 +371,7 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(1, 0, t2);
         stateManager.register(store2, stateRestoreCallback);
 
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
         assertFalse(store1.isOpen());
         assertFalse(store2.isOpen());
     }
@@ -382,7 +382,7 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(1, 0, t1);
         stateManager.register(store1, stateRestoreCallback);
         final Map<TopicPartition, Long> expected = Collections.singletonMap(t1, 25L);
-        stateManager.close(expected);
+        stateManager.close();
         final Map<TopicPartition, Long> result = readOffsetsCheckpoint();
         assertEquals(expected, result);
     }
@@ -398,7 +398,7 @@ public class GlobalStateManagerImplTest {
             }
         }, stateRestoreCallback);
 
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
     }
 
     @Test
@@ -415,7 +415,7 @@ public class GlobalStateManagerImplTest {
     @Test
     public void shouldUnlockGlobalStateDirectoryOnClose() throws IOException {
         stateManager.initialize();
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
         final StateDirectory stateDir = new StateDirectory(streamsConfig, new MockTime(), true);
         try {
             // should be able to get the lock now as it should've been released in close
@@ -438,9 +438,9 @@ public class GlobalStateManagerImplTest {
                 super.close();
             }
         }, stateRestoreCallback);
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
 
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
     }
 
     @Test
@@ -460,7 +460,7 @@ public class GlobalStateManagerImplTest {
         stateManager.register(store2, stateRestoreCallback);
 
         try {
-            stateManager.close(Collections.emptyMap());
+            stateManager.close();
         } catch (final ProcessorStateException e) {
             // expected
         }
@@ -539,7 +539,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(10, 0, t1);
         stateManager.register(store1, stateRestoreCallback);
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
 
         final Map<TopicPartition, Long> checkpointMap = stateManager.checkpointed();
         assertThat(checkpointMap, equalTo(Collections.singletonMap(t1, 10L)));
@@ -551,7 +551,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(10, 0, t3);
         stateManager.register(store3, stateRestoreCallback);
-        stateManager.close(Collections.emptyMap());
+        stateManager.close();
 
         assertThat(readOffsetsCheckpoint(), equalTo(Collections.emptyMap()));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
@@ -204,15 +204,14 @@ public class GlobalStateTaskTest {
 
 
     @Test
-    public void shouldCloseStateManagerWithOffsets() throws IOException {
+    public void shouldFlushStateManagerWithOffsets() throws IOException {
         final Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
         expectedOffsets.put(t1, 52L);
         expectedOffsets.put(t2, 100L);
         globalStateTask.initialize();
         globalStateTask.update(new ConsumerRecord<>(topic1, 1, 51, "foo".getBytes(), "foo".getBytes()));
-        globalStateTask.close();
+        globalStateTask.flushState();
         assertEquals(expectedOffsets, stateMgr.checkpointed());
-        assertTrue(stateMgr.closed);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -130,7 +130,7 @@ public class ProcessorStateManagerTest {
             assertThat(batchingRestoreCallback.getRestoredRecords().size(), is(1));
             assertTrue(batchingRestoreCallback.getRestoredRecords().contains(expectedKeyValue));
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -153,7 +153,7 @@ public class ProcessorStateManagerTest {
             assertTrue(persistentStore.keys.contains(intKey));
             assertEquals(9, persistentStore.values.get(0).length);
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -176,7 +176,7 @@ public class ProcessorStateManagerTest {
             assertTrue(persistentStore.keys.contains(intKey));
             assertEquals(17, persistentStore.values.get(0).length);
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -204,7 +204,7 @@ public class ProcessorStateManagerTest {
             stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
             assertTrue(changelogReader.wasRegistered(new TopicPartition(persistentStoreTopicName, 2)));
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -231,7 +231,7 @@ public class ProcessorStateManagerTest {
             stateMgr.register(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
             assertTrue(changelogReader.wasRegistered(new TopicPartition(nonPersistentStoreTopicName, 2)));
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -292,7 +292,7 @@ public class ProcessorStateManagerTest {
             assertEquals(-1L, (long) changeLogOffsets.get(partition3));
 
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -315,7 +315,7 @@ public class ProcessorStateManagerTest {
             assertEquals(mockKeyValueStore, stateMgr.getStore(nonPersistentStoreName));
 
         } finally {
-            stateMgr.close(Collections.emptyMap());
+            stateMgr.close();
         }
     }
 
@@ -353,7 +353,7 @@ public class ProcessorStateManagerTest {
             // close the state manager with the ack'ed offsets
             stateMgr.flush();
             stateMgr.checkpoint(ackedOffsets);
-            stateMgr.close(ackedOffsets);
+            stateMgr.close();
         }
         // make sure all stores are closed, and the checkpoint file is written.
         assertTrue(persistentStore.flushed);
@@ -399,7 +399,7 @@ public class ProcessorStateManagerTest {
             false,
             logContext);
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
-        stateMgr.close(null);
+        stateMgr.close();
         final Map<TopicPartition, Long> read = checkpoint.read();
         assertThat(read, equalTo(offsets));
     }
@@ -584,7 +584,7 @@ public class ProcessorStateManagerTest {
         stateManager.register(stateStore, stateStore.stateRestoreCallback);
 
         try {
-            stateManager.close(Collections.emptyMap());
+            stateManager.close();
             fail("Should throw ProcessorStateException if store close throws exception");
         } catch (final ProcessorStateException e) {
             // pass
@@ -697,7 +697,7 @@ public class ProcessorStateManagerTest {
         stateManager.register(stateStore2, stateStore2.stateRestoreCallback);
 
         try {
-            stateManager.close(Collections.emptyMap());
+            stateManager.close();
         } catch (final ProcessorStateException expected) { /* ignode */ }
         Assert.assertTrue(closedStore.get());
     }
@@ -722,7 +722,7 @@ public class ProcessorStateManagerTest {
             assertFalse(checkpointFile.exists());
         } finally {
             if (stateManager != null) {
-                stateManager.close(null);
+                stateManager.close();
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -352,13 +352,15 @@ public class ProcessorStateManagerTest {
         } finally {
             // close the state manager with the ack'ed offsets
             stateMgr.flush();
+            stateMgr.checkpoint(ackedOffsets);
             stateMgr.close(ackedOffsets);
         }
-        // make sure all stores are closed.
+        // make sure all stores are closed, and the checkpoint file is written.
         assertTrue(persistentStore.flushed);
         assertTrue(persistentStore.closed);
         assertTrue(nonPersistentStore.flushed);
         assertTrue(nonPersistentStore.closed);
+        assertTrue(checkpointFile.exists());
 
         // the checkpoint file should contain an offset from the persistent store only.
         final Map<TopicPartition, Long> checkpointedOffsets = checkpoint.read();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -354,12 +354,11 @@ public class ProcessorStateManagerTest {
             stateMgr.flush();
             stateMgr.close(ackedOffsets);
         }
-        // make sure all stores are closed, and the checkpoint file is written.
+        // make sure all stores are closed.
         assertTrue(persistentStore.flushed);
         assertTrue(persistentStore.closed);
         assertTrue(nonPersistentStore.flushed);
         assertTrue(nonPersistentStore.closed);
-        assertTrue(checkpointFile.exists());
 
         // the checkpoint file should contain an offset from the persistent store only.
         final Map<TopicPartition, Long> checkpointedOffsets = checkpoint.read();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -130,7 +130,7 @@ public class ProcessorStateManagerTest {
             assertThat(batchingRestoreCallback.getRestoredRecords().size(), is(1));
             assertTrue(batchingRestoreCallback.getRestoredRecords().contains(expectedKeyValue));
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -153,7 +153,7 @@ public class ProcessorStateManagerTest {
             assertTrue(persistentStore.keys.contains(intKey));
             assertEquals(9, persistentStore.values.get(0).length);
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -176,7 +176,7 @@ public class ProcessorStateManagerTest {
             assertTrue(persistentStore.keys.contains(intKey));
             assertEquals(17, persistentStore.values.get(0).length);
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -204,7 +204,7 @@ public class ProcessorStateManagerTest {
             stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
             assertTrue(changelogReader.wasRegistered(new TopicPartition(persistentStoreTopicName, 2)));
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -231,7 +231,7 @@ public class ProcessorStateManagerTest {
             stateMgr.register(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
             assertTrue(changelogReader.wasRegistered(new TopicPartition(nonPersistentStoreTopicName, 2)));
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -292,7 +292,7 @@ public class ProcessorStateManagerTest {
             assertEquals(-1L, (long) changeLogOffsets.get(partition3));
 
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -315,7 +315,7 @@ public class ProcessorStateManagerTest {
             assertEquals(mockKeyValueStore, stateMgr.getStore(nonPersistentStoreName));
 
         } finally {
-            stateMgr.close();
+            stateMgr.close(true);
         }
     }
 
@@ -353,7 +353,7 @@ public class ProcessorStateManagerTest {
             // close the state manager with the ack'ed offsets
             stateMgr.flush();
             stateMgr.checkpoint(ackedOffsets);
-            stateMgr.close();
+            stateMgr.close(true);
         }
         // make sure all stores are closed, and the checkpoint file is written.
         assertTrue(persistentStore.flushed);
@@ -399,7 +399,7 @@ public class ProcessorStateManagerTest {
             false,
             logContext);
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
-        stateMgr.close();
+        stateMgr.close(true);
         final Map<TopicPartition, Long> read = checkpoint.read();
         assertThat(read, equalTo(offsets));
     }
@@ -584,7 +584,7 @@ public class ProcessorStateManagerTest {
         stateManager.register(stateStore, stateStore.stateRestoreCallback);
 
         try {
-            stateManager.close();
+            stateManager.close(true);
             fail("Should throw ProcessorStateException if store close throws exception");
         } catch (final ProcessorStateException e) {
             // pass
@@ -697,7 +697,7 @@ public class ProcessorStateManagerTest {
         stateManager.register(stateStore2, stateStore2.stateRestoreCallback);
 
         try {
-            stateManager.close();
+            stateManager.close(true);
         } catch (final ProcessorStateException expected) { /* ignode */ }
         Assert.assertTrue(closedStore.get());
     }
@@ -722,7 +722,7 @@ public class ProcessorStateManagerTest {
             assertFalse(checkpointFile.exists());
         } finally {
             if (stateManager != null) {
-                stateManager.close();
+                stateManager.close(true);
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -367,7 +367,7 @@ public class StandbyTaskTest {
         );
 
         task.suspend();
-        task.closeStateManager(true);
+        task.closeStateManager();
 
         final File taskDir = stateDirectory.directoryForTask(taskId);
         final OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));
@@ -593,7 +593,7 @@ public class StandbyTaskTest {
             }
 
             @Override
-            void closeStateManager(final boolean writeCheckpoint) throws ProcessorStateException {
+            void closeStateManager() throws ProcessorStateException {
                 closedStateManager.set(true);
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -367,7 +367,7 @@ public class StandbyTaskTest {
         );
 
         task.suspend();
-        task.closeStateManager();
+        task.closeStateManager(true);
 
         final File taskDir = stateDirectory.directoryForTask(taskId);
         final OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));
@@ -593,7 +593,7 @@ public class StandbyTaskTest {
             }
 
             @Override
-            void closeStateManager() throws ProcessorStateException {
+            void closeStateManager(final boolean clean) throws ProcessorStateException {
                 closedStateManager.set(true);
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -366,6 +366,7 @@ public class StandbyTaskTest {
             singletonList(makeWindowedConsumerRecord(changelogName, 10, 1, 0L, 60_000L))
         );
 
+        task.suspend();
         task.closeStateManager(true);
 
         final File taskDir = stateDirectory.directoryForTask(taskId);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
@@ -45,7 +45,7 @@ public class StateManagerStub implements StateManager {
     public void flush() {}
 
     @Override
-    public void close(final Map<TopicPartition, Long> offsets) throws IOException {}
+    public void close() throws IOException {}
 
     @Override
     public StateStore getGlobalStore(final String name) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
@@ -45,7 +45,7 @@ public class StateManagerStub implements StateManager {
     public void flush() {}
 
     @Override
-    public void close() throws IOException {}
+    public void close(final boolean clean) throws IOException {}
 
     @Override
     public StateStore getGlobalStore(final String name) {

--- a/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
@@ -66,7 +66,7 @@ public class GlobalStateManagerStub implements GlobalStateManager {
     public void flush() {}
 
     @Override
-    public void close(final Map<TopicPartition, Long> offsets) throws IOException {
+    public void close() throws IOException {
         this.offsets.putAll(offsets);
         closed = true;
     }

--- a/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
@@ -66,7 +66,7 @@ public class GlobalStateManagerStub implements GlobalStateManager {
     public void flush() {}
 
     @Override
-    public void close() throws IOException {
+    public void close(final boolean clean) throws IOException {
         this.offsets.putAll(offsets);
         closed = true;
     }


### PR DESCRIPTION
This fix is aiming for #2 issue pointed out within https://issues.apache.org/jira/browse/KAFKA-7672
In the current setup, we do offset checkpoint file write when EOS is turned on during #suspend, which introduces the potential race condition during StateManager #closeSuspend call. To mitigate the problem, we attempt to always write checkpoint file in #suspend call.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
