### PR TITLE
KAFKA-7828: Execute Trogdor tasks with external commands

### DIFF
--- a/tests/bin/ExternalCommandExample.py
+++ b/tests/bin/ExternalCommandExample.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import sys
+import time
+
+# ExternalCommandExample.py demonstrates how the external command process communicates with the agent.
+
+parser = argparse.ArgumentParser(description='Python Trogdor External Command Example.')
+parser.add_argument('--spec', dest='spec', required=True)
+args = parser.parse_args()
+
+if __name__ == '__main__':
+    task = json.loads(args.spec)
+    print(json.dumps({"status":"Python external command runner executes command  " + " ".join(task["command"])}))
+    sys.stdout.flush()
+
+    time.sleep(10)
+    print(json.dumps({"error":"Something is wrong.",
+                      "log":"Please show this line.",
+                      "status":{"totalSent":50000,"averageLatencyMs":10.83734,"p50LatencyMs":8,"p95LatencyMs":38,"p99LatencyMs":61,"transactionsCommitted":0}}))
+    sys.stdout.flush()
+
+    for line in sys.stdin:
+        print(json.dumps({"log":line}))
+        sys.stdout.flush()
+        try:
+            comm = json.loads(line)
+            if ("action" in comm and comm["action"] == "stop"):
+                exit(0)
+        except ValueError:
+            print(json.dumps({"log": "Input line " + line + " is not a valid external runner command."}))

--- a/tests/bin/ExternalCommandExample.py
+++ b/tests/bin/ExternalCommandExample.py
@@ -20,27 +20,36 @@ import time
 
 # ExternalCommandExample.py demonstrates how the external command process communicates with the agent.
 
-parser = argparse.ArgumentParser(description='Python Trogdor External Command Example.')
-parser.add_argument('--spec', dest='spec', required=True)
-args = parser.parse_args()
-
 if __name__ == '__main__':
-    task = json.loads(args.spec)
-    print(json.dumps({"status":"Python external command runner executes command  " + " ".join(task["command"])}))
-    sys.stdout.flush()
-
-    time.sleep(10)
-    print(json.dumps({"error":"Something is wrong.",
-                      "log":"Please show this line.",
-                      "status":{"totalSent":50000,"averageLatencyMs":10.83734,"p50LatencyMs":8,"p95LatencyMs":38,"p99LatencyMs":61,"transactionsCommitted":0}}))
+    print(json.dumps({"status":"ExternalCommandExample.py started."}))
     sys.stdout.flush()
 
     for line in sys.stdin:
-        print(json.dumps({"log":line}))
-        sys.stdout.flush()
         try:
             comm = json.loads(line)
-            if ("action" in comm and comm["action"] == "stop"):
-                exit(0)
+            if "action" in comm:
+                action = comm["action"]
+                if action == "stop":
+                    exit(0)
+                elif action == "start":
+                    if "spec" in comm:
+                        task = comm["spec"]
+                        print(json.dumps({"status":"Started to execute the workload."}))
+                        sys.stdout.flush()
+                        time.sleep(5)
+                        print(json.dumps({"error":"Something is wrong.",
+                                          "log":"Please show this line.",
+                                          "status":{"totalSent":50000,"averageLatencyMs":10.83734,"p50LatencyMs":8,"p95LatencyMs":38,"p99LatencyMs":61,"transactionsCommitted":0}}))
+                        sys.stdout.flush()
+                        exit(0)
+                    else:
+                        print(json.dumps({"error": "No spec in command " + line}))
+                        sys.stdout.flush()
+
+                else:
+                    print(json.dumps({"log": "Unknown command action " + action}))
+            else:
+                print(json.dumps({"error": "Unknown control command " + line }))
+                sys.stdout.flush();
         except ValueError:
             print(json.dumps({"log": "Input line " + line + " is not a valid external runner command."}))

--- a/tests/bin/trogdor-run-external-command.sh
+++ b/tests/bin/trogdor-run-external-command.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COORDINATOR_ENDPOINT="localhost:8889"
+TASK_ID="external_command_$RANDOM"
+TASK_SPEC=$(
+cat <<EOF
+{
+    "id": "$TASK_ID",
+
+    "spec": {
+        "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
+        "command": ["python", "./tests/bin/ExternalCommandExample.py"],
+        "durationMs": 10000000,
+        "producerNode": "node0",
+        "workload":{
+            "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+            "bootstrapServers": "localhost:9092",
+            "targetMessagesPerSec": 10000,
+            "maxMessages": 50000,
+            "activeTopics": {
+                "foo[1-3]": {
+                    "numPartitions": 10,
+                    "replicationFactor": 1
+                }
+            },
+            "inactiveTopics": {
+                "foo[4-5]": {
+                    "numPartitions": 10,
+                    "replicationFactor": 1
+                }
+            }
+        }
+    }
+}
+EOF
+)
+./bin/trogdor.sh client --create-task "${TASK_SPEC}" "${COORDINATOR_ENDPOINT}"
+echo "\$TASK_ID = $TASK_ID"

