### PR TITLE
KAFKA-7855: Kafka Streams Maven Archetype quickstart fails to compile out of the box

### DIFF
--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
@@ -44,10 +44,9 @@ public class LineSplit {
 
         final StreamsBuilder builder = new StreamsBuilder();
 
-        KStream<String, String> source = builder.stream("streams-plaintext-input");
-
-        source.flatMapValues(value -> Arrays.asList(value.split("\\W+")))
-                .to("streams-linesplit-output");
+        builder.<String, String>stream("streams-plaintext-input")
+            .flatMapValues(value -> Arrays.asList(value.split("\\W+")))
+            .to("streams-linesplit-output");
 
         final Topology topology = builder.build();
         final KafkaStreams streams = new KafkaStreams(topology, props);

--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
@@ -44,9 +44,9 @@ public class LineSplit {
 
         final StreamsBuilder builder = new StreamsBuilder();
 
-        builder.stream("streams-plaintext-input")
-               .flatMapValues(value -> Arrays.asList(value.split("\\W+")))
-               .to("streams-linesplit-output");
+        KStream<String, String> source = builder.stream("streams-plaintext-input");
+        source.flatMapValues(value -> Arrays.asList(value.split("\\W+")))
+            .to("streams-linesplit-output");
 
         final Topology topology = builder.build();
         final KafkaStreams streams = new KafkaStreams(topology, props);

--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
@@ -45,8 +45,9 @@ public class LineSplit {
         final StreamsBuilder builder = new StreamsBuilder();
 
         KStream<String, String> source = builder.stream("streams-plaintext-input");
+
         source.flatMapValues(value -> Arrays.asList(value.split("\\W+")))
-            .to("streams-linesplit-output");
+                .to("streams-linesplit-output");
 
         final Topology topology = builder.build();
         final KafkaStreams streams = new KafkaStreams(topology, props);

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 


### PR DESCRIPTION
In the LineSplit.java example, the untyped KStream is resolved to `KStream<Object, Object>`. `value.split(..)` then  fails to build, because value is of type Object. 

Other possible solutions would be to add the type to the builder:
`builder.<String, String>stream(...).flatmap(..).to(...)`, or `builder.stream(..., Consumed.with(Serdes.String(), Serdes.String()))`.

This change matches the code in the [tutorial](http://kafka.apache.org/21/documentation/streams/tutorial).

WIP: It should be tested during compile that the Java resource files compiles. However, I haven't found any way to achieve this. Feedback appreciated! 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
