### PR TITLE
KAFKA-8011: Fix for race condition causing ConcurrentModificationException

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -152,7 +153,7 @@ public class RegexSourceIntegrationTest {
         final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("TEST-TOPIC-\\d"));
 
         pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
-        final List<String> assignedTopics = new ArrayList<>();
+        final List<String> assignedTopics = new CopyOnWriteArrayList<>();
         streams = new KafkaStreams(builder.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
             @Override
             public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
@@ -190,7 +191,7 @@ public class RegexSourceIntegrationTest {
 
         pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
 
-        final List<String> assignedTopics = new ArrayList<>();
+        final List<String> assignedTopics = new CopyOnWriteArrayList<>();
         streams = new KafkaStreams(builder.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
             @Override
             public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {


### PR DESCRIPTION
In the `RegexSourceIntegrationTest#testRegexMatchesTopicsAWhenCreated()` and `RegexSourceIntegrationTest#testRegexMatchesTopicsAWhenDeleted()` a race condition exists where the `ConsumerRebalanceListener` in the test modifies the list of subscribed topics when the condition for the test success is comparing the same array instance against expected values.

This PR should fix this race condition by using a `CopyOnWriteArrayList` which guarantees safe traversal of the list even when a concurrent modification is happening.  

Using the `CopyOnWriteArrayList` should not impact performance negatively as the number of traversals, a result of using `ArrayList.equals()`, far outnumber (`TestUtils.waitForCondition()` checks for a successful result every`100ms`) the possible modifications as there will be at most one topic name added/removed during the test.

For testing, I updated the `RegexSourceIntegrationTest`integration test and ran the suite of streams tests.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
