### PR TITLE
MINOR: Add verification step for Streams archetype to Jenkins build

### DIFF
--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -74,8 +74,9 @@
     </pre>
 
     <p>
-        The <code>pom.xml</code> file included in the project already has the Streams dependency defined,
-        and there are already several example programs written with Streams library under <code>src/main/java</code>.
+        The <code>pom.xml</code> file included in the project already has the Streams dependency defined.
+	Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java version.
+        Additionally, there are already several example programs written with Streams library under <code>src/main/java</code>.
         Since we are going to start writing such programs from scratch, we can now delete these examples:
     </p>
 

--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -75,7 +75,7 @@
 
     <p>
         The <code>pom.xml</code> file included in the project already has the Streams dependency defined.
-	Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java versions.
+        Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java versions.
     </p>
 
     <p>

--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -75,8 +75,11 @@
 
     <p>
         The <code>pom.xml</code> file included in the project already has the Streams dependency defined.
-	Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java version.
-        Additionally, there are already several example programs written with Streams library under <code>src/main/java</code>.
+	Note, that the generated <code>pom.xml</code> targets Java 8, and does not work with higher Java versions.
+    </p>
+
+    <p>
+        There are already several example programs written with Streams library under <code>src/main/java</code>.
         Since we are going to start writing such programs from scratch, we can now delete these examples:
     </p>
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -28,3 +28,45 @@
 ./gradlew unitTest integrationTest \
     --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
     || { echo 'Test steps failed'; exit 1; }
+
+# Verify that Kafka Streams archetype compiles
+if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then
+  echo "Skipping Kafka Streams archetype test for Java 11"
+  exit 0
+fi
+
+./gradlew streams:install clients:install connect:json:install connect:api:install \
+    || { echo 'Could not install kafka-streams.jar (and dependencies) locally`'; exit 1; }
+
+version=`grep "^version=" gradle.properties | cut -d= -f 2` \
+    || { echo 'Could not get version from `gradle.properties`'; exit 1; }
+
+cd streams/quickstart \
+    || { echo 'Could not change into directory `streams/quickstart`'; exit 1; }
+
+# variable $MAVEN_LATEST__HOME is provided by Jenkins (see build configuration)
+mvn=$MAVEN_LATEST__HOME/bin/mvn
+
+$mvn clean install -Dgpg.skip  \
+    || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
+
+mkdir test-streams-archetype && cd test-streams-archetype \
+    || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
+
+echo "Y" | $mvn archetype:generate \
+    -DarchetypeCatalog=local \
+    -DarchetypeGroupId=org.apache.kafka \
+    -DarchetypeArtifactId=streams-quickstart-java \
+    -DarchetypeVersion=$version \
+    -DgroupId=streams.examples \
+    -DartifactId=streams.examples \
+    -Dversion=0.1 \
+    -Dpackage=myapps \
+    || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
+
+cd streams.examples \
+    || { echo 'Could not change into directory `streams.examples`'; exit 1; }
+
+$mvn compile \
+    || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
+


### PR DESCRIPTION
Updates `./jenkins.sh` to build stream archetype and install it in local maven cache. Afterward, archetype is used to create a new maven project and maven project is compiled for verification.