### PR TITLE
MINOR: Close ZKDatabase

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -49,8 +49,7 @@ class EmbeddedZookeeper() extends Logging {
   val port = zookeeper.getClientPort
 
   def shutdown(): Unit = {
-    CoreUtils.swallow(zookeeper.shutdown(), this)
-    CoreUtils.swallow(zookeeper.getZKDatabase().close(), this)
+    // Also shuts down ZooKeeperServer
     CoreUtils.swallow(factory.shutdown(), this)
 
     def isDown(): Boolean = {
@@ -61,6 +60,7 @@ class EmbeddedZookeeper() extends Logging {
     }
 
     Iterator.continually(isDown()).exists(identity)
+    CoreUtils.swallow(zookeeper.getZKDatabase().close(), this)
 
     Utils.delete(logDir)
     Utils.delete(snapshotDir)

--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -50,6 +50,7 @@ class EmbeddedZookeeper() extends Logging {
 
   def shutdown(): Unit = {
     CoreUtils.swallow(zookeeper.shutdown(), this)
+    CoreUtils.swallow(zookeeper.getZKDatabase().close(), this)
     CoreUtils.swallow(factory.shutdown(), this)
 
     def isDown(): Boolean = {


### PR DESCRIPTION
Using the EmbeddedKafkaBroker on Windows fills up the temp folder because the ZKDatabase is never closed and therefore the data directory can not be deleted (Windows can't delete files where an open file handle exists).