### PR TITLE
KAFKA-7027: Add an overload build method in scala

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/StreamsBuilder.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/StreamsBuilder.scala
@@ -19,6 +19,7 @@
  */
 package org.apache.kafka.streams.scala
 
+import java.util.Properties
 import java.util.regex.Pattern
 
 import org.apache.kafka.streams.kstream.GlobalKTable
@@ -183,4 +184,14 @@ class StreamsBuilder(inner: StreamsBuilderJ = new StreamsBuilderJ) {
     inner.addGlobalStore(storeBuilder, topic, consumed, stateUpdateSupplier)
 
   def build(): Topology = inner.build()
+
+  /**
+   * Returns the `Topology` that represents the specified processing logic and accepts
+   * a `Properties` instance used to indicate whether to optimize topology or not.
+   *
+   * @param props the `Properties` used for building possibly optimized topology
+   * @return the `Topology` that represents the specified processing logic
+   * @see `org.apache.kafka.streams.StreamsBuilder#build`
+   */
+  def build(props: Properties): Topology = inner.build(props)
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -430,7 +430,7 @@ class TopologyTest extends JUnitSuite {
     assertNotEquals(getTopologyScala.build(props).describe.toString,
                     getTopologyScala.build(propsNoOptimization).describe.toString)
     assertEquals(getTopologyScala.build(propsNoOptimization).describe.toString,
-                 getTopologyScala.build(propsNoOptimization).describe.toString)
+                 getTopologyJava.build(propsNoOptimization).describe.toString)
     assertEquals(getTopologyScala.build(props).describe.toString, getTopologyJava.build(props).describe.toString)
   }
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -25,7 +25,6 @@ import java.util.{Locale, Properties}
 import java.util.regex.Pattern
 
 import org.apache.kafka.common.serialization.{Serdes => SerdesJ}
