### PR TITLE
KAFKA-7980 - Fix timing issue in SocketServerTest.testConnectionRateLimit

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1119,7 +1119,7 @@ class SocketServerTest extends JUnitSuite {
       assertEquals(Set.empty, errors)
       testableSelector.waitForOperations(SelectorOperation.Register, numConnections)
 
-      // In each iteration, SocketServer processes atmost connectionQueueSize (1 in this test)
+      // In each iteration, SocketServer processes at most connectionQueueSize (1 in this test)
       // new connections and then does poll() to process data from existing connections. So for
       // 5 connections, we expect 5 iterations. Since we stop when the 5th connection is processed,
       // we can safely check that there were atleast 4 polls prior to the 5th connection.

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1118,8 +1118,13 @@ class SocketServerTest extends JUnitSuite {
         "Connections not registered", waitTimeMs = 15000)
       assertEquals(Set.empty, errors)
       testableSelector.waitForOperations(SelectorOperation.Register, numConnections)
+
+      // In each iteration, SocketServer processes atmost connectionQueueSize (1 in this test)
+      // new connections and then does poll() to process data from existing connections. So for
+      // 5 connections, we expect 5 iterations. Since we stop when the 5th connection is processed,
+      // we can safely check that there were atleast 4 polls prior to the 5th connection.
       val pollCount = testableSelector.operationCounts(SelectorOperation.Poll)
-      assertTrue(s"Connections created too quickly: $pollCount", pollCount >= numConnections)
+      assertTrue(s"Connections created too quickly: $pollCount", pollCount >= numConnections - 1)
       verifyAcceptorBlockedPercent("PLAINTEXT", expectBlocked = true)
 
       assertProcessorHealthy(testableServer, sockets)


### PR DESCRIPTION
Test currently checks that there were at least 5 polls when 5 connections are established with connectionQueueSize=1. But we could be doing the check just after the 5th connection before the 5th poll, so updated the check to verify that there were at least 4 polls.

I could not recreate the failure with or without the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
