### PR TITLE
Embedded ConfigDef Validator issue

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1318,7 +1318,16 @@ public class ConfigDef {
      */
     private static Validator embeddedValidator(final String keyPrefix, final Validator base) {
         if (base == null) return null;
-        return (name, value) -> base.ensureValid(name.substring(keyPrefix.length()), value);
+        return new Validator {
+            void ensureValid(String name, Object value) {
+                return base.ensureValid(name.substring(keyPrefix.length()), value);
+            }
+
+            @Override
+            String toString() {
+                return base.toString();
+            }
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1318,16 +1318,16 @@ public class ConfigDef {
      */
     private static Validator embeddedValidator(final String keyPrefix, final Validator base) {
         if (base == null) return null;
-        return new Validator {
-            void ensureValid(String name, Object value) {
-                return base.ensureValid(name.substring(keyPrefix.length()), value);
+        return new Validator() {
+            public void ensureValid(String name, Object value) {
+                base.ensureValid(name.substring(keyPrefix.length()), value);
             }
 
             @Override
-            String toString() {
+            public String toString() {
                 return base.toString();
             }
-        }
+        };
     }
 
     /**


### PR DESCRIPTION
private static embeddedValidator should return an Anonymous Object instead of lambda

Using the lambda expression will cause issues with:
toRst()
toEnrichedRst()
toHTMLTable()

The lambda expression has no appropriate toString() override resulting in RST or HTML like: 
```  * Valid Values: org.apache.kafka.common.config.ConfigDef$$Lambda$27/785447854@29176cc1```

