### PR TITLE
KAFKA-8044: Add timeout to VerifiableProducer close to avoid indefinite blocking

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Properties;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
@@ -288,10 +289,14 @@ public class VerifiableProducer implements AutoCloseable {
         return key;
     }
 
+    public void close(Duration timeout) {
+        producer.close(timeout);
+        printJson(new ShutdownComplete());
+    }
+
     /** Close the producer to flush any remaining messages. */
     public void close() {
-        producer.close();
-        printJson(new ShutdownComplete());
+        close(Duration.ofSeconds(30));
     }
 
     @JsonPropertyOrder({ "timestamp", "name" })


### PR DESCRIPTION
- Add support to add delivery.timeout.ms  config in verifiable_producer.py

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
