### PR TITLE
HOTFIX: Fix Properties.putAll compiler error when compiling with Java 11

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -28,6 +28,7 @@ import com.yammer.metrics.{Metrics => YammerMetrics}
 import javax.net.ssl._
 import kafka.security.CredentialProvider
 import kafka.server.{KafkaConfig, ThrottledChannel}
+import kafka.utils.Implicits._
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.memory.MemoryPool
@@ -188,7 +189,7 @@ class SocketServerTest extends JUnitSuite {
   @Test
   def testControlPlaneRequest(): Unit = {
     val testProps = new Properties
-    testProps.putAll(props)
+    testProps ++= props
     testProps.put("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:5000")
     testProps.put("listener.security.protocol.map", "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT")
     testProps.put("control.plane.listener.name", "CONTROLLER")


### PR DESCRIPTION
Introduced by https://github.com/apache/kafka/pull/5921.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
