### PR TITLE
KAFKA-6755: Allow literal value for MaskField SMT

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/TransformationConfigTest.java
@@ -120,7 +120,7 @@ public class TransformationConfigTest {
         connProps.put("transforms", "example");
         connProps.put("transforms.example.type", MaskField.Value.class.getName());
         connProps.put("transforms.example.fields", "field");
-
+        connProps.put("transforms.example.replacement", "nothing");
 
         Plugins plugins = null; // Safe when we're only constructing the config
         new ConnectorConfig(plugins, connProps);

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -173,7 +173,7 @@
     <ul>
         <li>InsertField - Add a field using either static data or record metadata</li>
         <li>ReplaceField - Filter or rename fields</li>
-        <li>MaskField - Replace field with valid null value for the type (0, empty string, etc)</li>
+        <li>MaskField - Replace field with valid null value for the type (0, empty string, etc) or custom replacement (non-empty string or numeric value only)</li>
         <li>ValueToKey - Replace the record key with a new key formed from a subset of fields in the record value</li>
         <li>HoistField - Wrap the entire event as a single field inside a Struct or a Map</li>
         <li>ExtractField - Extract a specific field from Struct and Map and include only this field in results</li>


### PR DESCRIPTION
See [KIP-437](https://cwiki.apache.org/confluence/display/KAFKA/KIP-437%3A+Custom+replacement+for+MaskField+SMT), which has been adopted.

### Goal
Allow literal value for MaskField SMT instead of null-masking for masking out:
- IP address, 
- SSN
- other personally identifiable information (PII)

### Details
The existing `org.apache.kafka.connect.transforms.MaskField` SMT always uses the null value for field masking. This PR introduces additional config param `replacement`, which will be applied to all fields in `fields` list. In such a way you can mask any string or numeric values with any literal of your choice.

_example config:_
```
transforms=SSNMask,IPMask
transforms.SSNMask.type=org.apache.kafka.connect.transforms.MaskField$Value
transforms.SSNMask.fields=ssn
transforms.SSNMask.replacement=***-***-****
transforms.IPMask.type=org.apache.kafka.connect.transforms.MaskField$Value
transforms.IPMask.fields=ipAddress
transforms.IPMask.replacement=xxx.xxx.xxx.xxx
```
### Restrictions:
- only numeric or string values are supported (no Dates, Booleans, lists, maps)
- literal value in `replacement` should be convertable to the type(s) of the `fields` passed. Be aware of such situations:

_if the replacement cannot be converted to some of the fields passed, the exception will be thrown_
```
transforms=FieldMask
transforms.FieldMask.type=org.apache.kafka.connect.transforms.MaskField$Value
transforms.FieldMask.fields=ssn,age
transforms.FieldMask.replacement=string_replacement
```

_if the replacement can be converted to all of the fields types, but fields types are different, replacement will be converted to the desired types_:
```
transforms=FieldMask
transforms.FieldMask.type=org.apache.kafka.connect.transforms.MaskField$Value
transforms.FieldMask.fields=name,age
transforms.FieldMask.replacement=12
```

Masking lists, maps and Booleans with custom value seems useless.
Masking dates is not very flexible in `org.apache.kafka.connect.data.Values`. Custom parser is also a needless solution, until it is not required by the user.

### Testing
- Unit tests are provided, custom doc testing was held

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)