### PR TITLE
KAFKA-7884: Docs for message.format.version and log.message.format.version show invalid (corrupt?) "valid values"

### DIFF
--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -307,4 +307,6 @@ object ApiVersionValidator extends Validator {
       case e: IllegalArgumentException => throw new ConfigException(name, value.toString, e.getMessage)
     }
   }
+
+  override def toString: String = "[" + ApiVersion.allVersions.groupBy(_.shortVersion).keys.mkString(", ") + "]"
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -308,5 +308,5 @@ object ApiVersionValidator extends Validator {
     }
   }
 
-  override def toString: String = "[" + ApiVersion.allVersions.map(_.shortVersion).distinct.mkString(", ") + "]"
+  override def toString: String = "[" + ApiVersion.allVersions.map(_.version).distinct.mkString(", ") + "]"
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -308,5 +308,5 @@ object ApiVersionValidator extends Validator {
     }
   }
 
-  override def toString: String = "[" + ApiVersion.allVersions.groupBy(_.shortVersion).keys.mkString(", ") + "]"
+  override def toString: String = "[" + ApiVersion.allVersions.map(_.shortVersion).distinct.mkString(", ") + "]"
 }

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -121,8 +121,9 @@ class ApiVersionTest {
 
   @Test
   def testApiVersionValidator(): Unit = {
-    assertEquals(ApiVersion.allVersions.groupBy(_.shortVersion).keySet.size,
-      ApiVersionValidator.toString.split(",").length)
+    val str = ApiVersionValidator.toString
+    val apiVersions = str.slice(1, str.length).split(",")
+    assertEquals(ApiVersion.allVersions.groupBy(_.shortVersion).keySet.size, apiVersions.length)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -119,4 +119,10 @@ class ApiVersionTest {
     assertEquals("0.11.0", KAFKA_0_11_0_IV0.shortVersion)
   }
 
+  @Test
+  def testApiVersionValidator(): Unit = {
+    assertEquals(ApiVersion.allVersions.groupBy(_.shortVersion).keySet.size,
+      ApiVersionValidator.toString.split(",").length)
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -123,7 +123,7 @@ class ApiVersionTest {
   def testApiVersionValidator(): Unit = {
     val str = ApiVersionValidator.toString
     val apiVersions = str.slice(1, str.length).split(",")
-    assertEquals(ApiVersion.allVersions.groupBy(_.shortVersion).keySet.size, apiVersions.length)
+    assertEquals(ApiVersion.allVersions.size, apiVersions.length)
   }
 
 }


### PR DESCRIPTION
![apache kafka](https://user-images.githubusercontent.com/2375128/51978989-33f47600-24cf-11e9-89ef-c8116ff85947.png)
The reason for the problem is simple: `ApiVersionValidator#toString` is missing. In contrast, all other Validators like `ThrottledReplicaListValidator` or `Range`, have its own `toString` method.

This update solves this problem by adding `ApiVersionValidator#toString`. It also provides a unit test for it.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
