### PR TITLE
MINOR: upgrade to jdk8 8u202

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,9 @@ ec2_subnet_id = nil
 # are running Vagrant from within that VPC as well.
 ec2_associate_public_ip = nil
 
+jdk_major = '8'
+jdk_full = '8u202-linux-x64'
+
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then
   eval(File.read(local_config_file), binding, "Vagrantfile.local")
@@ -160,7 +163,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       name_node(zookeeper, name, ec2_instance_name_prefix)
       ip_address = "192.168.50." + (10 + i).to_s
       assign_local_ip(zookeeper, ip_address)
-      zookeeper.vm.provision "shell", path: "vagrant/base.sh"
+      zookeeper.vm.provision "shell", path: "vagrant/base.sh", env: {"JDK_MAJOR" => jdk_major, "JDK_FULL" => jdk_full}
       zk_jmx_port = enable_jmx ? (8000 + i).to_s : ""
       zookeeper.vm.provision "shell", path: "vagrant/zk.sh", :args => [i.to_s, num_zookeepers, zk_jmx_port]
     end
@@ -177,7 +180,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # host DNS isn't setup, we shouldn't use hostnames -- IP addresses must be
       # used to support clients running on the host.
       zookeeper_connect = zookeepers.map{ |zk_addr| zk_addr + ":2181"}.join(",")
-      broker.vm.provision "shell", path: "vagrant/base.sh"
+      broker.vm.provision "shell", path: "vagrant/base.sh", env: {"JDK_MAJOR" => jdk_major, "JDK_FULL" => jdk_full}
       kafka_jmx_port = enable_jmx ? (9000 + i).to_s : ""
       broker.vm.provision "shell", path: "vagrant/broker.sh", :args => [i.to_s, enable_dns ? name : ip_address, zookeeper_connect, kafka_jmx_port]
     end
@@ -189,7 +192,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       name_node(worker, name, ec2_instance_name_prefix)
       ip_address = "192.168.50." + (100 + i).to_s
       assign_local_ip(worker, ip_address)
-      worker.vm.provision "shell", path: "vagrant/base.sh"
+      worker.vm.provision "shell", path: "vagrant/base.sh", env: {"JDK_MAJOR" => jdk_major, "JDK_FULL" => jdk_full}
     end
   }
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,15 +75,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if Vagrant.has_plugin?("vagrant-cachier")
       override.cache.scope = :box
-      # Besides the defaults, we use a custom cache to handle the Oracle JDK
-      # download, which downloads via wget during an apt install. Because of the
-      # way the installer ends up using its cache directory, we need to jump
-      # through some hoops instead of just specifying a cache directly -- we
-      # share to a temporary location and the provisioning scripts symlink data
-      # to the right location.
-      override.cache.enable :generic, {
-        "oracle-jdk8" => { cache_dir: "/tmp/oracle-jdk8-installer-cache" },
-      }
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ ec2_keypair_file = nil
 
 ec2_region = "us-east-1"
 ec2_az = nil # Uses set by AWS
-ec2_ami = "ami-905730e8"
+ec2_ami = "ami-29ebb519"
 ec2_instance_type = "m3.medium"
 ec2_spot_instance = ENV['SPOT_INSTANCE'] ? ENV['SPOT_INSTANCE'] == 'true' : true
 ec2_spot_max_price = "0.113"  # On-demand price for instance type

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -40,11 +40,14 @@ if [ -z `which javac` ]; then
     apt-get install -y software-properties-common python-software-properties binutils gsfonts gsfonts-x11 java-common libfontenc1 libxfont1 x11-common xfonts-encodings xfonts-utils
 
     echo "===> Installing JDK..." 
-    mkdir -p /opt/jdk/8
-    cd /opt/jdk/8
+
+    mkdir -p /opt/jdk
+    cd /opt/jdk
+    rm -rf 8
     jdk_version='8u202'
     fetch_jdk_tgz $jdk_version
     tar zxf $(path_to_jdk_cache $jdk_version)
