### PR TITLE
MINOR: Add log when the consumer does not send an offset commit due to not being part of an active group

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -810,15 +810,16 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         }
 
         final Generation generation;
-        if (subscriptions.partitionsAutoAssigned())
+        if (subscriptions.partitionsAutoAssigned()) {
             generation = generation();
-        else
+            // if the generation is null, we are not part of an active group (and we expect to be).
+            // the only thing we can do is fail the commit and let the user rejoin the group in poll()
+            if (generation == null) {
+                log.info("Failing OffsetCommit request since the consumer is not part of an active group");
+                return RequestFuture.failure(new CommitFailedException());
+            }
+        } else
             generation = Generation.NO_GENERATION;
-
-        // if the generation is null, we are not part of an active group (and we expect to be).
-        // the only thing we can do is fail the commit and let the user rejoin the group in poll()
-        if (generation == null)
-            return RequestFuture.failure(new CommitFailedException());
 
         OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
                 new OffsetCommitRequestData()


### PR DESCRIPTION
When inspecting logs, it's hard to tell whether an `OffsetCommit` request was sent and [received a response that made it raise](https://github.com/apache/kafka/blob/027cbbaec521542f53274183daccc2073e91cfe9/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L843) a `CommitFailedException()` or whether the consumer did not send the request at all.

Since this is a rare case, we could add a log to say why this has happened. Another option is to allow the `CommitFailedException` class to accept a message in its constructor and explain the situation there. I'm not sure on the boundary of whether that counts as a public-facing change or not, so opted in for the log variant