### PR TITLE
KAFKA-7948: Feature to enable json field order retention in the JsonConverter

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -39,6 +39,30 @@ public class JsonConverterConfig extends ConverterConfig {
     private static final String SCHEMAS_CACHE_SIZE_DOC = "The maximum number of schemas that can be cached in this converter instance.";
     private static final String SCHEMAS_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
+    public static final String JSON_FIELD_ORDER_CONFIG = "json.field.order";
+    public static final String JSON_FIELD_ORDER_DEFAULT = "none";
+    private static final String JSON_FIELD_ORDER_DOC = "The order to apply to output fields in json structures. Options are 'none', "
+            + "'retained', or 'alphabetical'. Default 'none'. If 'retained' the order of json fields on the incoming messages is retained through "
+            + "output. This may be important for some downstream json parsers.";
+    private static final String JSON_FIELD_ORDER_DISPLAY = "JSON Field Order";
+
+    public enum JsonFieldOrder {
+        NONE, RETAINED;
+
+
+        public static JsonFieldOrder maybeValueOf(String string) {
+            if (string != null) {
+                for (JsonFieldOrder value : values()) {
+                    if (string.toUpperCase().equals(value.name())) {
+                        return value;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+
     private final static ConfigDef CONFIG;
 
     static {
@@ -49,6 +73,10 @@ public class JsonConverterConfig extends ConverterConfig {
                       orderInGroup++, Width.MEDIUM, SCHEMAS_ENABLE_DISPLAY);
         CONFIG.define(SCHEMAS_CACHE_SIZE_CONFIG, Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT, Importance.HIGH, SCHEMAS_CACHE_SIZE_DOC, group,
                       orderInGroup++, Width.MEDIUM, SCHEMAS_CACHE_SIZE_DISPLAY);
+
+
+        CONFIG.define(JSON_FIELD_ORDER_CONFIG, Type.STRING, JSON_FIELD_ORDER_DEFAULT, Importance.HIGH, JSON_FIELD_ORDER_DOC, "Output",
+                      0, Width.MEDIUM, JSON_FIELD_ORDER_DISPLAY);
     }
 
     public static ConfigDef configDef() {

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -41,8 +41,8 @@ public class JsonConverterConfig extends ConverterConfig {
 
     public static final String JSON_FIELD_ORDER_CONFIG = "json.field.order";
     public static final String JSON_FIELD_ORDER_DEFAULT = "none";
-    private static final String JSON_FIELD_ORDER_DOC = "The order to apply to output fields in json structures. Options are 'none', "
-            + "'retained', or 'alphabetical'. Default 'none'. If 'retained' the order of json fields on the incoming messages is retained through "
+    private static final String JSON_FIELD_ORDER_DOC = "The order to apply to output fields in json structures. Options are 'none' or "
+            + "'retained'. Default 'none'. If 'retained' the order of json fields on the incoming messages is retained through "
             + "output. This may be important for some downstream json parsers.";
     private static final String JSON_FIELD_ORDER_DISPLAY = "JSON Field Order";
 


### PR DESCRIPTION
This change affects the JsonConverter.

Some json parsers have particular requirements for field order in a json message. While this is not a part of the json spec and shouldn't really be necessary it is a reality for parsers we have on our mainframe. I have made this a configuration setting with a default of 'none' to retain the current functionality as is while giving users the option of enabling field order retention.

3 new test methods have been added to verify the behaviour of the setting is as expected when not set, set to 'none' and set to 'retained'. 

To engage the behaviour use:
`json.field.order=retained`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
