### PR TITLE
KAFKA-7939: Fix timing issue in KafkaAdminClientTest.testCreateTopicsRetryBackoff

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1261,6 +1261,11 @@ public class KafkaAdminClient extends AdminClient {
         return groupId == null;
     }
 
+    //for testing
+    int noOfPendingCalls() {
+        return runnable.pendingCalls.size();
+    }
+
     @Override
     public CreateTopicsResult createTopics(final Collection<NewTopic> newTopics,
                                            final CreateTopicsOptions options) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1262,7 +1262,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     //for testing
-    int noOfPendingCalls() {
+    int numPendingCalls() {
         return runnable.pendingCalls.size();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -353,9 +353,9 @@ public class KafkaAdminClientTest {
             TestUtils.waitForCondition(() -> mockClient.numAwaitingResponses() == 1,
                     "Failed awaiting CreateTopics first request failure");
 
-            // Wait until the retry request created in AdminClient
-            TestUtils.waitForCondition(() -> ((KafkaAdminClient) env.adminClient()).noOfPendingCalls() == 1,
-                "Failed to retry CreateTopics request");
+            // Wait until the retry call added to the queue in AdminClient
+            TestUtils.waitForCondition(() -> ((KafkaAdminClient) env.adminClient()).numPendingCalls() == 1,
+                "Failed to add retry CreateTopics call");
 
             time.sleep(retryBackoff);
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -352,6 +352,11 @@ public class KafkaAdminClientTest {
             // Wait until the first attempt has failed, then advance the time
             TestUtils.waitForCondition(() -> mockClient.numAwaitingResponses() == 1,
                     "Failed awaiting CreateTopics first request failure");
+
+            // Wait until the retry request created in AdminClient
+            TestUtils.waitForCondition(() -> ((KafkaAdminClient) env.adminClient()).noOfPendingCalls() == 1,
+                "Failed to retry CreateTopics request");
+
             time.sleep(retryBackoff);
 
             future.get();


### PR DESCRIPTION
There is a small timing window where ```time.sleep(retryBackoff)``` will get executed before adminClient adds retry request to the queue.  Added a check to wait until the retry call added to the queue in AdminClient.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
