### PR TITLE
MINOR: resolve some of the core project compilier warnings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
@@ -184,8 +184,8 @@ public class ListOffsetRequest extends AbstractRequest {
 
     public static final class PartitionData {
         public final long timestamp;
-        @Deprecated
-        public final int maxNumOffsets; // only supported in v0
+        // Note, this maximum number offsets is only used in ListOffsetRequest v0
+        public final int maxNumOffsets;
         public final Optional<Integer> currentLeaderEpoch;
 
         private PartitionData(long timestamp, int maxNumOffsets, Optional<Integer> currentLeaderEpoch) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -136,8 +136,7 @@ public class ListOffsetResponse extends AbstractResponse {
 
     public static final class PartitionData {
         public final Errors error;
-        // The offsets list is only used in ListOffsetResponse v0.
-        @Deprecated
+        // Note, the offsets list is only used in ListOffsetResponse v0.
         public final List<Long> offsets;
         public final Long timestamp;
         public final Long offset;
@@ -146,7 +145,6 @@ public class ListOffsetResponse extends AbstractResponse {
         /**
          * Constructor for ListOffsetResponse v0
          */
-        @Deprecated
         public PartitionData(Errors error, List<Long> offsets) {
             this.error = error;
             this.offsets = offsets;

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -144,7 +144,6 @@ public class OffsetCommitRequest extends AbstractRequest {
 
     // default values for old versions,
     // will be removed after these versions are deprecated
-    @Deprecated
     public static final long DEFAULT_TIMESTAMP = -1L;            // for V0, V1
 
     private final String groupId;
@@ -154,8 +153,8 @@ public class OffsetCommitRequest extends AbstractRequest {
     private final Map<TopicPartition, PartitionData> offsetData;
 
     public static final class PartitionData {
-        @Deprecated
-        public final long timestamp;                // for V1
+        // Note, only available for OffsetCommitRequest v1
+        public final long timestamp;
 
         public final long offset;
         public final String metadata;
@@ -351,7 +350,7 @@ public class OffsetCommitRequest extends AbstractRequest {
         return memberId;
     }
 
-    @Deprecated
+    // Note, the retention time is only used in OffsetCommitRequest v2
     public long retentionTime() {
         return retentionTime;
     }

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -29,8 +29,8 @@ case class MemberSummary(memberId: String,
                          metadata: Array[Byte],
                          assignment: Array[Byte])
 
-private object MemberMetadata {
-  def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]) = supportedProtocols.map(_._1).toSet
+object MemberMetadata {
+  private[group] def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]) = supportedProtocols.map(_._1).toSet
 }
 
 /**

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -101,6 +101,7 @@ object RequestChannel extends Logging {
     def requestDesc(details: Boolean): String = s"$header -- ${body[AbstractRequest].toString(details)}"
 
     def body[T <: AbstractRequest](implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+      val _ = nn // suppress scalac unused parameter warning
       bodyAndSize.request match {
         case r: T => r
         case r =>

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -228,7 +228,7 @@ object Defaults {
 
   /** ********* Sasl configuration ***********/
   val SaslMechanismInterBrokerProtocol = SaslConfigs.DEFAULT_SASL_MECHANISM
-  val SaslEnabledMechanisms = SaslConfigs.DEFAULT_SASL_ENABLED_MECHANISMS
+  val SaslEnabledMechanisms = BrokerSecurityConfigs.DEFAULT_SASL_ENABLED_MECHANISMS
   val SaslKerberosKinitCmd = SaslConfigs.DEFAULT_KERBEROS_KINIT_CMD
   val SaslKerberosTicketRenewWindowFactor = SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
   val SaslKerberosTicketRenewJitter = SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_JITTER

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -32,6 +32,7 @@ import kafka.utils._
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{AuthenticationException, TimeoutException, WakeupException}
+import org.apache.kafka.common.record.DefaultRecord
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.requests.ListOffsetRequest
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, Deserializer}
@@ -570,6 +571,11 @@ class ChecksumMessageFormatter extends MessageFormatter {
   }
 
   def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream) {
-    output.println(topicStr + "checksum:" + consumerRecord.checksum)
+    val checksum = DefaultRecord.computePartialChecksum(
+      consumerRecord.timestamp(),
+      consumerRecord.serializedKeySize(),
+      consumerRecord.serializedValueSize()
+    )
+    output.println(s"${topicStr}checksum:$checksum")
   }
 }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -20,7 +20,7 @@ package kafka.tools
 import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{CountDownLatch}
 import java.util.regex.Pattern
 import java.util.{Collections, Properties}
 
@@ -387,7 +387,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
     }
 
     def close(timeout: Long) {
-      this.producer.close(timeout, TimeUnit.MILLISECONDS)
+      this.producer.close(Duration.ofMillis(timeout))
     }
   }
 

--- a/core/src/main/scala/kafka/utils/NotNothing.scala
+++ b/core/src/main/scala/kafka/utils/NotNothing.scala
@@ -37,5 +37,8 @@ trait NotNothing[T]
 object NotNothing {
   private val evidence: NotNothing[Any] = new Object with NotNothing[Any]
 
-  implicit def notNothingEvidence[T](implicit n: T =:= T): NotNothing[T] = evidence.asInstanceOf[NotNothing[T]]
+  implicit def notNothingEvidence[T](implicit n: T =:= T): NotNothing[T] = {
+    val _ = n // suppress scalac unused parameter warning
+    evidence.asInstanceOf[NotNothing[T]]
+  }
 }


### PR DESCRIPTION
With this change this is the output of trying to generate the jar for the core project.
```
$ ./gradlew core:jar
core/src/main/scala/kafka/admin/AdminUtils.scala:64: trait AdminUtilities in package admin is deprecated (since 1.1.0): This class is deprecated and will be replaced by kafka.zk.AdminZkClient.
object AdminUtils extends Logging with AdminUtilities {
                                       ^
core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala:52: class AdminClient in package admin is deprecated (since 0.11.0): This class is deprecated in favour of org.apache.kafka.clients.admin.AdminClient and it will be removed in a future release.
  private def createAdminClient(opts: BrokerVersionCommandOptions): AdminClient = {
                                                                    ^
core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala:58: object AdminClient in package admin is deprecated (since 0.11.0): This class is deprecated in favour of org.apache.kafka.clients.admin.AdminClient and it will be removed in a future release.
    AdminClient.create(props)
    ^
core/src/main/scala/kafka/tools/MirrorMaker.scala:197: class BaseConsumerRecord in package consumer is deprecated (since 0.11.0.0): This class has been deprecated and will be removed in a future release. Please use org.apache.kafka.clients.consumer.ConsumerRecord instead.
    private def toBaseConsumerRecord(record: ConsumerRecord[Array[Byte], Array[Byte]]): BaseConsumerRecord =
                                                                                        ^
core/src/main/scala/kafka/tools/MirrorMaker.scala:198: class BaseConsumerRecord in package consumer is deprecated (since 0.11.0.0): This class has been deprecated and will be removed in a future release. Please use org.apache.kafka.clients.consumer.ConsumerRecord instead.
      BaseConsumerRecord(record.topic,
      ^
core/src/main/scala/kafka/tools/MirrorMaker.scala:417: class BaseConsumerRecord in package consumer is deprecated (since 0.11.0.0): This class has been deprecated and will be removed in a future release. Please use org.apache.kafka.clients.consumer.ConsumerRecord instead.
    def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]]
                       ^
core/src/main/scala/kafka/tools/MirrorMaker.scala:421: class BaseConsumerRecord in package consumer is deprecated (since 0.11.0.0): This class has been deprecated and will be removed in a future release. Please use org.apache.kafka.clients.consumer.ConsumerRecord instead.
    override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
                                ^
7 warnings found
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
