### PR TITLE
MINOR: Improve log messages when authentications fail

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -711,12 +711,15 @@ public class NetworkClient implements KafkaClient {
                 AuthenticationException exception = disconnectState.exception();
                 connectionStates.authenticationFailed(nodeId, now, exception);
                 metadataUpdater.handleAuthenticationFailure(exception);
-                log.error("Connection to node {} ({}) failed authentication due to: {}", nodeId, disconnectState.remoteAddress(), exception.getMessage());
+                log.error("Connection to node {} ({}) failed authentication due to: {}", nodeId,
+                    disconnectState.remoteAddress(), exception.getMessage());
                 break;
             case AUTHENTICATE:
-                // This warning applies to older brokers which don't provide feedback on authentication failures
-                log.warn("Connection to node {} ({}) terminated during authentication. This may indicate " +
-                        "that authentication failed due to invalid credentials.", nodeId, disconnectState.remoteAddress());
+                log.warn("Connection to node {} ({}) terminated during authentication. This may happen " +
+                    "due to any of the following reasons: (1) Authentication failed due to invalid " +
+                    "credentials with brokers older than 1.0.0, (2) Firewall blocking Kafka TLS " +
+                    "traffic (eg it may only allow HTTPS traffic), (3) Transient network issue.",
+                    nodeId, disconnectState.remoteAddress());
                 break;
             case NOT_CONNECTED:
                 log.warn("Connection to node {} ({}) could not be established. Broker may not be available.", nodeId, disconnectState.remoteAddress());

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -533,20 +533,7 @@ public class Selector implements Selectable, AutoCloseable {
 
                 /* if channel is not ready finish prepare */
                 if (channel.isConnected() && !channel.ready()) {
-                    try {
-                        channel.prepare();
-                    } catch (AuthenticationException e) {
-                        boolean isReauthentication = channel.successfulAuthentications() > 0;
-                        if (isReauthentication)
-                            sensors.failedReauthentication.record();
-                        else
-                            sensors.failedAuthentication.record();
-                        log.info("Address {} failed {}authentication ({})",
-                            channel.socketDescription(),
-                            isReauthentication ? "re-" : "",
-                            e.getClass().getName());
-                        throw e;
-                    }
+                    channel.prepare();
                     if (channel.ready()) {
                         long readyTimeMs = time.milliseconds();
                         boolean isReauthentication = channel.successfulAuthentications() > 1;
@@ -563,8 +550,8 @@ public class Selector implements Selectable, AutoCloseable {
                             if (!channel.connectedClientSupportsReauthentication())
                                 sensors.successfulAuthenticationNoReauth.record(1.0, readyTimeMs);
                         }
-                        log.debug("Address {} successfully {}authenticated",
-                            channel.socketDescription(), isReauthentication ? "re-" : "");
+                        log.debug("Successfully {}authenticated with {}", isReauthentication ?
+                            "re-" : "", channel.socketDescription());
                     }
                     List<NetworkReceive> responsesReceivedDuringReauthentication = channel
                             .getAndClearResponsesReceivedDuringReauthentication();
@@ -605,12 +592,22 @@ public class Selector implements Selectable, AutoCloseable {
 
             } catch (Exception e) {
                 String desc = channel.socketDescription();
-                if (e instanceof IOException)
+                if (e instanceof IOException) {
                     log.debug("Connection with {} disconnected", desc, e);
-                else if (e instanceof AuthenticationException) // will be logged later as error by clients
-                    log.debug("Connection with {} disconnected due to authentication exception", desc, e);
-                else
+                } else if (e instanceof AuthenticationException) {
+                    boolean isReauthentication = channel.successfulAuthentications() > 0;
+                    if (isReauthentication)
+                        sensors.failedReauthentication.record();
+                    else
+                        sensors.failedAuthentication.record();
+                    String exceptionMessage = e.getMessage();
+                    if (e instanceof DelayedResponseAuthenticationException)
+                        exceptionMessage = e.getCause().getMessage();
+                    log.info("Failed {}authentication with {} ({})", isReauthentication ? "re-" : "",
+                        desc, exceptionMessage);
+                } else {
                     log.warn("Unexpected error from {}; closing connection", desc, e);
+                }
 
                 if (e instanceof DelayedResponseAuthenticationException)
                     maybeDelayCloseOnAuthenticationFailure(channel);


### PR DESCRIPTION
- Include more detail in the client log message if the disconnection happens
during authentication.
- Include exception message in the Selector info entry when authentication
fails and unwrap `DelayedResponseAuthenticationException`.
- Remove duplicate debug log on authentication failure in the Selector.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
