### PR TITLE
KAFKA-7288 - Make sure no bytes buffered when relying on idle timeout in channel close test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -493,8 +493,10 @@ public class SelectorTest {
             do {
                 selector.poll(1000);
             } while (selector.completedReceives().isEmpty());
-        } while (selector.numStagedReceives(channel) == 0 && --retries > 0);
+        } while (selector.numStagedReceives(channel) == 0 && !channel.hasBytesBuffered() && --retries > 0);
         assertTrue("No staged receives after 100 attempts", selector.numStagedReceives(channel) > 0);
+        // We want to return without any bytes buffered to ensure that channel will be closed after idle time
+        assertFalse("Channel has bytes buffered", channel.hasBytesBuffered());
 
         return channel;
     }


### PR DESCRIPTION
SelectorTest.testCloseConnectionInClosingState sends and receives messages to get the channel into a state with staged receives and then waits for idle timeout to close the channel. When run with SSL, the channel may have buffered bytes that prevent the channel from being closed. Updated the test to wait until there are no buffered bytes as well. I have left the number of retries to achieve this state at 100, since my local runs always succeed the first time.

I wasn't able to recreate the failure with or without the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
