### PR TITLE
MINOR: Log exception thrown by consumer.poll() in VerifiableConsumer

### DIFF
--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -129,9 +129,9 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         time.sleep(6)
 
     @cluster(num_nodes=8)
-    @matrix(bounce_brokers=[True, False],
-            reassign_from_offset_zero=[True, False])
-    def test_reassign_partitions(self, bounce_brokers, reassign_from_offset_zero):
+    #@matrix(bounce_brokers=[True, False],
+    #        reassign_from_offset_zero=[True, False])
+    def test_reassign_partitions(self): #, bounce_brokers, reassign_from_offset_zero):
         """Reassign partitions tests.
         Setup: 1 zk, 4 kafka nodes, 1 topic with partitions=20, replication-factor=3,
         and min.insync.replicas=3
@@ -144,17 +144,17 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
             - Validate that every acked message was consumed
             """
         self.kafka.start()
-        if not reassign_from_offset_zero:
+        if not False:
             self.move_start_offset()
 
         self.producer = VerifiableProducer(self.test_context, self.num_producers,
                                            self.kafka, self.topic,
                                            throughput=self.producer_throughput,
-                                           enable_idempotence=True)
+                                           enable_idempotence=True, log_level="DEBUG")
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers,
                                         self.kafka, self.topic,
                                         consumer_timeout_ms=60000,
                                         message_validator=is_int)
 
         self.enable_idempotence=True
-        self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(bounce_brokers))
+        self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(False))

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -129,9 +129,9 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         time.sleep(6)
 
     @cluster(num_nodes=8)
-    #@matrix(bounce_brokers=[True, False],
-    #        reassign_from_offset_zero=[True, False])
-    def test_reassign_partitions(self): #, bounce_brokers, reassign_from_offset_zero):
+    @matrix(bounce_brokers=[True, False],
+            reassign_from_offset_zero=[True, False])
+    def test_reassign_partitions(self, bounce_brokers, reassign_from_offset_zero):
         """Reassign partitions tests.
         Setup: 1 zk, 4 kafka nodes, 1 topic with partitions=20, replication-factor=3,
         and min.insync.replicas=3
@@ -144,17 +144,17 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
             - Validate that every acked message was consumed
             """
         self.kafka.start()
-        if not False:
+        if not reassign_from_offset_zero:
             self.move_start_offset()
 
         self.producer = VerifiableProducer(self.test_context, self.num_producers,
                                            self.kafka, self.topic,
                                            throughput=self.producer_throughput,
-                                           enable_idempotence=True, log_level="DEBUG")
+                                           enable_idempotence=True)
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers,
                                         self.kafka, self.topic,
                                         consumer_timeout_ms=60000,
                                         message_validator=is_int)
 
         self.enable_idempotence=True
-        self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(False))
+        self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(bounce_brokers))

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -84,6 +84,8 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
  */
 public class VerifiableConsumer implements Closeable, OffsetCommitCallback, ConsumerRebalanceListener {
 
+    private static final Logger log = LoggerFactory.getLogger(VerifiableConsumer.class);
+
     private final ObjectMapper mapper = new ObjectMapper();
     private final PrintStream out;
     private final KafkaConsumer<String, String> consumer;
@@ -95,7 +97,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private int consumedMessages = 0;
 
     private CountDownLatch shutdownLatch = new CountDownLatch(1);
-    private final Logger log;
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,
@@ -111,7 +112,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         this.useAutoCommit = useAutoCommit;
         this.useAsyncCommit = useAsyncCommit;
         this.verbose = verbose;
-        this.log = LoggerFactory.getLogger(VerifiableConsumer.class);
         addKafkaSerializerModule();
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -42,7 +42,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -111,7 +112,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         this.useAutoCommit = useAutoCommit;
         this.useAsyncCommit = useAsyncCommit;
         this.verbose = verbose;
-        this.log = (new LogContext("[VerifiableConsumer] ")).logger(VerifiableConsumer.class);
+        this.log = LoggerFactory.getLogger(VerifiableConsumer.class);
         addKafkaSerializerModule();
     }
 


### PR DESCRIPTION
SecurityTest.test_client_ssl_endpoint_validation_failure is failing because it greps for 'SSLHandshakeException in the consumer and producer log files. With the fix for KAKFA-7773, the test uses the VerifiableConsumer instead of the ConsoleConsumer, which does not log the exception stack trace to the service log. This patch catches exceptions in the VerifiableConsumer and logs them in order to fix the test. Tested by running the test locally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
