### PR TITLE
MINOR: Add 2 minute timeout to KTableKTableLeftJoinTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -61,7 +61,7 @@ import static org.junit.Assert.assertTrue;
 public class KTableKTableLeftJoinTest {
 
     @Rule
-    final public Timeout globalTimeout = Timeout.seconds(120);
+    final public Timeout globalTimeout = Timeout.seconds(240);
 
     final private String topic1 = "topic1";
     final private String topic2 = "topic2";

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -38,7 +38,9 @@ import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +59,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class KTableKTableLeftJoinTest {
+
+    @Rule
+    final public Timeout globalTimeout = Timeout.seconds(120);
 
     final private String topic1 = "topic1";
     final private String topic2 = "topic2";


### PR DESCRIPTION
According to KAFKA-7933, this test sometimes takes over
an hour. We add a 2 minute timeout to fail faster until
we find the problem. Another benefit is that we now
collect logs when a test fails (since ed3071231).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
