### PR TITLE
HOTFIX: Compilation error in CommandLineUtils

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/CommandLineUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CommandLineUtilsTest.scala
@@ -127,7 +127,7 @@ class CommandLineUtilsTest {
       "--str-opt", "some-string-2",
       "--int-opt", "700",
       "--str-opt-nodef", "some-string-3",
-      "--int-opt-nodef", "800",
+      "--int-opt-nodef", "800"
     )
 
     CommandLineUtils.maybeMergeOptions(props, "skey", options, stringOpt)
@@ -158,7 +158,7 @@ class CommandLineUtilsTest {
       "--str-opt",
       "--int-opt",
       "--str-opt-nodef",
-      "--int-opt-nodef",
+      "--int-opt-nodef"
     )
 
     CommandLineUtils.maybeMergeOptions(props, "sokey", options, stringOptOptionalArg)


### PR DESCRIPTION
This was broken by #6084. The syntax works with Scala 2.12, but not 2.11.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
