### PR TITLE
MINOR: Change Trogdor agent's cleanup executor to a cached thread pool

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -290,13 +290,13 @@ public final class WorkerManager {
                 Math.max(0, spec.endMs() - time.milliseconds()));
         }
 
-        void transitionToStopping() {
+        Future<Void> transitionToStopping() {
             state = State.STOPPING;
             if (timeoutFuture != null) {
                 timeoutFuture.cancel(false);
                 timeoutFuture = null;
             }
-            workerCleanupExecutor.submit(new HaltWorker(this));
+            return workerCleanupExecutor.submit(new HaltWorker(this));
         }
 
         void transitionToDone() {

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -85,7 +85,7 @@ public final class WorkerManager {
     /**
      * An ExecutorService used to clean up TaskWorkers.
      */
-    private final ScheduledExecutorService workerCleanupExecutor;
+    private final ExecutorService workerCleanupExecutor;
 
     /**
      * An ExecutorService to help with shutting down.
@@ -161,7 +161,7 @@ public final class WorkerManager {
         this.workers = new HashMap<>();
         this.stateChangeExecutor = Executors.newSingleThreadScheduledExecutor(
                 ThreadUtils.createThreadFactory("WorkerManagerStateThread", false));
-        this.workerCleanupExecutor = Executors.newScheduledThreadPool(1,
+        this.workerCleanupExecutor = Executors.newCachedThreadPool(
             ThreadUtils.createThreadFactory("WorkerCleanupThread%d", false));
         this.shutdownExecutor = Executors.newScheduledThreadPool(0,
             ThreadUtils.createThreadFactory("WorkerManagerShutdownThread%d", false));


### PR DESCRIPTION
It is best to use a growing thread pool for worker cleanups. This lets us ensure that we close workers as fast as possible and not get slowed down on blocking cleanups.
