### PR TITLE
KAFKA-7909: Ensure timely rebalance completion after pending members rejoin or fail

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -760,6 +760,15 @@ public abstract class AbstractCoordinator implements Closeable {
     }
 
     /**
+     * @return true if the current generation's member ID is valid, false otherwise
+     */
+    // Visible for testing
+    final synchronized boolean hasValidMemberId() {
+        return generation != null && generation.hasMemberId();
+    }
+
+
+    /**
      * Reset the generation and memberId because we have fallen out of the group.
      */
     protected synchronized void resetGeneration() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1131,8 +1131,8 @@ public abstract class AbstractCoordinator implements Closeable {
         }
 
         /**
-         * @return true if this generation has a valid member id. A generation might not be {@link #NO_GENERATION}, but
-         * might be pending a join group request, in which case memberId will be an empty string.
+         * @return true if this generation has a valid member id, false otherwise. A member might have an id before
+         * it becomes part of a group generation.
          */
         public boolean hasMemberId() {
             return !memberId.isEmpty();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1122,7 +1122,7 @@ public abstract class AbstractCoordinator implements Closeable {
         }
 
         public boolean isValid() {
-            return generationId != OffsetCommitRequest.DEFAULT_GENERATION_ID;
+            return this != NO_GENERATION;
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -222,6 +222,7 @@ public class AbstractCoordinatorTest {
         assertTrue(consumerClient.poll(future, mockTime.timer(REQUEST_TIMEOUT_MS)));
         assertEquals(Errors.MEMBER_ID_REQUIRED.message(), future.exception().getMessage());
         assertTrue(coordinator.rejoinNeededOrPending());
+        assertTrue(coordinator.hasValidMemberId());
         assertTrue(coordinator.hasMatchingGenerationId(generation));
         future = coordinator.sendJoinGroupRequest();
         assertTrue(consumerClient.poll(future, mockTime.timer(REBALANCE_TIMEOUT_MS)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -744,6 +744,41 @@ public class ConsumerCoordinatorTest {
         assertNull(generation);
     }
 
+    /**
+     * This test checks if a consumer that has a valid member ID but an invalid generation
+     * ({@link org.apache.kafka.clients.consumer.internals.AbstractCoordinator.Generation#NO_GENERATION})
+     * can still execute a leave group request. Such a situation may arise when a consumer has initiated a JoinGroup
+     * request without a memberId, but is shutdown or restarted before it has a chance to initiate and complete the
+     * second request.
+     */
+    @Test
+    public void testConsumerWithValidMemberShouldLeaveGroup() {
+        subscriptions.subscribe(singleton(topic1), rebalanceListener);
+
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+
+        // here we return a DEFAULT_GENERATION_ID, but valid member id and leader id.
+        client.prepareResponse(joinGroupFollowerResponse(-1, "consumer-id", "leader-id", Errors.NONE));
+
+        // return a sync response to complete joinGroupIfNeeded(..)
+        client.prepareResponse(syncGroupResponse(singletonList(t1p), Errors.NONE));
+
+        // execute join group
+        coordinator.joinGroupIfNeeded(time.timer(Long.MAX_VALUE));
+
+        final AtomicBoolean received = new AtomicBoolean(false);
+        client.prepareResponse(new MockClient.RequestMatcher() {
+            @Override
+            public boolean matches(AbstractRequest body) {
+                received.set(true);
+                return true;
+            }
+        }, new LeaveGroupResponse(new LeaveGroupResponseData().setErrorCode(Errors.NONE.code())));
+        coordinator.maybeLeaveGroup();
+        assertTrue(received.get());
+    }
+
     @Test(expected = KafkaException.class)
     public void testUnexpectedErrorOnSyncGroup() {
         final String consumerId = "consumer";

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -918,10 +918,8 @@ class GroupCoordinator(val brokerId: Int,
   def onExpireHeartbeat(group: GroupMetadata, memberId: String, isPending: Boolean, heartbeatDeadline: Long) {
     group.inLock {
       if (isPending) {
-        debug(s"Pending member $memberId has been removed after session timeout expiration.")
         group.removePendingMember(memberId)
         if (group.is(PreparingRebalance)) {
-          debug(s"group was in preparing rebalance stage. will attempt to complete join now.")
           joinPurgatory.checkAndComplete(GroupKey(group.groupId))
         }
       } else if (!group.has(memberId)) {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -777,6 +777,12 @@ class GroupCoordinator(val brokerId: Int,
 
     maybePrepareRebalance(group, s"Adding new member $memberId")
     group.removePendingMember(memberId)
+
+    // attempt to complete JoinGroup
+    if (group.hasAllMembersJoined) {
+      info(s"all members have joined. attempting to complete JoinGroup for group ${group.groupId}")
+      onCompleteJoin(group)
+    }
   }
 
   private def updateMemberAndRebalance(group: GroupMetadata,

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -370,6 +370,7 @@ class GroupCoordinator(val brokerId: Int,
           // if a pending member is leaving, it needs to be removed from the pending list, heartbeat cancelled
           // and if necessary, prompt a JoinGroup completion.
           if (group.isPendingMember(memberId)) {
+            debug(s"Pending member $memberId is leaving group ${group.groupId}.")
             group.removePendingMember(memberId)
             heartbeatPurgatory.cancelForKey(MemberKey(groupId, memberId))
             if (group.is(PreparingRebalance)) {
@@ -927,6 +928,7 @@ class GroupCoordinator(val brokerId: Int,
   def onExpireHeartbeat(group: GroupMetadata, memberId: String, isPending: Boolean, heartbeatDeadline: Long) {
     group.inLock {
       if (isPending) {
+        info(s"Pending member $memberId in group ${group.groupId} has been removed after session timeout expiration.")
         group.removePendingMember(memberId)
         if (group.is(PreparingRebalance)) {
           joinPurgatory.checkAndComplete(GroupKey(group.groupId))

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -921,6 +921,7 @@ class GroupCoordinator(val brokerId: Int,
         debug(s"Pending member $memberId has been removed after session timeout expiration.")
         group.removePendingMember(memberId)
         if (group.is(PreparingRebalance)) {
+          debug(s"group was in preparing rebalance stage. will attempt to complete join now.")
           joinPurgatory.checkAndComplete(GroupKey(group.groupId))
         }
       } else if (!group.has(memberId)) {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -920,8 +920,8 @@ class GroupCoordinator(val brokerId: Int,
       if (isPending) {
         debug(s"Pending member $memberId has been removed after session timeout expiration.")
         group.removePendingMember(memberId)
-        if (group.is(CompletingRebalance)) {
-          heartbeatPurgatory.checkAndComplete(GroupKey(group.groupId))
+        if (group.is(PreparingRebalance)) {
+          joinPurgatory.checkAndComplete(GroupKey(group.groupId))
         }
       } else if (!group.has(memberId)) {
         debug(s"Member $memberId has already been removed from the group.")

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -373,8 +373,8 @@ class GroupCoordinator(val brokerId: Int,
             // if a pending member is leaving, it needs to be removed from the pending list, heartbeat cancelled
             // and if necessary, prompt a JoinGroup completion.
             info(s"Pending member $memberId is leaving group ${group.groupId}.")
-            heartbeatPurgatory.checkAndComplete(MemberKey(group.groupId, memberId))
             removePendingMemberAndUpdateGroup(group, memberId)
+            heartbeatPurgatory.checkAndComplete(MemberKey(group.groupId, memberId))
             responseCallback(Errors.NONE)
           } else if (!group.has(memberId)) {
             responseCallback(Errors.UNKNOWN_MEMBER_ID)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -255,6 +255,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def allMembers = members.keySet
 
+  def numPending = pendingMembers.size
+
   def allMemberMetadata = members.values.toList
 
   def rebalanceTimeoutMs = members.values.foldLeft(0) { (timeout, member) =>


### PR DESCRIPTION
Fix the following situations, where pending members (one that has a member-id, and has requested to join a group) can cause rebalance operations to fail: 

- In AbstractCoordinator, a pending consumer should be allowed to leave.
- A rebalance operation must successfully complete if a pending member either joins or times out.
- During a rebalance operation, a pending member must be able to leave a group.

Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
