### PR TITLE
KAFKA-8098: Fix Flaky Test testConsumerGroups

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1180,7 +1180,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
         }
         try {
           consumerThread.start
-         assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get().asScala.filter(_.groupId == testGroupId)

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1180,7 +1180,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
         }
         try {
           consumerThread.start
-          latch.await(30000, TimeUnit.MILLISECONDS)
+         assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get().asScala.filter(_.groupId == testGroupId)

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1169,7 +1169,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
             try {
               while (true) {
                 consumer.poll(JDuration.ofSeconds(5))
-                if (!consumer.assignment().isEmpty && latch.getCount > 0L)
+                if (!consumer.assignment.isEmpty && latch.getCount > 0L)
                   latch.countDown()
                 consumer.commitSync()
               }
@@ -1180,7 +1180,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
         }
         try {
           consumerThread.start
-          latch.await()
+          latch.await(30000, TimeUnit.MILLISECONDS)
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get().asScala.filter(_.groupId == testGroupId)

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -19,7 +19,7 @@ package kafka.api
 import java.{time, util}
 import java.util.{Collections, Properties}
 import java.util.Arrays.asList
-import java.util.concurrent.{ExecutionException, TimeUnit}
+import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit}
 import java.io.File
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
@@ -52,6 +52,7 @@ import kafka.zk.KafkaZkClient
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import java.lang.{Long => JLong}
+import java.time.{Duration => JDuration}
 
 import kafka.security.auth.{Cluster, Group, Topic}
 
@@ -1158,19 +1159,26 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
       newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
       val consumer = createConsumer(configOverrides = newConsumerConfig)
+      val latch = new CountDownLatch(1)
       try {
         // Start a consumer in a thread that will subscribe to a new group.
         val consumerThread = new Thread {
           override def run {
             consumer.subscribe(Collections.singleton(testTopicName))
-            while (true) {
-              consumer.poll(time.Duration.ofSeconds(5L))
-              consumer.commitSync()
+
+            try {
+              while (true) {
+                consumer.poll(JDuration.ofSeconds(5))
+                consumer.commitSync()
+              }
+            } catch {
+              case _: InterruptException => // Suppress the output to stderr
             }
           }
         }
         try {
           consumerThread.start
+          latch.await()
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get().asScala.filter(_.groupId == testGroupId)

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1169,6 +1169,8 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
             try {
               while (true) {
                 consumer.poll(JDuration.ofSeconds(5))
+                if (!consumer.assignment().isEmpty && latch.getCount > 0L)
+                  latch.countDown()
                 consumer.commitSync()
               }
             } catch {


### PR DESCRIPTION
- The flaky failure is caused by the fact that the main thread sometimes issues DescribeConsumerGroup request before the consumer assignment takes effect. Added a latch to make sure such situation is not going to happen.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
