### PR TITLE
KAFKA-8013: Avoid underflow when reading a Struct from a partially correct buffer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -71,7 +71,7 @@ public class Schema extends Type {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             try {
-                objects[i] = fields[i].def.type.read(buffer);
+                objects[i] = buffer.position() < buffer.limit() ? fields[i].def.type.read(buffer) : null;
             } catch (Exception e) {
                 throw new SchemaException("Error reading field '" + fields[i].def.name + "': " +
                                           (e.getMessage() == null ? e.getClass().getName() : e.getMessage()));

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -69,9 +69,10 @@ public class Schema extends Type {
     @Override
     public Struct read(ByteBuffer buffer) {
         Object[] objects = new Object[fields.length];
-        for (int i = 0; i < fields.length; i++) {
+        // Remaining fields stay 'null' if the buffer has some of the fields at the start but not all.
+        for (int i = 0; i < fields.length && buffer.hasRemaining(); i++) {
             try {
-                objects[i] = buffer.position() < buffer.limit() ? fields[i].def.type.read(buffer) : null;
+                objects[i] = fields[i].def.type.read(buffer);
             } catch (Exception e) {
                 throw new SchemaException("Error reading field '" + fields[i].def.name + "': " +
                                           (e.getMessage() == null ? e.getClass().getName() : e.getMessage()));

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -63,23 +63,31 @@ public class Schema extends Type {
         }
     }
 
+    @Override
+    public Struct read(ByteBuffer buffer) {
+        return read(buffer, false);
+    }
+
     /**
      * Read a struct from the buffer. Missing fields at the end of the buffer are replaced with
      * their default values if such fields are optional; otherwise a {@code SchemaException} is
      * thrown to signify that mandatory fields are missing.
      */
-    @Override
-    public Struct read(ByteBuffer buffer) {
+    public Struct read(ByteBuffer buffer, boolean tolerateMissingWithDefaults) {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             try {
-                if (buffer.hasRemaining()) {
-                    objects[i] = fields[i].def.type.read(buffer);
-                } else if (fields[i].def.hasDefaultValue) {
-                    objects[i] = fields[i].def.defaultValue;
+                if (tolerateMissingWithDefaults) {
+                    if (buffer.hasRemaining()) {
+                        objects[i] = fields[i].def.type.read(buffer);
+                    } else if (fields[i].def.hasDefaultValue) {
+                        objects[i] = fields[i].def.defaultValue;
+                    } else {
+                        throw new SchemaException("Missing value for field '" + fields[i].def.name +
+                                "' which has no default value");
+                    }
                 } else {
-                    throw new SchemaException("Missing value for field '" + fields[i].def.name +
-                                              "' which has no default value.");
+                    objects[i] = fields[i].def.type.read(buffer);
                 }
             } catch (Exception e) {
                 throw new SchemaException("Error reading field '" + fields[i].def.name + "': " +

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -28,15 +28,33 @@ public class Schema extends Type {
 
     private final BoundField[] fields;
     private final Map<String, BoundField> fieldsByName;
+    private final boolean tolerateMissingFieldsWithDefaults;
 
     /**
      * Construct the schema with a given list of its field values
      *
+     * @param fs the fields of this schema
+     *
      * @throws SchemaException If the given list have duplicate fields
      */
     public Schema(Field... fs) {
+        this(false, fs);
+    }
+
+    /**
+     * Construct the schema with a given list of its field values and the ability to tolerate
+     * missing optional fields with defaults at the end of the schema definition.
+     *
+     * @param tolerateMissingFieldsWithDefaults whether to accept records with missing optional
+     * fields the end of the schema
+     * @param fs the fields of this schema
+     *
+     * @throws SchemaException If the given list have duplicate fields
+     */
+    public Schema(boolean tolerateMissingFieldsWithDefaults, Field... fs) {
         this.fields = new BoundField[fs.length];
         this.fieldsByName = new HashMap<>();
+        this.tolerateMissingFieldsWithDefaults = tolerateMissingFieldsWithDefaults;
         for (int i = 0; i < this.fields.length; i++) {
             Field def = fs[i];
             if (fieldsByName.containsKey(def.name))
@@ -63,28 +81,26 @@ public class Schema extends Type {
         }
     }
 
+    /**
+     * Read a struct from the buffer. If this schema is configured to tolerate missing
+     * optional fields at the end of the buffer, these fields are replaced with their default
+     * values; otherwise, if the schema does not tolerate missing fields, or if missing fields
+     * don't have a default value, a {@code SchemaException} is thrown to signify that mandatory
+     * fields are missing.
+     */
     @Override
     public Struct read(ByteBuffer buffer) {
-        return read(buffer, false);
-    }
-
-    /**
-     * Read a struct from the buffer. Missing fields at the end of the buffer are replaced with
-     * their default values if such fields are optional; otherwise a {@code SchemaException} is
-     * thrown to signify that mandatory fields are missing.
-     */
-    public Struct read(ByteBuffer buffer, boolean tolerateMissingWithDefaults) {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             try {
-                if (tolerateMissingWithDefaults) {
+                if (tolerateMissingFieldsWithDefaults) {
                     if (buffer.hasRemaining()) {
                         objects[i] = fields[i].def.type.read(buffer);
                     } else if (fields[i].def.hasDefaultValue) {
                         objects[i] = fields[i].def.defaultValue;
                     } else {
                         throw new SchemaException("Missing value for field '" + fields[i].def.name +
-                                "' which has no default value");
+                                "' which has no default value.");
                     }
                 } else {
                     objects[i] = fields[i].def.type.read(buffer);

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -297,6 +297,7 @@ public class ProtocolSerializationTest {
     public void testReadWhenOptionalDataMissingAtTheEndIsTolerated() {
         Schema oldSchema = new Schema(new Field("field1", Type.NULLABLE_STRING));
         Schema newSchema = new Schema(
+                true,
                 new Field("field1", Type.NULLABLE_STRING),
                 new Field("field2", Type.NULLABLE_STRING, "", true, "default"),
                 new Field("field3", Type.NULLABLE_STRING, "", true, null),
@@ -307,7 +308,7 @@ public class ProtocolSerializationTest {
         ByteBuffer buffer = ByteBuffer.allocate(oldSchema.sizeOf(oldFormat));
         oldFormat.writeTo(buffer);
         buffer.flip();
-        Struct newFormat = newSchema.read(buffer, true);
+        Struct newFormat = newSchema.read(buffer);
         assertEquals(value, newFormat.get("field1"));
         assertEquals("default", newFormat.get("field2"));
         assertEquals(null, newFormat.get("field3"));
@@ -334,6 +335,7 @@ public class ProtocolSerializationTest {
     public void testReadWithMissingNonOptionalExtraDataAtTheEnd() {
         Schema oldSchema = new Schema(new Field("field1", Type.NULLABLE_STRING));
         Schema newSchema = new Schema(
+                true,
                 new Field("field1", Type.NULLABLE_STRING),
                 new Field("field2", Type.NULLABLE_STRING));
         String value = "foo bar baz";
@@ -341,7 +343,7 @@ public class ProtocolSerializationTest {
         ByteBuffer buffer = ByteBuffer.allocate(oldSchema.sizeOf(oldFormat));
         oldFormat.writeTo(buffer);
         buffer.flip();
-        SchemaException e = assertThrows(SchemaException.class, () -> newSchema.read(buffer, true));
+        SchemaException e = assertThrows(SchemaException.class, () -> newSchema.read(buffer));
         e.getMessage().contains("Missing value for field 'field2' which has no default value");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -278,4 +278,31 @@ public class ProtocolSerializationTest {
         assertNotEquals(emptyStruct1, mostlyEmptyStruct);
         assertNotEquals(mostlyEmptyStruct, emptyStruct1);
     }
+
+    @Test
+    public void testReadIgnoringExtraDataAtTheEnd() {
+        Schema oldSchema = new Schema(new Field("field1", Type.NULLABLE_STRING), new Field("field2", Type.NULLABLE_STRING));
+        Schema newSchema = new Schema(new Field("field1", Type.NULLABLE_STRING));
+        String value = "foo bar baz";
+        Struct oldFormat = new Struct(oldSchema).set("field1", value).set("field2", "fine to ignore");
+        ByteBuffer buffer = ByteBuffer.allocate(oldSchema.sizeOf(oldFormat));
+        oldFormat.writeTo(buffer);
+        buffer.flip();
+        Struct newFormat = newSchema.read(buffer);
+        assertEquals(value, newFormat.get("field1"));
+    }
+
+    @Test
+    public void testReadWhenDataIsMissingAtTheEnd() {
+        Schema oldSchema = new Schema(new Field("field1", Type.NULLABLE_STRING));
+        Schema newSchema = new Schema(new Field("field1", Type.NULLABLE_STRING), new Field("field2", Type.NULLABLE_STRING));
+        String value = "foo bar baz";
+        Struct oldFormat = new Struct(oldSchema).set("field1", value);
+        ByteBuffer buffer = ByteBuffer.allocate(oldSchema.sizeOf(oldFormat));
+        oldFormat.writeTo(buffer);
+        buffer.flip();
+        Struct newFormat = newSchema.read(buffer);
+        assertEquals(value, newFormat.get("field1"));
+        assertEquals(null, newFormat.get("field2"));
+    }
 }


### PR DESCRIPTION
Protocol compatibility can be facilitated if a Struct, that has been defined as an extension of a previous Struct by adding fields at the end of the older version, can read a message of an older version by ignoring the absence of the missing new fields. Reading the missing fields should be allowed by the definition of these fields (they have to be nullable).

* Tested by adding unit tests around Schema.read in both directions 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
