### PR TITLE
MINOR: Increase timeout for flaky test

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -55,7 +55,7 @@ public class ExampleConnectIntegrationTest {
     private static final int NUM_RECORDS_PRODUCED = 2000;
     private static final int NUM_TOPIC_PARTITIONS = 3;
     private static final int CONSUME_MAX_DURATION_MS = 5000;
-    private static final int CONNECTOR_SETUP_DURATION_MS = 15000;
+    private static final int CONNECTOR_SETUP_DURATION_MS = 60000;
     private static final int NUM_TASKS = 3;
     private static final String CONNECTOR_NAME = "simple-conn";
 


### PR DESCRIPTION
_**This is a WIP. Please do not merge.**_

This test was occasionally failing with timeout issues.  Even though on a laptop the test takes 5-6 seconds to setup connectors, on slow VMs, it might need more than the 15 seconds we were allowing it.

Signed-off-by: Arjun Satish <arjun@confluent.io>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
