### PR TITLE
MINOR: Log partition info when creating new request batch in controller

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -322,7 +322,7 @@ class ControllerBrokerRequestBatch(controller: KafkaController, stateChangeLogge
     if (updateMetadataRequestBrokerSet.nonEmpty)
       throw new IllegalStateException("Controller to broker state change requests batch is not empty while creating a " +
         s"new one. Some UpdateMetadata state changes to brokers $updateMetadataRequestBrokerSet with partition info " +
-        s"updateMetadataRequestPartitionInfoMap might be lost ")
+        s"$updateMetadataRequestPartitionInfoMap might be lost ")
   }
 
   def clear() {


### PR DESCRIPTION
Due to the missing `$`, the name was being logged instead of the value.