### PR TITLE
KAFKA-7492 : Updated javadocs for aggregate and reduce methods returning null behavior.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
@@ -146,7 +146,8 @@ public interface KGroupedStream<K, V> {
      *
      * @param reducer   a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
+     * processed as if it was the first message.
      */
     KTable<K, V> reduce(final Reducer<V> reducer);
 
@@ -208,7 +209,8 @@ public interface KGroupedStream<K, V> {
      * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
+     * processed as if it was the first message.
      */
     KTable<K, V> reduce(final Reducer<V> reducer,
                         final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
@@ -251,7 +253,8 @@ public interface KGroupedStream<K, V> {
      * @param aggregator    an {@link Aggregator} that computes a new aggregate result
      * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
+     * processed as if it was the first message.
      */
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> aggregator);
@@ -308,7 +311,8 @@ public interface KGroupedStream<K, V> {
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
      * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
+     * processed as if it was the first message.
      */
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> aggregator,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
@@ -146,8 +146,9 @@ public interface KGroupedStream<K, V> {
      *
      * @param reducer   a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
-     * processed as if it was the first message.
+     * latest (rolling) aggregate for each key. If the reduce function returns {@code null}, it is then interpreted as
+     * deletion for the key, and future messages of the same key coming from upstream operators
+     * will be handled as newly initialized value.
      */
     KTable<K, V> reduce(final Reducer<V> reducer);
 
@@ -209,8 +210,9 @@ public interface KGroupedStream<K, V> {
      * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
-     * processed as if it was the first message.
+     * latest (rolling) aggregate for each key. If the reduce function returns {@code null}, it is then interpreted as
+     * deletion for the key, and future messages of the same key coming from upstream operators
+     * will be handled as newly initialized value.
      */
     KTable<K, V> reduce(final Reducer<V> reducer,
                         final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
@@ -253,8 +255,9 @@ public interface KGroupedStream<K, V> {
      * @param aggregator    an {@link Aggregator} that computes a new aggregate result
      * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
-     * processed as if it was the first message.
+     * latest (rolling) aggregate for each key. If the aggregate function returns {@code null}, it is then interpreted as
+     * deletion for the key, and future messages of the same key coming from upstream operators
+     * will be handled as newly initialized value.
      */
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> aggregator);
@@ -311,8 +314,9 @@ public interface KGroupedStream<K, V> {
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
      * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key. Incase {@link KTable} returns null the following message will be
-     * processed as if it was the first message.
+     * latest (rolling) aggregate for each key. If the aggregate function returns {@code null}, it is then interpreted as
+     * deletion for the key, and future messages of the same key coming from upstream operators
+     * will be handled as newly initialized value.
      */
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> aggregator,


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

- This is update to the existing javadocs for KGroupedStream class. More details are available at 
https://stackoverflow.com/questions/52692202/what-happens-if-the-aggregator-of-a-kgroupedstream-returns-null


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
