### PR TITLE
KAFKA-7813: JmxTool throws NPE when --object-name is omitted

### DIFF
--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -18,17 +18,17 @@
  */
 package kafka.tools
 
-import java.util.Date
+import java.util.{Date, Objects}
 import java.text.SimpleDateFormat
+
 import javax.management._
 import javax.management.remote._
-
 import joptsimple.OptionParser
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.math._
-import kafka.utils.{CommandLineUtils , Exit, Logging}
+import kafka.utils.{CommandLineUtils, Exit, Logging}
 
 
 /**
@@ -140,7 +140,7 @@ object JmxTool extends Logging {
       else
         List(null)
 
-    val hasPatternQueries = queries.exists((name: ObjectName) => name.isPattern)
+    val hasPatternQueries = queries.filterNot(Objects.isNull).exists((name: ObjectName) => name.isPattern)
 
     var names: Iterable[ObjectName] = null
     def namesSet = Option(names).toSet.flatten

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -166,12 +166,12 @@ object JmxTool extends Logging {
 
     val numExpectedAttributes: Map[ObjectName, Int] =
       if (!attributesWhitelistExists)
-        names.map{(name: ObjectName) =>
+        names.map{name: ObjectName =>
           val mbean = mbsc.getMBeanInfo(name)
           (name, mbsc.getAttributes(name, mbean.getAttributes.map(_.getName)).size)}.toMap
       else {
         if (!hasPatternQueries)
-          names.map{(name: ObjectName) =>
+          names.map{name: ObjectName =>
             val mbean = mbsc.getMBeanInfo(name)
             val attributes = mbsc.getAttributes(name, mbean.getAttributes.map(_.getName))
             attributes.removeIf(name => {

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -174,11 +174,9 @@ object JmxTool extends Logging {
           names.map{name: ObjectName =>
             val mbean = mbsc.getMBeanInfo(name)
             val attributes = mbsc.getAttributes(name, mbean.getAttributes.map(_.getName))
-            attributes.removeIf(name => {
-              val attr = name.asInstanceOf[Attribute]
-              !attributesWhitelist.get.contains(attr.getName)
-            })
-            (name, attributes.size)}.toMap.filter(_._2 > 0)
+            val expectedAttributes = attributes.asScala.asInstanceOf[mutable.Buffer[Attribute]]
+              .filter(attr => attributesWhitelist.get.contains(attr.getName))
+            (name, expectedAttributes.size)}.toMap.filter(_._2 > 0)
         else
           queries.map((_, attributesWhitelist.get.length)).toMap
       }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7813

Running the JMX tool without --object-name parameter, results in a NullPointerException.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
