### PR TITLE
MINOR: Improve PlainSaslServer error message for empty tokens

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -73,29 +73,41 @@ public class PlainSaslServerTest {
 
     @Test
     public void emptyTokens() {
-        Exception e = assertThrows(SaslException.class, () ->
+        Exception e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("", "", "")));
         assertEquals("Authentication failed: username not specified", e.getMessage());
 
-        e = assertThrows(SaslException.class, () ->
+        e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("", "", "p")));
         assertEquals("Authentication failed: username not specified", e.getMessage());
 
-        e = assertThrows(SaslException.class, () ->
+        e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("", "u", "")));
         assertEquals("Authentication failed: password not specified", e.getMessage());
 
-        e = assertThrows(SaslException.class, () ->
+        e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("a", "", "")));
         assertEquals("Authentication failed: username not specified", e.getMessage());
 
-        e = assertThrows(SaslException.class, () ->
+        e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("a", "", "p")));
         assertEquals("Authentication failed: username not specified", e.getMessage());
 
-        e = assertThrows(SaslException.class, () ->
+        e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("a", "u", "")));
         assertEquals("Authentication failed: password not specified", e.getMessage());
+
+        String nul = "\u0000";
+
+        e = assertThrows(SaslAuthenticationException.class, () ->
+            saslServer.evaluateResponse(
+                String.format("%s%s%s%s%s%s", "a", nul, "u", nul, "p", nul).getBytes(StandardCharsets.UTF_8)));
+        assertEquals("Invalid SASL/PLAIN response: expected 3 tokens, got 4", e.getMessage());
+
+        e = assertThrows(SaslAuthenticationException.class, () ->
+            saslServer.evaluateResponse(
+                String.format("%s%s%s", "", nul, "u").getBytes(StandardCharsets.UTF_8)));
+        assertEquals("Invalid SASL/PLAIN response: expected 3 tokens, got 2", e.getMessage());
     }
 
     private byte[] saslMessage(String authorizationId, String userName, String password) {

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.security.plain.internals;
 
+import javax.security.sasl.SaslException;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.JaasContext;
@@ -67,6 +69,33 @@ public class PlainSaslServerTest {
     @Test(expected = SaslAuthenticationException.class)
     public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
         saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A));
+    }
+
+    @Test
+    public void emptyTokens() {
+        Exception e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("", "", "")));
+        assertEquals("Authentication failed: username not specified", e.getMessage());
+
+        e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("", "", "p")));
+        assertEquals("Authentication failed: username not specified", e.getMessage());
+
+        e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("", "u", "")));
+        assertEquals("Authentication failed: password not specified", e.getMessage());
+
+        e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("a", "", "")));
+        assertEquals("Authentication failed: username not specified", e.getMessage());
+
+        e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("a", "", "p")));
+        assertEquals("Authentication failed: username not specified", e.getMessage());
+
+        e = assertThrows(SaslException.class, () ->
+            saslServer.evaluateResponse(saslMessage("a", "u", "")));
+        assertEquals("Authentication failed: password not specified", e.getMessage());
     }
 
     private byte[] saslMessage(String authorizationId, String userName, String password) {

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.security.plain.internals;
 
-import javax.security.sasl.SaslException;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Empty username or password would result in the "expected 3 tokens"
error instead of "username not specified" or "password not specified".

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
