### PR TITLE
MINOR: Handle case where connector status endpoints returns 404

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -370,6 +370,7 @@
         <allow pkg="kafka.zk" />
         <allow pkg="kafka.utils" />
         <allow class="javax.servlet.http.HttpServletResponse" />
+        <allow class="javax.ws.rs.core.Response" />
       </subpackage>
     </subpackage>
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -174,9 +174,14 @@ public class ErrorHandlingIntegrationTest {
     }
 
     private boolean partitionsAssigned() {
-        ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
-        return info != null && info.tasks().size() == NUM_TASKS
-                && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1;
+        try {
+            ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
+            return info != null && info.tasks().size() == NUM_TASKS
+                    && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1;
+        }  catch (Exception e) {
+            log.error("Could not check connector state info. Swallowing exception.", e);
+            return false;
+        }
     }
 
     private void assertValue(String expected, Headers headers, String headerKey) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -174,9 +174,9 @@ public class ErrorHandlingIntegrationTest {
     }
 
     /**
-     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from from a
-     * {@link org.apache.kafka.test.TestUtils#waitForCondition} in this test that throws errors if this
-     * method continues to return false after the specified duration has elapsed.
+     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from a
+     * {@link org.apache.kafka.test.TestUtils#waitForCondition} that will throw an error if this method continued
+     * to return false after the specified duration has elapsed.
      *
      * @return true if each task was assigned a partition each, false if this was not true or an error occurred when
      * executing this operation.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -134,7 +134,7 @@ public class ErrorHandlingIntegrationTest {
 
         connect.configureConnector(CONNECTOR_NAME, props);
 
-        waitForCondition(this::partitionsAssigned,
+        waitForCondition(this::checkForPartitionAssignment,
                 CONNECTOR_SETUP_DURATION_MS,
                 "Connector task was not assigned a partition.");
 
@@ -173,13 +173,22 @@ public class ErrorHandlingIntegrationTest {
         connect.deleteConnector(CONNECTOR_NAME);
     }
 
-    private boolean partitionsAssigned() {
+    /**
+     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from from a
+     * {@link org.apache.kafka.test.TestUtils#waitForCondition} in this test that throws errors if this
+     * method continues to return false after the specified duration has elapsed.
+     *
+     * @return true if each task was assigned a partition each, false if this was not true or an error occurred when
+     * executing this operation.
+     */
+    private boolean checkForPartitionAssignment() {
         try {
             ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
             return info != null && info.tasks().size() == NUM_TASKS
                     && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1;
         }  catch (Exception e) {
-            log.error("Could not check connector state info. Swallowing exception.", e);
+            // Log the exception and return that the partitions were not assigned
+            log.error("Could not check connector state info.", e);
             return false;
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -73,6 +74,7 @@ public class ErrorHandlingIntegrationTest {
     private static final int NUM_RECORDS_PRODUCED = 20;
     private static final int EXPECTED_CORRECT_RECORDS = 19;
     private static final int EXPECTED_INCORRECT_RECORDS = 1;
+    private static final int NUM_TASKS = 1;
     private static final int CONNECTOR_SETUP_DURATION_MS = 5000;
     private static final int CONSUME_MAX_DURATION_MS = 5000;
 
@@ -105,7 +107,7 @@ public class ErrorHandlingIntegrationTest {
         // setup connector config
         Map<String, String> props = new HashMap<>();
         props.put(CONNECTOR_CLASS_CONFIG, "MonitorableSink");
-        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPICS_CONFIG, "test-topic");
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -132,8 +134,7 @@ public class ErrorHandlingIntegrationTest {
 
         connect.configureConnector(CONNECTOR_NAME, props);
 
-        waitForCondition(() -> connect.connectorStatus(CONNECTOR_NAME).tasks().size() == 1
-                        && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1,
+        waitForCondition(this::partitionsAssigned,
                 CONNECTOR_SETUP_DURATION_MS,
                 "Connector task was not assigned a partition.");
 
@@ -170,6 +171,12 @@ public class ErrorHandlingIntegrationTest {
         }
 
         connect.deleteConnector(CONNECTOR_NAME);
+    }
+
+    private boolean partitionsAssigned() {
+        ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
+        return info != null && info.tasks().size() == NUM_TASKS
+                && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1;
     }
 
     private void assertValue(String expected, Headers headers, String headerKey) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -141,9 +141,9 @@ public class ExampleConnectIntegrationTest {
     }
 
     /**
-     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from from a
-     * {@link org.apache.kafka.test.TestUtils#waitForCondition} in this test that throws errors if this
-     * method continues to return false after the specified duration has elapsed.
+     * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from a
+     * {@link org.apache.kafka.test.TestUtils#waitForCondition} that will throw an error if this method continued
+     * to return false after the specified duration has elapsed.
      *
      * @return true if each task was assigned a partition each, false if this was not true or an error occurred when
      * executing this operation.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -24,6 +24,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -47,6 +49,8 @@ import static org.junit.Assert.assertEquals;
  */
 @Category(IntegrationTest.class)
 public class ExampleConnectIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ExampleConnectIntegrationTest.class);
 
     private static final int NUM_RECORDS_PRODUCED = 2000;
     private static final int NUM_TOPIC_PARTITIONS = 3;
@@ -137,8 +141,13 @@ public class ExampleConnectIntegrationTest {
     }
 
     private boolean partitionsAssigned() {
-        ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
-        return info != null && info.tasks().size() == NUM_TASKS
-                && connectorHandle.tasks().stream().allMatch(th -> th.partitionsAssigned() == 1);
+        try {
+            ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
+            return info != null && info.tasks().size() == NUM_TASKS
+                    && connectorHandle.tasks().stream().allMatch(th -> th.partitionsAssigned() == 1);
+        } catch (Exception e) {
+            log.error("Could not check connector state info. Swallowing exception.", e);
+            return false;
+        }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -250,7 +250,6 @@ public class EmbeddedConnectCluster {
             if (status != null) {
                 throw new ConnectRestException(status, "Invalid endpoint: " + url, e);
             }
-
             // invalid response code, re-throw the IOException.
             throw e;
         }


### PR DESCRIPTION
The integration test framework for Connect provides a `org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster#connectorStatus` method that checks the status of a Connector via the REST endpoint and deserializes the response into a `ConnectorStateInfo` object. If the connector creation request has just been finished, and task creation delayed for some reason (for example, rebalancing is ongoing), the REST API returns a 404 on the `connectors/{connectorName}/status` endpoint, and causes the test to fail with the exception:

```
[2019-01-19 03:47:59,289] (Test worker) ERROR Could not read connector state (org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster:178)
java.io.FileNotFoundException: http://localhost:38625/connectors/simple-conn/status
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1909)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1509)
	at org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster.executeGet(EmbeddedConnectCluster.java:223)
	at org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster.connectorStatus(EmbeddedConnectCluster.java:176)
	at org.apache.kafka.connect.integration.ExampleConnectIntegrationTest.lambda$testProduceConsumeConnector$1(ExampleConnectIntegrationTest.java:117)
	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:355)
	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:342)
	at org.apache.kafka.connect.integration.ExampleConnectIntegrationTest.testProduceConsumeConnector(ExampleConnectIntegrationTest.java:117)
```

This fix handles the 404 case instead of simply re-throwing the Exception.

Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
