### PR TITLE
KAFKA-5511 ConfigKeyBuilder for ConfigDef

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1080,6 +1080,91 @@ public class ConfigDef {
         }
     }
 
+    public static class ConfigKeyBuilder {
+
+        private final String name;
+        private final Type type;
+        private final Importance importance;
+        private final String documentation;
+        private Object defaultValue;
+        private Validator validator;
+        private String group;
+        private int orderInGroup;
+        private Width width;
+        private String displayName;
+        private List<String> dependents;
+        private Recommender recommender;
+        private boolean internalConfig;
+
+        private static final int DEFAULT_ORDER_IN_GROUP = -1;
+
+        public ConfigKeyBuilder(String name, Type type, String documentation, Importance importance) {
+            this.name = name;
+            this.type = type;
+            this.documentation = documentation;
+            this.importance = importance;
+            this.defaultValue = NO_DEFAULT_VALUE;
+            this.group = "";
+            this.orderInGroup = DEFAULT_ORDER_IN_GROUP;
+            this.width = Width.NONE;
+            this.displayName = name;
+        }
+
+        public ConfigKeyBuilder defaultValue(Object defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public ConfigKeyBuilder validator(Validator validator) {
+            this.validator = validator;
+            return this;
+        }
+
+        public ConfigKeyBuilder group(String group) {
+            this.group = group;
+            return this;
+        }
+
+        public ConfigKeyBuilder orderInGroup(int orderInGroup) {
+            this.orderInGroup = orderInGroup;
+            return this;
+        }
+
+        public ConfigKeyBuilder width(Width width) {
+            this.width = width;
+            return this;
+        }
+
+        public ConfigKeyBuilder displayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public ConfigKeyBuilder dependents(List<String> dependents) {
+            this.dependents = dependents;
+            return this;
+        }
+
+        public ConfigKeyBuilder recommender(Recommender recommender) {
+            this.recommender = recommender;
+            return this;
+        }
+
+        public ConfigKeyBuilder internalConfig(boolean internalConfig) {
+            this.internalConfig = internalConfig;
+            return this;
+        }
+
+        public ConfigKey build() {
+            if(dependents == null) {
+                this.dependents = Collections.emptyList();
+            }
+
+            return new ConfigKey(name, type, defaultValue, validator, importance, documentation, group, orderInGroup,
+                    width, displayName, dependents, recommender, internalConfig);
+        }
+    }
+
     protected List<String> headers() {
         return Arrays.asList("Name", "Description", "Type", "Default", "Valid Values", "Importance");
     }

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -145,7 +145,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Validator validator, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName, List<String> dependents, Recommender recommender) {
-        return define(new ConfigKeyBuilder(name, type, documentation, importance)
+        return define(new ConfigKeyBuilder(name, type, importance, documentation)
                 .defaultValue(defaultValue)
                 .validator(validator)
                 .group(group)
@@ -409,14 +409,12 @@ public class ConfigDef {
      * @param name              The name of the config parameter
      * @param type              The type of the config
      * @param defaultValue      The default value to use if this config isn't present
-     * @param importance
+     * @param importance        the importance of this config
      * @return This ConfigDef so you can chain calls
      */
     public ConfigDef defineInternal(final String name, final Type type, final Object defaultValue, final Importance importance) {
-        return define(new ConfigKeyBuilder(name, type, "", importance)
+        return define(new ConfigKeyBuilder(name, type, importance)
                 .defaultValue(defaultValue)
-                .group("")
-                .width(Width.NONE)
                 .displayName(name)
                 .internalConfig()
                 .build());
@@ -1113,7 +1111,7 @@ public class ConfigDef {
 
         private static final int DEFAULT_ORDER_IN_GROUP = -1;
 
-        public ConfigKeyBuilder(String name, Type type, String documentation, Importance importance) {
+        public ConfigKeyBuilder(String name, Type type, Importance importance, String documentation) {
             this.name = name;
             this.type = type;
             this.documentation = documentation;
@@ -1123,6 +1121,10 @@ public class ConfigDef {
             this.orderInGroup = DEFAULT_ORDER_IN_GROUP;
             this.width = Width.NONE;
             this.displayName = "";
+        }
+
+        public ConfigKeyBuilder(String name, Type type, Importance importance) {
+            this(name, type, importance, "");
         }
 
         public ConfigKeyBuilder defaultValue(Object defaultValue) {

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -413,7 +413,13 @@ public class ConfigDef {
      * @return This ConfigDef so you can chain calls
      */
     public ConfigDef defineInternal(final String name, final Type type, final Object defaultValue, final Importance importance) {
-        return define(new ConfigKey(name, type, defaultValue, null, importance, "", "", -1, Width.NONE, name, Collections.<String>emptyList(), null, true));
+        return define(new ConfigKeyBuilder(name, type, "", importance)
+                .defaultValue(defaultValue)
+                .group("")
+                .width(Width.NONE)
+                .displayName(name)
+                .internalConfig()
+                .build());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1117,7 +1117,6 @@ public class ConfigDef {
             this.documentation = documentation;
             this.importance = importance;
             this.defaultValue = NO_DEFAULT_VALUE;
-            this.group = "";
             this.orderInGroup = DEFAULT_ORDER_IN_GROUP;
             this.width = Width.NONE;
             this.displayName = "";

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1116,7 +1116,7 @@ public class ConfigDef {
             this.group = "";
             this.orderInGroup = DEFAULT_ORDER_IN_GROUP;
             this.width = Width.NONE;
-            this.displayName = name;
+            this.displayName = "";
         }
 
         public ConfigKeyBuilder defaultValue(Object defaultValue) {
@@ -1159,8 +1159,8 @@ public class ConfigDef {
             return this;
         }
 
-        public ConfigKeyBuilder internalConfig(boolean internalConfig) {
-            this.internalConfig = internalConfig;
+        public ConfigKeyBuilder internalConfig() {
+            this.internalConfig = true;
             return this;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1165,7 +1165,7 @@ public class ConfigDef {
         }
 
         public ConfigKey build() {
-            if(dependents == null) {
+            if (dependents == null) {
                 this.dependents = Collections.emptyList();
             }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -145,7 +145,16 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Validator validator, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName, List<String> dependents, Recommender recommender) {
-        return define(new ConfigKey(name, type, defaultValue, validator, importance, documentation, group, orderInGroup, width, displayName, dependents, recommender, false));
+        return define(new ConfigKeyBuilder(name, type, documentation, importance)
+                .defaultValue(defaultValue)
+                .validator(validator)
+                .group(group)
+                .orderInGroup(orderInGroup)
+                .width(width)
+                .displayName(displayName)
+                .dependents(dependents)
+                .recommender(recommender)
+                .build());
     }
 
     /**


### PR DESCRIPTION
This patch adds ConfigKeyBuilder in order to improve readability in the future configuration definitions and avoid some parameters order related bugs.

Using the builder inside the all arguments `define` method we can reuse all previous written tests, which cover all the changes, in addition there are other unit tests, which match the `ConfigKey` properties.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
