### PR TITLE
MINOR: Add information to command line doc of producer performance tool

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -247,7 +247,7 @@ public class ProducerPerformance {
                 .required(true)
                 .type(Integer.class)
                 .metavar("THROUGHPUT")
-                .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
+                .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec. Set this to -1 to disable throttling.");
 
         parser.addArgument("--producer-props")
                  .nargs("+")


### PR DESCRIPTION
The command line producer performance tool has a the required parameter _--throughput_ which controls the target number of messages to be sent per second. If no throttling is desired this can be set to a [negative number ](https://github.com/apache/kafka/blob/d0e436c471ba4122ddcc0f7a1624546f97c4a517/tools/src/main/java/org/apache/kafka/tools/ThroughputThrottler.java#L70) - but this is not specified in the command line help text.

No jira because this is a minor fix. No added tests, as this just changes a string variable, no actual code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
