### PR TITLE
Minor: Prevent resource leak in tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -400,6 +400,7 @@ public class KafkaConsumerTest {
         consumer.updateAssignmentMetadataIfNeeded(time.timer(Long.MAX_VALUE));
 
         assertTrue(heartbeatReceived.get());
+        consumer.close(Duration.ofMillis(0));
     }
 
     @Test
@@ -432,6 +433,7 @@ public class KafkaConsumerTest {
         consumer.poll(Duration.ZERO);
 
         assertTrue(heartbeatReceived.get());
+        consumer.close(Duration.ofMillis(0));
     }
 
     @Test
@@ -454,6 +456,7 @@ public class KafkaConsumerTest {
         // The underlying client should NOT get a fetch request
         final Queue<ClientRequest> requests = client.requests();
         assertEquals(0, requests.size());
+        consumer.close(Duration.ofMillis(0));
     }
 
     @SuppressWarnings({"deprecation", "rawtypes"})


### PR DESCRIPTION
Few minor improvements:
* Wrapped KafkaConsumer with try-with-resources to make sure than stream is closed after test completion despite the test status (success/failure);
* Removed unused private method;
* added SupressWarning where needed to address compiler warnings;
* use static imports across all asserts for consistency.