### PR TITLE
MINOR: drop dbAccessor reference on close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -377,6 +377,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         fOptions.close();
         db.close();
 
+        dbAccessor = null;
         userSpecifiedOptions = null;
         wOptions = null;
         fOptions = null;


### PR DESCRIPTION
Very minor, but we should drop the reference to `dbAccessor` in the RocksDBStore after we close it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