-import org.apache.kafka.common.utils.Bytes
 import org.apache.kafka.streams.kstream.{Joined => JoinedJ, Materialized => MaterializedJ}
 import org.apache.kafka.streams.kstream.{
   Aggregator,
@@ -45,7 +44,6 @@ import org.apache.kafka.streams.processor.{AbstractProcessor, ProcessorContext, 
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.Serdes._
 import org.apache.kafka.streams.scala.kstream._
-import org.apache.kafka.streams.state.KeyValueStore
 import org.apache.kafka.streams.{StreamsBuilder => StreamsBuilderJ, _}
 import org.junit.Assert._
 import org.junit._
@@ -284,13 +282,15 @@ class TopologyTest extends JUnitSuite {
     val props = new Properties()
     props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE)
 
-    val COUNT_TOPIC = "countTopic"
+    val propsNoOptimization = new Properties()
+    propsNoOptimization.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.NO_OPTIMIZATION)
+
     val AGGREGATION_TOPIC = "aggregationTopic"
     val REDUCE_TOPIC = "reduceTopic"
     val JOINED_TOPIC = "joinedTopic"
 
     // build the Scala topology
-    def getTopologyScala: TopologyDescription = {
+    def getTopologyScala: StreamsBuilder = {
 
       val aggregator = (_: String, v: String, agg: Int) => agg + v.length
       val reducer = (v1: String, v2: String) => v1 + ":" + v2
@@ -308,36 +308,39 @@ class TopologyTest extends JUnitSuite {
         .mapValues((v: String) => v.toUpperCase(Locale.getDefault))
         .process(() => new SimpleProcessor(processorValueCollector))
 
-      val countStream: KStream[String, Long] =
-        mappedStream.groupByKey.count()(Materialized.`with`(Serdes.String, Serdes.Long)).toStream
-      countStream.to(COUNT_TOPIC)(Produced.`with`(Serdes.String, Serdes.Long))
-
-      mappedStream.groupByKey
+      val stream2 = mappedStream.groupByKey
         .aggregate(0)(aggregator)(Materialized.`with`(Serdes.String, Serdes.Integer))
         .toStream
-        .to(AGGREGATION_TOPIC)(Produced.`with`(Serdes.String, Serdes.Integer))
+      stream2.to(AGGREGATION_TOPIC)(Produced.`with`(Serdes.String, Serdes.Integer))
 
       // adding operators for case where the repartition node is further downstream
-      mappedStream
+      val stream3 = mappedStream
         .filter((_: String, _: String) => true)
         .peek((k: String, v: String) => System.out.println(k + ":" + v))
         .groupByKey
         .reduce(reducer)(Materialized.`with`(Serdes.String, Serdes.String))
         .toStream
-        .to(REDUCE_TOPIC)(Produced.`with`(Serdes.String, Serdes.String))
+      stream3.to(REDUCE_TOPIC)(Produced.`with`(Serdes.String, Serdes.String))
 
       mappedStream
         .filter((k: String, _: String) => k == "A")
-        .join(countStream)((v1: String, v2: Long) => v1 + ":" + v2.toString, JoinWindows.of(Duration.ofMillis(5000)))(
-          Joined.`with`(Serdes.String, Serdes.String, Serdes.Long)
+        .join(stream2)((v1: String, v2: Int) => v1 + ":" + v2.toString, JoinWindows.of(Duration.ofMillis(5000)))(
+          Joined.`with`(Serdes.String, Serdes.String, Serdes.Integer)
         )
         .to(JOINED_TOPIC)
 
-      builder.build(props).describe()
+      mappedStream
+        .filter((k: String, _: String) => k == "A")
+        .join(stream3)((v1: String, v2: String) => v1 + ":" + v2.toString, JoinWindows.of(Duration.ofMillis(5000)))(
+          Joined.`with`(Serdes.String, Serdes.String, Serdes.String)
+        )
+        .to(JOINED_TOPIC)
+
+      builder
     }
 
     // build the Java topology
-    def getTopologyJava: TopologyDescription = {
+    def getTopologyJava: StreamsBuilderJ = {
 
       val initializer: Initializer[Integer] = () => 0
       val aggregator: Aggregator[String, String, Integer] = (_: String, v: String, agg: Integer) => agg + v.length
@@ -345,8 +348,9 @@ class TopologyTest extends JUnitSuite {
       val valueMapper: ValueMapper[String, String] = (v: String) => v.toUpperCase(Locale.getDefault)
       val processorValueCollector = new util.ArrayList[String]
       val processorSupplier: ProcessorSupplier[String, String] = () => new SimpleProcessor(processorValueCollector)
-      val valueJoiner: ValueJoiner[String, java.lang.Long, String] = (v1: String, v2: java.lang.Long) =>
+      val valueJoiner2: ValueJoiner[String, java.lang.Integer, String] = (v1: String, v2: java.lang.Integer) =>
         v1 + ":" + v2.toString
+      val valueJoiner3: ValueJoiner[String, String, String] = (v1: String, v2: String) => v1 + ":" + v2.toString
 
       val builder = new StreamsBuilderJ
 
@@ -359,40 +363,42 @@ class TopologyTest extends JUnitSuite {
         .mapValues[String](valueMapper)
         .process(processorSupplier)
 
-      val countStream = mappedStream.groupByKey
-        .count(
-          MaterializedJ.`with`[String, java.lang.Long, KeyValueStore[Bytes, Array[Byte]]](Serdes.String, SerdesJ.Long)
-        )
-        .toStream
-      countStream.to(COUNT_TOPIC, Produced.`with`(Serdes.String, SerdesJ.Long))
-
-      mappedStream.groupByKey
+      val stream2 = mappedStream.groupByKey
         .aggregate(initializer, aggregator, MaterializedJ.`with`(Serdes.String, SerdesJ.Integer))
         .toStream
-        .to(AGGREGATION_TOPIC, Produced.`with`(Serdes.String, SerdesJ.Integer))
+      stream2.to(AGGREGATION_TOPIC, Produced.`with`(Serdes.String, SerdesJ.Integer))
 
       // adding operators for case where the repartition node is further downstream
-      mappedStream
+      val stream3 = mappedStream
         .filter((_: String, _: String) => true)
         .peek((k: String, v: String) => System.out.println(k + ":" + v))
         .groupByKey
         .reduce(reducer, MaterializedJ.`with`(Serdes.String, Serdes.String))
         .toStream
-        .to(REDUCE_TOPIC, Produced.`with`(Serdes.String, Serdes.String))
+      stream3.to(REDUCE_TOPIC, Produced.`with`(Serdes.String, Serdes.String))
 
       mappedStream
         .filter((k: String, _: String) => k == "A")
-        .join(countStream,
-              valueJoiner,
+        .join(stream2,
+              valueJoiner2,
               JoinWindows.of(Duration.ofMillis(5000)),
-              JoinedJ.`with`(Serdes.String, Serdes.String, SerdesJ.Long))
+              JoinedJ.`with`(Serdes.String, Serdes.String, SerdesJ.Integer))
         .to(JOINED_TOPIC)
 
-      builder.build(props).describe()
+      mappedStream
+        .filter((k: String, _: String) => k == "A")
+        .join(stream3,
+              valueJoiner3,
+              JoinWindows.of(Duration.ofMillis(5000)),
+              JoinedJ.`with`(Serdes.String, Serdes.String, SerdesJ.String))
+        .to(JOINED_TOPIC)
+
+      builder
     }
 
-    // should match
-    assertEquals(getTopologyScala, getTopologyJava)
+    assertNotEquals(getTopologyScala.build(props).describe.toString,
+                    getTopologyScala.build(propsNoOptimization).describe.toString)
+    assertEquals(getTopologyScala.build(props).describe.toString, getTopologyJava.build(props).describe.toString)
   }
 
   private class SimpleProcessor private[TopologyTest] (val valueList: util.List[String])


### PR DESCRIPTION
The Java API can pass a Properties object to StreamsBuilder#build, to allow, e.g., topology optimization, while the Scala API does not yet. The latter only delegates the work to the underlying Java implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
