### PR TITLE
Update kafka-run-class.bat

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -111,7 +111,7 @@ IF ["%JMX_PORT%"] NEQ [""] (
 
 rem Log directory to use
 IF ["%LOG_DIR%"] EQU [""] (
-    set LOG_DIR="%BASE_DIR%/logs"
+    set LOG_DIR=%BASE_DIR%/logs
 )
 
 rem Log4j settings


### PR DESCRIPTION
Removed quotes from LogDir variable generation as there are additional quotes in Line 127..
This caused problems when those batch files are invoked from a path that contains space characters.
