### PR TITLE
KAFKA-7758: Reuse KGroupedStream/KGroupedTable with named repartition topics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -20,12 +20,15 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+
+import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder;
+import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.optimizableRepartitionNodeBuilder;
+
 
 import java.util.Collections;
 import java.util.Set;
@@ -79,7 +82,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         StreamsGraphNode parentNode = streamsGraphNode;
 
         if (repartitionRequired) {
-            final OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = OptimizableRepartitionNode.optimizableRepartitionNodeBuilder();
+            final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
             final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeBuilder.name();
             sourceName = createRepartitionSource(repartitionTopicPrefix, repartitionNodeBuilder);
 
@@ -113,13 +116,16 @@ class GroupedStreamAggregateBuilder<K, V> {
     }
 
     /**
-     * @return the new sourceName if repartitioned. Otherwise the name of this stream
+     * @return the new sourceName of the repartitioned source
      */
     private String createRepartitionSource(final String repartitionTopicNamePrefix,
-                                           final OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder<K, V> optimizableRepartitionNodeBuilder) {
-        // if repartition required the operation
-        // captured needs to be set in the graph
-        return KStreamImpl.createRepartitionedSource(builder, keySerde, valueSerde, repartitionTopicNamePrefix, optimizableRepartitionNodeBuilder);
+                                           final OptimizableRepartitionNodeBuilder<K, V> optimizableRepartitionNodeBuilder) {
+
+        return KStreamImpl.createRepartitionedSource(builder,
+                                                     keySerde,
+                                                     valueSerde,
+                                                     repartitionTopicNamePrefix,
+                                                     optimizableRepartitionNodeBuilder);
 
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -86,6 +86,10 @@ class GroupedStreamAggregateBuilder<K, V> {
             final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeBuilder.name();
             sourceName = createRepartitionSource(repartitionTopicPrefix, repartitionNodeBuilder);
 
+            // First time through we need to create a repartition node.
+            // Any subsequent calls to GroupedStreamAggregateBuilder#build we check if
+            // the user has provided a name for the repartition topic, is so we re-use
+            // the existing repartition node, otherwise we create a new one.
             if (repartitionNode == null || userProvidedRepartitionTopicName == null) {
                 repartitionNode = repartitionNodeBuilder.build();
             }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -34,7 +34,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.kafka.streams.kstream.Grouped.as;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -86,8 +85,8 @@ public class RepartitionTopicNamingTest {
     public void shouldFailWithSameRepartitionTopicName() {
         try {
             final StreamsBuilder builder = new StreamsBuilder();
-            builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(as("grouping")).count().toStream();
-            builder.<String, String>stream("topicII").selectKey((k, v) -> k).groupByKey(as("grouping")).count().toStream();
+            builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping")).count().toStream();
+            builder.<String, String>stream("topicII").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping")).count().toStream();
             builder.build();
             fail("Should not build re-using repartition topic name");
         } catch (final TopologyException te) {
@@ -98,7 +97,7 @@ public class RepartitionTopicNamingTest {
     @Test
     public void shouldNotFailWithSameRepartitionTopicNameUsingSameKGroupedStream() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count().toStream().to("output-one");
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
         final String topologyString = builder.build().describe().toString();
@@ -141,7 +140,7 @@ public class RepartitionTopicNamingTest {
     @Test
     public void shouldNotFailWithSameRepartitionTopicNameUsingSameKGroupedStreamOptimizationsOn() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count();
         final Properties properties = new Properties();
@@ -175,7 +174,7 @@ public class RepartitionTopicNamingTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count();
         builder.build(properties);
@@ -293,9 +292,9 @@ public class RepartitionTopicNamingTest {
         final KTable<String, String> ktable = builder.table("topic");
 
         if (otherOperations) {
-            ktable.filter((k, v) -> true).groupBy(KeyValue::pair, as(ktableGroupByTopicName)).count();
+            ktable.filter((k, v) -> true).groupBy(KeyValue::pair, Grouped.as(ktableGroupByTopicName)).count();
         } else {
-            ktable.groupBy(KeyValue::pair, as(ktableGroupByTopicName)).count();
+            ktable.groupBy(KeyValue::pair, Grouped.as(ktableGroupByTopicName)).count();
         }
 
         return builder.build().describe().toString();
@@ -311,15 +310,15 @@ public class RepartitionTopicNamingTest {
 
         if (isGroupByKey) {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(as(groupedTimeWindowRepartitionTopicName)).windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(Grouped.as(groupedTimeWindowRepartitionTopicName)).windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
             } else {
-                selectKeyStream.groupByKey(as(groupedTimeWindowRepartitionTopicName)).windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
+                selectKeyStream.groupByKey(Grouped.as(groupedTimeWindowRepartitionTopicName)).windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
             }
         } else {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, as(groupedTimeWindowRepartitionTopicName)).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, Grouped.as(groupedTimeWindowRepartitionTopicName)).count();
             } else {
-                selectKeyStream.groupBy(kvMapper, as(groupedTimeWindowRepartitionTopicName)).count();
+                selectKeyStream.groupBy(kvMapper, Grouped.as(groupedTimeWindowRepartitionTopicName)).count();
             }
         }
 
@@ -336,15 +335,15 @@ public class RepartitionTopicNamingTest {
         final String groupedSessionWindowRepartitionTopicName = "session-window-grouping";
         if (isGroupByKey) {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(Grouped.as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
             } else {
-                selectKeyStream.groupByKey(as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
+                selectKeyStream.groupByKey(Grouped.as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
             }
         } else {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, Grouped.as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
             } else {
-                selectKeyStream.groupBy(kvMapper, as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
+                selectKeyStream.groupBy(kvMapper, Grouped.as(groupedSessionWindowRepartitionTopicName)).windowedBy(SessionWindows.with(Duration.ofMillis(10L))).count();
             }
         }
 
@@ -361,15 +360,15 @@ public class RepartitionTopicNamingTest {
         final String groupByAndCountRepartitionTopicName = "kstream-grouping";
         if (isGroupByKey) {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(as(groupByAndCountRepartitionTopicName)).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupByKey(Grouped.as(groupByAndCountRepartitionTopicName)).count();
             } else {
-                selectKeyStream.groupByKey(as(groupByAndCountRepartitionTopicName)).count();
+                selectKeyStream.groupByKey(Grouped.as(groupByAndCountRepartitionTopicName)).count();
             }
         } else {
             if (otherOperations) {
-                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, as(groupByAndCountRepartitionTopicName)).count();
+                selectKeyStream.filter((k, v) -> true).mapValues(v -> v).groupBy(kvMapper, Grouped.as(groupByAndCountRepartitionTopicName)).count();
             } else {
-                selectKeyStream.groupBy(kvMapper, as(groupByAndCountRepartitionTopicName)).count();
+                selectKeyStream.groupBy(kvMapper, Grouped.as(groupByAndCountRepartitionTopicName)).count();
             }
         }
 
@@ -426,17 +425,17 @@ public class RepartitionTopicNamingTest {
         mappedStream.filter((k, v) -> k.equals("B")).mapValues(v -> v.toUpperCase(Locale.getDefault()))
                 .process(() -> new SimpleProcessor(processorValueCollector));
 
-        final KStream<String, Long> countStream = mappedStream.groupByKey(as(firstRepartitionTopicName)).count(Materialized.with(Serdes.String(), Serdes.Long())).toStream();
+        final KStream<String, Long> countStream = mappedStream.groupByKey(Grouped.as(firstRepartitionTopicName)).count(Materialized.with(Serdes.String(), Serdes.Long())).toStream();
 
         countStream.to(COUNT_TOPIC, Produced.with(Serdes.String(), Serdes.Long()));
 
-        mappedStream.groupByKey(as(secondRepartitionTopicName)).aggregate(initializer,
+        mappedStream.groupByKey(Grouped.as(secondRepartitionTopicName)).aggregate(initializer,
                 aggregator,
                 Materialized.with(Serdes.String(), Serdes.Integer()))
                 .toStream().to(AGGREGATION_TOPIC, Produced.with(Serdes.String(), Serdes.Integer()));
 
         // adding operators for case where the repartition node is further downstream
-        mappedStream.filter((k, v) -> true).peek((k, v) -> System.out.println(k + ":" + v)).groupByKey(as(thirdRepartitionTopicName))
+        mappedStream.filter((k, v) -> true).peek((k, v) -> System.out.println(k + ":" + v)).groupByKey(Grouped.as(thirdRepartitionTopicName))
                 .reduce(reducer, Materialized.with(Serdes.String(), Serdes.String()))
                 .toStream().to(REDUCE_TOPIC, Produced.with(Serdes.String(), Serdes.String()));
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -85,8 +85,13 @@ public class RepartitionTopicNamingTest {
     public void shouldFailWithSameRepartitionTopicName() {
         try {
             final StreamsBuilder builder = new StreamsBuilder();
-            builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping")).count().toStream();
-            builder.<String, String>stream("topicII").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping")).count().toStream();
+            builder.<String, String>stream("topic").selectKey((k, v) -> k)
+                                            .groupByKey(Grouped.as("grouping"))
+                                            .count().toStream();
+
+            builder.<String, String>stream("topicII").selectKey((k, v) -> k)
+                                              .groupByKey(Grouped.as("grouping"))
+                                              .count().toStream();
             builder.build();
             fail("Should not build re-using repartition topic name");
         } catch (final TopologyException te) {
@@ -97,29 +102,72 @@ public class RepartitionTopicNamingTest {
     @Test
     public void shouldNotFailWithSameRepartitionTopicNameUsingSameKGroupedStream() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey(Grouped.as("grouping"));
+
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count().toStream().to("output-one");
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
+
         final String topologyString = builder.build().describe().toString();
         assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
-        assertTrue(topologyString.contains("grouping" + "-repartition"));
+        assertTrue(topologyString.contains("grouping-repartition"));
+    }
+
+    @Test
+    public void shouldNotFailWithSameRepartitionTopicNameUsingSameTimeWindowStream() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey(Grouped.as("grouping"));
+
+        final TimeWindowedKStream<String, String> timeWindowedKStream = kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L)));
+
+        timeWindowedKStream.count().toStream().to("output-one");
+        timeWindowedKStream.reduce((v, v2) -> v + v2).toStream().to("output-two");
+        kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
+
+        final String topologyString = builder.build().describe().toString();
+        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertTrue(topologyString.contains("grouping-repartition"));
+    }
+
+    @Test
+    public void shouldNotFailWithSameRepartitionTopicNameUsingSameSessionWindowStream() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey(Grouped.as("grouping"));
+
+        final SessionWindowedKStream<String, String> sessionWindowedKStream = kGroupedStream.windowedBy(SessionWindows.with(Duration.ofMillis(10L)));
+
+        sessionWindowedKStream.count().toStream().to("output-one");
+        sessionWindowedKStream.reduce((v, v2) -> v + v2).toStream().to("output-two");
+        kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
+
+        final String topologyString = builder.build().describe().toString();
+        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertTrue(topologyString.contains("grouping-repartition"));
     }
 
     @Test
     public void shouldNotFailWithSameRepartitionTopicNameUsingSameKGroupedTable() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedTable<String, String> kGroupedTable = builder.<String, String>table("topic").groupBy(KeyValue::pair, Grouped.as("grouping"));
+        final KGroupedTable<String, String> kGroupedTable = builder.<String, String>table("topic")
+                                                                   .groupBy(KeyValue::pair, Grouped.as("grouping"));
         kGroupedTable.count().toStream().to("output-count");
         kGroupedTable.reduce((v, v2) -> v2, (v, v2) -> v2).toStream().to("output-reduce");
         final String topologyString = builder.build().describe().toString();
         assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
-        assertTrue(topologyString.contains("grouping" + "-repartition"));
+        assertTrue(topologyString.contains("grouping-repartition"));
     }
 
     @Test
     public void shouldNotReuseRepartitionNodeWithUnamedRepartitionTopics() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey();
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey();
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count().toStream().to("output-one");
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
         final String topologyString = builder.build().describe().toString();
@@ -136,11 +184,12 @@ public class RepartitionTopicNamingTest {
         assertThat(2, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
     }
 
-
     @Test
     public void shouldNotFailWithSameRepartitionTopicNameUsingSameKGroupedStreamOptimizationsOn() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey(Grouped.as("grouping"));
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count();
         final Properties properties = new Properties();
@@ -159,8 +208,12 @@ public class RepartitionTopicNamingTest {
             final KStream<String, String> stream2 = builder.<String, String>stream("topic2").selectKey((k, v) -> k);
             final KStream<String, String> stream3 = builder.<String, String>stream("topic3").selectKey((k, v) -> k);
 
-            final KStream<String, String> joined = stream1.join(stream2, (v1, v2) -> v1 + v2, JoinWindows.of(Duration.ofMillis(30L)), Joined.named("join-repartition"));
-            joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.of(Duration.ofMillis(30L)), Joined.named("join-repartition"));
+            final KStream<String, String> joined = stream1.join(stream2, (v1, v2) -> v1 + v2,
+                                                                JoinWindows.of(Duration.ofMillis(30L)),
+                                                                Joined.named("join-repartition"));
+
+            joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.of(Duration.ofMillis(30L)),
+                                                      Joined.named("join-repartition"));
             builder.build();
             fail("Should not build re-using repartition topic name");
         } catch (final TopologyException te) {
@@ -168,13 +221,14 @@ public class RepartitionTopicNamingTest {
         }
     }
 
-
     @Test
     public void shouldPassWithSameRepartitionTopicNameUsingSameKGroupedStreamOptimized() {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
-        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(Grouped.as("grouping"));
+        final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic")
+                                                                     .selectKey((k, v) -> k)
+                                                                     .groupByKey(Grouped.as("grouping"));
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count();
         kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count();
         builder.build(properties);


### PR DESCRIPTION
This PR adds support for re-using a `KGroupedStream` or `KGroupedTable object after executing an aggregation operation with a named repartition topic. 

`KGroupedStream` example
```java
final KGroupedStream<String, String> kGroupedStream = builder.<String, String>stream("topic").selectKey((k, v) -> k).groupByKey(as("grouping"));
kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(10L))).count().toStream().to("output-one");
kGroupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(30L))).count().toStream().to("output-two");
```
`KGroupedTable` example
```java
final KGroupedTable<String, String> kGroupedTable = builder.<String, String>table("topic").groupBy(KeyValue::pair, Grouped.as("grouping"));
 kGroupedTable.count().toStream().to("output-count");
 kGroupedTable.reduce((v, v2) -> v2, (v, v2) -> v2).toStream().to("output-reduce");
```
This approach will not cause any compatibility issues for two reasons

1. Aggregations requiring repartitioning without naming the repartition topic maintain the same topology structure, which is the default mode today.  So by not reusing the repartition graph node, the numbering and structure of the topology remains the same.
2. Aggregations where the repartition topic _*is*_ named, it is not possible at the moment to re-use either the `KGroupedStream` or `KGroupedTable` object as Kafka Streams throws an `InvalidTopologyException` when building the topology. Hence you can't even deploy the application.

I've added unit tests for each case and ran our existing suite of streams tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
