### PR TITLE
KAFKA-8044: Increase stop timeout for VerifiableProducer in ReassignPartitionsTest

### DIFF
--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -108,7 +108,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         """
         producer = VerifiableProducer(self.test_context, 1, self.kafka, self.topic,
                                       throughput=-1, enable_idempotence=True,
-                                      create_time=1000)
+                                      create_time=1000, stop_timeout_sec=200)
         producer.start()
         wait_until(lambda: producer.num_acked > 0,
                    timeout_sec=30,


### PR DESCRIPTION
- increase stop timeout from 150 to 200 seconds to avoid transient failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