+    mv jdk1.8.0_202 8
     for bin in /opt/jdk/8/bin/* ; do 
       name=$(basename $bin)
       update-alternatives --install /usr/bin/$name $name $bin 1091 && update-alternatives --set $name $bin

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -49,7 +49,7 @@ if [ -z `which javac` ]; then
     cd /opt/jdk
     rm -rf $JDK_MAJOR
     mkdir -p $JDK_MAJOR
-    cd $JKD_MAJOR
+    cd $JDK_MAJOR
     fetch_jdk_tgz $JDK_FULL
     tar x --strip-components=1 -zf $(path_to_jdk_cache $JDK_FULL)
     for bin in /opt/jdk/$JDK_MAJOR/bin/* ; do 

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -34,8 +34,8 @@ fetch_jdk_tgz() {
   fi
 }
 
-JDK_MAJOR=8
-JDK_FULL='8u202-linux-x64'
+JDK_MAJOR="${JDK_MAJOR:-8}"
+JDK_FULL="${JDK_FULL:-8u202-linux-x64}"
 
 if [ -z `which javac` ]; then
     apt-get -y update
@@ -47,7 +47,7 @@ if [ -z `which javac` ]; then
     cd /opt/jdk
     rm -rf $JDK_MAJOR
     fetch_jdk_tgz $JDK_FULL
-    tar --strip-components=1 zxf $(path_to_jdk_cache $JDK_FULL)
+    tar x --strip-components=1 zf $(path_to_jdk_cache $JDK_FULL)
     for bin in /opt/jdk/$JDK_MAJOR/bin/* ; do 
       name=$(basename $bin)
       update-alternatives --install /usr/bin/$name $name $bin 1081 && update-alternatives --set $name $bin

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -22,7 +22,7 @@ export KIBOSH_VERSION=d85ac3ec44be0700efe605c16289fd901cfdaa13
 
 path_to_jdk_cache() {
   jdk_version=$1
-  echo "/tmp/{jdk_version}.tar.gz"
+  echo "/tmp/${jdk_version}.tar.gz"
 }
 
 fetch_jdk_tgz() {

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -48,8 +48,10 @@ if [ -z `which javac` ]; then
     mkdir -p /opt/jdk
     cd /opt/jdk
     rm -rf $JDK_MAJOR
+    mkdir -p $JDK_MAJOR
+    cd $JKD_MAJOR
     fetch_jdk_tgz $JDK_FULL
-    tar x --strip-components=1 zf $(path_to_jdk_cache $JDK_FULL)
+    tar x --strip-components=1 -zf $(path_to_jdk_cache $JDK_FULL)
     for bin in /opt/jdk/$JDK_MAJOR/bin/* ; do 
       name=$(basename $bin)
       update-alternatives --install /usr/bin/$name $name $bin 1081 && update-alternatives --set $name $bin

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -20,38 +20,38 @@ set -ex
 # If you update this, also update tests/docker/Dockerfile
 export KIBOSH_VERSION=d85ac3ec44be0700efe605c16289fd901cfdaa13
 
+path_to_jdk_cache() {
+  jdk_version=$1
+  echo "/var/cache/oracle-jdk8-installer/jdk-${jdk_version}-linux-64.tar.gz"
+}
+
+fetch_jdk_tgz() {
+  jdk_version=$1
+
+  if [ ! -e $(path_to_jdk_cache $jdk_version) ]; then
+    mkdir -p $(dirname $(path_to_jdk_cache $jdk_version))
+    # Grab a copy of the JDK since it has moved and original downloader won't work
+    curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-${jdk_version}-linux-x64.tar.gz" -o $(path_to_jdk_cache $jdk_version)
+  fi
+}
+
 if [ -z `which javac` ]; then
     apt-get -y update
-    apt-get install -y software-properties-common python-software-properties
-    add-apt-repository -y ppa:webupd8team/java
-    apt-get -y update
+    apt-get install -y software-properties-common python-software-properties binutils gsfonts gsfonts-x11 java-common libfontenc1 libxfont1 x11-common xfonts-encodings xfonts-utils
 
-    # Try to share cache. See Vagrantfile for details
-    mkdir -p /var/cache/oracle-jdk8-installer
-    if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
-        find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
-    fi
-    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz" ]; then
-      # Grab a copy of the JDK since it has moved and original downloader won't work
-      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u171-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz
-    fi
-
-    /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-
-    # oracle-javaX-installer runs wget with a dot progress indicator which ends up
-    # as one line per dot in the build logs.
-    # To avoid this noise we redirect all output to a file that we only show if apt-get fails.
-    echo "Installing JDK..."
-    if ! apt-get -y install oracle-java8-installer oracle-java8-set-default >/tmp/jdk_install.log 2>&1 ; then
-        cat /tmp/jdk_install.log
-        echo "ERROR: JDK install failed"
-        exit 1
-    fi
+    echo "===> Installing JDK..." 
+    mkdir -p /opt/jdk/8
+    cd /opt/jdk/8
+    jdk_version='8u202'
+    fetch_jdk_tgz $jdk_version
+    tar zxf $(path_to_jdk_cache $jdk_version)
+    for bin in /opt/jdk/8/bin/* ; do 
+      name=$(basename $bin)
+      update-alternatives --install /usr/bin/$name $name $bin 1091 && update-alternatives --set $name $bin
+    done
+    echo "export JAVA_HOME=/opt/jdk/8\nexport PATH=\$PATH:\$JAVA_HOME/bin" > /etc/profile.d/jdk.sh
     echo "JDK installed: $(javac -version 2>&1)"
 
-    if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
-        cp -R /var/cache/oracle-jdk8-installer/* /tmp/oracle-jdk8-installer-cache
-    fi
 fi
 
 chmod a+rw /opt

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -22,15 +22,17 @@ export KIBOSH_VERSION=d85ac3ec44be0700efe605c16289fd901cfdaa13
 
 path_to_jdk_cache() {
   jdk_version=$1
-  echo "/tmp/${jdk_version}.tar.gz"
+  echo "/tmp/jdk-${jdk_version}.tar.gz"
 }
 
 fetch_jdk_tgz() {
   jdk_version=$1
 
-  if [ ! -e $(path_to_jdk_cache $jdk_version) ]; then
-    mkdir -p $(dirname $(path_to_jdk_cache $jdk_version))
-    curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-${jdk_version}.tar.gz" -o $(path_to_jdk_cache $jdk_version)
+  path=$(path_to_jdk_cache $jdk_version)
+
+  if [ ! -e $path ]; then
+    mkdir -p $(dirname $path)
+    curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-${jdk_version}.tar.gz" -o $path
   fi
 }
 


### PR DESCRIPTION
Upgrade from 171 to 202. Unpack and install directly from a cached tgz rather than going via the installer deb from webupd8. The installer is still on 8u919 while we want 202.

Testing via kafka branch builder job

https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2305/
