### PR TITLE
KAFKA-8070: Increase consumer startup timeout in system tests

### DIFF
--- a/tests/kafkatest/sanity_checks/test_console_consumer.py
+++ b/tests/kafkatest/sanity_checks/test_console_consumer.py
@@ -63,7 +63,7 @@ class ConsoleConsumerTest(Test):
         node = self.consumer.nodes[0]
 
         wait_until(lambda: self.consumer.alive(node),
-            timeout_sec=10, backoff_sec=.2, err_msg="Consumer was too slow to start")
+            timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
         self.logger.info("consumer started in %s seconds " % str(time.time() - t0))
 
         # Verify that log output is happening

--- a/tests/kafkatest/tests/core/consumer_group_command_test.py
+++ b/tests/kafkatest/tests/core/consumer_group_command_test.py
@@ -67,7 +67,7 @@ class ConsumerGroupCommandTest(Test):
         self.start_consumer()
         consumer_node = self.consumer.nodes[0]
         wait_until(lambda: self.consumer.alive(consumer_node),
-                   timeout_sec=10, backoff_sec=.2, err_msg="Consumer was too slow to start")
+                   timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
         kafka_node = self.kafka.nodes[0]
         if security_protocol is not SecurityConfig.PLAINTEXT:
             prop_file = str(self.kafka.security_config.client_config())

--- a/tests/kafkatest/tests/core/get_offset_shell_test.py
+++ b/tests/kafkatest/tests/core/get_offset_shell_test.py
@@ -85,7 +85,7 @@ class GetOffsetShellTest(Test):
 
         node = self.consumer.nodes[0]
 
-        wait_until(lambda: self.consumer.alive(node), timeout_sec=10, backoff_sec=.2, err_msg="Consumer was too slow to start")
+        wait_until(lambda: self.consumer.alive(node), timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
 
         # Assert that offset is correctly indicated by GetOffsetShell tool
         wait_until(lambda: "%s:%s:%s" % (TOPIC, NUM_PARTITIONS - 1, MAX_MESSAGES) in self.kafka.get_offset_shell(TOPIC, None, 1000, 1, -1), timeout_sec=10,

--- a/tests/kafkatest/tests/tools/log4j_appender_test.py
+++ b/tests/kafkatest/tests/tools/log4j_appender_test.py
@@ -87,7 +87,7 @@ class Log4jAppenderTest(Test):
         node = self.consumer.nodes[0]
 
         wait_until(lambda: self.consumer.alive(node),
-            timeout_sec=10, backoff_sec=.2, err_msg="Consumer was too slow to start")
+            timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
 
         # Verify consumed messages count
         wait_until(lambda: self.messages_received_count == MAX_MESSAGES, timeout_sec=10,


### PR DESCRIPTION
We currently use 10 seconds as the timeout for ConsoleConsumer process to be started in ConsumerGroupCommandTest. For tests using SSL, this requires SSL keystores to be created first and then the process is started. Looking at successful test runs, it typically takes between 5 and 7 seconds to start SSL-enabled consumer process. But there have been several test failures that show `Consumer was too slow to start` in tests using SSL. The logs from the last two failures in ConsumerGroupCommand test had consumers which successfully started with SSL, but took ~13 seconds to log their first message. Hence changing the timeout to 20 seconds in system tests that check for consumer start up.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
