### PR TITLE
KAFKA-7829; Javadoc should show that AdminClient.alterReplicaLogDirs() is supported in Kafka 1.1.0 or later

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -389,14 +389,17 @@ public abstract class AdminClient implements AutoCloseable {
     public abstract AlterConfigsResult alterConfigs(Map<ConfigResource, Config> configs, AlterConfigsOptions options);
 
     /**
-     * Change the log directory for the specified replicas. This API is currently only useful if it is used
-     * before the replica has been created on the broker. It will support moving replicas that have already been created after
-     * KIP-113 is fully implemented.
+     * Change the log directory for the specified replicas. If the replica does not exist on the broker, the result
+     * shows REPLICA_NOT_AVAILABLE for the given replica and the replica will be created in the given log directory on the
+     * broker when it is created later. If the replica already exists on the broker, the replica will be moved to the given
+     * log directory if it is not already there.
+     *
+     * This operation is not transactional so it may succeed for some replicas while fail for others.
      *
      * This is a convenience method for #{@link AdminClient#alterReplicaLogDirs(Map, AlterReplicaLogDirsOptions)} with default options.
      * See the overload for more details.
      *
-     * This operation is supported by brokers with version 1.0.0 or higher.
+     * This operation is supported by brokers with version 1.1.0 or higher.
      *
      * @param replicaAssignment  The replicas with their log directory absolute path
      * @return                   The AlterReplicaLogDirsResult
@@ -406,13 +409,14 @@ public abstract class AdminClient implements AutoCloseable {
     }
 
     /**
-     * Change the log directory for the specified replicas. This API is currently only useful if it is used
-     * before the replica has been created on the broker. It will support moving replicas that have already been created after
-     * KIP-113 is fully implemented.
+     * Change the log directory for the specified replicas. If the replica does not exist on the broker, the result
+     * shows REPLICA_NOT_AVAILABLE for the given replica and the replica will be created in the given log directory on the
+     * broker when it is created later. If the replica already exists on the broker, the replica will be moved to the given
+     * log directory if it is not already there.
      *
      * This operation is not transactional so it may succeed for some replicas while fail for others.
      *
-     * This operation is supported by brokers with version 1.0.0 or higher.
+     * This operation is supported by brokers with version 1.1.0 or higher.
      *
      * @param replicaAssignment  The replicas with their log directory absolute path
      * @param options            The options to use when changing replica dir

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -466,8 +466,7 @@ object ReassignPartitionsCommand extends Logging {
                       "The format to use is - \n" +
                       "{\"partitions\":\n\t[{\"topic\": \"foo\",\n\t  \"partition\": 1,\n\t  \"replicas\": [1,2,3],\n\t  \"log_dirs\": [\"dir1\",\"dir2\",\"dir3\"] }],\n\"version\":1\n}\n" +
                       "Note that \"log_dirs\" is optional. When it is specified, its length must equal the length of the replicas list. The value in this list " +
-                      "can be either \"any\" or the absolution path of the log directory on the broker. If absolute log directory path is specified, it is currently required that " +
-                      "the replica has not already been created on that broker. The replica will then be created in the specified log directory on the broker later.")
+                      "can be either \"any\" or the absolution path of the log directory on the broker. If absolute log directory path is specified, the replica will be moved to the specified log directory on the broker.")
                       .withRequiredArg
                       .describedAs("manual assignment json file path")
                       .ofType(classOf[String])


### PR DESCRIPTION
In ReassignPartitionsCommand, the --reassignment-json-file option says "...If absolute log directory path is specified, it is currently required that the replica has not already been created on that broker...". This is inaccurate since we support moving existing replicas to new log dirs.

In addition, the Javadoc of AdminClient.alterReplicaLogDirs(...) should show the API is supported by brokers with version 1.1.0 or later.
