### PR TITLE
MINOR: gradle-related version upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ buildscript {
 
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
-    classpath "org.ajoberstar:grgit:1.9.3"
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+    classpath "org.ajoberstar.grgit:grgit-core:3.1.1"
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
     classpath 'org.scoverage:gradle-scoverage:2.5.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
     classpath 'org.owasp:dependency-check-gradle:4.0.2'
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.17.0"
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.23.0"
     classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9"
   }
 }
@@ -91,7 +91,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "5.1.1"
+  gradleVersion = "5.4.1"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 
@@ -120,7 +120,7 @@ if (file('.git').exists()) {
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These
     // restrict us only to files that are checked in or are staged.
-    def repo = Grgit.open(project.getRootDir())
+    def repo = Grgit.open(currentDir: project.getRootDir())
     excludes = new ArrayList<String>(repo.clean(ignore: false, directories: true, dryRun: true))
     // And some of the files that we have checked in should also be excluded from this check
     excludes.addAll([
@@ -432,7 +432,7 @@ subprojects {
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = checkstyleConfigProperties("import-control.xml")
-    toolVersion = '8.10'
+    toolVersion = '8.20'
   }
 
   configure(checkstyleMain) {
@@ -448,7 +448,7 @@ subprojects {
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 
   spotbugs {
-    toolVersion = '3.1.8'
+    toolVersion = '3.1.12'
     excludeFilter = file("$rootDir/gradle/spotbugs-exclude.xml")
     ignoreFailures = false
   }
@@ -467,7 +467,7 @@ subprojects {
     apply plugin: "jacoco"
 
     jacoco {
-      toolVersion = "0.8.2"
+      toolVersion = "0.8.3"
     }
 
     // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock


### PR DESCRIPTION
details:
 * gradle:                  5.1.1  -->>  5.4.1
 * grgit:                   1.9.3  -->>  3.1.1 (breaking change release: artifact name is changed; also, Grgit.open' usage is slightly refactored)
 * gradle-versions-plugin:  0.20.0 -->> 0.21.0
 * shadow:                  4.0.3  -->>  4.0.4
 * spotless-plugin-gradle: 3.17.0  -->> 3.23.0
 * checkstyle:                8.10 -->> 8.20
 * spotbugs:                 3.1.8 -->> 3.1.12
 * jacoco:                   0.8.2 -->> 0.8.3

related release notes:
 * gradle:
       ** https://github.com/gradle/gradle/releases/tag/v5.2.0
       ** https://github.com/gradle/gradle/releases/tag/v5.2.1
       ** https://github.com/gradle/gradle/releases/tag/v5.3.0
       ** https://github.com/gradle/gradle/releases/tag/v5.3.1
       ** https://github.com/gradle/gradle/releases/tag/v5.4.0
       ** https://github.com/gradle/gradle/releases/tag/v5.4.1
 * grgit:
       ** https://github.com/ajoberstar/grgit/releases/tag/2.0.0
       ** https://github.com/ajoberstar/grgit/releases/tag/3.0.0
       ** https://github.com/ajoberstar/grgit/releases/tag/3.1.0
 * gradle-versions-plugin:
       ** https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.21.0
 * shadow:
       ** https://github.com/johnrengelman/shadow/releases/tag/4.0.4
 * spotless-plugin-gradle:
       ** https://github.com/diffplug/spotless/blob/gradle/3.23.0/plugin-gradle/CHANGES.md
 * checkstyle:
       ** http://checkstyle.sourceforge.net/releasenotes.html#Release_8.20
 * spotbugs:
       ** https://github.com/spotbugs/spotbugs/blob/3.1.12/CHANGELOG.md
 * jacoco:
       ** https://github.com/jacoco/jacoco/releases/tag/v0.8.3

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
