### PR TITLE
[WIP] KIP-81 Bound Fetch memory usage in the consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -72,6 +72,11 @@ final class InFlightRequests {
         return inFlightRequest;
     }
 
+    public NetworkClient.InFlightRequest peekNext(String node) {
+        NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).peekLast();
+        return inFlightRequest;
+    }
+
     /**
      * Get the last request we sent to the given node (but don't remove it from the queue)
      * @param node The node id

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -745,6 +745,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     new ApiVersions(),
                     throttleTimeSensor,
                     logContext);
+            channelBuilder.setMemoryPoolHelper(netClient);
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.network;
 import java.nio.channels.SelectionKey;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.memory.MemoryPool;
 
@@ -43,5 +44,7 @@ public interface ChannelBuilder extends AutoCloseable, Configurable {
      */
     @Override
     void close();
+
+    void setMemoryPoolHelper(MemoryPoolHelper netClient);
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -137,7 +137,7 @@ public class ChannelBuilders {
                         time);
                 break;
             case PLAINTEXT:
-                channelBuilder = new PlaintextChannelBuilder(listenerName);
+                channelBuilder = new PlaintextChannelBuilder(mode, listenerName);
                 break;
             default:
                 throw new IllegalArgumentException("Unexpected securityProtocol " + securityProtocol);

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -132,11 +132,13 @@ public class KafkaChannel implements AutoCloseable {
     private int successfulAuthentications;
     private boolean midWrite;
     private long lastReauthenticationStartNanos;
+    private MemoryPoolHelper memoryPoolHelper;
 
-    public KafkaChannel(String id, TransportLayer transportLayer, Supplier<Authenticator> authenticatorCreator, int maxReceiveSize, MemoryPool memoryPool) {
+    public KafkaChannel(String id, TransportLayer transportLayer, Supplier<Authenticator> authenticatorCreator, int maxReceiveSize, MemoryPool memoryPool, MemoryPoolHelper memoryPoolHelper) {
         this.id = id;
         this.transportLayer = transportLayer;
         this.authenticatorCreator = authenticatorCreator;
+        this.memoryPoolHelper = memoryPoolHelper;
         this.authenticator = authenticatorCreator.get();
         this.networkThreadTimeNanos = 0L;
         this.maxReceiveSize = maxReceiveSize;
@@ -421,7 +423,7 @@ public class KafkaChannel implements AutoCloseable {
     }
 
     private long receive(NetworkReceive receive) throws IOException {
-        return receive.readFrom(transportLayer);
+        return receive.readFrom(transportLayer, memoryPoolHelper.usePool(id));
     }
 
     private boolean send(Send send) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/network/MemoryPoolHelper.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/MemoryPoolHelper.java
@@ -1,0 +1,13 @@
+package org.apache.kafka.common.network;
+
+public interface MemoryPoolHelper {
+    
+    public MemoryPoolHelper SERVER_MODE = new MemoryPoolHelper() {
+        @Override
+        public boolean usePool(String nodeId) {
+            return true;
+        }
+    };
+
+    boolean usePool(String nodeId);
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -40,6 +40,7 @@ public class NetworkReceive implements Receive {
     private final MemoryPool memoryPool;
     private int requestedBufferSize = -1;
     private ByteBuffer buffer;
+    private Boolean usePool = null;
 
 
     public NetworkReceive(String source, ByteBuffer buffer) {
@@ -88,7 +89,8 @@ public class NetworkReceive implements Receive {
         return !size.hasRemaining() && buffer != null && !buffer.hasRemaining();
     }
 
-    public long readFrom(ScatteringByteChannel channel) throws IOException {
+    public long readFrom(ScatteringByteChannel channel, boolean usePool) throws IOException {
+        this.usePool = usePool;
         int read = 0;
         if (size.hasRemaining()) {
             int bytesRead = channel.read(size);
@@ -152,6 +154,12 @@ public class NetworkReceive implements Receive {
      */
     public int size() {
         return payload().limit() + size.limit();
+    }
+
+    @Override
+    public boolean usePool() {
+        // TODO Auto-generated method stub
+        return usePool;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
@@ -35,12 +35,15 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
     private static final Logger log = LoggerFactory.getLogger(PlaintextChannelBuilder.class);
     private final ListenerName listenerName;
     private Map<String, ?> configs;
+    private MemoryPoolHelper memoryPoolHelper = MemoryPoolHelper.SERVER_MODE;
+    private Mode mode;
 
     /**
      * Constructs a plaintext channel builder. ListenerName is non-null whenever
      * it's instantiated in the broker and null otherwise.
      */
-    public PlaintextChannelBuilder(ListenerName listenerName) {
+    public PlaintextChannelBuilder(Mode mode, ListenerName listenerName) {
+        this.mode = mode;
         this.listenerName = listenerName;
     }
 
@@ -54,7 +57,7 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
             PlaintextTransportLayer transportLayer = new PlaintextTransportLayer(key);
             Supplier<Authenticator> authenticatorCreator = () -> new PlaintextAuthenticator(configs, transportLayer, listenerName);
             return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
-                    memoryPool != null ? memoryPool : MemoryPool.NONE);
+                    memoryPool != null ? memoryPool : MemoryPool.NONE, memoryPoolHelper);
         } catch (Exception e) {
             log.warn("Failed to create channel due to ", e);
             throw new KafkaException(e);
@@ -97,6 +100,13 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
             if (principalBuilder instanceof Closeable)
                 Utils.closeQuietly((Closeable) principalBuilder, "principal builder");
         }
+    }
+
+    @Override
+    public void setMemoryPoolHelper(MemoryPoolHelper netClient) {
+        this.memoryPoolHelper = netClient;
+        // TODO Auto-generated method stub
+        
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/Receive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Receive.java
@@ -41,7 +41,7 @@ public interface Receive extends Closeable {
      * @return The number of bytes read
      * @throws IOException If the reading fails
      */
-    long readFrom(ScatteringByteChannel channel) throws IOException;
+    long readFrom(ScatteringByteChannel channel, boolean usePool) throws IOException;
 
     /**
      * Do we know yet how much memory we require to fully read this
@@ -52,4 +52,6 @@ public interface Receive extends Closeable {
      * Has the underlying memory required to complete reading been allocated yet?
      */
     boolean memoryAllocated();
+    
+    boolean usePool();
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -89,6 +89,8 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
     private Map<String, Long> connectionsMaxReauthMsByMechanism;
     private final Time time;
 
+    private MemoryPoolHelper netClient = MemoryPoolHelper.SERVER_MODE;
+
     public SaslChannelBuilder(Mode mode,
                               Map<String, JaasContext> jaasContexts,
                               SecurityProtocol securityProtocol,
@@ -207,7 +209,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                         transportLayer,
                         subjects.get(clientSaslMechanism));
             }
-            return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize, memoryPool != null ? memoryPool : MemoryPool.NONE);
+            return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize, memoryPool != null ? memoryPool : MemoryPool.NONE, netClient);
         } catch (Exception e) {
             log.info("Failed to create channel due to ", e);
             throw new KafkaException(e);
@@ -339,5 +341,12 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
             default:
                 return SaslClientCallbackHandler.class;
         }
+    }
+
+    @Override
+    public void setMemoryPoolHelper(MemoryPoolHelper netClient) {
+        this.netClient = netClient;
+        // TODO Auto-generated method stub
+        
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -50,6 +50,9 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
     private Map<String, ?> configs;
     private SslPrincipalMapper sslPrincipalMapper;
 
+    private MemoryPoolHelper memoryPoolHelper = MemoryPoolHelper.SERVER_MODE;
+;
+
     /**
      * Constructs a SSL channel builder. ListenerName is provided only
      * for server channel builder and will be null for client channel builder.
@@ -100,7 +103,7 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
             SslTransportLayer transportLayer = buildTransportLayer(sslFactory, id, key, peerHost(key));
             Supplier<Authenticator> authenticatorCreator = () -> new SslAuthenticator(configs, transportLayer, listenerName, sslPrincipalMapper);
             return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
-                    memoryPool != null ? memoryPool : MemoryPool.NONE);
+                    memoryPool != null ? memoryPool : MemoryPool.NONE, memoryPoolHelper);
         } catch (Exception e) {
             log.info("Failed to create channel due to ", e);
             throw new KafkaException(e);
@@ -205,5 +208,12 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
         public boolean complete() {
             return true;
         }
+    }
+
+    @Override
+    public void setMemoryPoolHelper(MemoryPoolHelper netClient) {
+        this.memoryPoolHelper = netClient;
+        // TODO Auto-generated method stub
+        
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -218,6 +218,7 @@ public enum ApiKeys {
     public final Schema[] requestSchemas;
     public final Schema[] responseSchemas;
     public final boolean requiresDelayedAllocation;
+    public final boolean requiresPoolAllocation;
 
     ApiKeys(int id, String name, Schema[] requestSchemas, Schema[] responseSchemas) {
         this(id, name, false, requestSchemas, responseSchemas);
@@ -255,6 +256,7 @@ public enum ApiKeys {
             }
         }
         this.requiresDelayedAllocation = requestRetainsBufferReference;
+        this.requiresPoolAllocation = id == 1; //FETCH
         this.requestSchemas = requestSchemas;
         this.responseSchemas = responseSchemas;
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -404,7 +404,7 @@ public class SaslClientAuthenticator implements Authenticator {
 
     private byte[] receiveResponseOrToken() throws IOException {
         if (netInBuffer == null) netInBuffer = new NetworkReceive(node);
-        netInBuffer.readFrom(transportLayer);
+        netInBuffer.readFrom(transportLayer, false);
         byte[] serverPacket = null;
         if (netInBuffer.complete()) {
             netInBuffer.payload().rewind();

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -264,7 +264,7 @@ public class SaslServerAuthenticator implements Authenticator {
             // allocate on heap (as opposed to any socket server memory pool)
             if (netInBuffer == null) netInBuffer = new NetworkReceive(MAX_RECEIVE_SIZE, connectionId);
     
-            netInBuffer.readFrom(transportLayer);
+            netInBuffer.readFrom(transportLayer, false);
             if (!netInBuffer.complete())
                 return;
             netInBuffer.payload().rewind();

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -85,7 +85,7 @@ public class SelectorTest {
         this.server = new EchoServer(SecurityProtocol.PLAINTEXT, configs);
         this.server.start();
         this.time = new MockTime();
-        this.channelBuilder = new PlaintextChannelBuilder(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT));
+        this.channelBuilder = new PlaintextChannelBuilder(Mode.CLIENT, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT));
         this.channelBuilder.configure(configs);
         this.metrics = new Metrics();
         this.selector = new Selector(5000, this.metrics, time, "MetricGroup", channelBuilder, new LogContext());
@@ -310,7 +310,7 @@ public class SelectorTest {
 
     @Test
     public void registerFailure() throws Exception {
-        ChannelBuilder channelBuilder = new PlaintextChannelBuilder(null) {
+        ChannelBuilder channelBuilder = new PlaintextChannelBuilder(Mode.CLIENT, null) {
             @Override
             public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize,
                     MemoryPool memoryPool) throws KafkaException {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -848,7 +848,7 @@ public class SslTransportLayerTest {
 
     @Test
     public void testClosePlaintext() throws Exception {
-        testClose(SecurityProtocol.PLAINTEXT, new PlaintextChannelBuilder(null));
+        testClose(SecurityProtocol.PLAINTEXT, new PlaintextChannelBuilder(Mode.CLIENT, null));
     }
 
     private void testClose(SecurityProtocol securityProtocol, ChannelBuilder clientChannelBuilder) throws Exception {


### PR DESCRIPTION
As discussed in https://github.com/apache/kafka/pull/4934#discussion_r236339139, this is a PoC implementation for KIP-81. This does not rely on tagging Node to determine which responses should be allocated in the MemoryPool.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
