### PR TITLE
KAFKA-5488: A method-chaining way to build branches for topology

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KafkaStreamBrancher.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KafkaStreamBrancher.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Provides a method-chaining way to build {@link KStream#branch branches} in
+ * Kafka Streams processor topology.
+ * <p>
+ * Example of usage:
+ * <pre>
+ * {@code
+ * new KafkaStreamsBrancher<String, String>()
+ *    .addBranch((key, value) -> value.contains("A"), ks->ks.to("A"))
+ *    .addBranch((key, value) -> value.contains("B"), ks->ks.to("B"))
+ *    //default branch should not necessarily be defined in the end
+ *    .addDefaultBranch(ks->ks.to("C"))
+ *    .onTopOf(builder.stream("source"))
+ * }
+ * </pre>
+ *
+ * @param <K> Type of keys
+ * @param <V> Type of values
+ * @author Ivan Ponomarev
+ * @since 2.2.4
+ */
+public final class KafkaStreamBrancher<K, V> {
+
+	private final List<Predicate<? super K, ? super V>> predicateList = new ArrayList<>();
+	private final List<Consumer<? super KStream<K, V>>> consumerList = new ArrayList<>();
+	private Consumer<? super KStream<K, V>> defaultConsumer;
+
+	/**
+	 * Defines a new branch.
+	 *
+	 * @param predicate {@link Predicate} instance
+	 * @param consumer  The consumer of this branch's {@code KStream}
+	 * @return {@code this}
+	 */
+	public KafkaStreamBrancher<K, V> addBranch(Predicate<? super K, ? super V> predicate,
+											Consumer<? super KStream<K, V>> consumer) {
+		this.predicateList.add(Objects.requireNonNull(predicate));
+		this.consumerList.add(Objects.requireNonNull(consumer));
+		return this;
+	}
+
+	/**
+	 * Defines a default branch. To this stream will be directed all the messages that
+	 * were not dispatched to other branches. This method should not necessarily be called in the end
+	 * of chain.
+	 *
+	 * @param consumer The consumer of this branch's {@code KStream}
+	 * @return {@code this}
+	 */
+	public KafkaStreamBrancher<K, V> addDefaultBranch(Consumer<? super KStream<K, V>> consumer) {
+		this.defaultConsumer = Objects.requireNonNull(consumer);
+		return this;
+	}
+
+	/**
+	 * Terminating method that builds branches on top of given {@code KStream}.
+	 *
+	 * @param stream {@code KStream} to split
+	 */
+	public void onTopOf(KStream<K, V> stream) {
+		if (this.defaultConsumer != null) {
+			this.predicateList.add((k, v) -> true);
+			this.consumerList.add(this.defaultConsumer);
+		}
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		Predicate<? super K, ? super V>[] predicates = this.predicateList.toArray(new Predicate[0]);
+		KStream<K, V>[] result = stream.branch(predicates);
+		for (int i = 0; i < this.consumerList.size(); i++) {
+			this.consumerList.get(i).accept(result[i]);
+		}
+	}
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KafkaStreamsBrancherTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KafkaStreamsBrancherTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream;
+
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+class KafkaStreamsBrancherTest {
+	@Test
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	void correctConsumersAreCalled() {
+		Predicate p1 = Mockito.mock(Predicate.class);
+		Predicate p2 = Mockito.mock(Predicate.class);
+		KStream input = Mockito.mock(KStream.class);
+		KStream[] result = new KStream[]{Mockito.mock(KStream.class),
+				Mockito.mock(KStream.class), Mockito.mock(KStream.class)};
+		Mockito.when(input.branch(Mockito.eq(p1), Mockito.eq(p2), Mockito.any()))
+				.thenReturn(result);
+		AtomicInteger invocations = new AtomicInteger(0);
+		new KafkaStreamBrancher()
+				.addBranch(
+						p1,
+						ks -> {
+							assertSame(result[0], ks);
+							assertEquals(0, invocations.getAndIncrement());
+						})
+				.addDefaultBranch(ks -> {
+					assertSame(result[2], ks);
+					assertEquals(2, invocations.getAndIncrement());
+				})
+				.addBranch(p2,
+						ks -> {
+							assertSame(result[1], ks);
+							assertEquals(1, invocations.getAndIncrement());
+						})
+				.onTopOf(input);
+
+		assertEquals(3, invocations.get());
+	}
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KafkaStreamsBrancherTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KafkaStreamsBrancherTest.java
@@ -26,36 +26,36 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-class KafkaStreamsBrancherTest {
-	@Test
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	void correctConsumersAreCalled() {
-		Predicate p1 = Mockito.mock(Predicate.class);
-		Predicate p2 = Mockito.mock(Predicate.class);
-		KStream input = Mockito.mock(KStream.class);
-		KStream[] result = new KStream[]{Mockito.mock(KStream.class),
-				Mockito.mock(KStream.class), Mockito.mock(KStream.class)};
-		Mockito.when(input.branch(Mockito.eq(p1), Mockito.eq(p2), Mockito.any()))
-				.thenReturn(result);
-		AtomicInteger invocations = new AtomicInteger(0);
-		new KafkaStreamBrancher()
-				.addBranch(
-						p1,
-						ks -> {
-							assertSame(result[0], ks);
-							assertEquals(0, invocations.getAndIncrement());
-						})
-				.addDefaultBranch(ks -> {
-					assertSame(result[2], ks);
-					assertEquals(2, invocations.getAndIncrement());
-				})
-				.addBranch(p2,
-						ks -> {
-							assertSame(result[1], ks);
-							assertEquals(1, invocations.getAndIncrement());
-						})
-				.onTopOf(input);
+public class KafkaStreamsBrancherTest {
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void correctConsumersAreCalled() {
+        Predicate p1 = Mockito.mock(Predicate.class);
+        Predicate p2 = Mockito.mock(Predicate.class);
+        KStream input = Mockito.mock(KStream.class);
+        KStream[] result = new KStream[]{Mockito.mock(KStream.class),
+                Mockito.mock(KStream.class), Mockito.mock(KStream.class)};
+        Mockito.when(input.branch(Mockito.eq(p1), Mockito.eq(p2), Mockito.any()))
+                .thenReturn(result);
+        AtomicInteger invocations = new AtomicInteger(0);
+        assertSame(input, new KafkaStreamBrancher()
+                .branch(
+                        p1,
+                        ks -> {
+                            assertSame(result[0], ks);
+                            assertEquals(0, invocations.getAndIncrement());
+                        })
+                .defaultBranch(ks -> {
+                    assertSame(result[2], ks);
+                    assertEquals(2, invocations.getAndIncrement());
+                })
+                .branch(p2,
+                        ks -> {
+                            assertSame(result[1], ks);
+                            assertEquals(1, invocations.getAndIncrement());
+                        })
+                .onTopOf(input));
 
-		assertEquals(3, invocations.get());
-	}
+        assertEquals(3, invocations.get());
+    }
 }


### PR DESCRIPTION
`KStream.branch` method uses varargs to supply predicates and returns array of streams ('[Each stream in the result array corresponds position-wise (index) to the predicate in the supplied predicates](http://home.apache.org/~ijuma/kafka-0.10.0.1-rc1/javadoc/org/apache/kafka/streams/kstream/KStream.html)'). 

This is poor API design that makes building branches very inconvenient because of 'impedance mismatch' between arrays and generics in Java language.

 * In general, the code  have low cohesion: we need to define predicates in one place, and respective stream processors in another place of code. 
 
 * If the number of predicates is predefined, this method forces us to use 'magic numbers' to extract the right branch from the result (see examples [here](https://stackoverflow.com/questions/48950580/kafka-streams-send-on-different-topics-depending-on-streams-data)).
 
 * If we need to build branches dynamically (e. g. one branch per enum value) we inevitably have to deal with 'generic arrays' and 'unchecked typecasts'.
 
The proposed class `KafkaStreamBrancher` introduces new standard way to build branches on top of KStream. 

Instead of 

```java
KStream<String, String> source_o365_user_activity = builder.stream("source");
KStream<String, String>[] branches = source_o365_user_activity.branch( 
      (key, value) -> value.contains("A"),
      (key, value) -> value.contains("B"),
      (key, value) -> true
     );

branches[0].to("A");
branches[1].to("B");
branches[2].to("C");
```

we can use

```java
new KafkaStreamsBrancher<String, String>()
   .branch((key, value) -> value.contains("A"), ks->ks.to("A"))
   .branch((key, value) -> value.contains("B"), ks->ks.to("B"))
   //default branch should not necessarily be defined in the end!
   .defaultBranch(ks->ks.to("C"))
   .onTopOf(builder.stream("source"))
```



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
