### PR TITLE
state.cleanup.delay.ms default is 600,000 ms (10 minutes).

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -272,7 +272,7 @@
           <tr class="row-odd"><td>state.cleanup.delay.ms</td>
             <td>Low</td>
             <td colspan="2">The amount of time in milliseconds to wait before deleting state when a partition has migrated.</td>
-            <td>6000000 milliseconds</td>
+            <td>600000 milliseconds</td>
           </tr>
           <tr class="row-even"><td>state.dir</td>
             <td>High</td>


### PR DESCRIPTION
If I'm counting my zeros correctly, I believe the default cleanup delay is 600_000ms, not 6_000_000 as written in the docs.

Default value here: https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java#L681

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
