### PR TITLE
KAFKA-8058: Fix ConnectClusterStateImpl.connectors() method

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
@@ -57,7 +57,10 @@ public class ConnectClusterStateImpl implements ConnectClusterState {
         try {
             // Should take no more than 10 seconds to get a list of connectors. Any longer than this
             // and it's very likely something is wrong.
-            connectorsLatch.await(10, TimeUnit.SECONDS);
+            boolean success = connectorsLatch.await(10, TimeUnit.SECONDS);
+            if (!success) {
+                throw new ConnectException("Timed out while retrieving list of connectors");
+            }
         } catch (InterruptedException e) {
             throw new ConnectException("Interrupted while retrieving list of connectors", e);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeoutException;
 
 public class ConnectClusterStateImpl implements ConnectClusterState {
     
-    private static final long CONNECTORS_TIMEOUT_MS = 10_000;
+    private static final long CONNECTORS_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
 
     private HerderProvider herderProvider;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
@@ -37,11 +37,11 @@ import java.util.concurrent.TimeoutException;
 
 public class ConnectClusterStateImpl implements ConnectClusterState {
     
-    private static final long CONNECTORS_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+    private final long herderRequestTimeoutMs;
+    private final HerderProvider herderProvider;
 
-    private HerderProvider herderProvider;
-
-    public ConnectClusterStateImpl(HerderProvider herderProvider) {
+    public ConnectClusterStateImpl(long connectorsTimeoutMs, HerderProvider herderProvider) {
+        this.herderRequestTimeoutMs = connectorsTimeoutMs;
         this.herderProvider = herderProvider;
     }
 
@@ -50,7 +50,7 @@ public class ConnectClusterStateImpl implements ConnectClusterState {
         FutureCallback<Collection<String>> connectorsCallback = new FutureCallback<>();
         herderProvider.get().connectors(connectorsCallback);
         try {
-            return connectorsCallback.get(CONNECTORS_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            return connectorsCallback.get(herderRequestTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new ConnectException("Failed to retrieve list of connectors", e);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImpl.java
@@ -37,19 +37,12 @@ import java.util.concurrent.TimeoutException;
 
 public class ConnectClusterStateImpl implements ConnectClusterState {
     
-    private static final long CONNECTORS_TIMEOUT_MS_DEFAULT = 10_000;
+    private static final long CONNECTORS_TIMEOUT_MS = 10_000;
 
     private HerderProvider herderProvider;
-    private long connectorsTimeoutMs;
 
     public ConnectClusterStateImpl(HerderProvider herderProvider) {
-        this(herderProvider, CONNECTORS_TIMEOUT_MS_DEFAULT);
-    }
-    
-    // To enable a lower timeout during testing (don't want to add ten seconds to every run)
-    ConnectClusterStateImpl(HerderProvider herderProvider, long connectorsTimeoutMs) {
         this.herderProvider = herderProvider;
-        this.connectorsTimeoutMs = connectorsTimeoutMs;
     }
 
     @Override
@@ -57,7 +50,7 @@ public class ConnectClusterStateImpl implements ConnectClusterState {
         FutureCallback<Collection<String>> connectorsCallback = new FutureCallback<>();
         herderProvider.get().connectors(connectorsCallback);
         try {
-            return connectorsCallback.get(connectorsTimeoutMs, TimeUnit.MILLISECONDS);
+            return connectorsCallback.get(CONNECTORS_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new ConnectException("Failed to retrieve list of connectors", e);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -310,9 +310,9 @@ public class RestServer {
             config, ConnectRestExtension.class);
 
         long herderRequestTimeoutMs = ConnectorsResource.REQUEST_TIMEOUT_MS;
-        if (config instanceof DistributedConfig) {
-            long rebalanceTimeoutMs = config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
-            herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs);
+        Integer rebalanceTimeoutMs = config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+        if (rebalanceTimeoutMs != null) {
+            herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());
         }
 
         ConnectRestExtensionContext connectRestExtensionContext =

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.HerderProvider;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.health.ConnectClusterStateImpl;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectExceptionMapper;
@@ -308,10 +309,16 @@ public class RestServer {
             config.getList(WorkerConfig.REST_EXTENSION_CLASSES_CONFIG),
             config, ConnectRestExtension.class);
 
+        long herderRequestTimeoutMs = ConnectorsResource.REQUEST_TIMEOUT_MS;
+        if (config instanceof DistributedConfig) {
+            long rebalanceTimeoutMs = config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+            herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs);
+        }
+
         ConnectRestExtensionContext connectRestExtensionContext =
             new ConnectRestExtensionContextImpl(
                 new ConnectRestConfigurable(resourceConfig),
-                new ConnectClusterStateImpl(provider)
+                new ConnectClusterStateImpl(herderRequestTimeoutMs, provider)
             );
         for (ConnectRestExtension connectRestExtension : connectRestExtensions) {
             connectRestExtension.register(connectRestExtensionContext);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -66,7 +66,7 @@ public class ConnectorsResource {
     // session timeout to complete, during which we cannot serve some requests. Ideally we could reduce this, but
     // we need to consider all possible scenarios this could fail. It might be ok to fail with a timeout in rare cases,
     // but currently a worker simply leaving the group can take this long as well.
-    private static final long REQUEST_TIMEOUT_MS = 90 * 1000;
+    public static final long REQUEST_TIMEOUT_MS = 90 * 1000;
 
     private final HerderProvider herderProvider;
     private final WorkerConfig config;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(PowerMockRunner.class)
 public class ConnectClusterStateImplTest {
@@ -66,7 +67,6 @@ public class ConnectClusterStateImplTest {
         assertEquals(expectedConnectors, connectClusterState.connectors());
     }
 
-    @Test(expected = ConnectException.class)
     public void connectorsFailure() {
         Capture<Callback<Collection<String>>> callback = EasyMock.newCapture();
         herder.connectors(EasyMock.capture(callback));
@@ -79,6 +79,6 @@ public class ConnectClusterStateImplTest {
             }
         });
         EasyMock.replay(herder);
-        connectClusterState.connectors();
+        assertThrows(ConnectException.class, connectClusterState::connectors);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
@@ -31,6 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
@@ -44,11 +45,12 @@ public class ConnectClusterStateImplTest {
     protected HerderProvider herderProvider;
     protected ConnectClusterStateImpl connectClusterState;
     protected Collection<String> expectedConnectors;
+    protected long herderRequestTimeoutMs = TimeUnit.SECONDS.toMillis(10);
     
     @Before
     public void setUp() {
         herderProvider = new HerderProvider(herder);
-        connectClusterState = new ConnectClusterStateImpl(herderProvider);
+        connectClusterState = new ConnectClusterStateImpl(herderRequestTimeoutMs, herderProvider);
         expectedConnectors = Arrays.asList("sink1", "source1", "source2");
     }
     
@@ -67,6 +69,7 @@ public class ConnectClusterStateImplTest {
         assertEquals(expectedConnectors, connectClusterState.connectors());
     }
 
+    @Test
     public void connectorsFailure() {
         Capture<Callback<Collection<String>>> callback = EasyMock.newCapture();
         herder.connectors(EasyMock.capture(callback));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.health;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.HerderProvider;
+import org.apache.kafka.connect.util.Callback;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ConnectClusterStateImplTest {
+  
+    protected static final long CONNECTORS_TIMEOUT_MS = 2_000;
+    
+    protected Herder mockHerder;
+    protected HerderProvider herderProvider;
+    protected ConnectClusterStateImpl connectClusterState;
+    protected Collection<String> expectedConnectors;
+    
+    @Before
+    public void setUp() {
+        mockHerder = EasyMock.mock(Herder.class);
+        herderProvider = new HerderProvider(mockHerder);
+        connectClusterState = new ConnectClusterStateImpl(herderProvider, CONNECTORS_TIMEOUT_MS);
+        expectedConnectors = Arrays.asList("sink1", "source1", "source2");
+    }
+    
+    @Test
+    public void fastConnectors() {
+        assertEquals(expectedConnectors, connectorsWithDelay(0, TimeUnit.MILLISECONDS));
+    }
+    
+    @Test
+    public void slowConnectors() {
+        assertEquals(
+                expectedConnectors,
+                connectorsWithDelay(CONNECTORS_TIMEOUT_MS / 2, TimeUnit.MILLISECONDS)
+        );
+    }
+    
+    @Test(expected = ConnectException.class)
+    public void timedOutConnectors() {
+        connectorsWithDelay(CONNECTORS_TIMEOUT_MS + 500, TimeUnit.MILLISECONDS);
+    }
+    
+    protected Collection<String> connectorsWithDelay(long delay, TimeUnit timeUnit) {
+        mockHerder.connectors(EasyMock.anyObject());
+        EasyMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public Void answer() {
+                    Callback<Collection<String>> connectorsCallback =
+                            (Callback<Collection<String>>) EasyMock.getCurrentArguments()[0];
+                    new Thread(new DelayedConnectorsReturn(
+                            delay,
+                            timeUnit,
+                            expectedConnectors,
+                            connectorsCallback
+                    )).start();
+                    return null;
+                }
+        });
+        EasyMock.replay(mockHerder);
+        return connectClusterState.connectors();
+    }
+    
+    protected static class DelayedConnectorsReturn implements Runnable {
+        
+        private final long delay;
+        private final TimeUnit timeUnit;
+        private final Collection<String> connectors;
+        private final Callback<Collection<String>> connectorsCallback;
+
+        public DelayedConnectorsReturn(
+                long delay,
+                TimeUnit timeUnit,
+                Collection<String> connectors,
+                Callback<Collection<String>> connectorsCallback
+        ) {
+            this.delay = delay;
+            this.timeUnit = timeUnit;
+            this.connectors = connectors;
+            this.connectorsCallback = connectorsCallback;
+        }
+
+        @Override
+        public void run() {
+            try {
+                timeUnit.sleep(delay);
+            } catch (InterruptedException e) {
+                fail("Interrupted while simulating delay");
+            }
+            connectorsCallback.onCompletion(null, connectors);
+        }
+    }
+}


### PR DESCRIPTION
This makes the `ConnectClusterStateImpl.connectors()` method synchronous, whereas before it was implicitly asynchronous with no way to tell whether it had completed or not.

More detail can be found in the [Jira](https://issues.apache.org/jira/browse/KAFKA-8058).

~Tested manually. Seems like a light enough change that even unit tests would be overkill, but if reviewers feel differently tests can be added.~
A unit test has also been added for the `ConnectClusterStateImpl` class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
