### PR TITLE
Slight change on server.properties documentation

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -24,6 +24,7 @@ broker.id=0
 
 # The address the socket server listens on. It will get the value returned from 
 # java.net.InetAddress.getCanonicalHostName() if not configured.
+# java.net.InetAddress.getLocalHost().getCanonicalHostName() if not configured.
 #   FORMAT:
 #     listeners = listener_name://host_name:port
 #   EXAMPLE:

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -530,7 +530,7 @@ object KafkaConfig {
   "Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may " +
   "need to be different from the interface to which the broker binds. If this is not set, " +
   "it will use the value for <code>host.name</code> if configured. Otherwise " +
-  "it will use the value returned from java.net.InetAddress.getCanonicalHostName()."
+  "it will use the value returned from java.net.InetAddress.getLocalHost().getCanonicalHostName()."
   val AdvertisedPortDoc = "DEPRECATED: only used when <code>advertised.listeners</code> or <code>listeners</code> are not set. " +
   "Use <code>advertised.listeners</code> instead. \n" +
   "The port to publish to ZooKeeper for clients to use. In IaaS environments, this may " +


### PR DESCRIPTION
I didn't find any `java.net.InetAddress.getCanonicalHostName()` usage in the code.
But I find `java.net.InetAddress.getLocalHost.getCanonicalHostName` in  `https://github.com/apache/kafka/blob/4b29487fa9d3d4ff8adaaaa6204db796eccd3a68/core/src/main/scala/kafka/server/KafkaServer.scala`.
So, if the internal kafka use the localhost value, I think I should change the documentation to appropriate value.

I dont think that I changed anything, therefore, no need to change any test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
