### PR TITLE
MINOR: add warning for long grace period for suppress

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 import java.time.Duration;
 import java.util.Objects;
 
-public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppressed<K> {
+public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppressed<K>, NamedSuppressed<K> {
     private final String name;
     private final StrictBufferConfig bufferConfig;
 
@@ -57,6 +57,11 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
         final FinalResultsSuppressionBuilder<?> that = (FinalResultsSuppressionBuilder<?>) o;
         return Objects.equals(name, that.name) &&
             Objects.equals(bufferConfig, that.bufferConfig);
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/NamedSuppressed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/NamedSuppressed.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.suppress;
+
+import org.apache.kafka.streams.kstream.Suppressed;
+
+/**
+ * Internally-facing interface to work around the fact that all Suppressed config objects
+ * are name-able, but do not present a getter (for consistency with other config objects).
+ * If we allow getters on config objects in the future, we can delete this interface.
+ */
+public interface NamedSuppressed<K> extends Suppressed<K> {
+    String name();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.kstream.internals.suppress.TimeDefinitions.TimeD
 import java.time.Duration;
 import java.util.Objects;
 
-public class SuppressedInternal<K> implements Suppressed<K> {
+public class SuppressedInternal<K> implements Suppressed<K>, NamedSuppressed<K> {
     private static final Duration DEFAULT_SUPPRESSION_TIME = Duration.ofMillis(Long.MAX_VALUE);
     private static final StrictBufferConfigImpl DEFAULT_BUFFER_CONFIG = (StrictBufferConfigImpl) BufferConfig.unbounded();
 
@@ -62,6 +62,7 @@ public class SuppressedInternal<K> implements Suppressed<K> {
         return new SuppressedInternal<>(name, timeToWaitForMoreEvents, bufferConfig, timeDefinition, safeToDropTombstones);
     }
 
+    @Override
     public String name() {
         return name;
     }


### PR DESCRIPTION
Unfortunately, the default grace period is 24 hours, soif people don't explicitly set
the grace period before `Suppress.untilWindowCloses`, the suppression would
appear to do nothing for a long time.

My advice is to always explicitly set the grace period when using final-results
suppression, but there's no clean way to enforce it.
Maybe a warning is good enough?


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
