### PR TITLE
KAFKA-7288; Fix check in SelectorTest to wait for no buffered bytes

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -493,7 +493,7 @@ public class SelectorTest {
             do {
                 selector.poll(1000);
             } while (selector.completedReceives().isEmpty());
-        } while (selector.numStagedReceives(channel) == 0 && !channel.hasBytesBuffered() && --retries > 0);
+        } while ((selector.numStagedReceives(channel) == 0 || channel.hasBytesBuffered()) && --retries > 0);
         assertTrue("No staged receives after 100 attempts", selector.numStagedReceives(channel) > 0);
         // We want to return without any bytes buffered to ensure that channel will be closed after idle time
         assertFalse("Channel has bytes buffered", channel.hasBytesBuffered());


### PR DESCRIPTION
Fix the check added in PR #6390 to actually wait for no buffered bytes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
