### PR TITLE
KAFKA-7925 - Create credentials only once for sun.security.jgss.native

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -560,7 +560,7 @@ public class SaslClientAuthenticator implements Authenticator {
      *     During Kerberos re-login, principal is reset on Subject. An exception is
      *     thrown so that the connection is retried after any configured backoff.
      */
-    static final String firstPrincipal(Subject subject) {
+    public static final String firstPrincipal(Subject subject) {
         Set<Principal> principals = subject.getPrincipals();
         synchronized (principals) {
             Iterator<Principal> iterator = principals.iterator();

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
@@ -17,23 +17,45 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.TestSecurityConfig;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.utils.Time;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+
 public class SaslChannelBuilderTest {
+
+    @After
+    public void tearDown() {
+        System.clearProperty(SaslChannelBuilder.GSS_NATIVE_PROP);
+    }
 
     @Test
     public void testCloseBeforeConfigureIsIdempotent() {
@@ -47,7 +69,7 @@ public class SaslChannelBuilderTest {
     @Test
     public void testCloseAfterConfigIsIdempotent() {
         SaslChannelBuilder builder = createChannelBuilder(SecurityProtocol.SASL_PLAINTEXT);
-        builder.configure(new HashMap<String, Object>());
+        builder.configure(new HashMap<>());
         assertNotNull(builder.loginManagers().get("PLAIN"));
         builder.close();
         assertTrue(builder.loginManagers().isEmpty());
@@ -69,13 +91,88 @@ public class SaslChannelBuilderTest {
         assertTrue(builder.loginManagers().isEmpty());
     }
 
+    @Test
+    public void testNativeGssapiCredentials() throws Exception {
+        System.setProperty(SaslChannelBuilder.GSS_NATIVE_PROP, "true");
+
+        TestJaasConfig jaasConfig = new TestJaasConfig();
+        jaasConfig.addEntry("jaasContext", TestGssapiLoginModule.class.getName(), new HashMap<>());
+        JaasContext jaasContext = new JaasContext("jaasContext", JaasContext.Type.SERVER, jaasConfig, null);
+        Map<String, JaasContext> jaasContexts = Collections.singletonMap("GSSAPI", jaasContext);
+        GSSManager gssManager = Mockito.mock(GSSManager.class);
+        GSSName gssName = Mockito.mock(GSSName.class);
+        Mockito.when(gssManager.createName(Mockito.anyString(), Mockito.any()))
+                .thenAnswer(unused -> gssName);
+        Oid oid = new Oid("1.2.840.113554.1.2.2");
+        Mockito.when(gssManager.createCredential(gssName, GSSContext.INDEFINITE_LIFETIME, oid, GSSCredential.ACCEPT_ONLY))
+                .thenAnswer(unused -> Mockito.mock(GSSCredential.class));
+
+        SaslChannelBuilder channelBuilder1 = createGssapiChannelBuilder(jaasContexts, gssManager);
+        assertEquals(1, channelBuilder1.subject("GSSAPI").getPrincipals().size());
+        assertEquals(1, channelBuilder1.subject("GSSAPI").getPrivateCredentials().size());
+
+        SaslChannelBuilder channelBuilder2 = createGssapiChannelBuilder(jaasContexts, gssManager);
+        assertEquals(1, channelBuilder2.subject("GSSAPI").getPrincipals().size());
+        assertEquals(1, channelBuilder2.subject("GSSAPI").getPrivateCredentials().size());
+        assertSame(channelBuilder1.subject("GSSAPI"), channelBuilder2.subject("GSSAPI"));
+
+        Mockito.verify(gssManager, Mockito.times(1))
+                .createCredential(gssName, GSSContext.INDEFINITE_LIFETIME, oid, GSSCredential.ACCEPT_ONLY);
+    }
+
+    private SaslChannelBuilder createGssapiChannelBuilder(Map<String, JaasContext> jaasContexts, GSSManager gssManager) {
+        SaslChannelBuilder channelBuilder = new SaslChannelBuilder(Mode.SERVER, jaasContexts,
+                SecurityProtocol.SASL_PLAINTEXT,
+                new ListenerName("GSSAPI"), false, "GSSAPI",
+                true, null, null, Time.SYSTEM) {
+
+            @Override
+            protected GSSManager gssManager() {
+                return gssManager;
+            }
+        };
+        Map<String, Object> props = Collections.singletonMap(SaslConfigs.SASL_KERBEROS_SERVICE_NAME, "kafka");
+        channelBuilder.configure(new TestSecurityConfig(props).values());
+        return channelBuilder;
+    }
+
+
     private SaslChannelBuilder createChannelBuilder(SecurityProtocol securityProtocol) {
         TestJaasConfig jaasConfig = new TestJaasConfig();
-        jaasConfig.addEntry("jaasContext", PlainLoginModule.class.getName(), new HashMap<String, Object>());
+        jaasConfig.addEntry("jaasContext", PlainLoginModule.class.getName(), new HashMap<>());
         JaasContext jaasContext = new JaasContext("jaasContext", JaasContext.Type.SERVER, jaasConfig, null);
         Map<String, JaasContext> jaasContexts = Collections.singletonMap("PLAIN", jaasContext);
         return new SaslChannelBuilder(Mode.CLIENT, jaasContexts, securityProtocol, new ListenerName("PLAIN"),
                 false, "PLAIN", true, null, null, Time.SYSTEM);
     }
 
+    public static final class TestGssapiLoginModule implements LoginModule {
+        private Subject subject;
+
+        @Override
+        public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+            this.subject = subject;
+        }
+
+        @Override
+        public boolean login() throws LoginException {
+            subject.getPrincipals().add(new KafkaPrincipal("User", "kafka@kafka1.example.com"));
+            return true;
+        }
+
+        @Override
+        public boolean commit() throws LoginException {
+            return true;
+        }
+
+        @Override
+        public boolean abort() throws LoginException {
+            return true;
+        }
+
+        @Override
+        public boolean logout() throws LoginException {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
When `sun.security.jgss.native=true`, we currently create a new server credential for every new client connection and add to the private credential set of the server's Subject. This is expensive and can result in an unbounded number of private credentials in the Subject used by the broker. The PR creates a credential immediately after login so that a single credential can be reused.

This was tested by Abhi who raised the issue. See https://issues.apache.org/jira/browse/KAFKA-7925 for details.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
