### PR TITLE
KAFKA-7741: Streams exclude javax dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -966,7 +966,13 @@ project(':streams') {
 
   dependencies {
     compile project(':clients')
-    compile project(':connect:json')  // this dependency should be removed after we unify data API
+
+    // this dependency should be removed after we unify data API
+    compile(project(':connect:json')) {
+      // this transitive dependency is not used in Streams, and it breaks SBT builds
+      exclude module: 'javax.ws.rs-api'
+    }
+
     compile libs.slf4jApi
     compile libs.rocksDBJni
 


### PR DESCRIPTION
As documented in https://issues.apache.org/jira/browse/KAFKA-7741,
the javax dependency we receive transitively from connect is incompatible
with SBT builds.

Streams doesn't use the portion of Connect that needs the dependency,
so we can fix the builds by simply excluding it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
