### PR TITLE
MINOR: Increase produce timeout to 120 seconds

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -75,7 +75,7 @@ public class EmbeddedKafkaCluster extends ExternalResource {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddedKafkaCluster.class);
 
-    private static final long DEFAULT_PRODUCE_SEND_DURATION_MS = 500;
+    private static final long DEFAULT_PRODUCE_SEND_DURATION_MS = TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS);
 
     // Kafka Config
     private final KafkaServer[] brokers;
@@ -254,7 +254,7 @@ public class EmbeddedKafkaCluster extends ExternalResource {
         try {
             producer.send(msg).get(DEFAULT_PRODUCE_SEND_DURATION_MS, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            throw new KafkaException("Could not produce message to topic=" + topic, e);
+            throw new KafkaException("Could not produce message: " + msg, e);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -75,7 +75,7 @@ public class EmbeddedKafkaCluster extends ExternalResource {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddedKafkaCluster.class);
 
-    private static final long DEFAULT_PRODUCE_SEND_DURATION_MS = TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS);
+    private static final long DEFAULT_PRODUCE_SEND_DURATION_MS = TimeUnit.SECONDS.toMillis(120); 
 
     // Kafka Config
     private final KafkaServer[] brokers;


### PR DESCRIPTION
This gives more room to pass this test on systems with low
resources running many parallel tests.

Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
