### PR TITLE
KAFKA-7956 In ShutdownableThread, immediately complete the shutdown if the thread has not been started

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -61,6 +61,7 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
   def start(): Unit = thread.start()
 
   def close(): Unit = {
+    thread.initiateShutdown()
     clearAndPut(KafkaController.ShutdownEventThread)
     thread.awaitShutdown()
   }
@@ -83,7 +84,7 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
 
     override def doWork(): Unit = {
       queue.take() match {
-        case KafkaController.ShutdownEventThread => initiateShutdown()
+        case KafkaController.ShutdownEventThread =>
         case controllerEvent =>
           _state = controllerEvent.state
 

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -84,7 +84,7 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
 
     override def doWork(): Unit = {
       queue.take() match {
-        case KafkaController.ShutdownEventThread =>
+        case KafkaController.ShutdownEventThread => // The shutting down of the thread has been initiated at this point. Ignore this event.
         case controllerEvent =>
           _state = controllerEvent.state
 

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -29,11 +29,10 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
   private val shutdownComplete = new CountDownLatch(1)
 
   def shutdown(): Unit = {
+    initiateShutdown()
     if (this.isAlive) {
-      initiateShutdown()
       awaitShutdown()
     } else {
-      shutdownInitiated.countDown()
       shutdownComplete.countDown()
     }
   }

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -29,8 +29,13 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
   private val shutdownComplete = new CountDownLatch(1)
 
   def shutdown(): Unit = {
-    initiateShutdown()
-    awaitShutdown()
+    if (this.isAlive) {
+      initiateShutdown()
+      awaitShutdown()
+    } else {
+      shutdownInitiated.countDown()
+      shutdownComplete.countDown()
+    }
   }
 
   def isShutdownComplete: Boolean = {

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -30,11 +30,7 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
 
   def shutdown(): Unit = {
     initiateShutdown()
-    if (this.isAlive) {
-      awaitShutdown()
-    } else {
-      shutdownComplete.countDown()
-    }
+    awaitShutdown()
   }
 
   def isShutdownComplete: Boolean = {
@@ -58,8 +54,10 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    * After calling initiateShutdown(), use this API to wait until the shutdown is complete
    */
   def awaitShutdown(): Unit = {
-    shutdownComplete.await()
-    info("Shutdown completed")
+    if (this.isAlive) {
+      shutdownComplete.await()
+      info("Shutdown completed")
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -81,10 +81,6 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    */
   def doWork(): Unit
 
-  override def start(): Unit = {
-    isStarted = true
-    super.start()
-  }
   override def run(): Unit = {
     isStarted = true
     info("Starting")

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -30,7 +30,11 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
 
   def shutdown(): Unit = {
     initiateShutdown()
-    awaitShutdown()
+    if (this.isAlive) {
+      awaitShutdown()
+    } else {
+      shutdownComplete.countDown()
+    }
   }
 
   def isShutdownComplete: Boolean = {
@@ -54,10 +58,8 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    * After calling initiateShutdown(), use this API to wait until the shutdown is complete
    */
   def awaitShutdown(): Unit = {
-    if (this.isAlive) {
-      shutdownComplete.await()
-      info("Shutdown completed")
-    }
+    shutdownComplete.await()
+    info("Shutdown completed")
   }
 
   /**

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -27,7 +27,8 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
   this.logIdent = "[" + name + "]: "
   private val shutdownInitiated = new CountDownLatch(1)
   private val shutdownComplete = new CountDownLatch(1)
-
+  @volatile private var isStarted: Boolean = false
+  
   def shutdown(): Unit = {
     initiateShutdown()
     awaitShutdown()
@@ -54,9 +55,13 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    * After calling initiateShutdown(), use this API to wait until the shutdown is complete
    */
   def awaitShutdown(): Unit = {
-    if (this.isAlive)
-      shutdownComplete.await()
-    info("Shutdown completed")
+    if (shutdownInitiated.getCount != 0)
+      throw new IllegalStateException("initiateShutdown() was not called before awaitShutdown()")
+    else {
+      if (isStarted)
+        shutdownComplete.await()
+      info("Shutdown completed")
+    }
   }
 
   /**
@@ -76,7 +81,12 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    */
   def doWork(): Unit
 
+  override def start(): Unit = {
+    isStarted = true
+    super.start()
+  }
   override def run(): Unit = {
+    isStarted = true
     info("Starting")
     try {
       while (isRunning)

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -30,11 +30,7 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
 
   def shutdown(): Unit = {
     initiateShutdown()
-    if (this.isAlive) {
-      awaitShutdown()
-    } else {
-      shutdownComplete.countDown()
-    }
+    awaitShutdown()
   }
 
   def isShutdownComplete: Boolean = {
@@ -58,7 +54,8 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
    * After calling initiateShutdown(), use this API to wait until the shutdown is complete
    */
   def awaitShutdown(): Unit = {
-    shutdownComplete.await()
+    if (this.isAlive)
+      shutdownComplete.await()
     info("Shutdown completed")
   }
 


### PR DESCRIPTION
In some test cases it's desirable to instantiate a subclass of `ShutdownableThread` without starting it. Since most subclasses of `ShutdownableThread` put cleanup logic in `ShutdownableThread.shutdown()`, being able to call `shutdown()` on the non-running thread would be useful.

This change allows us to avoid blocking in `ShutdownableThread.shutdown()` if the thread's `run()` method has not been called. We also add a check that `initiateShutdown()` was called before `awaitShutdown()`, to protect against the case where a user calls `awaitShutdown()` before the thread has been started, and unexpectedly is not blocked on the thread shutting down. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
