### PR TITLE
KAFKA-7996: KafkaStreams does not pass timeout when closing Producer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -307,6 +307,11 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
 
+    /** {@code close.wait.ms } */
+    @SuppressWarnings("WeakerAccess")
+    public static final String CLOSE_WAIT_MS_CONFIG = "close.wait.ms";
+    private static final String CLOSE_WAIT_MS_DOC = "The amount of time in milliseconds to block waiting for closing the streams producer.";
+
     /**
      * {@code default.deserialization.exception.handler}
      */
@@ -509,6 +514,12 @@ public class StreamsConfig extends AbstractConfig {
                     "",
                     Importance.MEDIUM,
                     CLIENT_ID_DOC)
+            .define(CLOSE_WAIT_MS_CONFIG,
+                    Type.LONG,
+                    500L,
+                    atLeast(0),
+                    Importance.MEDIUM,
+                    CLOSE_WAIT_MS_DOC)
             .define(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
                     Type.CLASS,
                     LogAndFailExceptionHandler.class.getName(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -49,6 +49,7 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -199,7 +200,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 id.toString(),
                 logContext,
                 productionExceptionHandler,
-                metrics.skippedRecordsSensor()
+                metrics.skippedRecordsSensor(),
+                Duration.ofMillis(config.getLong(StreamsConfig.CLOSE_WAIT_MS_CONFIG))
             );
         } else {
             this.recordCollector = recordCollector;


### PR DESCRIPTION
Here is the draft fix. The approach is simple - it adds a new parameter for `StreamThread.TaskCreator` and `RecordCollectorImpl` to denote the close wait duration; I found two `Producer#close()` in streams module but if there is omitted one, don't hesitate to give me a comment.

Since it introduces a new config, `close.wait.ms`, it needs a KIP. Isn't it?

cc/ @mjsax @bbejeck

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
