### PR TITLE
getConfiguredInstance may return a confusing error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -301,7 +301,9 @@ public class AbstractConfig {
             return null;
         Object o = Utils.newInstance(c);
         if (!t.isInstance(o))
-            throw new KafkaException(c.getName() + " is not an instance of " + t.getName());
+            throw new KafkaException(c.getName() + " is not an instance of " + t.getName()
+                +((o.getClass().getClassLoader() != t.getClass().getClassLoader())
+                    ?" possibly because the two classes have different classloaders":""));
         if (o instanceof Configurable)
             ((Configurable) o).configure(originals());
         return t.cast(o);


### PR DESCRIPTION
For getConfiguredInstance, if there are classloader differences for the two classes such as in the following error output, this method puts out an error message than makes no sense on the face of it. It looks like Kafka is conflicting with itself.

eg. org.apache.kafka.common.KafkaException: org.apache.kafka.common.serialization.ByteArraySerializer is not an instance of org.apache.kafka.common.serialization.Serializer

The proposed changes indicate that the problem could be the result of classloader differences allowing someone to look in the appropriate direction to resolve their issue.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
