### PR TITLE
KAFKA-7856: Fix vulnerability CWE-331

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLogin.java
@@ -18,7 +18,7 @@ package org.apache.kafka.common.security.oauthbearer.internals.expiring;
 
 import java.util.Date;
 import java.util.Objects;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.Configuration;
@@ -124,7 +124,7 @@ public abstract class ExpiringCredentialRefreshingLogin {
 
     private static final Logger log = LoggerFactory.getLogger(ExpiringCredentialRefreshingLogin.class);
     private static final long DELAY_SECONDS_BEFORE_NEXT_RETRY_WHEN_RELOGIN_FAILS = 10L;
-    private static final Random RNG = new Random();
+    private static final SecureRandom RNG = new SecureRandom();
     private final Time time;
     private Thread refresherThread;
 


### PR DESCRIPTION
fix vulnerability pointed by CWE.
Cryptographic Issues by Insufficient Entropy (CWE-331 - Flaw medium,SANS
TOP 25)
This change should be promoted to new versions.