### PR TITLE
MINOR: Update Trogdor StringExpander regex to handle epilogue

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/common/StringExpander.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/StringExpander.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  */
 public class StringExpander {
     private final static Pattern NUMERIC_RANGE_PATTERN =
-        Pattern.compile("(.*?)\\[([0-9]*)\\-([0-9]*)\\](.*?)");
+        Pattern.compile("(.*)\\[([0-9]*)\\-([0-9]*)\\](.*)");
 
     public static HashSet<String> expand(String val) {
         HashSet<String> set = new HashSet<>();

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/StringExpanderTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/StringExpanderTest.java
@@ -58,5 +58,20 @@ public class StringExpanderTest {
             "[[ wow52 ]]"
         ));
         assertEquals(expected3, StringExpander.expand("[[ wow[50-52] ]]"));
+
+        HashSet<String> expected4 = new HashSet<>(Arrays.asList(
+            "foo1bar",
+            "foo2bar",
+            "foo3bar"
+        ));
+        assertEquals(expected4, StringExpander.expand("foo[1-3]bar"));
+
+        // should expand latest range first
+        HashSet<String> expected5 = new HashSet<>(Arrays.asList(
+            "start[1-3]middle1epilogue",
+            "start[1-3]middle2epilogue",
+            "start[1-3]middle3epilogue"
+        ));
+        assertEquals(expected5, StringExpander.expand("start[1-3]middle[1-3]epilogue"));
     }
 }


### PR DESCRIPTION
As @yangxi pointed out, having the lazy quantifier `?` in the epilogue group of the regex `(.*?)` would mean that strings after the range quantifier would not get caught. e.g `"aaa[1-2]aa" => "aaa1, aaa2"`

Also see/play-around with https://regex101.com/r/WGIT7W/1

I also removed the lazy quantifier in the beginning - no strong opinion there - but I'd somehow prefer if the regex would pick the right-most range expression when using nested expressions. Removing the lazy quantifier in the beginning ensures that. Seems more natural.

cc @cmccabe for review