--- a/tests/bin/trogdor-run-external-command.sh
+++ b/tests/bin/trogdor-run-external-command.sh
@@ -25,7 +25,7 @@ cat <<EOF
         "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
         "command": ["python", "./tests/bin/ExternalCommandExample.py"],
         "durationMs": 10000000,
-        "producerNode": "node0",
+        "commandNode": "node0",
         "workload":{
             "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
             "bootstrapServers": "localhost:9092",

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.workload;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.kafka.trogdor.task.TaskController;
+import org.apache.kafka.trogdor.task.TaskSpec;
+import org.apache.kafka.trogdor.task.TaskWorker;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * ExternalCommandSpec describes a task that executes Trogdor tasks with the command.
+ *
+ * An example uses the python runner to execute the ProduceBenchSpec task.
+ *
+ * #{@code
+ *   {
+ *      "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
+ *      "command": ["python", "/path/to/trogdor/python/runner"],
+ *      "durationMs": 10000000,
+ *      "producerNode": "node0",
+ *      "workload": {
+ *        "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+ *        "bootstrapServers": "localhost:9092",
+ *        "targetMessagesPerSec": 10,
+ *        "maxMessages": 100,
+ *        "activeTopics": {
+ *          "foo[1-3]": {
+ *            "numPartitions": 3,
+ *            "replicationFactor": 1
+ *          }
+ *        },
+ *        "inactiveTopics": {
+ *          "foo[4-5]": {
+ *            "numPartitions": 3,
+ *            "replicationFactor": 1
+ *          }
+ *        }
+ *     }
+ *   }
+ */
+public class ExternalCommandSpec extends TaskSpec {
+    private final String producerNode;
+    private final List<String> command;
+    private final JsonNode workload;
+
+    @JsonCreator
+    public ExternalCommandSpec(
+            @JsonProperty("startMs") long startMs,
+            @JsonProperty("durationMs") long durationMs,
+            @JsonProperty("producerNode") String producerNode,
+            @JsonProperty("command") List<String> command,
+            @JsonProperty("workload") JsonNode workload) {
+        super(startMs, durationMs);
+        this.producerNode = (producerNode == null) ? "" : producerNode;
+        this.command = command;
+        this.workload = workload;
+    }
+
+    @JsonProperty
+    public String producerNode() {
+        return producerNode;
+    }
+
+    @JsonProperty
+    public List<String> command() {
+        return command;
+    }
+
+    @JsonProperty
+    public JsonNode workload() {
+        return workload;
+    }
+
+    @Override
+    public TaskController newController(String id) {
+        return topology -> Collections.singleton(producerNode);
+    }
+
+    @Override
+    public TaskWorker newTaskWorker(String id) {
+        return new ExternalCommandWorker(id, this);
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.apache.kafka.trogdor.task.TaskController;
 import org.apache.kafka.trogdor.task.TaskSpec;
 import org.apache.kafka.trogdor.task.TaskWorker;
@@ -74,8 +75,8 @@ public class ExternalCommandSpec extends TaskSpec {
             @JsonProperty("workload") JsonNode workload) {
         super(startMs, durationMs);
         this.commandNode = (commandNode == null) ? "" : commandNode;
-        this.command = (command == null) ? new ArrayList<String>() : command;
-        this.workload = workload;
+        this.command = (command == null) ? Collections.unmodifiableList(new ArrayList<String>()) : command;
+        this.workload = (workload == null) ? NullNode.instance : workload;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandSpec.java
@@ -20,10 +20,12 @@ package org.apache.kafka.trogdor.workload;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import org.apache.kafka.trogdor.task.TaskController;
 import org.apache.kafka.trogdor.task.TaskSpec;
 import org.apache.kafka.trogdor.task.TaskWorker;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -59,7 +61,7 @@ import java.util.List;
  *   }
  */
 public class ExternalCommandSpec extends TaskSpec {
-    private final String producerNode;
+    private final String commandNode;
     private final List<String> command;
     private final JsonNode workload;
 
@@ -67,18 +69,18 @@ public class ExternalCommandSpec extends TaskSpec {
     public ExternalCommandSpec(
             @JsonProperty("startMs") long startMs,
             @JsonProperty("durationMs") long durationMs,
-            @JsonProperty("producerNode") String producerNode,
+            @JsonProperty("commandNode") String commandNode,
             @JsonProperty("command") List<String> command,
             @JsonProperty("workload") JsonNode workload) {
         super(startMs, durationMs);
-        this.producerNode = (producerNode == null) ? "" : producerNode;
-        this.command = command;
+        this.commandNode = (commandNode == null) ? "" : commandNode;
+        this.command = (command == null) ? new ArrayList<String>() : command;
         this.workload = workload;
     }
 
     @JsonProperty
-    public String producerNode() {
-        return producerNode;
+    public String commandNode() {
+        return commandNode;
     }
 
     @JsonProperty
@@ -93,7 +95,7 @@ public class ExternalCommandSpec extends TaskSpec {
 
     @Override
     public TaskController newController(String id) {
-        return topology -> Collections.singleton(producerNode);
+        return topology -> Collections.singleton(commandNode);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
@@ -97,7 +97,6 @@ public class ExternalCommandWorker implements TaskWorker {
     public ExternalCommandWorker(String id, ExternalCommandSpec spec) {
         this.id = id;
         this.spec = spec;
-
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
@@ -56,7 +56,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * Start a task {"action":"start", "spec":ExternalCommandSpec}.
  *
- * Stop a task {"action":"stop", "spec":ExternalCommandSpec}.
+ * Stop a task {"action":"stop", "spec":ExternalCommandSpec}. The external process should exit after seeing a stop
+ * command even there is no proceeding start command.
+ *
  *
  *
  * Communication API: {"status":val, "log":val, "error":"msg"}
@@ -225,8 +227,10 @@ public class ExternalCommandWorker implements TaskWorker {
             if (process.isAlive()) {
                 this.stopTask();
                 process.waitFor(1, TimeUnit.MINUTES);
-                process.destroy();
-                process.waitFor();
+                if (process.isAlive()) {
+                    process.destroy();
+                    process.waitFor();
+                }
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.workload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.trogdor.common.JsonUtil;
+import org.apache.kafka.trogdor.common.Platform;
+import org.apache.kafka.trogdor.common.ThreadUtils;
+import org.apache.kafka.trogdor.common.WorkerUtils;
+import org.apache.kafka.trogdor.task.TaskWorker;
+import org.apache.kafka.trogdor.task.WorkerStatusTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * ExternalCommandWorker drives the Trogdor task with an external command.
+ *
+ * ExternalCommandWorker starts an external process to execute the command. Communication between the external process
+ * and ExternalCommandWorker should follow these APIs:
+ *
+ * Control API:
+ *
+ * ExternalCommandWorker should pass one argument, --spec taskSpec, that shows the Trogdor task.
+ *
+ * ExternalCommandWorker can send a stop command to the external process's stdin, formatted as JSON object {"action":"stop"}.
+ *
+ * Communication API:
+ *
+ * ExternalCommandWorker should continuously monitor the stdout and the stderr of the external process line by line.
+ *
+ * For any JSON object the external process writes to its stdout, if the object has the "status" field, this worker should set
+ * its status with the "status" value, if the object has the "error" field and the value is a JSON string, this worker should
+ * set the agent error message with the "error" value, and if the object has the "log" field, this worker should put the "log"
+ * value it its log.
+ *
+ * For any line the external process writes to its stderr, this worker should save the line to its error log and set the
+ * error message with the line.
+ */
+public class ExternalCommandWorker implements TaskWorker {
+    private static final Logger log = LoggerFactory.getLogger(ProduceBenchWorker.class);
+
+    private final String id;
+
+    private final ExternalCommandSpec spec;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    private ScheduledExecutorService executor;
+
+    private Process worker;
+
+    private String errMsg = "";
+
+    private WorkerStatusTracker status;
+
+    private KafkaFutureImpl<String> doneFuture;
+
+    public ExternalCommandWorker(String id, ExternalCommandSpec spec) {
+        this.id = id;
+        this.spec = spec;
+    }
+
+    @Override
+    public void start(Platform platform, WorkerStatusTracker status,
+                      KafkaFutureImpl<String> doneFuture) throws Exception {
+        if (!running.compareAndSet(false, true)) {
+            throw new IllegalStateException("ExternalCommandWorker is already running.");
+        }
+        log.info("{}: Activating ExternalCommandWorker with {}", id, spec);
+        this.executor = Executors.newScheduledThreadPool(2,
+            ThreadUtils.createThreadFactory("ExternalCommandWorkerThread%d", false));
+        this.status = status;
+        this.doneFuture = doneFuture;
+        executor.submit(new Prepare());
+    }
+
+    public class Prepare implements Runnable {
+        @Override
+        public void run() {
+            try {
+                ArrayList<String> command = new ArrayList<String>(spec.command());
+                command.add("--spec");
+                command.add(spec.toString());
+                log.info("ExternalCommandWorker executes command: {}", command);
+                ProcessBuilder workerBuilder = new ProcessBuilder(command);
+                worker = workerBuilder.start();
+                Future updater = executor.submit(new StatusUpdater());
+                Future errorUpdater = executor.submit(new ErrorUpdater());
+                worker.waitFor();
+                updater.get();
+                errorUpdater.get();
+                int workerExitValue = worker.exitValue();
+                log.info("ExternalWorker finished with the exit value: {}.", workerExitValue);
+                if (workerExitValue != 0 && errMsg.isEmpty()) {
+                    errMsg = "ExternalWorker exited with error code " + worker.exitValue();
+                }
+                log.info("StatusUpdater terminated.");
+                doneFuture.complete(errMsg);
+            } catch (IOException e) {
+                log.info("Stdout of ExternalWorker is closed.");
+            } catch (InterruptedException e) {
+                log.info("StatusUpdadter interrupted.");
+            } catch (Exception e) {
+                WorkerUtils.abort(log, "Prepare", e, doneFuture);
+            }
+        }
+    }
+
+    public class ErrorUpdater implements Runnable {
+        BufferedReader br;
+        ErrorUpdater() {
+            br = new BufferedReader(new InputStreamReader(worker.getErrorStream(), StandardCharsets.UTF_8));
+        }
+        @Override
+        public void run() {
+            try {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    log.error("ExternalWorker (stderr):{}", line);
+                    errMsg = line;
+                }
+            } catch (IOException ioe) {
+                log.info("Stderr of ExternalWorker is closed.");
+            } catch (Exception e) {
+                WorkerUtils.abort(log, "ErrorUpdater", e, doneFuture);
+            }
+        }
+    }
+
+    /**
+     * StatusUpdater reads ProcessWorker's stdout line by line. If the line is a JSON object, StatusUpdater updates
+     * the status with the JSON object.
+     */
+    public class StatusUpdater implements Runnable {
+
+        BufferedReader br;
+        StatusUpdater() {
+            br = new BufferedReader(new InputStreamReader(worker.getInputStream(), StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public void run() {
+            try {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    log.info("Worker (stdout):{}", line);
+                    try {
+                        JsonNode resp = JsonUtil.JSON_SERDE.readTree(line);
+                        if (resp.has("status")) {
+                            status.update(resp.get("status"));
+                        }
+                        if (resp.has("log")) {
+                            log.info("External Worker: {}", resp.get("log").toString());
+                        }
+                        if (resp.has("error")) {
+                            JsonNode errNode = resp.get("error");
+                            if (errNode.getNodeType() == JsonNodeType.STRING) {
+                                errMsg = errNode.asText();
+                            }
+                        }
+                    } catch (IOException e) {
+                        // not a JSON string
+                    }
+                }
+            } catch (Exception e) {
+                WorkerUtils.abort(log, "StatusUpdater", e, doneFuture);
+            }
+        }
+    }
+
+
+    @Override
+    public void stop(Platform platform) throws Exception {
+        if (!running.compareAndSet(true, false)) {
+            throw new IllegalStateException("ExternalCommandWorker is not running.");
+        }
+        log.info("{}: Deactivating ExternalCommandWorker.", id);
+        if (worker.isAlive()) {
+            log.info("{}: Send the stop command to the external worker.", id);
+            PrintWriter p = new PrintWriter(worker.getOutputStream());
+            p.println("{\"action\" : \"stop\"}");
+            p.flush();
+        }
+        worker.waitFor(1, TimeUnit.MINUTES);
+        if (worker.isAlive()) {
+            log.info("{}: Destroy the external worker since it is still alive after 1 minute.");
+            worker.destroy();
+        }
+        doneFuture.complete(errMsg);
+        executor.shutdownNow();
+        executor.awaitTermination(1, TimeUnit.DAYS);
+        this.executor = null;
+        this.worker = null;
+        this.status = null;
+        this.doneFuture = null;
+    }
+}


### PR DESCRIPTION
Allow the Trogdor agent to execute Trogdor tasks with external commands such as a python Kafka client.

+ ExternalCommandSpec describes the external command and its workload.
+ ExternalCommandWorker uses a external process to execute the command.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)