### PR TITLE
MINOR: Update Trogdor ConnectionStressWorker status at the end of execution

### DIFF
--- a/tests/spec/connection_stress_test.json
+++ b/tests/spec/connection_stress_test.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// An example task specification for running a connection stress test in Trogdor.
+// See TROGDOR.md for details.
+//
+
+{
+  "class": "org.apache.kafka.trogdor.workload.ConnectionStressSpec",
+  "durationMs": 60000,
+  "clientNode": "node0",
+  "bootstrapServers": "localhost:9092",
+  "targetConnectionsPerSec": 100,
+  "numThreads": 10,
+  "action": "CONNECT"
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -99,12 +99,14 @@ public class ConnectionStressWorker implements TaskWorker {
         log.info("{}: Activating ConnectionStressWorker with {}", id, spec);
         this.doneFuture = doneFuture;
         this.status = status;
-        this.totalConnections = 0;
-        this.totalFailedConnections  = 0;
-        this.startTimeMs = TIME.milliseconds();
+        synchronized (ConnectionStressWorker.this) {
+            this.totalConnections = 0;
+            this.totalFailedConnections = 0;
+            this.nextReportTime = 0;
+            this.startTimeMs = TIME.milliseconds();
+        }
         this.throttle = new ConnectStressThrottle(WorkerUtils.
             perSecToPerPeriod(spec.targetConnectionsPerSec(), THROTTLE_PERIOD_MS));
-        this.nextReportTime = 0;
         this.workerExecutor = Executors.newFixedThreadPool(spec.numThreads(),
             ThreadUtils.createThreadFactory("ConnectionStressWorkerThread%d", false));
         for (int i = 0; i < spec.numThreads(); i++) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -115,8 +115,7 @@ public class ConnectionStressWorker implements TaskWorker {
     }
 
     /**
-     * Update the worker's status.
-     * This method should be called inside a lock on the ConnectionStressWorker object
+     * Update the worker's status and next status report time.
      */
     private synchronized void updateStatus(long lastTimeMs) {
         status.update(JsonUtil.JSON_SERDE.valueToTree(

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -116,7 +116,7 @@ public class ConnectionStressWorker implements TaskWorker {
      * Update the worker's status.
      * This method should be called inside a lock on the ConnectionStressWorker object
      */
-    private void updateStatus(long lastTimeMs) {
+    private synchronized void updateStatus(long lastTimeMs) {
         status.update(JsonUtil.JSON_SERDE.valueToTree(
                 new StatusData(totalConnections,
                         totalFailedConnections,
@@ -254,9 +254,7 @@ public class ConnectionStressWorker implements TaskWorker {
         doneFuture.complete("");
         workerExecutor.shutdownNow();
         workerExecutor.awaitTermination(1, TimeUnit.DAYS);
-        synchronized (ConnectionStressWorker.this) {
-            updateStatus(throttle.lastTimeMs());
-        }
+        updateStatus(throttle.lastTimeMs());
         this.workerExecutor = null;
         this.status = null;
     }


### PR DESCRIPTION
I was testing this worker locally and found that it would not report correct numbers after it shutting down due to the `durationMs` passing.

Status before patch:
```
{"tasks":{"connect":{"state":"DONE","spec":{"class":"org.apache.kafka.trogdor.workload.ConnectionStressSpec","startMs":1552576318156,"durationMs":60000,"clientNode":["node0"],"bootstrapServers":"localhost:9092","targetConnectionsPerSec":100,"numThreads":10,"action":"CONNECT"},"startedMs":1552576318159,"doneMs":1552576378366,"cancelled":false,"status":{"totalConnections":4021,"totalFailedConnections":0,"connectsPerSec":100.19186205865498}}

"connect2":{"state":"RUNNING","spec":{"class":"org.apache.kafka.trogdor.workload.ConnectionStressSpec","startMs":1552576480870,"durationMs":60000,"clientNode":["node0"],"bootstrapServers":"localhost:9092","targetConnectionsPerSec":200,"numThreads":10,"action":"CONNECT"},"startedMs":1552576480870,"status":{"totalConnections":8021,"totalFailedConnections":0,"connectsPerSec":200.3797246995928}}}}
```

Status after patch:
```
"tasks":{"connect_newer1":{"state":"DONE","spec":{"class":"org.apache.kafka.trogdor.workload.ConnectionStressSpec","startMs":1552579728411,"durationMs":60000,"clientNode":["node0"],"bootstrapServers":"localhost:9092","targetConnectionsPerSec":100,"numThreads":10,"action":"CONNECT"},"startedMs":1552579728412,"doneMs":1552579788645,"cancelled":false,"status":{"totalConnections":6010,"totalFailedConnections":0,"connectsPerSec":100.19004434368019}}

"connect_newer2":{"state":"DONE","spec":{"class":"org.apache.kafka.trogdor.workload.ConnectionStressSpec","startMs":1552579472885,"durationMs":60000,"clientNode":["node0"],"bootstrapServers":"localhost:9092","targetConnectionsPerSec":200,"numThreads":10,"action":"CONNECT"},"startedMs":1552579472891,"doneMs":1552579533114,"cancelled":false,"status":{"totalConnections":11980,"totalFailedConnections":0,"connectsPerSec":200.31434973079624}}}}
```