### PR TITLE
MINOR: gradle and gradle plugins version upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
     // For Apache Rat plugin to ignore non-Git files
     classpath "org.ajoberstar.grgit:grgit-gradle:3.0.0"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
-    classpath 'org.scoverage:gradle-scoverage:3.0.0'
+    classpath 'org.scoverage:gradle-scoverage:2.5.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     classpath 'org.owasp:dependency-check-gradle:4.0.2'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.18.0"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     classpath 'org.owasp:dependency-check-gradle:4.0.2'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.18.0"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.10"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9"
   }
 }
 
@@ -120,7 +120,7 @@ if (file('.git').exists()) {
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These
     // restrict us only to files that are checked in or are staged.
-    def repo = Grgit.open(currentDir: file('.'))
+    def repo = Grgit.open(currentDir: project.getRootDir())
     excludes = new ArrayList<String>(repo.clean(ignore: false, directories: true, dryRun: true))
     // And some of the files that we have checked in should also be excluded from this check
     excludes.addAll([

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,13 @@ buildscript {
 
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
-    classpath "org.ajoberstar:grgit:1.9.3"
+    classpath "org.ajoberstar.grgit:grgit-gradle:3.0.0"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
-    classpath 'org.scoverage:gradle-scoverage:2.5.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+    classpath 'org.scoverage:gradle-scoverage:3.0.0'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     classpath 'org.owasp:dependency-check-gradle:4.0.2'
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.17.0"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9"
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.18.0"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.10"
   }
 }
 
@@ -91,7 +91,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "5.1.1"
+  gradleVersion = "5.2.1"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 
@@ -120,7 +120,7 @@ if (file('.git').exists()) {
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These
     // restrict us only to files that are checked in or are staged.
-    def repo = Grgit.open(project.getRootDir())
+    def repo = Grgit.open(currentDir: file('.'))
     excludes = new ArrayList<String>(repo.clean(ignore: false, directories: true, dryRun: true))
     // And some of the files that we have checked in should also be excluded from this check
     excludes.addAll([


### PR DESCRIPTION
details:
 * gradle:                  5.1.1  -->>  5.2.1
 * grgit:                   1.9.3  -->>  3.0.0 (breaking change release, 'Grgit.open' usage is refactored)
 * ~~gradle-scoverage:        2.5.0  -->>  3.0.0~~ `(opted out, see comments below)`
 * shadow:                  4.0.3  -->>  4.0.4
 * ~~spotless-plugin-gradle: 3.17.0  -->> 3.18.0~~ `(opted out, see comments below)`
 * spotbugs-gradle-plugin:  1.6.9  -->>  1.6.10

related links:
 * https://github.com/gradle/gradle/releases/tag/v5.2.0, https://github.com/gradle/gradle/releases/tag/v5.2.1
 * https://github.com/ajoberstar/grgit/releases/tag/3.0.0
 * https://github.com/scoverage/gradle-scoverage/releases/tag/3.0.0
 * https://github.com/johnrengelman/shadow/releases/tag/4.0.4
 * https://github.com/diffplug/spotless/blob/gradle/3.18.0/CHANGES.md
 * https://github.com/spotbugs/spotbugs-gradle-plugin/blob/1.6.10/CHANGELOG.md#1610---2019-02-18




