### PR TITLE
MINOR: Update Zookeeper version in documentation to 3.4.13 which is currently used by Kafka

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1999,7 +1999,7 @@ All the following metrics have a recording level of <code>debug</code>:
   <h3><a id="zk" href="#zk">6.7 ZooKeeper</a></h3>
 
   <h4><a id="zkversion" href="#zkversion">Stable version</a></h4>
-  The current stable branch is 3.4 and the latest release of that branch is 3.4.9.
+  The current stable branch is 3.4 and the latest release of that branch is 3.4.13.
 
   <h4><a id="zkops" href="#zkops">Operationalizing ZooKeeper</a></h4>
   Operationally, we do the following for a healthy ZooKeeper installation:

--- a/docs/security.html
+++ b/docs/security.html
@@ -1847,7 +1847,7 @@
     <h4><a id="zk_authz_ensemble" href="#zk_authz_ensemble">7.6.3 Migrating the ZooKeeper ensemble</a></h4>
     It is also necessary to enable authentication on the ZooKeeper ensemble. To do it, we need to perform a rolling restart of the server and set a few properties. Please refer to the ZooKeeper documentation for more detail:
     <ol>
-        <li><a href="http://zookeeper.apache.org/doc/r3.4.9/zookeeperProgrammers.html#sc_ZooKeeperAccessControl">Apache ZooKeeper documentation</a></li>
+        <li><a href="http://zookeeper.apache.org/doc/r3.4.13/zookeeperProgrammers.html#sc_ZooKeeperAccessControl">Apache ZooKeeper documentation</a></li>
         <li><a href="https://cwiki.apache.org/confluence/display/ZOOKEEPER/Zookeeper+and+SASL">Apache ZooKeeper wiki</a></li>
     </ol>
 </script>


### PR DESCRIPTION
It seems that the current version of the [documentation](http://kafka.apache.org/documentation/#zkversion) still references Zookeeper 3.4.9 as the current version. But we are now using Zookeeper 3.4.13. This PR updates the version to 3.4.13.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
