### PR TITLE
MINOR: Remove deprecated assertThat method usage from KafkaLog4jAppenderTest

### DIFF
--- a/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
+++ b/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.log4jappender;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -89,9 +90,9 @@ public class KafkaLog4jAppenderTest {
         PropertyConfigurator.configure(props);
 
         MockKafkaLog4jAppender mockKafkaLog4jAppender = getMockKafkaLog4jAppender();
-        Assert.assertThat(
-            mockKafkaLog4jAppender.getProducerProperties().getProperty(SaslConfigs.SASL_MECHANISM),
-            equalTo("PLAIN"));
+        assertThat(
+                mockKafkaLog4jAppender.getProducerProperties().getProperty(SaslConfigs.SASL_MECHANISM),
+                equalTo("PLAIN"));
     }
 
     @Test
@@ -106,9 +107,9 @@ public class KafkaLog4jAppenderTest {
         PropertyConfigurator.configure(props);
 
         MockKafkaLog4jAppender mockKafkaLog4jAppender = getMockKafkaLog4jAppender();
-        Assert.assertThat(
-            mockKafkaLog4jAppender.getProducerProperties().getProperty(SaslConfigs.SASL_JAAS_CONFIG),
-            equalTo("jaas-config"));
+        assertThat(
+                mockKafkaLog4jAppender.getProducerProperties().getProperty(SaslConfigs.SASL_JAAS_CONFIG),
+                equalTo("jaas-config"));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class KafkaLog4jAppenderTest {
     private void testProducerPropertyNotSet(String name) {
         PropertyConfigurator.configure(getLog4jConfig(false));
         MockKafkaLog4jAppender mockKafkaLog4jAppender = getMockKafkaLog4jAppender();
-        Assert.assertThat(mockKafkaLog4jAppender.getProducerProperties().stringPropertyNames(), not(hasItem(name)));
+        assertThat(mockKafkaLog4jAppender.getProducerProperties().stringPropertyNames(), not(hasItem(name)));
     }
 
     @Test


### PR DESCRIPTION
- Replace `Assert.assertThat` with `MatcherAssert.assertThat`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
