### PR TITLE
KAFKA-8067 - Kafka Connect JsonConverter Missing Optional field handling

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -717,6 +717,7 @@ public class JsonConverter implements Converter, HeaderConverter {
 
     private static Object convertToConnect(Schema schema, JsonNode jsonValue) {
         final Schema.Type schemaType;
+        jsonValue = jsonValue == null ? JsonNodeFactory.instance.nullNode() : jsonValue;
         if (schema != null) {
             schemaType = schema.type();
             if (jsonValue == null || jsonValue.isNull()) {

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -717,7 +717,7 @@ public class JsonConverter implements Converter, HeaderConverter {
 
     private static Object convertToConnect(Schema schema, JsonNode jsonValue) {
         final Schema.Type schemaType;
-        jsonValue = jsonValue == null ? JsonNodeFactory.instance.nullNode() : jsonValue;
+        jsonValue = jsonValue == null ? JSON_NODE_FACTORY.nullNode() : jsonValue;
         if (schema != null) {
             schemaType = schema.type();
             if (jsonValue == null || jsonValue.isNull()) {

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -147,7 +147,7 @@ public class JsonConverterTest {
     @Test
     public void stringToConnectOptional() {
         Schema schema = SchemaBuilder.string().version(1).optional().schema();
-        String msg = "{ \"schema\": { \"type\": \"string\", \"version\": 1, \"optional\": true, \"default\": null }, \"payload\": null }";
+        String msg = "{ \"schema\": { \"type\": \"string\", \"version\": 1, \"optional\": true }, \"payload\": null }";
         SchemaAndValue schemaAndValue = converter.toConnectData(TOPIC, msg.getBytes());
         assertEquals(schema, schemaAndValue.schema());
         assertNull(schemaAndValue.value());


### PR DESCRIPTION
*The JsonConverter is failing with NPE on Struct/Map types with missing optional fields while top level primitives are being handled correctly prior to this patch.*

*Unit tests to cover NPE on required Struct/Map cases with optional/null default variants.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
