### PR TITLE
make sure replica.fetch.max.bytes will always >= to max.message.bytes

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1101,5 +1101,6 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
       s"Only GSSAPI mechanism is supported for inter-broker communication with SASL when inter.broker.protocol.version is set to $interBrokerProtocolVersionString")
     require(!interBrokerUsesSasl || saslEnabledMechanisms.contains(saslMechanismInterBrokerProtocol),
       s"${KafkaConfig.SaslMechanismInterBrokerProtocolProp} must be included in ${KafkaConfig.SaslEnabledMechanismsProp} when SASL is used for inter-broker communication")
+    require(messageMaxBytes <= replicaFetchMaxBytes, "replica.fetch.max.bytes needs to be equal or greater than max.message.bytes, otherwise the replication might fail")
   }
 }


### PR DESCRIPTION
so when the max.message.bytes is bigger than replica.fetch.max.bytes will cause the replica fetch blocked. This will leads to only the leader partition is available, and change the replica.fetch.max.bytes
later on might cause the data loss.