### PR TITLE
MINOR: Update dependencies for Kafka 2.2

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.12.7
+  SCALA_VERSION=2.12.8
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.12.7
+  set SCALA_VERSION=2.12.8
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,10 @@ buildscript {
     classpath "org.ajoberstar:grgit:1.9.3"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
     classpath 'org.scoverage:gradle-scoverage:2.5.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
-    classpath 'org.owasp:dependency-check-gradle:3.3.4'
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.16.0"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.5"
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+    classpath 'org.owasp:dependency-check-gradle:4.0.2'
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.17.0"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9"
   }
 }
 
@@ -89,7 +89,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "5.0"
+  gradleVersion = "5.1"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.2.0-SNAPSHOT
-scalaVersion=2.12.7
+scalaVersion=2.12.8
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
 // Add Scala version
 def defaultScala211Version = '2.11.12'
-def defaultScala212Version = '2.12.7'
+def defaultScala212Version = '2.12.8'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
     versions["scala"] = defaultScala211Version
@@ -52,9 +52,9 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.60",
-  easymock: "4.0.1",
-  jackson: "2.9.7",
-  jetty: "9.4.12.v20180830",
+  easymock: "4.0.2",
+  jackson: "2.9.8",
+  jetty: "9.4.14.v20181114",
   jersey: "2.27",
   jmh: "1.21",
   hamcrest: "2.1",
@@ -76,8 +76,8 @@ versions += [
   lz4: "1.5.0",
   mavenArtifact: "3.6.0",
   metrics: "2.2.0",
-  mockito: "2.23.0",
-  powermock: "2.0.0-RC.3",
+  mockito: "2.23.4",
+  powermock: "2.0.0",
   reflections: "0.9.11",
   rocksDB: "5.15.10",
   scalatest: "3.0.5",
@@ -86,7 +86,7 @@ versions += [
   snappy: "1.1.7.2",
   zkclient: "0.11",
   zookeeper: "3.4.13",
-  zstd: "1.3.7-1"
+  zstd: "1.3.8-1"
 ]
 
 libs += [

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -112,7 +112,7 @@ class RatPlugin implements Plugin<Project> {
       mavenCentral()
     }
     project.dependencies {
-      rat 'org.apache.rat:apache-rat-tasks:0.12'
+      rat 'org.apache.rat:apache-rat-tasks:0.13'
     }
   }
 }


### PR DESCRIPTION
- Scala 2.12.7 -> 2.12.8
- Gradle 5.0 -> 5.1
- Jetty 9.4.12 -> 9.4.14
- Rat 0.12 -> 0.13
- Patch bumps for easymock, jackson, powermock
- Patch bumps for gradle plugins: shadow, spotbugs, dependency-check, spotless

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
