### PR TITLE
MINOR: Add all topics created check streams broker bounce test (2.1)

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
@@ -143,6 +143,21 @@ class StreamsBrokerBounceTest(Test):
                 count += 1
         return count
 
+    def confirm_topics_on_all_brokers(self, expected_topic_set):
+        for node in self.kafka.nodes:
+            match_count = 0
+            # need to iterate over topic_list as list_topics returns a python generator so values fetched lazily
+            # so we can't just compare directly we must iterate over what's returned
+            topic_list_generator = self.kafka.list_topics("placeholder", node)
+            for topic in topic_list_generator:
+                if topic in expected_topic_set:
+                    match_count += 1
+
+            if len(expected_topic_set) != match_count:
+                return False
+
+        return True
+
         
     def setup_system(self, start_processor=True):
         # Setup phase
@@ -153,7 +168,7 @@ class StreamsBrokerBounceTest(Test):
         self.kafka.start()
 
         # allow some time for topics to be created
-        wait_until(lambda: self.get_topics_count() >= (len(self.topics) * self.num_kafka_nodes),
+        wait_until(lambda: self.confirm_topics_on_all_brokers(set(self.topics.keys())),
                    timeout_sec=60,
                    err_msg="Broker did not create all topics in 60 seconds ")
 

--- a/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
@@ -91,6 +91,7 @@ class StreamsBrokerBounceTest(Test):
     def __init__(self, test_context):
         super(StreamsBrokerBounceTest, self).__init__(test_context)
         self.replication = 3
+        self.num_kafka_nodes = self.replication
         self.partitions = 3
         self.topics = {
             'echo' : { 'partitions': self.partitions, 'replication-factor': self.replication,

--- a/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
@@ -91,7 +91,6 @@ class StreamsBrokerBounceTest(Test):
     def __init__(self, test_context):
         super(StreamsBrokerBounceTest, self).__init__(test_context)
         self.replication = 3
-        self.num_kafka_nodes = self.replication
         self.partitions = 3
         self.topics = {
             'echo' : { 'partitions': self.partitions, 'replication-factor': self.replication,
@@ -134,19 +133,11 @@ class StreamsBrokerBounceTest(Test):
         for num in range(0, num_failures - 1):
             signal_node(self, self.kafka.nodes[num], sig)
 
-    def get_topics_count(self):
-        count = 0
-        for node in self.kafka.nodes:
-            topic_list = self.kafka.list_topics("placeholder", node)
-            # need to iterate over topic_list as list_topics returns a python generator so values fetched lazily
-            for topic in topic_list:
-                count += 1
-        return count
-
     def confirm_topics_on_all_brokers(self, expected_topic_set):
         for node in self.kafka.nodes:
             match_count = 0
-            # need to iterate over topic_list as list_topics returns a python generator so values fetched lazily
+            # need to iterate over topic_list_generator as kafka.list_topics()
+            # returns a python generator so values are fetched lazily
             # so we can't just compare directly we must iterate over what's returned
             topic_list_generator = self.kafka.list_topics("placeholder", node)
             for topic in topic_list_generator:


### PR DESCRIPTION
The `StreamsBrokerBounceTest.test_broker_type_bounce` experienced what looked like a transient failure. After looking over this test and failure, it seems like it is vulnerable to timing error that streams will start before the kafka service creates all topics.

```
org.apache.kafka.streams.errors.TopologyException: Invalid topology: stream-thread [SmokeTest-44232843-7798-4a19-b0a8-56deedd866e6-StreamThread-1-consumer] Topic not found: sum
        at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor$CopartitionedTopicsValidator.validate(StreamsPartitionAssignor.java:923)
        at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.ensureCopartitioning(StreamsPartitionAssignor.java:902)
        at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assign(StreamsPartitionAssignor.java:468)
        at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.performAssignment(ConsumerCoordinator.java:419)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.onJoinLeader(AbstractCoordinator.java:592)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.access$1100(AbstractCoordinator.java:94)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$JoinGroupResponseHandler.handle(AbstractCoordinator.java:544)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$JoinGroupResponseHandler.handle(AbstractCoordinator.java:527)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$CoordinatorResponseHandler.onSuccess(AbstractCoordinator.java:894)
        at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$CoordinatorResponseHandler.onSuccess(AbstractCoordinator.java:874)
```
After making the changes, I kicked off a [branch builder with five repeats](http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2019-02-07--001.1549590732--bbejeck--MINOR_add_all_topics_created_check_StreamsBrokerBounceTest_2_1--0b0d239/report.html)

Note that the reason I chose five repeats is the test uses a matrix and generate eight versions of the test and each test lasts about 5 minutes. There will be mirrored PRs for `2.0`, `2.2` and `trunk`.