### PR TITLE
Enable pending reassignments cancellation/rollback

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -98,7 +98,11 @@ object ControllerState {
     def value = 14
   }
 
+  case object ReassignCancel extends ControllerState {
+    def value = 15
+  }
+
   val values: Seq[ControllerState] = Seq(Idle, ControllerChange, BrokerChange, TopicChange, TopicDeletion,
     PartitionReassignment, AutoLeaderBalance, ManualLeaderBalance, ControlledShutdown, IsrChange, LeaderAndIsrResponseReceived,
-    LogDirChange, ControllerShutdown, UncleanLeaderElectionEnable, TopicUncleanLeaderElectionEnable)
+    LogDirChange, ControllerShutdown, UncleanLeaderElectionEnable, TopicUncleanLeaderElectionEnable, ReassignCancel)
 }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -493,46 +493,46 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   }
 
   /**
-    * This callback is invoked by the reassigned partitions listener. When an admin command initiates a partition
-    * reassignment, it creates the /admin/reassign_partitions path that triggers the zookeeper listener.
-    * Reassigning replicas for a partition goes through a few steps listed in the code.
-    * RAR = Reassigned replicas
-    * OAR = Original list of replicas for partition
-    * AR = current assigned replicas
-    *
-    * 1. Update AR in ZK with OAR + RAR.
-    * 2. Send LeaderAndIsr request to every replica in OAR + RAR (with AR as OAR + RAR). We do this by forcing an update
-    *    of the leader epoch in zookeeper.
-    * 3. Start new replicas RAR - OAR by moving replicas in RAR - OAR to NewReplica state.
-    * 4. Wait until all replicas in RAR are in sync with the leader.
-    * 5  Move all replicas in RAR to OnlineReplica state.
-    * 6. Set AR to RAR in memory.
-    * 7. If the leader is not in RAR, elect a new leader from RAR. If new leader needs to be elected from RAR, a LeaderAndIsr
-    *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
-    *    In any case, the LeaderAndIsr request will have AR = RAR. This will prevent the leader from adding any replica in
-    *    RAR - OAR back in the isr.
-    * 8. Move all replicas in OAR - RAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
-    *    isr to remove OAR - RAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
-    *    After that, we send a StopReplica (delete = false) to the replicas in OAR - RAR.
-    * 9. Move all replicas in OAR - RAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
-    *    the replicas in OAR - RAR to physically delete the replicas on disk.
-    * 10. Update AR in ZK with RAR.
-    * 11. Update the /admin/reassign_partitions path in ZK to remove this partition.
-    * 12. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
-    *
-    * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
-    * may go through the following transition.
-    * AR                 leader/isr
-    * {1,2,3}            1/{1,2,3}           (initial state)
-    * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
-    * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (step 4)
-    * {1,2,3,4,5,6}      4/{1,2,3,4,5,6}     (step 7)
-    * {1,2,3,4,5,6}      4/{4,5,6}           (step 8)
-    * {4,5,6}            4/{4,5,6}           (step 10)
-    *
-    * Note that we have to update AR in ZK with RAR last since it's the only place where we store OAR persistently.
-    * This way, if the controller crashes before that step, we can still recover.
-    */
+   * This callback is invoked by the reassigned partitions listener. When an admin command initiates a partition
+   * reassignment, it creates the /admin/reassign_partitions path that triggers the zookeeper listener.
+   * Reassigning replicas for a partition goes through a few steps listed in the code.
+   * RAR = Reassigned replicas
+   * OAR = Original list of replicas for partition
+   * AR = current assigned replicas
+   *
+   * 1. Update AR in ZK with OAR + RAR.
+   * 2. Send LeaderAndIsr request to every replica in OAR + RAR (with AR as OAR + RAR). We do this by forcing an update
+   *    of the leader epoch in zookeeper.
+   * 3. Start new replicas RAR - OAR by moving replicas in RAR - OAR to NewReplica state.
+   * 4. Wait until all replicas in RAR are in sync with the leader.
+   * 5  Move all replicas in RAR to OnlineReplica state.
+   * 6. Set AR to RAR in memory.
+   * 7. If the leader is not in RAR, elect a new leader from RAR. If new leader needs to be elected from RAR, a LeaderAndIsr
+   *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
+   *    In any case, the LeaderAndIsr request will have AR = RAR. This will prevent the leader from adding any replica in
+   *    RAR - OAR back in the isr.
+   * 8. Move all replicas in OAR - RAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
+   *    isr to remove OAR - RAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
+   *    After that, we send a StopReplica (delete = false) to the replicas in OAR - RAR.
+   * 9. Move all replicas in OAR - RAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
+   *    the replicas in OAR - RAR to physically delete the replicas on disk.
+   * 10. Update AR in ZK with RAR.
+   * 11. Update the /admin/reassign_partitions path in ZK to remove this partition.
+   * 12. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
+   *
+   * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
+   * may go through the following transition.
+   * AR                 leader/isr
+   * {1,2,3}            1/{1,2,3}           (initial state)
+   * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
+   * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (step 4)
+   * {1,2,3,4,5,6}      4/{1,2,3,4,5,6}     (step 7)
+   * {1,2,3,4,5,6}      4/{4,5,6}           (step 8)
+   * {4,5,6}            4/{4,5,6}           (step 10)
+   *
+   * Note that we have to update AR in ZK with RAR last since it's the only place where we store OAR persistently.
+   * This way, if the controller crashes before that step, we can still recover.
+   */
   private def onPartitionReassignment(topicPartition: TopicPartition, reassignedPartitionContext: ReassignedPartitionsContext) {
     if (zkClient.reassignCancelInPlace) return // if the ReassignCancelZNode exists , skip reassignment
     val reassignedReplicas = reassignedPartitionContext.newReplicas
@@ -576,40 +576,40 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   }
 
   /**
-    * This callback is invoked by the reassign cancel listener. When an admin command initiates a partition
-    * reassignment cancellation, it creates the /admin/cancel_reassignment_in_progress path that triggers the zookeeper listener.
-    * Reassigning replicas for a partition goes through a few steps listed in the code.
-    * RAR = Reassigned replicas
-    * OAR = Original list of replicas for partition
-    * AR = current assigned replicas
-    *
-    * 1. Set AR to OAR in memory.
-    * 2. If the leader is not in OAR, elect a new leader from OAR. If new leader needs to be elected from OAR, a LeaderAndIsr
-    *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
-    *    In any case, the LeaderAndIsr request will have AR = OAR. This will prevent the leader from adding any replica in
-    *    OAR - RAR back in the isr.
-    * 3. Move all replicas in RAR - OAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
-    *    isr to remove RAR - OAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
-    *    After that, we send a StopReplica (delete = false) to the replicas in RAR - OAR.
-    * 4. Move all replicas in RAR - OAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
-    *    the replicas in RAR - OAR to physically delete the replicas on disk.
-    * 5. Update AR in ZK with OAR.
-    * 6. Update the /admin/reassign_partitions path in ZK to remove this partition.
-    * 7. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
-    *
-    * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
-    * may go through the following transition.
-    * AR                 leader/isr
-    * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (initial state)
-    * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
-    * {1,2,3}            1/{1,2,3}           (step 3)
-    * {1,2,3}            1/{1,2,3}           (step 4)
-    * {1,2,3}            1/{1,2,3}           (step 6)
-    * {1,2,3}            1/{1,2,3}           (step 7)
-    *
-    * Note that we have to update AR in ZK with OAR last since it's the only place where we store OAR persistently.
-    * This way, if the controller crashes before that step, we can still recover.
-    */
+   * This callback is invoked by the reassign cancel listener. When an admin command initiates a partition
+   * reassignment cancellation, it creates the /admin/cancel_reassignment_in_progress path that triggers the zookeeper listener.
+   * Reassigning replicas for a partition goes through a few steps listed in the code.
+   * RAR = Reassigned replicas
+   * OAR = Original list of replicas for partition
+   * AR = current assigned replicas
+   *
+   * 1. Set AR to OAR in memory.
+   * 2. If the leader is not in OAR, elect a new leader from OAR. If new leader needs to be elected from OAR, a LeaderAndIsr
+   *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
+   *    In any case, the LeaderAndIsr request will have AR = OAR. This will prevent the leader from adding any replica in
+   *    OAR - RAR back in the isr.
+   * 3. Move all replicas in RAR - OAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
+   *    isr to remove RAR - OAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
+   *    After that, we send a StopReplica (delete = false) to the replicas in RAR - OAR.
+   * 4. Move all replicas in RAR - OAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
+   *    the replicas in RAR - OAR to physically delete the replicas on disk.
+   * 5. Update AR in ZK with OAR.
+   * 6. Update the /admin/reassign_partitions path in ZK to remove this partition.
+   * 7. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
+   *
+   * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
+   * may go through the following transition.
+   * AR                 leader/isr
+   * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (initial state)
+   * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
+   * {1,2,3}            1/{1,2,3}           (step 3)
+   * {1,2,3}            1/{1,2,3}           (step 4)
+   * {1,2,3}            1/{1,2,3}           (step 6)
+   * {1,2,3}            1/{1,2,3}           (step 7)
+   *
+   * Note that we have to update AR in ZK with OAR last since it's the only place where we store OAR persistently.
+   * This way, if the controller crashes before that step, we can still recover.
+   */
   private def onReassignCancel(topicPartition: TopicPartition, reassignedPartitionContext: ReassignedPartitionsContext): Unit = {
     val reassignedReplicas = reassignedPartitionContext.newReplicas
     val originalReplicas = reassignedPartitionContext.originalReplicas
@@ -637,32 +637,64 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   }
 
   /** Trigger reassignment cancellation
-    *
-    * @throws IllegalStateException if a partition in `partitionsBeingReassigned` does not have originalReplicas
-    *                               to cancel/rollback the reassignments.
-    */
+   *
+   * skip to cancel/rollback the reassignments if a partition in `partitionsBeingReassigned` does not have originalReplicas
+   */
   private def maybeTriggerReassignCancel(topicPartitions: Set[TopicPartition]) {
-    if (zkClient.reassignCancelInPlace) {
-      val partitionsToBeRemovedFromReassignment = scala.collection.mutable.Set.empty[TopicPartition]
-      topicPartitions.foreach { tp =>
-        if (topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic) || !zkClient.topicExists(tp.topic)) {
-          info(s"Removing reassignment of $tp since the topic is currently being deleted or does not exist.")
-          partitionsToBeRemovedFromReassignment.add(tp)
+    try {
+      if (zkClient.reassignCancelInPlace) {
+        val partitionsToBeRemovedFromReassignment = scala.collection.mutable.Set.empty[TopicPartition]
+        topicPartitions.foreach { tp =>
+          if (topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic) || !zkClient.topicExists(tp.topic)) {
+            info(s"Removing reassignment of $tp since the topic is currently being deleted or does not exist.")
+            partitionsToBeRemovedFromReassignment.add(tp)
+          }
         }
-      }
-      if (!partitionsToBeRemovedFromReassignment.isEmpty) {
-        removePartitionsFromReassignedPartitions(partitionsToBeRemovedFromReassignment)
-      }
+        if (!partitionsToBeRemovedFromReassignment.isEmpty) {
+          removePartitionsFromReassignedPartitions(partitionsToBeRemovedFromReassignment)
+        }
 
-      controllerContext.partitionsBeingReassigned.foreach { case(tp, context) =>
-        if (context.originalReplicas.isEmpty) {
-          throw new IllegalStateException(s"partition $tp does not have originalReplicas to cancel / rollback the reassignments. " +
-            s"partitionsBeingReassigned: ${controllerContext.partitionsBeingReassigned.mkString(", ")}")
+        controllerContext.partitionsBeingReassigned.foreach { case (tp, reassignedContext) =>
+          if (Option(reassignedContext.originalReplicas).isEmpty || reassignedContext.originalReplicas.isEmpty) {
+            error(s"partition $tp does not have originalReplicas to cancel / rollback the reassignments. " +
+              s"partitionsBeingReassigned: ${controllerContext.partitionsBeingReassigned.mkString(", ")}")
+          }
+          else {
+            val atLeastOneOriginalReplicaInIsr = atLeastOneReplicaInIsr(tp, reassignedContext.originalReplicas)
+            val allNewReplicasAreOffline = reassignedContext.newReplicas.forall(brokerId => !(controllerContext.isReplicaOnline(brokerId, tp)))
+            // Only cancel reassignment of the tp if either at least one of the origical replica is in ISR.
+            // OR  all the NewReplicas are offline, cluster in bad state for the topic/partition, just cance/rollback.
+            if (!atLeastOneOriginalReplicaInIsr && !allNewReplicasAreOffline) {
+              info(s"Skip cancel reassignment of %s, newReplicas: %s, originalReplicas: %s, because either at least one of the origical replica is in ISR is: %s, AND all the NewReplicas are offline is: %s".format(tp, reassignedContext.newReplicas, reassignedContext.originalReplicas, atLeastOneOriginalReplicaInIsr, allNewReplicasAreOffline))
+            }
+            else {
+              try {
+                info(s"Cancel reassignment of %s, newReplicas: %s, rollback with originalReplicas: %s".format(tp, reassignedContext.newReplicas, reassignedContext.originalReplicas))
+                // mark topic ineligible for deletion for the partitions being reassignment cancelled
+                topicDeletionManager.markTopicIneligibleForDeletion(Set(tp.topic))
+                onReassignCancel(tp, reassignedContext)
+              }
+              catch {
+                case e: ControllerMovedException =>
+                  error(s"Error cancelling reassignment of partition $tp because controller has moved to another broker", e)
+                  throw e
+                case e: Throwable =>
+                  error(s"Error cancelling reassignment of partition $tp", e)
+              }
+            }
+          }
         }
-        onReassignCancel(tp, context)
       }
+    }
+    catch {
+      case e: Throwable =>
+        error(s"Error cancelling reassignment of partition", e)
+    }
+    finally {
       // delete reassignment cancel znode
-      zkClient.deleteReassignCancel()
+      zkClient.deleteReassignCancel(controllerContext.epochZkVersion)
+      // Ensure we detect future reassignment cancellation
+      eventManager.put(ReassignCancel)
     }
   }
 
@@ -853,18 +885,24 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     }
   }
 
