### PR TITLE
KAFKA-7950: Kafka tools GetOffsetShell -time description

### DIFF
--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -46,9 +46,9 @@ object GetOffsetShell {
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: If timestamp value greater than recently commited record timestamp is given, then no offset is returned.]")
+    val timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: No offset is returned, if the timestamp greater than recently commited record timestamp is given.]")
                            .withRequiredArg
-                           .describedAs("timestamp/-1(latest)/-2(earliest) ")
+                           .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])
                            .defaultsTo(-1L)
     parser.accepts("offsets", "DEPRECATED AND IGNORED: number of offsets returned")

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -48,7 +48,7 @@ object GetOffsetShell {
                            .defaultsTo("")
     val timeOpt = parser.accepts("time", "timestamp of the offsets before that")
                            .withRequiredArg
-                           .describedAs("timestamp/-1(latest)/-2(earliest)")
+                           .describedAs("timestamp/-1(latest)/-2(earliest) [Note: If timestamp value greater than recently commited record timestamp is given, then no offset is returned.")
                            .ofType(classOf[java.lang.Long])
                            .defaultsTo(-1L)
     parser.accepts("offsets", "DEPRECATED AND IGNORED: number of offsets returned")

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -46,9 +46,9 @@ object GetOffsetShell {
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "timestamp of the offsets before that")
+    val timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: If timestamp value greater than recently commited record timestamp is given, then no offset is returned.]")
                            .withRequiredArg
-                           .describedAs("timestamp/-1(latest)/-2(earliest) [Note: If timestamp value greater than recently commited record timestamp is given, then no offset is returned.")
+                           .describedAs("timestamp/-1(latest)/-2(earliest) ")
                            .ofType(classOf[java.lang.Long])
                            .defaultsTo(-1L)
     parser.accepts("offsets", "DEPRECATED AND IGNORED: number of offsets returned")


### PR DESCRIPTION
Added additional description for the "time" parameter for GetOffsetShell which adds " No offset is returned if timestamp provided is greater than recently committed record timestamp." in the description.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
