### PR TITLE
KAFKA-8039 - Use MockTime in fast reauth test to avoid transient failures

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 
@@ -158,8 +159,10 @@ public class NioEchoServer extends Thread {
         waitForMetrics("failed-reauthentication", failedReauthentications,
                 EnumSet.of(MetricType.TOTAL, MetricType.RATE));
         waitForMetrics("successful-authentication-no-reauth", 0, EnumSet.of(MetricType.TOTAL));
-        waitForMetrics("reauthentication-latency", Math.signum(successfulReauthentications),
-                EnumSet.of(MetricType.MAX, MetricType.AVG));
+        if (!(time instanceof MockTime)) {
+            waitForMetrics("reauthentication-latency", Math.signum(successfulReauthentications),
+                    EnumSet.of(MetricType.MAX, MetricType.AVG));
+        }
     }
 
     public void verifyAuthenticationNoReauthMetric(int successfulAuthenticationNoReauths) throws InterruptedException {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1473,7 +1473,7 @@ public class SaslAuthenticatorTest {
      * Second re-authentication must fail if it is sooner than one second after the first
      */
     @Test
-    public void testCannotReauthenticateAgainFasterThanMaxReauth() throws Exception {
+    public void testCannotReauthenticateAgainFasterThanOneSecond() throws Exception {
         String node = "0";
         time = new MockTime();
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -101,6 +101,7 @@ import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.authenticator.TestDigestLoginModule.DigestServerCallbackHandler;
@@ -139,6 +140,7 @@ public class SaslAuthenticatorTest {
     @Before
     public void setup() throws Exception {
         LoginManager.closeAll();
+        time = Time.SYSTEM;
         serverCertStores = new CertStores(true, "localhost");
         clientCertStores = new CertStores(false, "localhost");
         saslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
@@ -1471,8 +1473,9 @@ public class SaslAuthenticatorTest {
      * Second re-authentication must fail if it is sooner than one second after the first
      */
     @Test
-    public void testCannotReauthenticateAgainFasterThanOneSecond() throws Exception {
+    public void testCannotReauthenticateAgainFasterThanMaxReauth() throws Exception {
         String node = "0";
+        time = new MockTime();
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
         configureMechanisms(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
                 Arrays.asList(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM));
@@ -1486,7 +1489,7 @@ public class SaslAuthenticatorTest {
              * Now sleep long enough so that the next write will cause re-authentication,
              * which we expect to succeed.
              */
-            delay((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
+            time.sleep((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
             checkClientConnection(node);
             server.verifyAuthenticationMetrics(1, 0);
             server.verifyReauthenticationMetrics(1, 0);
@@ -1497,14 +1500,16 @@ public class SaslAuthenticatorTest {
              * expected the one byte-plus-node response but got the SaslHandshakeRequest
              * instead
              */
-            delay((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
+            time.sleep((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
             NetworkTestUtils.checkClientConnection(selector, node, 1, 1);
             fail("Expected a failure when trying to re-authenticate to quickly, but that did not occur");
         } catch (AssertionError e) {
             String expectedResponseTextRegex = "\\w-" + node;
             String receivedResponseTextRegex = ".*" + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
             assertTrue(
-                    "Should have received the SaslHandshakeRequest bytes back since we re-authenticated too quickly, but instead we got our generated message echoed back, implying re-auth succeeded when it should not have",
+                    "Should have received the SaslHandshakeRequest bytes back since we re-authenticated too quickly, " +
+                    "but instead we got our generated message echoed back, implying re-auth succeeded when it " +
+                    "should not have: " + e,
                     e.getMessage().matches(
                             ".*\\<\\[" + expectedResponseTextRegex + "]>.*\\<\\[" + receivedResponseTextRegex + "]>"));
             server.verifyReauthenticationMetrics(1, 0); // unchanged
@@ -1904,7 +1909,7 @@ public class SaslAuthenticatorTest {
     }
 
     private void checkAuthenticationAndReauthentication(SecurityProtocol securityProtocol, String node)
-            throws Exception, InterruptedException {
+            throws Exception {
         try {
             createClientConnection(securityProtocol, node);
             checkClientConnection(node);


### PR DESCRIPTION
Test uses 100ms as `connections.max.reauth.ms` and checks that a second reauthentication doesn't occur within the hard-coded 1 second minimum interval. But since the interval is small, we cannot guarantee that the time between the two checks is not higher than 1 second. Change the test to use MockTime so that we can control the time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
