### PR TITLE
[KAFKA-7024] Rocksdb state directory should be created before opening…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -157,6 +157,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         try {
             try {
                 Files.createDirectories(dbDir.getParentFile().toPath());
+                Files.createDirectories(dbDir.getAbsoluteFile().toPath());
                 db = RocksDB.open(options, dbDir.getAbsolutePath());
             } catch (final RocksDBException e) {
                 throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir.toString(), e);


### PR DESCRIPTION
In ```RocksDBStore.openDB``` we call

```Files.createDirectories(dir.getParentFile().toPath()); ```
```return RocksDB.open(options, dir.getAbsolutePath());  ```

We would also add the absolute file path as well to avoid the extra logging.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
