### PR TITLE
KAFKA-7990: Close streams at the end in KafkaStreamsTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -456,6 +456,9 @@ public class KafkaStreamsTest {
         } finally {
             // stop the thread so we don't interfere with other tests etc
             keepRunning.set(false);
+            if (streams != null) {
+                streams.close();
+            }
         }
     }
 


### PR DESCRIPTION
This fix is already in 2.1+ branches, but did not get into older branches.

Should be cherry-picked all the way to 0.10.2.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
