### PR TITLE
KAFKA-7959: Delete leader epoch cache files with old message format versions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/RecordVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordVersion.java
@@ -34,6 +34,15 @@ public enum RecordVersion {
         this.value = (byte) value;
     }
 
+    /**
+     * Check whether this version precedes another version.
+     *
+     * @return true only if the magic value is less than the other's
+     */
+    public boolean precedes(RecordVersion other) {
+        return this.value < other.value;
+    }
+
     public static RecordVersion lookup(byte value) {
         if (value < 0 || value >= VALUES.length)
             throw new IllegalArgumentException("Unknown record version: " + value);

--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -59,10 +59,10 @@ class Replica(val brokerId: Int,
 
   def epochs: Option[LeaderEpochFileCache] = {
     log.flatMap { log =>
-      if (log.recordVersion.value < RecordVersion.V2.value)
-        None
-      else
+      if (log.supportsLeaderEpoch)
         Some(log.leaderEpochCache)
+      else
+        None
     }
   }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -315,7 +315,7 @@ class Log(@volatile var dir: File,
     val checkpointFile = new LeaderEpochCheckpointFile(LeaderEpochFile.newFile(dir), logDirFailureChannel)
     val cache = new LeaderEpochFileCache(topicPartition, logEndOffset _, checkpointFile)
 
-    if (!supportsLeaderEpoch && cache.latestEpoch == UNDEFINED_EPOCH) {
+    if (!supportsLeaderEpoch && cache.nonEmpty) {
       warn(s"Clearing non-empty leader epoch cache due to incompatible message format $recordVersion")
       cache.clearAndFlush()
     }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -37,6 +37,7 @@ import kafka.server.{BrokerTopicStats, FetchDataInfo, LogDirFailureChannel, LogO
 import kafka.utils._
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.record._
+import org.apache.kafka.common.requests.EpochEndOffset.UNDEFINED_EPOCH
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.apache.kafka.common.requests.{IsolationLevel, ListOffsetRequest}
 import org.apache.kafka.common.utils.{Time, Utils}
@@ -314,7 +315,7 @@ class Log(@volatile var dir: File,
     val checkpointFile = new LeaderEpochCheckpointFile(LeaderEpochFile.newFile(dir), logDirFailureChannel)
     val cache = new LeaderEpochFileCache(topicPartition, logEndOffset _, checkpointFile)
 
-    if (!supportsLeaderEpoch && cache.epochEntries.nonEmpty) {
+    if (!supportsLeaderEpoch && cache.latestEpoch == UNDEFINED_EPOCH) {
       warn(s"Clearing non-empty leader epoch cache due to incompatible message format $recordVersion")
       cache.clearAndFlush()
     }

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -84,6 +84,10 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
     }
   }
 
+  def nonEmpty: Boolean = inReadLock(lock) {
+    epochs.nonEmpty
+  }
+
   /**
     * Returns the current Leader Epoch. This is the latest epoch
     * which has messages assigned to it.

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2642,11 +2642,12 @@ class LogTest {
   }
 
   private def assertLeaderEpochCacheEmpty(log: Log): Unit = {
-    assertEquals(UNDEFINED_EPOCH, log.leaderEpochCache.latestEpoch)
+    assertFalse(log.leaderEpochCache.nonEmpty)
+
     // check that the file is empty as well
     val checkpointFile = new LeaderEpochCheckpointFile(LeaderEpochFile.newFile(log.dir))
     val cache = new LeaderEpochFileCache(log.topicPartition, log.logEndOffset _, checkpointFile)
-    assertTrue(cache.epochEntries.isEmpty)
+    assertFalse(cache.nonEmpty)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter.BatchRetention
 import org.apache.kafka.common.record._
+import org.apache.kafka.common.requests.EpochEndOffset.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.apache.kafka.common.requests.IsolationLevel
 import org.apache.kafka.common.utils.{Time, Utils}
@@ -2597,6 +2598,36 @@ class LogTest {
 
   def topicPartitionName(topic: String, partition: String): String =
     topic + "-" + partition
+
+  /**
+    * Due to KAFKA-7968, we want to make sure that we do not
+    * make use of old leader epoch cache files when the message format does not support it
+    */
+  @Test
+  def testOldMessageFormatDeletesEpochCacheIfUnsupported(): Unit = {
+    def createRecords = TestUtils.singletonRecords(value = "test".getBytes, timestamp = mockTime.milliseconds - 1000)
+    val epochCacheSupportingConfig = LogTest.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000, retentionMs = 999)
+
+    // append some records to create segments and assign some epochs to create epoch files
+    val log = createLog(logDir, epochCacheSupportingConfig)
+    for (_ <- 0 until 100)
+      log.appendAsLeader(createRecords, leaderEpoch = 0)
+    log.leaderEpochCache.assign(0, 40)
+    log.leaderEpochCache.assign(1, 90)
+    assertEquals((1, 100), log.leaderEpochCache.endOffsetFor(1))
+
+    // instantiate the log with an old format that does not support the leader epoch
+    val epochCacheNonSupportingConfig = LogTest.createLogConfig(segmentBytes = createRecords.sizeInBytes * 5, segmentIndexBytes = 1000,
+      retentionMs = 999, messageFormatVersion = "0.10.2")
+    val log2 = createLog(logDir, epochCacheNonSupportingConfig)
+    assertEquals((UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET),
+      log2.leaderEpochCache.endOffsetFor(1))
+
+    // ensure the cache files are deleted
+    val log3 = createLog(logDir, epochCacheSupportingConfig)
+    assertEquals((UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET),
+      log3.leaderEpochCache.endOffsetFor(1))
+  }
 
   @Test
   def testDeleteOldSegments() {

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -51,6 +51,7 @@ class OffsetsForLeaderEpochTest {
     val logManager = createNiceMock(classOf[kafka.log.LogManager])
     expect(mockCache.endOffsetFor(epochRequested)).andReturn(epochAndOffset)
     expect(mockLog.leaderEpochCache).andReturn(mockCache).anyTimes()
+    expect(mockLog.supportsLeaderEpoch).andReturn(true).anyTimes()
     expect(mockLog.recordVersion).andReturn(RecordVersion.V2).anyTimes()
     expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
     replay(mockCache, mockLog, logManager)


### PR DESCRIPTION
KAFKA-7897 fixed a critical bug where replica followers would inadequately use the leader epoch cache for truncating their logs upon becoming a follower. The root of the issue was that a regression in KAFKA-7415 caused the leader epoch cache to be populated upon becoming a leader, even if the message format was older and did not support epoch caches. This resulted in very sparsely populated caches which the brokers would make use of when becoming a follower, resulting in huge log truncations.

KAFKA-7897 fixed that problem by not updating the leader epoch cache if the message format does not support it. It was merged all the way back to 1.1 but due to significant branch divergence the patches for 2.0 and below were simplified. As said in the commit:
> Note this is a simplified fix than what was merged to trunk in #6232 since the branches have diverged significantly. Rather than removing the epoch cache file, we guard usage of the cache with the record version.

Due to the previous problem, we still had the sparsely populated epoch cache file present. This results in the same bug being hit at a different time. When the message format gets upgraded to support the leader epoch cache, brokers start to make use of it. This results in the same large truncations we saw in KAFKA-7897.

The key difference is that the patches for 2.1 and trunk deleted the non-empty leader epoch cache files if the log message format did not support it.
We should update the earlier versions to do the same thing. That way, users that have upgraded to 2.0.1 but are still using the old message formats/protocol will have their epochs cleaned up on the first roll that upgrades the `inter.broker.protocol.version`