### PR TITLE
KAFKA-7930: topic is not internal if explicitly listed in args

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -656,7 +656,8 @@ public class StreamsResetter {
 
 
     private boolean isInternalTopic(final String topicName) {
-        return topicName.startsWith(options.valueOf(applicationIdOption) + "-")
+        return !isInputTopic(topicName) && !isIntermediateTopic(topicName)
+            && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
             && (topicName.endsWith("-changelog") || topicName.endsWith("-repartition"));
     }
 

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -656,6 +656,13 @@ public class StreamsResetter {
 
 
     private boolean isInternalTopic(final String topicName) {
+        // if topic is specified either in --input-topics or --intermediate-topics
+        // and also matches the "internal" topic criteria, then tool will
+        // first process it as "input" or "intermediate" topic (i.e. reset to earliest / latest)
+        // and then delete it because it is "internal", which is wierd and misleading
+        // if topic is specified either in --input-topics or --intermediate-topics
+        // most likely it is not intended for deletion
+        // more in: https://issues.apache.org/jira/browse/KAFKA-7930
         return !isInputTopic(topicName) && !isIntermediateTopic(topicName)
             && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
             && (topicName.endsWith("-changelog") || topicName.endsWith("-repartition"));

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -656,13 +656,10 @@ public class StreamsResetter {
 
 
     private boolean isInternalTopic(final String topicName) {
-        // if topic is specified either in --input-topics or --intermediate-topics
-        // and also matches the "internal" topic criteria, then tool will
-        // first process it as "input" or "intermediate" topic (i.e. reset to earliest / latest)
-        // and then delete it because it is "internal", which is wierd and misleading
-        // if topic is specified either in --input-topics or --intermediate-topics
-        // most likely it is not intended for deletion
-        // more in: https://issues.apache.org/jira/browse/KAFKA-7930
+        // Specified input/intermediate topics might be named like internal topics (by chance).
+        // Even is this is not expected in general, we need to exclude those topics here
+        // and don't consider them as internal topics even if they follow the same naming schema.
+        // Cf. https://issues.apache.org/jira/browse/KAFKA-7930
         return !isInputTopic(topicName) && !isIntermediateTopic(topicName)
             && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
             && (topicName.endsWith("-changelog") || topicName.endsWith("-repartition"));


### PR DESCRIPTION
Simplest fix: topic is not internal if explicitly listed in --input-topics or --intermediate-topics.