+  private def atLeastOneReplicaInIsr(partition: TopicPartition, replicas: Seq[Int]): Boolean = {
+    zkClient.getTopicPartitionStates(Seq(partition)).get(partition).exists { leaderIsrAndControllerEpoch =>
+      replicas.exists(leaderIsrAndControllerEpoch.leaderAndIsr.isr.contains)
+    }
+  }
+
   private def rollbackReassignedPartitionLeaderIfRequired(topicPartition: TopicPartition,
                                                       reassignedPartitionContext: ReassignedPartitionsContext) {
     val originalReplicas = reassignedPartitionContext.originalReplicas
     val currentLeader = controllerContext.partitionLeadershipInfo(topicPartition).leaderAndIsr.leader
     // change the assigned replica list to just the reassigned replicas in the cache so it gets sent out on the LeaderAndIsr
-    // request to the current or new leader. This will prevent it from adding the old replicas to the ISR
+    // request to the current or new leader. This will prevent it from adding the new replicas to the ISR
     val oldAndNewReplicas = controllerContext.partitionReplicaAssignment(topicPartition)
     controllerContext.updatePartitionReplicaAssignment(topicPartition, originalReplicas)
     if (!reassignedPartitionContext.originalReplicas.contains(currentLeader)) {
       info(s"Leader $currentLeader for partition $topicPartition being rollbacked for reassignment, " +
         s"is not in the new list of replicas ${originalReplicas.mkString(",")}. Re-electing leader")
-      // move the leader to one of the alive and caught up new replicas
+      // move the leader to one of the alive and caught up OAR replicas
       partitionStateMachine.handleStateChanges(Seq(topicPartition), OnlinePartition, Option(PreferredReplicaPartitionLeaderElectionStrategy ))
     } else {
       // check if the leader is alive or not
@@ -1572,7 +1610,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
       // the `path exists` check for free
       if (zkClient.registerZNodeChangeHandlerAndCheckExistence(reassignCancelHandler)) {
         val partitionReassignment = zkClient.getPartitionReassignment
-
+        info(s"cancelling pending reassignments: %s".format(partitionReassignment))
         // if controllerContext.partitionsBeingReassigned had been populated by previous Reassignments and still pending.
         // Re-populate controllerContext.partitionsBeingReassigned, in case /admin/reassign_cancel is in place,
         // and Controller has a failover.

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -93,6 +93,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   private val topicDeletionHandler = new TopicDeletionHandler(this, eventManager)
   private val partitionModificationsHandlers: mutable.Map[String, PartitionModificationsHandler] = mutable.Map.empty
   private val partitionReassignmentHandler = new PartitionReassignmentHandler(this, eventManager)
+  private val reassignCancelHandler = new ReassignCancelHandler(this, eventManager)
   private val preferredReplicaElectionHandler = new PreferredReplicaElectionHandler(this, eventManager)
   private val isrChangeNotificationHandler = new IsrChangeNotificationHandler(this, eventManager)
   private val logDirEventNotificationHandler = new LogDirEventNotificationHandler(this, eventManager)
@@ -240,7 +241,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     val childChangeHandlers = Seq(brokerChangeHandler, topicChangeHandler, topicDeletionHandler, logDirEventNotificationHandler,
       isrChangeNotificationHandler)
     childChangeHandlers.foreach(zkClient.registerZNodeChildChangeHandler)
-    val nodeChangeHandlers = Seq(preferredReplicaElectionHandler, partitionReassignmentHandler)
+    val nodeChangeHandlers = Seq(preferredReplicaElectionHandler, partitionReassignmentHandler, reassignCancelHandler)
     nodeChangeHandlers.foreach(zkClient.registerZNodeChangeHandlerAndCheckExistence)
 
     info("Deleting log dir event notifications")
@@ -266,6 +267,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
 
     info(s"Ready to serve as the new controller with epoch $epoch")
     maybeTriggerPartitionReassignment(controllerContext.partitionsBeingReassigned.keySet)
+    maybeTriggerReassignCancel(controllerContext.partitionsBeingReassigned.keySet)
     topicDeletionManager.tryTopicDeletion()
     val pendingPreferredReplicaElections = fetchPendingPreferredReplicaElections()
     onPreferredReplicaElection(pendingPreferredReplicaElections)
@@ -299,6 +301,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     // de-register listeners
     zkClient.unregisterZNodeChildChangeHandler(isrChangeNotificationHandler.path)
     zkClient.unregisterZNodeChangeHandler(partitionReassignmentHandler.path)
+    zkClient.unregisterZNodeChangeHandler(reassignCancelHandler.path)
     zkClient.unregisterZNodeChangeHandler(preferredReplicaElectionHandler.path)
     zkClient.unregisterZNodeChildChangeHandler(logDirEventNotificationHandler.path)
     unregisterBrokerModificationsHandler(brokerModificationsHandlers.keySet)
@@ -490,47 +493,48 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   }
 
   /**
-   * This callback is invoked by the reassigned partitions listener. When an admin command initiates a partition
-   * reassignment, it creates the /admin/reassign_partitions path that triggers the zookeeper listener.
-   * Reassigning replicas for a partition goes through a few steps listed in the code.
-   * RAR = Reassigned replicas
-   * OAR = Original list of replicas for partition
-   * AR = current assigned replicas
-   *
-   * 1. Update AR in ZK with OAR + RAR.
-   * 2. Send LeaderAndIsr request to every replica in OAR + RAR (with AR as OAR + RAR). We do this by forcing an update
-   *    of the leader epoch in zookeeper.
-   * 3. Start new replicas RAR - OAR by moving replicas in RAR - OAR to NewReplica state.
-   * 4. Wait until all replicas in RAR are in sync with the leader.
-   * 5  Move all replicas in RAR to OnlineReplica state.
-   * 6. Set AR to RAR in memory.
-   * 7. If the leader is not in RAR, elect a new leader from RAR. If new leader needs to be elected from RAR, a LeaderAndIsr
-   *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
-   *    In any case, the LeaderAndIsr request will have AR = RAR. This will prevent the leader from adding any replica in
-   *    RAR - OAR back in the isr.
-   * 8. Move all replicas in OAR - RAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
-   *    isr to remove OAR - RAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
-   *    After that, we send a StopReplica (delete = false) to the replicas in OAR - RAR.
-   * 9. Move all replicas in OAR - RAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
-   *    the replicas in OAR - RAR to physically delete the replicas on disk.
-   * 10. Update AR in ZK with RAR.
-   * 11. Update the /admin/reassign_partitions path in ZK to remove this partition.
-   * 12. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
-   *
-   * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
-   * may go through the following transition.
-   * AR                 leader/isr
-   * {1,2,3}            1/{1,2,3}           (initial state)
-   * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
-   * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (step 4)
-   * {1,2,3,4,5,6}      4/{1,2,3,4,5,6}     (step 7)
-   * {1,2,3,4,5,6}      4/{4,5,6}           (step 8)
-   * {4,5,6}            4/{4,5,6}           (step 10)
-   *
-   * Note that we have to update AR in ZK with RAR last since it's the only place where we store OAR persistently.
-   * This way, if the controller crashes before that step, we can still recover.
-   */
+    * This callback is invoked by the reassigned partitions listener. When an admin command initiates a partition
+    * reassignment, it creates the /admin/reassign_partitions path that triggers the zookeeper listener.
+    * Reassigning replicas for a partition goes through a few steps listed in the code.
+    * RAR = Reassigned replicas
+    * OAR = Original list of replicas for partition
+    * AR = current assigned replicas
+    *
+    * 1. Update AR in ZK with OAR + RAR.
+    * 2. Send LeaderAndIsr request to every replica in OAR + RAR (with AR as OAR + RAR). We do this by forcing an update
+    *    of the leader epoch in zookeeper.
+    * 3. Start new replicas RAR - OAR by moving replicas in RAR - OAR to NewReplica state.
+    * 4. Wait until all replicas in RAR are in sync with the leader.
+    * 5  Move all replicas in RAR to OnlineReplica state.
+    * 6. Set AR to RAR in memory.
+    * 7. If the leader is not in RAR, elect a new leader from RAR. If new leader needs to be elected from RAR, a LeaderAndIsr
+    *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
+    *    In any case, the LeaderAndIsr request will have AR = RAR. This will prevent the leader from adding any replica in
+    *    RAR - OAR back in the isr.
+    * 8. Move all replicas in OAR - RAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
+    *    isr to remove OAR - RAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
+    *    After that, we send a StopReplica (delete = false) to the replicas in OAR - RAR.
+    * 9. Move all replicas in OAR - RAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
+    *    the replicas in OAR - RAR to physically delete the replicas on disk.
+    * 10. Update AR in ZK with RAR.
+    * 11. Update the /admin/reassign_partitions path in ZK to remove this partition.
+    * 12. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
+    *
+    * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
+    * may go through the following transition.
+    * AR                 leader/isr
+    * {1,2,3}            1/{1,2,3}           (initial state)
+    * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
+    * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (step 4)
+    * {1,2,3,4,5,6}      4/{1,2,3,4,5,6}     (step 7)
+    * {1,2,3,4,5,6}      4/{4,5,6}           (step 8)
+    * {4,5,6}            4/{4,5,6}           (step 10)
+    *
+    * Note that we have to update AR in ZK with RAR last since it's the only place where we store OAR persistently.
+    * This way, if the controller crashes before that step, we can still recover.
+    */
   private def onPartitionReassignment(topicPartition: TopicPartition, reassignedPartitionContext: ReassignedPartitionsContext) {
+    if (zkClient.reassignCancelInPlace) return // if the ReassignCancelZNode exists , skip reassignment
     val reassignedReplicas = reassignedPartitionContext.newReplicas
     if (!areReplicasInIsr(topicPartition, reassignedReplicas)) {
       info(s"New replicas ${reassignedReplicas.mkString(",")} for partition $topicPartition being reassigned not yet " +
@@ -572,6 +576,97 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
   }
 
   /**
+    * This callback is invoked by the reassign cancel listener. When an admin command initiates a partition
+    * reassignment cancellation, it creates the /admin/cancel_reassignment_in_progress path that triggers the zookeeper listener.
+    * Reassigning replicas for a partition goes through a few steps listed in the code.
+    * RAR = Reassigned replicas
+    * OAR = Original list of replicas for partition
+    * AR = current assigned replicas
+    *
+    * 1. Set AR to OAR in memory.
+    * 2. If the leader is not in OAR, elect a new leader from OAR. If new leader needs to be elected from OAR, a LeaderAndIsr
+    *    will be sent. If not, then leader epoch will be incremented in zookeeper and a LeaderAndIsr request will be sent.
+    *    In any case, the LeaderAndIsr request will have AR = OAR. This will prevent the leader from adding any replica in
+    *    OAR - RAR back in the isr.
+    * 3. Move all replicas in RAR - OAR to OfflineReplica state. As part of OfflineReplica state change, we shrink the
+    *    isr to remove RAR - OAR in zookeeper and send a LeaderAndIsr ONLY to the Leader to notify it of the shrunk isr.
+    *    After that, we send a StopReplica (delete = false) to the replicas in RAR - OAR.
+    * 4. Move all replicas in RAR - OAR to NonExistentReplica state. This will send a StopReplica (delete = true) to
+    *    the replicas in RAR - OAR to physically delete the replicas on disk.
+    * 5. Update AR in ZK with OAR.
+    * 6. Update the /admin/reassign_partitions path in ZK to remove this partition.
+    * 7. After electing leader, the replicas and isr information changes. So resend the update metadata request to every broker.
+    *
+    * For example, if OAR = {1, 2, 3} and RAR = {4,5,6}, the values in the assigned replica (AR) and leader/isr path in ZK
+    * may go through the following transition.
+    * AR                 leader/isr
+    * {1,2,3,4,5,6}      1/{1,2,3,4,5,6}     (initial state)
+    * {1,2,3,4,5,6}      1/{1,2,3}           (step 2)
+    * {1,2,3}            1/{1,2,3}           (step 3)
+    * {1,2,3}            1/{1,2,3}           (step 4)
+    * {1,2,3}            1/{1,2,3}           (step 6)
+    * {1,2,3}            1/{1,2,3}           (step 7)
+    *
+    * Note that we have to update AR in ZK with OAR last since it's the only place where we store OAR persistently.
+    * This way, if the controller crashes before that step, we can still recover.
+    */
+  private def onReassignCancel(topicPartition: TopicPartition, reassignedPartitionContext: ReassignedPartitionsContext): Unit = {
+    val reassignedReplicas = reassignedPartitionContext.newReplicas
+    val originalReplicas = reassignedPartitionContext.originalReplicas
+    //val newReplicasNotInOldReplicaList = reassignedReplicas.toSet -- controllerContext.partitionReplicaAssignment(topicPartition).toSet
+    val newAndOldReplicas = (reassignedPartitionContext.newReplicas ++ controllerContext.partitionReplicaAssignment(topicPartition)).toSet
+    val oldReplicas = controllerContext.partitionReplicaAssignment(topicPartition).toSet -- reassignedReplicas.toSet
+    //1. Set AR to OAR in memory.
+    //2. Send LeaderAndIsr request with a potential new leader (if current leader not in OAR) and
+    //   a new AR (using OAR) and same isr to every broker in RAR
+    rollbackReassignedPartitionLeaderIfRequired(topicPartition, reassignedPartitionContext)
+    //3. replicas in RAR - OAR -> Offline (force those replicas out of isr)
+    //4. replicas in RAR - OAR -> NonExistentReplica (force those replicas to be deleted)
+    val newReplicas = reassignedReplicas.toSet  -- originalReplicas.toSet
+    stopOldReplicasOfReassignedPartition(topicPartition, reassignedPartitionContext, newReplicas)
+    //5. Update AR in ZK with OAR.
+    updateAssignedReplicasForPartition(topicPartition, originalReplicas)
+    //Optionally Send LeaderAndIsr request to every replica in OAR + RAR (with AR as OAR).
+    //updateLeaderEpochAndSendRequest(topicPartition, controllerContext.partitionReplicaAssignment(topicPartition),newAndOldReplicas.toSeq)
+    //6. Update the /admin/reassign_partitions path in ZK to remove this partition.
+    removePartitionsFromReassignedPartitions(Set(topicPartition))
+    //7. After electing leader, the replicas and isr information changes, so resend the update metadata request to every broker
+    sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq, Set(topicPartition))
+    // signal delete topic thread if reassignment for some partitions belonging to topics being deleted just completed
+    topicDeletionManager.resumeDeletionForTopics(Set(topicPartition.topic))
+  }
+
+  /** Trigger reassignment cancellation
+    *
+    * @throws IllegalStateException if a partition in `partitionsBeingReassigned` does not have originalReplicas
+    *                               to cancel/rollback the reassignments.
+    */
+  private def maybeTriggerReassignCancel(topicPartitions: Set[TopicPartition]) {
+    if (zkClient.reassignCancelInPlace) {
+      val partitionsToBeRemovedFromReassignment = scala.collection.mutable.Set.empty[TopicPartition]
+      topicPartitions.foreach { tp =>
+        if (topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic) || !zkClient.topicExists(tp.topic)) {
+          info(s"Removing reassignment of $tp since the topic is currently being deleted or does not exist.")
+          partitionsToBeRemovedFromReassignment.add(tp)
+        }
+      }
+      if (!partitionsToBeRemovedFromReassignment.isEmpty) {
+        removePartitionsFromReassignedPartitions(partitionsToBeRemovedFromReassignment)
+      }
+
+      controllerContext.partitionsBeingReassigned.foreach { case(tp, context) =>
+        if (context.originalReplicas.isEmpty) {
+          throw new IllegalStateException(s"partition $tp does not have originalReplicas to cancel / rollback the reassignments. " +
+            s"partitionsBeingReassigned: ${controllerContext.partitionsBeingReassigned.mkString(", ")}")
+        }
+        onReassignCancel(tp, context)
+      }
+      // delete reassignment cancel znode
+      zkClient.deleteReassignCancel()
+    }
+  }
+
+  /**
    * Trigger partition reassignment for the provided partitions if the assigned replicas are not the same as the
    * reassigned replicas (as defined in `ControllerContext.partitionsBeingReassigned`) and if the topic has not been
    * deleted.
@@ -583,6 +678,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
    * @throws IllegalStateException if a partition is not in `partitionsBeingReassigned`
    */
   private def maybeTriggerPartitionReassignment(topicPartitions: Set[TopicPartition]) {
+    if (zkClient.reassignCancelInPlace) return // If ReassignCancelZnode exists, skip reassignments.
     val partitionsToBeRemovedFromReassignment = scala.collection.mutable.Set.empty[TopicPartition]
     topicPartitions.foreach { tp =>
       if (topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic)) {
@@ -691,9 +787,9 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     val partitionsBeingReassigned = zkClient.getPartitionReassignment
     info(s"Partitions being reassigned: $partitionsBeingReassigned")
 
-    controllerContext.partitionsBeingReassigned ++= partitionsBeingReassigned.iterator.map { case (tp, newReplicas) =>
+    controllerContext.partitionsBeingReassigned ++= partitionsBeingReassigned.iterator.map { case (tp, replicas_type) =>
       val reassignIsrChangeHandler = new PartitionReassignmentIsrChangeHandler(this, eventManager, tp)
-      tp -> new ReassignedPartitionsContext(newReplicas, reassignIsrChangeHandler)
+      tp -> new ReassignedPartitionsContext(replicas_type("replicas"), replicas_type("original_replicas"), reassignIsrChangeHandler)
     }
   }
 
@@ -753,6 +849,34 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
         info(s"Leader $currentLeader for partition $topicPartition being reassigned, " +
           s"is already in the new list of replicas ${reassignedReplicas.mkString(",")} but is dead")
         partitionStateMachine.handleStateChanges(Seq(topicPartition), OnlinePartition, Option(ReassignPartitionLeaderElectionStrategy))
+      }
+    }
+  }
+
+  private def rollbackReassignedPartitionLeaderIfRequired(topicPartition: TopicPartition,
+                                                      reassignedPartitionContext: ReassignedPartitionsContext) {
+    val originalReplicas = reassignedPartitionContext.originalReplicas
+    val currentLeader = controllerContext.partitionLeadershipInfo(topicPartition).leaderAndIsr.leader
+    // change the assigned replica list to just the reassigned replicas in the cache so it gets sent out on the LeaderAndIsr
+    // request to the current or new leader. This will prevent it from adding the old replicas to the ISR
+    val oldAndNewReplicas = controllerContext.partitionReplicaAssignment(topicPartition)
+    controllerContext.updatePartitionReplicaAssignment(topicPartition, originalReplicas)
+    if (!reassignedPartitionContext.originalReplicas.contains(currentLeader)) {
+      info(s"Leader $currentLeader for partition $topicPartition being rollbacked for reassignment, " +
+        s"is not in the new list of replicas ${originalReplicas.mkString(",")}. Re-electing leader")
+      // move the leader to one of the alive and caught up new replicas
+      partitionStateMachine.handleStateChanges(Seq(topicPartition), OnlinePartition, Option(PreferredReplicaPartitionLeaderElectionStrategy ))
+    } else {
+      // check if the leader is alive or not
+      if (controllerContext.isReplicaOnline(currentLeader, topicPartition)) {
+        info(s"Leader $currentLeader for partition $topicPartition being rollbacked for reassignment, " +
+          s"is already in the new list of replicas ${originalReplicas.mkString(",")} and is alive")
+        // shrink replication factor and update the leader epoch in zookeeper to use on the next LeaderAndIsrRequest
+        updateLeaderEpochAndSendRequest(topicPartition, oldAndNewReplicas, originalReplicas)
+      } else {
+        info(s"Leader $currentLeader for partition $topicPartition being rollbacked for reassignment, " +
+          s"is already in the new list of replicas ${originalReplicas.mkString(",")} but is dead")
+        partitionStateMachine.handleStateChanges(Seq(topicPartition), OnlinePartition, Option(PreferredReplicaPartitionLeaderElectionStrategy ))
       }
     }
   }
@@ -858,7 +982,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
       // Ensure we detect future reassignments
       eventManager.put(PartitionReassignment)
     } else {
-      val reassignment = updatedPartitionsBeingReassigned.mapValues(_.newReplicas)
+      val reassignment = updatedPartitionsBeingReassigned.map { case (tp, replicas_type) => tp -> scala.Predef.Map("replicas" -> replicas_type.newReplicas, "original_replicas" -> replicas_type.originalReplicas)}.toMap
       try zkClient.setOrCreatePartitionReassignment(reassignment, controllerContext.epochZkVersion)
       catch {
         case e: KeeperException => throw new AdminOperationException(e)
@@ -1438,6 +1562,31 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     }
   }
 
