### PR TITLE
MINOR: Extended Scala serdes implicit conversions with optional custom naming

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
@@ -60,24 +60,47 @@ object ImplicitConversions {
 
   implicit def tuple2ToKeyValue[K, V](tuple: (K, V)): KeyValue[K, V] = new KeyValue(tuple._1, tuple._2)
 
-  // we would also like to allow users implicit serdes
-  // and these implicits will convert them to `Grouped`, `Produced` or `Consumed`
+  // we would also like to allow users implicit serdes and optional repartition topic / state stores names
+  // and these implicits will convert them to `Grouped`, `Produced`, `Consumed`, `Materialized` and `Joined`
 
-  implicit def groupedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] =
+  implicit def groupedFromNameAndSerde[K, V](repartitionTopicName: String)
+                                         (implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] = {
+    Grouped.`with`[K, V](repartitionTopicName)
+  }
+
+  implicit def groupedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] = {
     Grouped.`with`[K, V]
+  }
 
-  implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] =
+  implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] = {
     Consumed.`with`[K, V]
+  }
 
-  implicit def producedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Produced[K, V] =
+  implicit def producedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Produced[K, V] = {
     Produced.`with`[K, V]
+  }
+
+  implicit def materializedFromNameAndSerde[K, V, S <: StateStore](stateStoreName: String)
+                                                               (implicit keySerde: Serde[K],
+                                                                valueSerde: Serde[V]): Materialized[K, V, S] = {
+    Materialized.as[K, V, S](stateStoreName)
+  }
 
   implicit def materializedFromSerde[K, V, S <: StateStore](implicit keySerde: Serde[K],
-                                                            valueSerde: Serde[V]): Materialized[K, V, S] =
+                                                            valueSerde: Serde[V]): Materialized[K, V, S] = {
     Materialized.`with`[K, V, S]
+  }
+
+  implicit def joinedFromNameAndKeyValueOtherSerde[K, V, VO](name: String)
+                                                         (implicit keySerde: Serde[K],
+                                                          valueSerde: Serde[V],
+                                                          otherValueSerde: Serde[VO]): Joined[K, V, VO] = {
+    Joined.`with`[K, V, VO](name)
+  }
 
   implicit def joinedFromKeyValueOtherSerde[K, V, VO](implicit keySerde: Serde[K],
                                                       valueSerde: Serde[V],
-                                                      otherValueSerde: Serde[VO]): Joined[K, V, VO] =
+                                                      otherValueSerde: Serde[VO]): Joined[K, V, VO] = {
     Joined.`with`[K, V, VO]
+  }
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
@@ -35,9 +35,9 @@ import org.apache.kafka.streams.scala.kstream._
 import scala.language.implicitConversions
 
 /**
- * Implicit conversions between the Scala wrapper objects and the underlying Java
- * objects.
- */
+  * Implicit conversions between the Scala wrapper objects and the underlying Java
+  * objects.
+  */
 object ImplicitConversions {
 
   implicit def wrapKStream[K, V](inner: KStreamJ[K, V]): KStream[K, V] =
@@ -64,7 +64,7 @@ object ImplicitConversions {
   // and these implicits will convert them to `Grouped`, `Produced`, `Consumed`, `Materialized` and `Joined`
 
   implicit def groupedFromNameAndSerde[K, V](repartitionTopicName: String)
-                                         (implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] = {
+                                            (implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] = {
     Grouped.`with`[K, V](repartitionTopicName)
   }
 
@@ -81,8 +81,8 @@ object ImplicitConversions {
   }
 
   implicit def materializedFromNameAndSerde[K, V, S <: StateStore](stateStoreName: String)
-                                                               (implicit keySerde: Serde[K],
-                                                                valueSerde: Serde[V]): Materialized[K, V, S] = {
+                                                                  (implicit keySerde: Serde[K],
+                                                                   valueSerde: Serde[V]): Materialized[K, V, S] = {
     Materialized.as[K, V, S](stateStoreName)
   }
 
@@ -92,9 +92,9 @@ object ImplicitConversions {
   }
 
   implicit def joinedFromNameAndKeyValueOtherSerde[K, V, VO](name: String)
-                                                         (implicit keySerde: Serde[K],
-                                                          valueSerde: Serde[V],
-                                                          otherValueSerde: Serde[VO]): Joined[K, V, VO] = {
+                                                            (implicit keySerde: Serde[K],
+                                                             valueSerde: Serde[V],
+                                                             otherValueSerde: Serde[VO]): Joined[K, V, VO] = {
     Joined.`with`[K, V, VO](name)
   }
 


### PR DESCRIPTION
Since custom state store and repartition topic naming in DSL API is now possible in Kafka 2.1.0, this proposed feature enhance implicit conversions for the Scala API making it possible to call (assuming `val stream: KGroupedStream[K, V]`:

`stream.aggregate(initializer)(aggregateFunc)("customNameTopic")`

instead of:
`stream.aggregate(initializer)(aggregateFunc)(Materialized.as[K, V, ByteArrayWindowStore]("customStateStoreName")`

This change is backward compatible, that said: `stream.aggregate(initializer)(aggregateFunc)` also works with default naming convention.

These implicit conversions are propagated for `Materialized`, `Grouped` and `Joined` as well.