### PR TITLE
KAFKA-7808: AdminClient#describeTopics should not throw InvalidTopicException if topic name is not found

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -56,6 +56,7 @@ import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.JmxReporter;
@@ -1461,7 +1462,7 @@ public class KafkaAdminClient extends AdminClient {
                         continue;
                     }
                     if (!cluster.topics().contains(topicName)) {
-                        future.completeExceptionally(new InvalidTopicException("Topic " + topicName + " not found."));
+                        future.completeExceptionally(new UnknownTopicOrPartitionException("Topic " + topicName + " not found."));
                         continue;
                     }
                     boolean isInternal = cluster.internalTopics().contains(topicName);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -235,8 +235,7 @@ public class MockAdminClient extends AdminClient {
             }
             if (!topicDescriptions.containsKey(requestedTopic)) {
                 KafkaFutureImpl<TopicDescription> future = new KafkaFutureImpl<>();
-                future.completeExceptionally(new UnknownTopicOrPartitionException(
-                    String.format("Topic %s unknown.", requestedTopic)));
+                future.completeExceptionally(new UnknownTopicOrPartitionException("Topic " + requestedTopic + " not found."));
                 topicDescriptions.put(requestedTopic, future);
             }
         }


### PR DESCRIPTION
Currently, `AdminClient#describeTopics` is called in `WorkerUtils#[getMatchingTopicPartitions,verifyTopics]` only. However, `WorkerUtils#getMatchingTopicPartitions` does not being called by anyone - so it should be removed.

1. Update `KafkaAdminClient#describeTopics` to throw `UnknownTopicOrPartitionException`.
2. Change the Exception message thrown by `MockAdminClient#describeTopics`: for consistency with `KafkaAdminClient`.
3. Remove unused method: `WorkerUtils#getMatchingTopicPartitions`.
4. Add @throws description on `WorkerUtils#verifyTopics`: when `UnknownTopicOrPartitionException` is thrown.
5. Expand javadoc on `WorkerUtils#createTopics(Logger, AdminClient, Map, boolean)`: the only method which calls `WorkerUtils#verifyTopics`.

Since the `Throwable` instance thrown by `WorkerUtils#createTopics(Logger, AdminClient, Map, boolean)` is caught by `[ProduceBenchWorker,RoundTripWorker].Prepare`, we don't need more cleanup.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
