### PR TITLE
KAFKA-6455: Extend CacheFlushListener to forward timestamp

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ForwardingCacheFlushListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ForwardingCacheFlushListener.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
+import org.apache.kafka.streams.state.internals.CacheFlushListener;
 
 class ForwardingCacheFlushListener<K, V> implements CacheFlushListener<K, V> {
     private final InternalProcessorContext context;
@@ -32,11 +34,12 @@ class ForwardingCacheFlushListener<K, V> implements CacheFlushListener<K, V> {
     @Override
     public void apply(final K key,
                       final V newValue,
-                      final V oldValue) {
+                      final V oldValue,
+                      final long timestamp) {
         final ProcessorNode prev = context.currentNode();
         context.setCurrentNode(myNode);
         try {
-            context.forward(key, new Change<>(newValue, oldValue));
+            context.forward(key, new Change<>(newValue, oldValue),  To.all().withTimestamp(timestamp));
         } finally {
             context.setCurrentNode(prev);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.time.Duration;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -35,6 +34,7 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/To.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/To.java
@@ -53,7 +53,7 @@ public class To {
      * @return a new {@link To} instance configured for all downstream processor
      */
     public static To all() {
-        return new To((String) null, -1);
+        return new To(null, -1);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -134,8 +134,11 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
         throw new UnsupportedOperationException("this should not happen: schedule() not supported in global processor context.");
     }
 
+    /**
+     * @throws UnsupportedOperationException on every invocation
+     */
     @Override
     public long streamTime() {
-        throw new RuntimeException("Stream time is not implemented for the global processor context.");
+        throw new UnsupportedOperationException("Stream-time is not defined for global tasks.");
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -32,8 +31,6 @@ import java.util.List;
 
 public class GlobalProcessorContextImpl extends AbstractProcessorContext {
 
-    private final static To SEND_TO_ALL = To.all();
-    private final ToInternal toInternal = new ToInternal();
 
     public GlobalProcessorContextImpl(final StreamsConfig config,
                                       final StateManager stateMgr,
@@ -50,48 +47,25 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
     @SuppressWarnings("unchecked")
     @Override
     public <K, V> void forward(final K key, final V value) {
-        forward(key, value, SEND_TO_ALL);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <K, V> void forward(final K key, final V value, final To to) {
-        toInternal.update(to);
-        if (toInternal.hasTimestamp()) {
-            recordContext.setTimestamp(toInternal.timestamp());
-        }
         final ProcessorNode previousNode = currentNode();
         try {
-            final List<ProcessorNode<K, V>> children = (List<ProcessorNode<K, V>>) currentNode().children();
-            final String sendTo = toInternal.child();
-            if (sendTo != null) {
-                final ProcessorNode child = currentNode().getChild(sendTo);
-                if (child == null) {
-                    throw new StreamsException("Unknown downstream node: " + sendTo + " either does not exist or is not" +
-                        " connected to this processor.");
-                }
-                forward(child, key, value);
-            } else {
-                if (children.size() == 1) {
-                    final ProcessorNode child = children.get(0);
-                    forward(child, key, value);
-                } else {
-                    for (final ProcessorNode child : children) {
-                        forward(child, key, value);
-                    }
-                }
+            for (final ProcessorNode child : (List<ProcessorNode<K, V>>) currentNode().children()) {
+                setCurrentNode(child);
+                child.process(key, value);
             }
         } finally {
             setCurrentNode(previousNode);
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <K, V> void forward(final ProcessorNode child,
-                                final K key,
-                                final V value) {
-        setCurrentNode(child);
-        child.process(key, value);
+    /**
+     * No-op. This should only be called on GlobalStateStore#flush and there should be no child nodes
+     */
+    @Override
+    public <K, V> void forward(final K key, final V value, final To to) {
+        if (!currentNode().children().isEmpty()) {
+            throw new IllegalStateException("This method should only be called on 'GlobalStateStore.flush' that should not have any children.");
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -153,24 +153,19 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         }
         final ProcessorNode previousNode = currentNode();
         try {
-            final List<ProcessorNode<K, V>> children = (List<ProcessorNode<K, V>>) currentNode().children();
             final String sendTo = toInternal.child();
-            if (sendTo != null) {
+            if (sendTo == null) {
+                final List<ProcessorNode<K, V>> children = (List<ProcessorNode<K, V>>) currentNode().children();
+                for (final ProcessorNode child : children) {
+                    forward(child, key, value);
+                }
+            } else {
                 final ProcessorNode child = currentNode().getChild(sendTo);
                 if (child == null) {
                     throw new StreamsException("Unknown downstream node: " + sendTo
                         + " either does not exist or is not connected to this processor.");
                 }
                 forward(child, key, value);
-            } else {
-                if (children.size() == 1) {
-                    final ProcessorNode child = children.get(0);
-                    forward(child, key, value);
-                } else {
-                    for (final ProcessorNode child : children) {
-                        forward(child, key, value);
-                    }
-                }
             }
         } finally {
             setCurrentNode(previousNode);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -72,11 +72,11 @@ public class ProcessorNode<K, V> {
         return processor;
     }
 
-    public final List<ProcessorNode<?, ?>> children() {
+    public List<ProcessorNode<?, ?>> children() {
         return children;
     }
 
-    final ProcessorNode getChild(final String childName) {
+    ProcessorNode getChild(final String childName) {
         return childByName.get(childName);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CacheFlushListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CacheFlushListener.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.kstream.internals;
-
-import org.apache.kafka.streams.state.internals.ThreadCache;
+package org.apache.kafka.streams.state.internals;
 
 /**
  * Listen to cache flush events
@@ -30,6 +28,7 @@ public interface CacheFlushListener<K, V> {
      * @param key         key of the entry
      * @param newValue    current value
      * @param oldValue    previous value
+     * @param timestamp   timestamp of new value
      */
-    void apply(final K key, final V newValue, final V oldValue);
+    void apply(final K key, final V newValue, final V oldValue, final long timestamp);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachedStateStore.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
-
 public interface CachedStateStore<K, V> {
     /**
      * Set the {@link CacheFlushListener} to be notified when entries are flushed from the

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -97,9 +96,11 @@ class CachingKeyValueStore<K, V> extends WrappedStateStore.AbstractStateStore im
                 }
                 // we rely on underlying store to handle null new value bytes as deletes
                 underlying.put(entry.key(), entry.newValue());
-                flushListener.apply(serdes.keyFrom(entry.key().get()),
-                                    serdes.valueFrom(entry.newValue()),
-                                    oldValue);
+                flushListener.apply(
+                    serdes.keyFrom(entry.key().get()),
+                    serdes.valueFrom(entry.newValue()),
+                    oldValue,
+                    entry.entry().context().timestamp());
             } else {
                 underlying.put(entry.key(), entry.newValue());
             }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -177,7 +176,11 @@ class CachingSessionStore<K, AGG> extends WrappedStateStore.AbstractStateStore i
                 final AGG newValue = serdes.valueFrom(entry.newValue());
                 final AGG oldValue = newValue == null || sendOldValues ? fetchPrevious(rawKey, key.window()) : null;
                 if (!(newValue == null && oldValue == null)) {
-                    flushListener.apply(key, newValue, oldValue);
+                    flushListener.apply(
+                        key,
+                        newValue,
+                        oldValue,
+                        entry.entry().context().timestamp());
                 }
             }
             bytesStore.put(new Windowed<>(rawKey, key.window()), entry.newValue());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -111,7 +110,11 @@ class CachingWindowStore<K, V> extends WrappedStateStore.AbstractStateStore impl
             context.setRecordContext(entry.entry().context());
             try {
                 final V oldValue = sendOldValues ? fetchPrevious(key, windowedKey.window().start()) : null;
-                flushListener.apply(windowedKey, serdes.valueFrom(entry.newValue()), oldValue);
+                flushListener.apply(
+                    windowedKey,
+                    serdes.valueFrom(entry.newValue()),
+                    oldValue,
+                    entry.entry().context().timestamp());
             } finally {
                 context.setRecordContext(current);
             }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
@@ -98,7 +99,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             new ThreadCache(new LogContext("testCache "), 100000, metrics)
         ) {
             @Override
-            public <K, V> void forward(final K key, final V value) {
+            public <K, V> void forward(final K key, final V value, final To to) {
                 results.add(KeyValue.pair(key, value));
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class GlobalProcessorContextImplTest {
+    private static final String GLOBAL_STORE_NAME = "global-store";
+    private static final String UNKNOWN_STORE = "unknown-store";
+    private static final String CHILD_ONE = "childOne";
+    private static final String CHILD_TWO = "childOne";
+
+    private GlobalProcessorContextImpl globalContext;
+
+    private ProcessorNode childOne;
+    private ProcessorNode childTwo;
+    private ProcessorRecordContext recordContext;
+
+    @Before
+    public void setup() {
+        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+        expect(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("dummy-id");
+        expect(streamsConfig.defaultValueSerde()).andReturn(Serdes.ByteArray());
+        expect(streamsConfig.defaultKeySerde()).andReturn(Serdes.ByteArray());
+        replay(streamsConfig);
+
+        final StateManager stateManager = mock(StateManager.class);
+        expect(stateManager.getGlobalStore(GLOBAL_STORE_NAME)).andReturn(mock(KeyValueStore.class));
+        expect(stateManager.getGlobalStore(UNKNOWN_STORE)).andReturn(null);
+        replay(stateManager);
+
+        globalContext = new GlobalProcessorContextImpl(
+            streamsConfig,
+            stateManager,
+            null,
+            null);
+
+        final ProcessorNode processorNode = mock(ProcessorNode.class);
+        globalContext.setCurrentNode(processorNode);
+
+        childOne = mock(ProcessorNode.class);
+        childTwo = mock(ProcessorNode.class);
+
+        expect(processorNode.children())
+            .andReturn(asList(childOne, childTwo))
+            .anyTimes();
+        expect(processorNode.getChild(CHILD_ONE))
+            .andReturn(childOne);
+        expect(processorNode.getChild(CHILD_TWO))
+            .andReturn(childTwo);
+        expect(processorNode.getChild(anyString()))
+            .andReturn(null);
+        replay(processorNode);
+
+        recordContext = mock(ProcessorRecordContext.class);
+        globalContext.setRecordContext(recordContext);
+    }
+
+    @Test
+    public void shouldReturnGlobalOrNullStore() {
+        assertThat(globalContext.getStateStore(GLOBAL_STORE_NAME), new IsInstanceOf(KeyValueStore.class));
+        assertNull(globalContext.getStateStore(UNKNOWN_STORE));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldForwardToAllChildren() {
+        childOne.process(null, null);
+        expectLastCall();
+        childTwo.process(null, null);
+        expectLastCall();
+
+        replay(childOne, childTwo, recordContext);
+        globalContext.forward(null, null);
+        verify(childOne, childTwo, recordContext);
+    }
+
+    @Test(expected = StreamsException.class)
+    public void shouldFailToForwardToUnknownChild() {
+        globalContext.forward(null, null, To.child("unknownProcessorName"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldForwardToSpecifiedChild() {
+        childOne.process(null, null);
+        expectLastCall();
+
+        replay(childOne, childTwo, recordContext);
+        globalContext.forward(null, null, To.child(CHILD_ONE));
+        verify(childOne, childTwo, recordContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldSetTimestampOnForward() {
+        childOne.process(null, null);
+        expectLastCall();
+        childTwo.process(null, null);
+        expectLastCall();
+        recordContext.setTimestamp(42L);
+        expectLastCall();
+
+        replay(childOne, childTwo, recordContext);
+        globalContext.forward(null, null, To.all().withTimestamp(42L));
+        verify(childOne, childTwo, recordContext);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotSupportForwardingViaChildIndex() {
+        globalContext.forward(null, null, 0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotSupportForwardingViaChildName() {
+        globalContext.forward(null, null, "processorName");
+    }
+
+    @Test
+    public void shouldNotFailOnNoOpCommit() {
+        globalContext.commit();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToSchedulePunctuationsUsingDeprecatedApi() {
+        globalContext.schedule(0L, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToSchedulePunctuations() {
+        globalContext.schedule(null, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToGetStreamTime() {
+        globalContext.streamTime();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -16,12 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.function.Consumer;
-
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -38,6 +32,12 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
 import static org.easymock.EasyMock.anyLong;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
@@ -340,7 +339,10 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         final Map<K, Change<V>> forwarded = new HashMap<>();
 
         @Override
-        public void apply(final K key, final V newValue, final V oldValue) {
+        public void apply(final K key,
+                          final V newValue,
+                          final V oldValue,
+                          final long timestamp) {
             forwarded.put(key, new Change<>(newValue, oldValue));
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -233,7 +233,7 @@ public class CachingSessionStoreTest {
         final Windowed<String> aDeserialized = new Windowed<>("a", new SessionWindow(0, 0));
         final List<KeyValue<Windowed<String>, Change<String>>> flushed = new ArrayList<>();
         cachingStore.setFlushListener(
-            (key, newValue, oldValue) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
+            (key, newValue, oldValue, timestamp) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
             true
         );
 
@@ -262,7 +262,7 @@ public class CachingSessionStoreTest {
         final Windowed<String> aDeserialized = new Windowed<>("a", new SessionWindow(0, 0));
         final List<KeyValue<Windowed<String>, Change<String>>> flushed = new ArrayList<>();
         cachingStore.setFlushListener(
-            (key, newValue, oldValue) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
+            (key, newValue, oldValue, timestamp) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
             false
         );
 
@@ -291,7 +291,7 @@ public class CachingSessionStoreTest {
         final Windowed<String> aDeserialized = new Windowed<>("a", new SessionWindow(0, 0));
         final List<KeyValue<Windowed<String>, Change<String>>> flushed = new ArrayList<>();
         cachingStore.setFlushListener(
-            (key, newValue, oldValue) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
+            (key, newValue, oldValue, timestamp) -> flushed.add(KeyValue.pair(key, new Change<>(newValue, oldValue))),
             false
         );
 


### PR DESCRIPTION
This PR is of part of the overall KIP-258 story. It does not resolve KAFKA-6455, but prepares it. It's only internal changes so we can merge right away.