### PR TITLE
KAFKA-7236: Add --under-min-isr option to describe topics command (KIP-351)

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -30,7 +30,7 @@ import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{ListTopicsOptions, NewPartitions, NewTopic, AdminClient => JAdminClient}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.config.ConfigResource.Type
 import org.apache.kafka.common.errors.{InvalidTopicException, TopicExistsException}
 import org.apache.kafka.common.internals.Topic
@@ -99,17 +99,18 @@ object TopicCommand extends Logging {
                                    leader: Option[Int],
                                    assignedReplicas: Seq[Int],
                                    isr: Seq[Int],
+                                   minIsr: Int,
                                    markedForDeletion: Boolean,
                                    describeConfigs: Boolean)
 
   class DescribeOptions(opts: TopicCommandOptions, liveBrokers: Set[Int]) {
-    val describeConfigs: Boolean = !opts.reportUnavailablePartitions && !opts.reportUnderReplicatedPartitions
+    val describeConfigs: Boolean = !opts.reportUnavailablePartitions && !opts.reportUnderReplicatedPartitions && !opts.reportUnderMinIsrPartitions
     val describePartitions: Boolean = !opts.reportOverriddenConfigs
-    private def hasUnderreplicatedPartitions(partitionDescription: PartitionDescription) = {
+    private def hasUnderReplicatedPartitions(partitionDescription: PartitionDescription) = {
       partitionDescription.isr.size < partitionDescription.assignedReplicas.size
     }
     private def shouldPrintUnderReplicatedPartitions(partitionDescription: PartitionDescription) = {
-      opts.reportUnderReplicatedPartitions && hasUnderreplicatedPartitions(partitionDescription)
+      opts.reportUnderReplicatedPartitions && hasUnderReplicatedPartitions(partitionDescription)
     }
     private def hasUnavailablePartitions(partitionDescription: PartitionDescription) = {
       partitionDescription.leader.isEmpty || !liveBrokers.contains(partitionDescription.leader.get)
@@ -117,11 +118,18 @@ object TopicCommand extends Logging {
     private def shouldPrintUnavailablePartitions(partitionDescription: PartitionDescription) = {
       opts.reportUnavailablePartitions && hasUnavailablePartitions(partitionDescription)
     }
+    private def hasUnderMinIsrPartitions(partitionDescription: PartitionDescription) = {
+      partitionDescription.isr.size < partitionDescription.minIsr
+    }
+    private def shouldPrintUnderMinIsrPartitions(partitionDescription: PartitionDescription) = {
+      opts.reportUnderMinIsrPartitions && hasUnderMinIsrPartitions(partitionDescription)
+    }
 
     def shouldPrintTopicPartition(partitionDesc: PartitionDescription): Boolean = {
       describeConfigs ||
         shouldPrintUnderReplicatedPartitions(partitionDesc) ||
-        shouldPrintUnavailablePartitions(partitionDesc)
+        shouldPrintUnavailablePartitions(partitionDesc) ||
+        shouldPrintUnderMinIsrPartitions(partitionDesc)
     }
   }
 
@@ -220,6 +228,8 @@ object TopicCommand extends Logging {
           }
         }
         if (describeOptions.describePartitions) {
+          val computedMinIsr = if (opts.reportUnderMinIsrPartitions)
+            allConfigs.get(new ConfigResource(ConfigResource.Type.TOPIC, td.name())).get().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value().toInt else 0
           for (partition <- sortedPartitions) {
             val partitionDesc = PartitionDescription(
               topic = td.name(),
@@ -227,6 +237,7 @@ object TopicCommand extends Logging {
               leader = Option(partition.leader()).map(_.id()),
               assignedReplicas = partition.replicas().asScala.map(_.id()),
               isr = partition.isr().asScala.map(_.id()),
+              minIsr = computedMinIsr,
               markedForDeletion = false,
               describeOptions.describeConfigs
             )
@@ -357,6 +368,7 @@ object TopicCommand extends Logging {
                   leader = if (leaderIsrEpoch.isEmpty) None else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
                   assignedReplicas,
                   isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr,
+                  minIsr = 0,
                   markedForDeletion,
                   describeOptions.describeConfigs
                 )
@@ -536,6 +548,8 @@ object TopicCommand extends Logging {
                                                             "if set when describing topics, only show under replicated partitions")
     private val reportUnavailablePartitionsOpt = parser.accepts("unavailable-partitions",
                                                             "if set when describing topics, only show partitions whose leader is not available")
+    private val reportUnderMinIsrPartitionsOpt = parser.accepts("under-minisr-partitions",
+                                                            "if set when describing topics, only show partitions whose isr count is less than the computed minimum. Not supported with the --zookeeper option.")
     private val topicsWithOverridesOpt = parser.accepts("topics-with-overrides",
                                                 "if set when describing topics, only show topics that have overridden configs")
     private val ifExistsOpt = parser.accepts("if-exists",
@@ -577,6 +591,7 @@ object TopicCommand extends Logging {
     def rackAwareMode: RackAwareMode = if (has(disableRackAware)) RackAwareMode.Disabled else RackAwareMode.Enforced
     def reportUnderReplicatedPartitions: Boolean = has(reportUnderReplicatedPartitionsOpt)
     def reportUnavailablePartitions: Boolean = has(reportUnavailablePartitionsOpt)
+    def reportUnderMinIsrPartitions: Boolean = has(reportUnderMinIsrPartitionsOpt)
     def reportOverriddenConfigs: Boolean = has(topicsWithOverridesOpt)
     def ifExists: Boolean = has(ifExistsOpt)
     def ifNotExists: Boolean = has(ifNotExistsOpt)
@@ -620,11 +635,13 @@ object TopicCommand extends Logging {
       if(options.has(createOpt))
           CommandLineUtils.checkInvalidArgs(parser, options, replicaAssignmentOpt, Set(partitionsOpt, replicationFactorOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, reportUnderReplicatedPartitionsOpt,
-        allTopicLevelOpts -- Set(describeOpt) + reportUnavailablePartitionsOpt + topicsWithOverridesOpt)
+        allTopicLevelOpts -- Set(describeOpt) + reportUnderMinIsrPartitionsOpt + reportUnavailablePartitionsOpt + topicsWithOverridesOpt)
+      CommandLineUtils.checkInvalidArgs(parser, options, reportUnderMinIsrPartitionsOpt,
+        allTopicLevelOpts -- Set(describeOpt) + reportUnderReplicatedPartitionsOpt + reportUnavailablePartitionsOpt + topicsWithOverridesOpt + zkConnectOpt)
       CommandLineUtils.checkInvalidArgs(parser, options, reportUnavailablePartitionsOpt,
-        allTopicLevelOpts -- Set(describeOpt) + reportUnderReplicatedPartitionsOpt + topicsWithOverridesOpt)
+        allTopicLevelOpts -- Set(describeOpt) + reportUnderReplicatedPartitionsOpt + reportUnderReplicatedPartitionsOpt + topicsWithOverridesOpt)
       CommandLineUtils.checkInvalidArgs(parser, options, topicsWithOverridesOpt,
-        allTopicLevelOpts -- Set(describeOpt) + reportUnderReplicatedPartitionsOpt + reportUnavailablePartitionsOpt)
+        allTopicLevelOpts -- Set(describeOpt) + reportUnderReplicatedPartitionsOpt + reportUnderMinIsrPartitionsOpt + reportUnavailablePartitionsOpt)
       CommandLineUtils.checkInvalidArgs(parser, options, ifExistsOpt, allTopicLevelOpts -- Set(alterOpt, deleteOpt, describeOpt) ++ Set(bootstrapServerOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, ifNotExistsOpt, allTopicLevelOpts -- Set(createOpt) ++ Set(bootstrapServerOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, excludeInternalTopicOpt, allTopicLevelOpts -- Set(listOpt, describeOpt))

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -549,7 +549,7 @@ object TopicCommand extends Logging {
     private val reportUnavailablePartitionsOpt = parser.accepts("unavailable-partitions",
                                                             "if set when describing topics, only show partitions whose leader is not available")
     private val reportUnderMinIsrPartitionsOpt = parser.accepts("under-minisr-partitions",
-                                                            "if set when describing topics, only show partitions whose isr count is less than the computed minimum. Not supported with the --zookeeper option.")
+                                                            "if set when describing topics, only show partitions whose isr count is less than the configured minimum. Not supported with the --zookeeper option.")
     private val topicsWithOverridesOpt = parser.accepts("topics-with-overrides",
                                                 "if set when describing topics, only show topics that have overridden configs")
     private val ifExistsOpt = parser.accepts("if-exists",

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -99,7 +99,7 @@ object TopicCommand extends Logging {
                                    leader: Option[Int],
                                    assignedReplicas: Seq[Int],
                                    isr: Seq[Int],
-                                   minIsr: Int,
+                                   minIsrCount: Int,
                                    markedForDeletion: Boolean,
                                    describeConfigs: Boolean)
 
@@ -119,7 +119,7 @@ object TopicCommand extends Logging {
       opts.reportUnavailablePartitions && hasUnavailablePartitions(partitionDescription)
     }
     private def hasUnderMinIsrPartitions(partitionDescription: PartitionDescription) = {
-      partitionDescription.isr.size < partitionDescription.minIsr
+      partitionDescription.isr.size < partitionDescription.minIsrCount
     }
     private def shouldPrintUnderMinIsrPartitions(partitionDescription: PartitionDescription) = {
       opts.reportUnderMinIsrPartitions && hasUnderMinIsrPartitions(partitionDescription)
@@ -228,7 +228,7 @@ object TopicCommand extends Logging {
           }
         }
         if (describeOptions.describePartitions) {
-          val computedMinIsr = if (opts.reportUnderMinIsrPartitions)
+          val computedMinIsrCount = if (opts.reportUnderMinIsrPartitions)
             allConfigs.get(new ConfigResource(ConfigResource.Type.TOPIC, td.name())).get().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value().toInt else 0
           for (partition <- sortedPartitions) {
             val partitionDesc = PartitionDescription(
@@ -237,7 +237,7 @@ object TopicCommand extends Logging {
               leader = Option(partition.leader()).map(_.id()),
               assignedReplicas = partition.replicas().asScala.map(_.id()),
               isr = partition.isr().asScala.map(_.id()),
-              minIsr = computedMinIsr,
+              minIsrCount = computedMinIsrCount,
               markedForDeletion = false,
               describeOptions.describeConfigs
             )
@@ -368,7 +368,7 @@ object TopicCommand extends Logging {
                   leader = if (leaderIsrEpoch.isEmpty) None else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
                   assignedReplicas,
                   isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr,
-                  minIsr = 0,
+                  minIsrCount = 0,
                   markedForDeletion,
                   describeOptions.describeConfigs
                 )
@@ -548,7 +548,7 @@ object TopicCommand extends Logging {
                                                             "if set when describing topics, only show under replicated partitions")
     private val reportUnavailablePartitionsOpt = parser.accepts("unavailable-partitions",
                                                             "if set when describing topics, only show partitions whose leader is not available")
-    private val reportUnderMinIsrPartitionsOpt = parser.accepts("under-minisr-partitions",
+    private val reportUnderMinIsrPartitionsOpt = parser.accepts("under-min-isr-partitions",
                                                             "if set when describing topics, only show partitions whose isr count is less than the configured minimum. Not supported with the --zookeeper option.")
     private val topicsWithOverridesOpt = parser.accepts("topics-with-overrides",
                                                 "if set when describing topics, only show topics that have overridden configs")

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -556,9 +556,49 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     try {
       killBroker(0)
       val output = TestUtils.grabConsoleOutput(
-        topicService.describeTopic(new TopicCommandOptions(Array("--under-minisr-partitions"))))
+        topicService.describeTopic(new TopicCommandOptions(Array("--under-min-isr-partitions"))))
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
+    } finally {
+      restartDeadBrokers()
+    }
+  }
+
+  /**
+    * Test describe --under-min-isr-partitions option with three topics:
+    *   (1) topic with partition under the configured min ISR count
+    *   (2) topic with under-replicated partition (but not under min ISR count)
+    *   (3) topic with offline partition
+    *
+    * Output should only display the (1) topic with partition under min ISR count and (3) topic with offline partition
+    */
+  @Test
+  def testDescribeUnderMinIsrPartitionsMixed(): Unit = {
+    val underMinIsrTopic = "under-min-isr-topic"
+    val notUnderMinIsrTopic = "not-under-min-isr-topic"
+    val offlineTopic = "offline-topic"
+
+    val configMap = new java.util.HashMap[String, String]()
+    configMap.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "6")
+
+    adminClient.createTopics(
+      java.util.Arrays.asList(
+        new NewTopic(underMinIsrTopic, 1, 6).configs(configMap),
+        new NewTopic(notUnderMinIsrTopic, 1, 6),
+        new NewTopic(offlineTopic, Collections.singletonMap(0, Collections.singletonList(0))))).all().get()
+
+    waitForTopicCreated(underMinIsrTopic)
+    waitForTopicCreated(notUnderMinIsrTopic)
+    waitForTopicCreated(offlineTopic)
+
+    try {
+      killBroker(0)
+      val output = TestUtils.grabConsoleOutput(
+        topicService.describeTopic(new TopicCommandOptions(Array("--under-min-isr-partitions"))))
+      val rows = output.split("\n")
+      assertTrue(rows(0).startsWith(s"\tTopic: $underMinIsrTopic"))
+      assertTrue(rows(1).startsWith(s"\tTopic: $offlineTopic"))
+      assertEquals(2, rows.length);
     } finally {
       restartDeadBrokers()
     }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -569,6 +569,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     *   (1) topic with partition under the configured min ISR count
     *   (2) topic with under-replicated partition (but not under min ISR count)
     *   (3) topic with offline partition
+    *   (4) topic with fully replicated partition
     *
     * Output should only display the (1) topic with partition under min ISR count and (3) topic with offline partition
     */
@@ -577,6 +578,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     val underMinIsrTopic = "under-min-isr-topic"
     val notUnderMinIsrTopic = "not-under-min-isr-topic"
     val offlineTopic = "offline-topic"
+    val fullyReplicatedTopic = "fully-replicated-topic"
 
     val configMap = new java.util.HashMap[String, String]()
     configMap.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "6")
@@ -585,11 +587,13 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       java.util.Arrays.asList(
         new NewTopic(underMinIsrTopic, 1, 6).configs(configMap),
         new NewTopic(notUnderMinIsrTopic, 1, 6),
-        new NewTopic(offlineTopic, Collections.singletonMap(0, Collections.singletonList(0))))).all().get()
+        new NewTopic(offlineTopic, Collections.singletonMap(0, Collections.singletonList(0))),
+        new NewTopic(fullyReplicatedTopic, Collections.singletonMap(0, java.util.Arrays.asList(1, 2, 3))))).all().get()
 
     waitForTopicCreated(underMinIsrTopic)
     waitForTopicCreated(notUnderMinIsrTopic)
     waitForTopicCreated(offlineTopic)
+    waitForTopicCreated(fullyReplicatedTopic)
 
     try {
       killBroker(0)

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -16,7 +16,6 @@
   */
 package kafka.admin
 
-import java.util
 import java.util.{Collections, Properties}
 
 import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
@@ -547,11 +546,11 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
 
   @Test
   def testDescribeUnderMinIsrPartitions(): Unit = {
-    val configMap = new util.HashMap[String, String]()
+    val configMap = new java.util.HashMap[String, String]()
     configMap.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "6")
 
     adminClient.createTopics(
-      util.Arrays.asList(new NewTopic(testTopicName, 1, 6).configs(configMap))).all().get()
+      Collections.singletonList(new NewTopic(testTopicName, 1, 6).configs(configMap))).all().get()
     waitForTopicCreated(testTopicName)
 
     try {

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -536,7 +536,6 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       killBroker(0)
       val output = TestUtils.grabConsoleOutput(
         topicService.describeTopic(new TopicCommandOptions(Array("--under-replicated-partitions"))))
-      println(output)
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
     } finally {
@@ -565,7 +564,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
   }
 
   /**
-    * Test describe --under-min-isr-partitions option with three topics:
+    * Test describe --under-min-isr-partitions option with four topics:
     *   (1) topic with partition under the configured min ISR count
     *   (2) topic with under-replicated partition (but not under min ISR count)
     *   (3) topic with offline partition


### PR DESCRIPTION
[KIP-351](https://cwiki.apache.org/confluence/display/KAFKA/KIP-351%3A+Add+--under-min-isr+option+to+describe+topics+command)

- Add `--under-min-isr` option to `TopicCommand` to report partitions under the configured `min.insync.replicas` value

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
