### PR TITLE
MINOR: Handle Metadata v0 all topics requests during parsing

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -146,9 +146,13 @@ public class MetadataRequest extends AbstractRequest {
         super(ApiKeys.METADATA, version);
         Object[] topicArray = struct.getArray(TOPICS_KEY_NAME);
         if (topicArray != null) {
-            topics = new ArrayList<>();
-            for (Object topicObj: topicArray) {
-                topics.add((String) topicObj);
+            if (topicArray.length == 0 && version == 0) {
+                topics = null;
+            } else {
+                topics = new ArrayList<>();
+                for (Object topicObj: topicArray) {
+                    topics.add((String) topicObj);
+                }
             }
         } else {
             topics = null;

--- a/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.protocol.types.Schema;

--- a/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
@@ -1,0 +1,39 @@
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MetadataRequestTest {
+
+    @Test
+    public void testEmptyMeansAllTopicsV0() {
+        Struct rawRequest = new Struct(MetadataRequest.schemaVersions()[0]);
+        rawRequest.set("topics", new Object[0]);
+        MetadataRequest parsedRequest = new MetadataRequest(rawRequest, (short) 0);
+        assertTrue(parsedRequest.isAllTopics());
+        assertNull(parsedRequest.topics());
+    }
+
+    @Test
+    public void testEmptyMeansEmptyForVersionsAboveV0() {
+        for (int i = 1; i < MetadataRequest.schemaVersions().length; i++) {
+            Schema schema = MetadataRequest.schemaVersions()[i];
+            Struct rawRequest = new Struct(schema);
+            rawRequest.set("topics", new Object[0]);
+            if (rawRequest.hasField("allow_auto_topic_creation"))
+                rawRequest.set("allow_auto_topic_creation", true);
+            MetadataRequest parsedRequest = new MetadataRequest(rawRequest, (short) i);
+            assertFalse(parsedRequest.isAllTopics());
+            assertEquals(Collections.emptyList(), parsedRequest.topics());
+        }
+    }
+
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -992,21 +992,12 @@ class KafkaApis(val requestChannel: RequestChannel,
     val metadataRequest = request.body[MetadataRequest]
     val requestVersion = request.header.apiVersion
 
-    val topics =
-      // Handle old metadata request logic. Version 0 has no way to specify "no topics".
-      if (requestVersion == 0) {
-        if (metadataRequest.topics() == null || metadataRequest.topics.isEmpty)
-          metadataCache.getAllTopics()
-        else
-          metadataRequest.topics.asScala.toSet
-      } else {
-        if (metadataRequest.isAllTopics)
-          metadataCache.getAllTopics()
-        else
-          metadataRequest.topics.asScala.toSet
-      }
+    val topics = if (metadataRequest.isAllTopics)
+      metadataCache.getAllTopics()
+    else
+      metadataRequest.topics.asScala.toSet
 
-    var (authorizedTopics, unauthorizedForDescribeTopics) =
+    val (authorizedTopics, unauthorizedForDescribeTopics) =
       topics.partition(topic => authorize(request.session, Describe, Resource(Topic, topic, LITERAL)))
 
     var unauthorizedForCreateTopics = Set[String]()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -997,7 +997,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     else
       metadataRequest.topics.asScala.toSet
 
-    val (authorizedTopics, unauthorizedForDescribeTopics) =
+    var (authorizedTopics, unauthorizedForDescribeTopics) =
       topics.partition(topic => authorize(request.session, Describe, Resource(Topic, topic, LITERAL)))
 
     var unauthorizedForCreateTopics = Set[String]()


### PR DESCRIPTION
Use of `MetadataRequest.isAllTopics` is not consistently defined for all versions of the api. For v0, it evaluates to false. This patch makes the behavior consistent for all versions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