+  case object ReassignCancel extends ControllerEvent {
+    override def state: ControllerState = ControllerState.ReassignCancel
+
+    override def process(): Unit = {
+      if (!isActive) return
+
+      // We need to register the watcher if the path doesn't exist in order to detect future reassignments and we get
+      // the `path exists` check for free
+      if (zkClient.registerZNodeChangeHandlerAndCheckExistence(reassignCancelHandler)) {
+        val partitionReassignment = zkClient.getPartitionReassignment
+
+        // if controllerContext.partitionsBeingReassigned had been populated by previous Reassignments and still pending.
+        // Re-populate controllerContext.partitionsBeingReassigned, in case /admin/reassign_cancel is in place,
+        // and Controller has a failover.
+        partitionReassignment.foreach { case (tp, replicas_type) =>
+          val reassignIsrChangeHandler = new PartitionReassignmentIsrChangeHandler(KafkaController.this, eventManager,
+            tp)
+          controllerContext.partitionsBeingReassigned.put(tp, ReassignedPartitionsContext(replicas_type("replicas"), replicas_type("original_replicas"), reassignIsrChangeHandler))
+        }
+
+        maybeTriggerReassignCancel(partitionReassignment.keySet)
+      }
+    }
+  }
+
   case object PartitionReassignment extends ControllerEvent {
     override def state: ControllerState = ControllerState.PartitionReassignment
 
@@ -1451,10 +1600,10 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
 
         // Populate `partitionsBeingReassigned` with all partitions being reassigned before invoking
         // `maybeTriggerPartitionReassignment` (see method documentation for the reason)
-        partitionReassignment.foreach { case (tp, newReplicas) =>
+        partitionReassignment.foreach { case (tp, replicas_type) =>
           val reassignIsrChangeHandler = new PartitionReassignmentIsrChangeHandler(KafkaController.this, eventManager,
             tp)
-          controllerContext.partitionsBeingReassigned.put(tp, ReassignedPartitionsContext(newReplicas, reassignIsrChangeHandler))
+          controllerContext.partitionsBeingReassigned.put(tp, ReassignedPartitionsContext(replicas_type("replicas"), replicas_type("original_replicas"), reassignIsrChangeHandler))
         }
 
         maybeTriggerPartitionReassignment(partitionReassignment.keySet)
@@ -1625,6 +1774,12 @@ class TopicDeletionHandler(controller: KafkaController, eventManager: Controller
   override def handleChildChange(): Unit = eventManager.put(controller.TopicDeletion)
 }
 
+class ReassignCancelHandler(controller: KafkaController, eventManager: ControllerEventManager) extends ZNodeChangeHandler {
+  override val path: String = ReassignCancelZNode.path
+
+  override def handleCreation(): Unit = eventManager.put(controller.ReassignCancel)
+}
+
 class PartitionReassignmentHandler(controller: KafkaController, eventManager: ControllerEventManager) extends ZNodeChangeHandler {
   override val path: String = ReassignPartitionsZNode.path
 
@@ -1665,6 +1820,7 @@ class ControllerChangeHandler(controller: KafkaController, eventManager: Control
 }
 
 case class ReassignedPartitionsContext(var newReplicas: Seq[Int] = Seq.empty,
+                                       var originalReplicas: Seq[Int]= Seq.empty,
                                        val reassignIsrChangeHandler: PartitionReassignmentIsrChangeHandler) {
 
   def registerReassignIsrChangeHandler(zkClient: KafkaZkClient): Unit =

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -58,7 +58,7 @@ object ZkUtils {
   val ClusterIdPath = s"$ClusterPath/id"
   val BrokerIdsPath = s"$BrokersPath/ids"
   val BrokerTopicsPath = s"$BrokersPath/topics"
-  val ReassignCancelPath = s"$AdminPath/reassign_cancel"
+  val ReassignCancelPath = s"$AdminPath/cancel_reassignment_in_progress"
   val ReassignPartitionsPath = s"$AdminPath/reassign_partitions"
   val DeleteTopicsPath = s"$AdminPath/delete_topics"
   val PreferredReplicaLeaderElectionPath = s"$AdminPath/preferred_replica_election"

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -870,8 +870,8 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   /**
     * Deletes the partitio reassignment canel znode.
     */
-  def deleteReassignCancel(): Unit = {
-    deletePath(ReassignCancelZNode.path)
+  def deleteReassignCancel(expectedControllerEpochZkVersion: Int): Unit = {
+    deletePath(ReassignCancelZNode.path, expectedControllerEpochZkVersion)
   }
 
   /**

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -787,7 +787,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * Returns all reassignments.
    * @return the reassignments for each partition.
    */
-  def getPartitionReassignment: collection.Map[TopicPartition, Seq[Int]] = {
+  def getPartitionReassignment: collection.Map[TopicPartition, Map[String, Seq[Int]]] = {
     val getDataRequest = GetDataRequest(ReassignPartitionsZNode.path)
     val getDataResponse = retryRequestUntilConnected(getDataRequest)
     getDataResponse.resultCode match {
@@ -795,7 +795,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
         ReassignPartitionsZNode.decode(getDataResponse.data) match {
           case Left(e) =>
             logger.warn(s"Ignoring partition reassignment due to invalid json: ${e.getMessage}", e)
-            Map.empty[TopicPartition, Seq[Int]]
+            Map.empty[TopicPartition, Map[String, Seq[Int]]]
           case Right(assignments) => assignments
         }
       case Code.NONODE => Map.empty
@@ -811,7 +811,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * @param expectedControllerEpochZkVersion expected controller epoch zkVersion.
    * @throws KeeperException if there is an error while setting or creating the znode
    */
-  def setOrCreatePartitionReassignment(reassignment: collection.Map[TopicPartition, Seq[Int]], expectedControllerEpochZkVersion: Int): Unit = {
+  def setOrCreatePartitionReassignment(reassignment: collection.Map[TopicPartition, Map[String, Seq[Int]]], expectedControllerEpochZkVersion: Int): Unit = {
 
     def set(reassignmentData: Array[Byte]): SetDataResponse = {
       val setDataRequest = SetDataRequest(ReassignPartitionsZNode.path, reassignmentData, ZkVersion.MatchAnyVersion)
@@ -839,7 +839,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * @param reassignment the reassignment to set on the reassignment znode.
    * @throws KeeperException if there is an error while creating the znode
    */
-  def createPartitionReassignment(reassignment: Map[TopicPartition, Seq[Int]])  = {
+  def createPartitionReassignment(reassignment: Map[TopicPartition, Map[String, Seq[Int]]])  = {
     createRecursive(ReassignPartitionsZNode.path, ReassignPartitionsZNode.encode(reassignment))
   }
 
@@ -857,6 +857,29 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    */
   def reassignPartitionsInProgress(): Boolean = {
     pathExists(ReassignPartitionsZNode.path)
+  }
+
+  /**
+    * Creates the partition reassignment cancel znode.
+    * @throws KeeperException if there is an error while creating the znode
+    */
+  def createReassignCancel()  = {
+    createRecursive(ReassignCancelZNode.path)
+  }
+
+  /**
+    * Deletes the partitio reassignment canel znode.
+    */
+  def deleteReassignCancel(): Unit = {
+    deletePath(ReassignCancelZNode.path)
+  }
+
+  /**
+    * Checks if reassign cancellation is in place
+    * @return true if /admin/reassign_cancel is in place , else false
+    */
+  def reassignCancelInPlace(): Boolean = {
+    pathExists(ReassignCancelZNode.path)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -66,6 +66,14 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
   }
 
   @Test
+  def shouldCorrectlyParseValidMinimumCancelOptions(): Unit = {
+    val args = Array(
+      "--zookeeper", "localhost:1234",
+      "--cancel")
+    ReassignPartitionsCommand.validateAndParseArgs(args)
+  }
+
+  @Test
   def shouldAllowThrottleOptionOnExecute(): Unit = {
     val args = Array(
       "--zookeeper", "localhost:1234",
@@ -99,7 +107,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
   @Test
   def shouldFailIfBlankArg(): Unit = {
     val args = Array(" ")
-    shouldFailWith("Command must include exactly one action: --generate, --execute or --verify", args)
+    shouldFailWith("Command must include exactly one action: --generate, --execute, --verify or --cancel", args)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -394,10 +394,10 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertEquals(Map.empty, zkClient.getPartitionReassignment)
 
     val reassignment = Map(
-      new TopicPartition("topic_a", 0) -> Seq(0, 1, 3),
-      new TopicPartition("topic_a", 1) -> Seq(2, 1, 3),
-      new TopicPartition("topic_b", 0) -> Seq(4, 5),
-      new TopicPartition("topic_c", 0) -> Seq(5, 3)
+      new TopicPartition("topic_a", 0) -> Map("replicas" -> Seq(0, 1, 3), "original_replicas" -> Seq(0, 1, 2)),
+      new TopicPartition("topic_a", 1) -> Map("replicas" -> Seq(2, 1, 3), "original_replicas" -> Seq(0, 1, 2)),
+      new TopicPartition("topic_b", 0) -> Map("replicas" -> Seq(4, 5), "original_replicas" -> Seq(3, 4)),
+      new TopicPartition("topic_c", 0) -> Map("replicas" -> Seq(5, 3), "original_replicas" -> Seq(5, 4))
     )
 
     // Should throw ControllerMovedException if the controller epoch zkVersion does not match
@@ -951,6 +951,15 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertFalse(zkClient.reassignPartitionsInProgress)
     zkClient.createRecursive(ReassignPartitionsZNode.path)
     assertTrue(zkClient.reassignPartitionsInProgress)
+  }
+
+  @Test
+  def testReassignCancelInPlace(): Unit = {
+    assertFalse(zkClient.reassignCancelInPlace)
+    zkClient.createReassignCancel()
+    assertTrue(zkClient.reassignCancelInPlace)
+    zkClient.deleteReassignCancel()
+    assertFalse(zkClient.reassignCancelInPlace)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -958,7 +958,7 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertFalse(zkClient.reassignCancelInPlace)
     zkClient.createReassignCancel()
     assertTrue(zkClient.reassignCancelInPlace)
-    zkClient.deleteReassignCancel()
+    zkClient.deleteReassignCancel(controllerEpochZkVersion)
     assertFalse(zkClient.reassignCancelInPlace)
   }
 

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -29,9 +29,10 @@ class ReassignPartitionsZNodeTest {
   private val partition1 = 0
   private val replica1 = 1
   private val replica2 = 2
+  private val replica3 = 3
 
-  private val reassignPartitionData = Map(new TopicPartition(topic, partition1) -> Seq(replica1, replica2))
-  private val reassignmentJson = """{"version":1,"partitions":[{"topic":"foo","partition":0,"replicas":[1,2]}]}"""
+  private val reassignPartitionData = Map(new TopicPartition(topic, partition1) -> Map("replicas"->Seq(replica1, replica2),"original_replicas"->Seq(replica1, replica3)))
+  private val reassignmentJson = """{"version":1,"partitions":[{"topic":"foo","partition":0,"replicas":[1,2],"original_replicas":[1,3]}]}"""
 
   @Test
   def testEncode() {
@@ -51,6 +52,6 @@ class ReassignPartitionsZNodeTest {
     val result = ReassignPartitionsZNode.decode(reassignmentJson.getBytes)
     assertTrue(result.isRight)
     val assignmentMap = result.right.get
-    assertEquals(Seq(replica1, replica2), assignmentMap(new TopicPartition(topic, partition1)))
+    assertEquals(Seq(replica1, replica2), assignmentMap(new TopicPartition(topic, partition1))("replicas"))
   }
 }

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -53,5 +53,6 @@ class ReassignPartitionsZNodeTest {
     assertTrue(result.isRight)
     val assignmentMap = result.right.get
     assertEquals(Seq(replica1, replica2), assignmentMap(new TopicPartition(topic, partition1))("replicas"))
+    assertEquals(Seq(replica1, replica3), assignmentMap(new TopicPartition(topic, partition1))("original_replicas"))
   }
 }

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -498,6 +498,27 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.debug("Verify partition reassignment:")
         self.logger.debug(output)
 
+    def execute_reassign_cancel(self, node=None):
+        """Run the cancel pending reassign partitions admin tool in "cancel" mode
+        """
+        if node is None:
+            node = self.nodes[0]
+
+        # create command
+        cmd = "%s " % self.path.script( "kafka-reassign-partitions.sh", node)
+        cmd += "--zookeeper %s " % self.zk_connect_setting()
+        cmd += "--cancel"
+
+        # send command
+        self.logger.info("Executing cancel / rollback pending partition reassignment...")
+        self.logger.debug(cmd)
+        output = ""
+        for line in node.account.ssh_capture(cmd):
+            output += line
+
+        self.logger.debug("Verify cancel / rollback pending partition reassignment:")
+        self.logger.debug(output)
+
     def search_data_files(self, topic, messages):
         """Check if a set of messages made it into the Kakfa data files. Note that
         this method takes no account of replication. It simply looks for the

--- a/tests/kafkatest/tests/core/reassign_cancel_test.py
+++ b/tests/kafkatest/tests/core/reassign_cancel_test.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import config_property
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
+import random
+import time
+import copy
+
+class ReassignCancelTest(ProduceConsumeValidateTest):
+    """
+    These tests validate cancellation / rollback of PENDING partition reassignments.
+    Create a topic with few partitions, load some data, trigger partition re-assignment with and without broker failure,
+    Cancel pending reassignments
+    check that partition re-assignment cancellation / rollback can complete and there is no data loss.
+    """
+
+    def __init__(self, test_context):
+        """:type test_context: ducktape.tests.test.TestContext"""
+        super(ReassignCancelTest, self).__init__(test_context=test_context)
+
+        self.topic = "test_topic"
+        self.num_partitions = 20
+        self.zk = ZookeeperService(test_context, num_nodes=1)
+        # We set the min.insync.replicas to match the replication factor because
+        # it makes the test more stringent. If min.isr = 2 and
+        # replication.factor=3, then the test would tolerate the failure of
+        # reassignment for upto one replica per partition, which is not
+        # desirable for this test in particular.
+        self.kafka = KafkaService(test_context, num_nodes=5, zk=self.zk,
+                                  server_prop_overides=[
+                                      [config_property.LOG_ROLL_TIME_MS, "5000"],
+                                      [config_property.LOG_RETENTION_CHECK_INTERVAL_MS, "5000"]
+                                  ],
+                                  topics={self.topic: {
+                                      "partitions": self.num_partitions,
+                                      "replication-factor": 3,
+                                      'configs': {
+                                          "min.insync.replicas": 3,
+                                      }}
+                                  })
+        self.timeout_sec = 60
+        self.producer_throughput = 1000
+        self.num_producers = 1
+        self.num_consumers = 1
+
+    def setup(self):
+        self.zk.start()
+
+    def min_cluster_size(self):
+        # override this since we're adding services outside of the constructor
+        return super(ReassignCancelTest, self).min_cluster_size() + self.num_producers + self.num_consumers
+
+    def clean_bounce_some_brokers(self):
+        """Bounce every other broker"""
+        for node in self.kafka.nodes[::2]:
+            self.kafka.restart_node(node, clean_shutdown=True)
+
+    def reassign_cancel(self, bounce_brokers):
+        partition_info = self.kafka.parse_describe_topic(self.kafka.describe_topic(self.topic))
+        original_partition_info = copy.deepcopy(partition_info)
+        self.logger.debug("Partitions before reassignment:" + str(partition_info))
+
+        # replace the broker_id 4 with 5 for every partition if 4 exists in the replicas, and 5 not exists in the replicas
+        for i in range(0, self.num_partitions):
+            partition_info["partitions"][i]["replicas"] = [x if (x!=4 or 5 in partition_info["partitions"][i]["replicas"]) else 5 for x in partition_info["partitions"][i]["replicas"]]
+        self.logger.debug("Jumbled partitions: " + str(partition_info))
+
+        # send reassign partitions command
+        self.kafka.execute_reassign_partitions(partition_info, throttle=1024)
+
+        if bounce_brokers:
+            # bounce a few brokers at the same time
+            self.clean_bounce_some_brokers()
+
+        # send cancel pending reassign partitions command
+        self.kafka.execute_reassign_cancel()
+
+        # Wait until finished or timeout
+        wait_until(lambda: self.kafka.verify_reassign_partitions(original_partition_info),
+                   timeout_sec=self.timeout_sec, backoff_sec=.5)
+
+    def move_start_offset(self):
+        """We move the start offset of the topic by writing really old messages
+        and waiting for them to be cleaned up.
+        """
+        producer = VerifiableProducer(self.test_context, 1, self.kafka, self.topic,
+                                      throughput=-1, enable_idempotence=True, stop_timeout_sec=600,
+                                      create_time=1000)
+        producer.start()
+        wait_until(lambda: producer.num_acked > 0,
+                   timeout_sec=30,
+                   err_msg="Failed to get an acknowledgement for %ds" % 30)
+        # Wait 8 seconds to let the topic be seeded with messages that will
+        # be deleted. The 8 seconds is important, since we should get 2 deleted
+        # segments in this period based on the configured log roll time and the
+        # retention check interval.
+        time.sleep(8)
+        for node in producer.nodes:
+            #producer.stop()
+            producer.clean_node(node)
+        self.logger.info("Seeded topic with %d messages which will be deleted" %\
+                         producer.num_acked)
+        # Since the configured check interval is 5 seconds, we wait another
+        # 6 seconds to ensure that at least one more cleaning so that the last
+        # segment is deleted. An altenate to using timeouts is to poll each
+        # partition until the log start offset matches the end offset. The
+        # latter is more robust.
+        time.sleep(6)
+
+    @cluster(num_nodes=10)
+    @matrix(bounce_brokers=[True, False],
+            reassign_from_offset_zero=[True, False])
+    def test_reassign_cancel(self, bounce_brokers, reassign_from_offset_zero):
+        """Reassign partitions tests.
+        Setup: 1 zk, 4 kafka nodes, 1 topic with partitions=20, replication-factor=3,
+        and min.insync.replicas=3
+
+            - Produce messages in the background
+            - Consume messages in the background
+            - Reassign partitions
+            - When done cancelling pending reassign partitions, stop producing, and finish consuming
+            - Validate that every acked message was consumed
+            """
+        self.kafka.start()
+        if not reassign_from_offset_zero:
+            self.move_start_offset()
+
+        self.producer = VerifiableProducer(self.test_context, self.num_producers,
+                                           self.kafka, self.topic, stop_timeout_sec=150,
+                                           throughput=self.producer_throughput,
+                                           enable_idempotence=True)
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers,
+                                        self.kafka, self.topic,
+                                        consumer_timeout_ms=60000,
+                                        message_validator=is_int)
+
+        self.enable_idempotence=True
+        self.run_produce_consume_validate(core_test_action=lambda: self.reassign_cancel(bounce_brokers))


### PR DESCRIPTION
Enable pending reassignments (reassignments still in-flight in /admin/reassign_partitions) cancellation/rollback.

Please see https://cwiki.apache.org/confluence/display/KAFKA/KIP-236%3A+Interruptible+Partition+Reassignment

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
