### PR TITLE
KAFKA-3881: use plain topic tag in Fetcher metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1445,7 +1445,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             String name = "topic." + topic + ".bytes-fetched";
             Sensor bytesFetched = this.metrics.getSensor(name);
             if (bytesFetched == null) {
-                Map<String, String> metricTags = Collections.singletonMap("topic", topic.replace('.', '_'));
+                Map<String, String> metricTags = Collections.singletonMap("topic", topic);
 
                 bytesFetched = this.metrics.sensor(name);
                 bytesFetched.add(this.metrics.metricInstance(metricsRegistry.topicFetchSizeAvg,
@@ -1461,8 +1461,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             name = "topic." + topic + ".records-fetched";
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
-                Map<String, String> metricTags = new HashMap<>(1);
-                metricTags.put("topic", topic.replace('.', '_'));
+                Map<String, String> metricTags = Collections.singletonMap("topic", topic);
 
                 recordsFetched = this.metrics.sensor(name);
                 recordsFetched.add(this.metrics.metricInstance(metricsRegistry.topicRecordsPerRequestAvg,
@@ -1492,7 +1491,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             Sensor recordsLead = this.metrics.getSensor(name);
             if (recordsLead == null) {
                 Map<String, String> metricTags = new HashMap<>(2);
-                metricTags.put("topic", tp.topic().replace('.', '_'));
+                metricTags.put("topic", tp.topic());
                 metricTags.put("partition", String.valueOf(tp.partition()));
 
                 recordsLead = this.metrics.sensor(name);
@@ -1511,7 +1510,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             Sensor recordsLag = this.metrics.getSensor(name);
             if (recordsLag == null) {
                 Map<String, String> metricTags = new HashMap<>(2);
-                metricTags.put("topic", tp.topic().replace('.', '_'));
+                metricTags.put("topic", tp.topic());
                 metricTags.put("partition", String.valueOf(tp.partition()));
 
                 recordsLag = this.metrics.sensor(name);


### PR DESCRIPTION
Reverts topic.replace conversion of dots to underbars in topic values for Fetcher metrics, so topic values are consistent across metrics.

The original `topic.replace` code was introduced in https://github.com/apache/kafka/pull/939 following a pattern where the topic value would be prefixed with "topic-" and dots would be converted to underbars. This pattern was then partially backed out, leaving the dots conversion by mistake.

Note that all other metric collections use the topic value as-is without conversion, so this change should align topic values from Fetcher with other metric topic values. The failure to align only happens when the topic value has a dot, so is understandably hard to find otherwise.