### PR TITLE
MINOR: Add snap packaging.

### DIFF
--- a/snap/local/script-wrapper.bash
+++ b/snap/local/script-wrapper.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+export PATH=$SNAP/usr/lib/jvm/default-java/bin:$PATH
+
+$SNAP/opt/kafka/bin/$_wrapper_script "$@"

--- a/snap/local/start-kafka-wrapper.bash
+++ b/snap/local/start-kafka-wrapper.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -f $SNAP_DATA/server.properties ]; then
+	cp $SNAP/opt/kafka/config/server.properties $SNAP_DATA/server.properties
+fi
+
+export PATH=$SNAP/usr/lib/jvm/default-java/bin:$PATH
+export LOG_DIR=$SNAP_DATA/log
+
+$SNAP/opt/kafka/bin/kafka-server-start.sh $SNAP_DATA/server.properties

--- a/snap/local/start-zookeeper-wrapper.bash
+++ b/snap/local/start-zookeeper-wrapper.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -f $SNAP_DATA/zookeeper.properties ]; then
+	cp $SNAP/opt/kafka/config/zookeeper.properties $SNAP_DATA/zookeeper.properties
+fi
+
+export PATH=$SNAP/usr/lib/jvm/default-java/bin:$PATH
+export LOG_DIR=$SNAP_DATA/log
+
+$SNAP/opt/kafka/bin/zookeeper-server-start.sh $SNAP_DATA/zookeeper.properties

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,90 @@
+name: kafka
+base: core18
+version: '2.1.0'
+summary: Apache Kafka is a distributed streaming platform
+description: |
+    Kafka is generally used for two broad classes of applications:
+    - Building real-time streaming data pipelines that reliably get data between systems or applications
+    - Building real-time streaming applications that transform or react to the streams of data 
+
+grade: stable
+confinement: strict
+
+apps:
+  kafka:
+    command: start-kafka-wrapper.bash
+    daemon: simple
+    plugs: [network, network-bind, removable-media]
+  zookeeper:
+    command: start-zookeeper-wrapper.bash
+    daemon: simple
+    plugs: [network, network-bind, removable-media]
+  topics:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: kafka-topics.sh
+  console-consumer:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: kafka-console-consumer.sh
+  console-producer:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: kafka-console-producer.sh
+  consumer-groups:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: kafka-consumer-groups.sh
+  reassign-partitions:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: kafka-reassign-partitions.sh
+  zookeeper-shell:
+    command: script-wrapper.bash
+    plugs: [network, network-bind]
+    environment:
+      _wrapper_script: zookeeper-shell.sh
+
+parts:
+  deps:
+    stage-packages:
+    - default-jre-headless
+    build-packages:
+    - default-jdk-headless
+    - unzip
+    plugin: nil
+    override-build: |-
+      # NOTE: snapcraft gradle plugin currently does not work with kafka build
+      wget -O gradle-5.1.1-bin.zip https://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+      unzip gradle-5.1.1-bin.zip
+  gradle:
+    after:
+    - deps
+    plugin: nil
+    source: https://github.com/apache/kafka.git
+    source-depth: 1
+    source-tag: 2.1.0
+    override-build: |-
+      export PATH=$(pwd)/../../deps/build/gradle-5.1.1/bin:$PATH
+      gradle
+      ./gradlew releaseTarGz
+  wrapper:
+    plugin: dump
+    source: snap/local
+  install:
+    after:
+    - gradle
+    plugin: nil
+    override-build: |-
+      tarball=$(pwd)/../../gradle/build/core/build/distributions/kafka_2.11-2.1.0.tgz
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/kafka
+      (cd $SNAPCRAFT_PART_INSTALL/opt/kafka; tar --strip-components=1 -xzvf $tarball)
+    stage:
+    - opt
+    prime:
+    - opt


### PR DESCRIPTION
This adds snap packaging (https://snapcraft.io) for Kafka.

[If this is considered more than a minor patch, I'm happy to open a JIRA ticket or post to the ml to discuss further, please advise. This is also my first PR into Kafka.. if packaging like this belongs elsewhere, please let me know where I should propose it.]

Strict confinement is used; all processes are run in an apparmor-restricted environment with access to the network and removable-media on the host. removable-media allows the use of mounted volumes for the log directory.

Kafka and zookeeper are installed as systemd services for a nice standalone, out-of-the-box, no-configuration-necessary experience. You install the snap and kafka is running on localhost. The zookeeper service can be disabled if an external zookeeper is used instead.

The snap build requires snapcraft 3.0 and multipass. So far, I've tested on Ubuntu 18.04.

Testing at a minimum would involve scripting an install of the snap on a VM and a smoke test, perhaps creating topics and running console producer/consumer.