### PR TITLE
KAFKA-7937: Fix Flaky Test ResetConsumerGroupOffsetTest.testResetOffs…

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -86,6 +86,10 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
     val args = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", "missing.group", "--all-topics",
       "--to-current", "--execute")
     val consumerGroupCommand = getConsumerGroupService(args)
+    // Make sure we got a coordinator
+    TestUtils.waitUntilTrue(() => {
+      consumerGroupCommand.collectGroupState().coordinator.host() == "localhost"
+    }, "Can't find a coordinator.", maxRetries = 3)
     val resetOffsets = consumerGroupCommand.resetOffsets()
     assertEquals(Map.empty, resetOffsets)
     assertEquals(resetOffsets, committedOffsets(group = "missing.group"))


### PR DESCRIPTION
Address the comments on PR-6307. Sorry for new PR, but one of the comments was to move the PR to another branch.

***
Since the test fails sometimes on lack of coordinator, I'm giving it a bit more attempts to find it.

I admit that I haven't been able to actually reproduce this failure, so I'm only hoping this fixes it. But it doesn't fail more often than it used to (on my machine)

Fixing on 2.2 because the intent is to fix enough flakes to allow for a clean release.