### PR TITLE
MINOR: capture result timestamps in Kafka Streams DSL tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -232,14 +232,14 @@ public class StreamsBuilderTest {
         source.process(processorSupplier);
 
         final ConsumerRecordFactory<String, String> recordFactory =
-            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create("topic-source", "A", "aa"));
         }
 
         // no exception was thrown
-        assertEquals(Collections.singletonList("A:aa"), processorSupplier.theCapturedProcessor().processed);
+        assertEquals(Collections.singletonList("A:aa (ts: 0)"), processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test
@@ -254,14 +254,14 @@ public class StreamsBuilderTest {
         through.process(throughProcessorSupplier);
 
         final ConsumerRecordFactory<String, String> recordFactory =
-            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create("topic-source", "A", "aa"));
         }
 
-        assertEquals(Collections.singletonList("A:aa"), sourceProcessorSupplier.theCapturedProcessor().processed);
-        assertEquals(Collections.singletonList("A:aa"), throughProcessorSupplier.theCapturedProcessor().processed);
+        assertEquals(Collections.singletonList("A:aa (ts: 0)"), sourceProcessorSupplier.theCapturedProcessor().processed);
+        assertEquals(Collections.singletonList("A:aa (ts: 0)"), throughProcessorSupplier.theCapturedProcessor().processed);
     }
     
     @Test
@@ -277,7 +277,7 @@ public class StreamsBuilderTest {
         merged.process(processorSupplier);
 
         final ConsumerRecordFactory<String, String> recordFactory =
-            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic1, "A", "aa"));
@@ -286,7 +286,7 @@ public class StreamsBuilderTest {
             driver.pipeInput(recordFactory.create(topic1, "D", "dd"));
         }
 
-        assertEquals(asList("A:aa", "B:bb", "C:cc", "D:dd"), processorSupplier.theCapturedProcessor().processed);
+        assertEquals(asList("A:aa (ts: 0)", "B:bb (ts: 0)", "C:cc (ts: 0)", "D:dd (ts: 0)"), processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValuesTest.java
@@ -35,9 +35,9 @@ import java.util.Properties;
 import static org.junit.Assert.assertArrayEquals;
 
 public class KStreamFlatMapValuesTest {
-
-    private String topicName = "topic";
-    private final ConsumerRecordFactory<Integer, Integer> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new IntegerSerializer());
+    private final String topicName = "topic";
+    private final ConsumerRecordFactory<Integer, Integer> recordFactory =
+        new ConsumerRecordFactory<>(new IntegerSerializer(), new IntegerSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
     @Test
@@ -45,14 +45,11 @@ public class KStreamFlatMapValuesTest {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final ValueMapper<Number, Iterable<String>> mapper =
-            new ValueMapper<Number, Iterable<String>>() {
-                @Override
-                public Iterable<String> apply(final Number value) {
-                    final ArrayList<String> result = new ArrayList<String>();
-                    result.add("v" + value);
-                    result.add("V" + value);
-                    return result;
-                }
+            value -> {
+                final ArrayList<String> result = new ArrayList<>();
+                result.add("v" + value);
+                result.add("V" + value);
+                return result;
             };
 
         final int[] expectedKeys = {0, 1, 2, 3};
@@ -68,7 +65,7 @@ public class KStreamFlatMapValuesTest {
             }
         }
 
-        final String[] expected = {"0:v0", "0:V0", "1:v1", "1:V1", "2:v2", "2:V2", "3:v3", "3:V3"};
+        final String[] expected = {"0:v0 (ts: 0)", "0:V0 (ts: 0)", "1:v1 (ts: 0)", "1:V1 (ts: 0)", "2:v2 (ts: 0)", "2:V2 (ts: 0)", "3:v3 (ts: 0)", "3:V3 (ts: 0)"};
 
         assertArrayEquals(expected, supplier.theCapturedProcessor().processed.toArray());
     }
@@ -79,15 +76,12 @@ public class KStreamFlatMapValuesTest {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final ValueMapperWithKey<Integer, Number, Iterable<String>> mapper =
-                new ValueMapperWithKey<Integer, Number, Iterable<String>>() {
-            @Override
-            public Iterable<String> apply(final Integer readOnlyKey, final Number value) {
+            (readOnlyKey, value) -> {
                 final ArrayList<String> result = new ArrayList<>();
                 result.add("v" + value);
                 result.add("k" + readOnlyKey);
                 return result;
-            }
-        };
+            };
 
         final int[] expectedKeys = {0, 1, 2, 3};
 
@@ -103,7 +97,7 @@ public class KStreamFlatMapValuesTest {
             }
         }
 
-        final String[] expected = {"0:v0", "0:k0", "1:v1", "1:k1", "2:v2", "2:k2", "3:v3", "3:k3"};
+        final String[] expected = {"0:v0 (ts: 0)", "0:k0 (ts: 0)", "1:v1 (ts: 0)", "1:k1 (ts: 0)", "2:v2 (ts: 0)", "2:k2 (ts: 0)", "3:v3 (ts: 0)", "3:k3 (ts: 0)"};
 
         assertArrayEquals(expected, supplier.theCapturedProcessor().processed.toArray());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamGlobalKTableLeftJoinTest {
-
     final private String streamTopic = "streamTopic";
     final private String globalTableTopic = "globalTableTopic";
 
@@ -65,14 +64,11 @@ public class KStreamGlobalKTableLeftJoinTest {
         final Consumed<String, String> tableConsumed = Consumed.with(Serdes.String(), Serdes.String());
         stream = builder.stream(streamTopic, streamConsumed);
         table = builder.globalTable(globalTableTopic, tableConsumed);
-        keyMapper = new KeyValueMapper<Integer, String, String>() {
-            @Override
-            public String apply(final Integer key, final String value) {
-                final String[] tokens = value.split(",");
-                // Value is comma delimited. If second token is present, it's the key to the global ktable.
-                // If not present, use null to indicate no match
-                return tokens.length > 1 ? tokens[1] : null;
-            }
+        keyMapper = (key, value) -> {
+            final String[] tokens = value.split(",");
+            // Value is comma delimited. If second token is present, it's the key to the global ktable.
+            // If not present, use null to indicate no match
+            return tokens.length > 1 ? tokens[1] : null;
         };
         stream.leftJoin(table, keyMapper, MockValueJoiner.TOSTRING_JOINER).process(supplier);
 
@@ -88,7 +84,8 @@ public class KStreamGlobalKTableLeftJoinTest {
     }
 
     private void pushToStream(final int messageCount, final String valuePrefix, final boolean includeForeignKey) {
-        final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer());
+        final ConsumerRecordFactory<Integer, String> recordFactory =
+            new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer(), 0L);
         for (int i = 0; i < messageCount; i++) {
             String value = valuePrefix + expectedKeys[i];
             if (includeForeignKey) {
@@ -99,14 +96,16 @@ public class KStreamGlobalKTableLeftJoinTest {
     }
 
     private void pushToGlobalTable(final int messageCount, final String valuePrefix) {
-        final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+        final ConsumerRecordFactory<String, String> recordFactory =
+            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
         for (int i = 0; i < messageCount; i++) {
             driver.pipeInput(recordFactory.create(globalTableTopic, "FKey" + expectedKeys[i], valuePrefix + expectedKeys[i]));
         }
     }
 
     private void pushNullValueToGlobalTable(final int messageCount) {
-        final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+        final ConsumerRecordFactory<String, String> recordFactory =
+            new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
         for (int i = 0; i < messageCount; i++) {
             driver.pipeInput(recordFactory.create(globalTableTopic, "FKey" + expectedKeys[i], (String) null));
         }
@@ -114,7 +113,8 @@ public class KStreamGlobalKTableLeftJoinTest {
 
     @Test
     public void shouldNotRequireCopartitioning() {
-        final Collection<Set<String>> copartitionGroups = TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals("KStream-GlobalKTable joins do not need to be co-partitioned", 0, copartitionGroups.size());
     }
@@ -125,7 +125,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push two items to the primary stream. the globalTable is empty
 
         pushToStream(2, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+null", "1:X1,FKey1+null");
+        processor.checkAndClearProcessResult("0:X0,FKey0+null (ts: 0)", "1:X1,FKey1+null (ts: 0)");
     }
 
     @Test
@@ -134,7 +134,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push two items to the primary stream. the globalTable is empty
 
         pushToStream(2, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+null", "1:X1,FKey1+null");
+        processor.checkAndClearProcessResult("0:X0,FKey0+null (ts: 0)", "1:X1,FKey1+null (ts: 0)");
 
         // push two items to the globalTable. this should not produce any item.
 
@@ -144,7 +144,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push all four items to the primary stream. this should produce four items.
 
         pushToStream(4, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+Y0", "1:X1,FKey1+Y1", "2:X2,FKey2+null", "3:X3,FKey3+null");
+        processor.checkAndClearProcessResult("0:X0,FKey0+Y0 (ts: 0)", "1:X1,FKey1+Y1 (ts: 0)", "2:X2,FKey2+null (ts: 0)", "3:X3,FKey3+null (ts: 0)");
 
         // push all items to the globalTable. this should not produce any item
 
@@ -154,7 +154,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push all four items to the primary stream. this should produce four items.
 
         pushToStream(4, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+YY0", "1:X1,FKey1+YY1", "2:X2,FKey2+YY2", "3:X3,FKey3+YY3");
+        processor.checkAndClearProcessResult("0:X0,FKey0+YY0 (ts: 0)", "1:X1,FKey1+YY1 (ts: 0)", "2:X2,FKey2+YY2 (ts: 0)", "3:X3,FKey3+YY3 (ts: 0)");
 
         // push all items to the globalTable. this should not produce any item
 
@@ -173,7 +173,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push all four items to the primary stream. this should produce four items.
 
         pushToStream(4, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+Y0", "1:X1,FKey1+Y1", "2:X2,FKey2+null", "3:X3,FKey3+null");
+        processor.checkAndClearProcessResult("0:X0,FKey0+Y0 (ts: 0)", "1:X1,FKey1+Y1 (ts: 0)", "2:X2,FKey2+null (ts: 0)", "3:X3,FKey3+null (ts: 0)");
 
     }
 
@@ -188,7 +188,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push all four items to the primary stream. this should produce four items.
 
         pushToStream(4, "X", true);
-        processor.checkAndClearProcessResult("0:X0,FKey0+Y0", "1:X1,FKey1+Y1", "2:X2,FKey2+Y2", "3:X3,FKey3+Y3");
+        processor.checkAndClearProcessResult("0:X0,FKey0+Y0 (ts: 0)", "1:X1,FKey1+Y1 (ts: 0)", "2:X2,FKey2+Y2 (ts: 0)", "3:X3,FKey3+Y3 (ts: 0)");
 
         // push two items with null to the globalTable as deletes. this should not produce any item.
 
@@ -198,7 +198,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // push all four items to the primary stream. this should produce four items.
 
         pushToStream(4, "XX", true);
-        processor.checkAndClearProcessResult("0:XX0,FKey0+null", "1:XX1,FKey1+null", "2:XX2,FKey2+Y2", "3:XX3,FKey3+Y3");
+        processor.checkAndClearProcessResult("0:XX0,FKey0+null (ts: 0)", "1:XX1,FKey1+null (ts: 0)", "2:XX2,FKey2+Y2 (ts: 0)", "3:XX3,FKey3+Y3 (ts: 0)");
     }
 
     @Test
@@ -213,7 +213,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         // this should produce four items.
 
         pushToStream(4, "XXX", false);
-        processor.checkAndClearProcessResult("0:XXX0+null", "1:XXX1+null", "2:XXX2+null", "3:XXX3+null");
+        processor.checkAndClearProcessResult("0:XXX0+null (ts: 0)", "1:XXX1+null (ts: 0)", "2:XXX2+null (ts: 0)", "3:XXX3+null (ts: 0)");
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -85,10 +85,11 @@ public class KStreamImplTest {
     private KStream<String, String> testStream;
     private StreamsBuilder builder;
 
-    private final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<String, String> recordFactory =
+        new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    private Serde<String> mySerde = new Serdes.StringSerde();
+    private final Serde<String> mySerde = new Serdes.StringSerde();
 
     @Before
     public void before() {
@@ -132,7 +133,7 @@ public class KStreamImplTest {
 
         stream4.to("topic-5");
 
-        streams2[1].through("topic-6").process(new MockProcessorSupplier<String, Integer>());
+        streams2[1].through("topic-6").process(new MockProcessorSupplier<>());
 
         assertEquals(2 + // sources
             2 + // stream1
@@ -225,41 +226,41 @@ public class KStreamImplTest {
         assertEquals(((AbstractStream) stream1.groupByKey(Grouped.with(mySerde, mySerde))).keySerde(), mySerde);
         assertEquals(((AbstractStream) stream1.groupByKey(Grouped.with(mySerde, mySerde))).valueSerde(), mySerde);
 
-        assertEquals(((AbstractStream) stream1.groupBy(selector)).keySerde(), null);
+        assertNull(((AbstractStream) stream1.groupBy(selector)).keySerde());
         assertEquals(((AbstractStream) stream1.groupBy(selector)).valueSerde(), consumedInternal.valueSerde());
         assertEquals(((AbstractStream) stream1.groupBy(selector, Grouped.with(mySerde, mySerde))).keySerde(), mySerde);
         assertEquals(((AbstractStream) stream1.groupBy(selector, Grouped.with(mySerde, mySerde))).valueSerde(), mySerde);
 
-        assertEquals(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde(), null);
-        assertEquals(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde());
+        assertNull(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde());
         assertEquals(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).keySerde(), mySerde);
         assertNull(((AbstractStream) stream1.join(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).valueSerde());
 
-        assertEquals(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde(), null);
-        assertEquals(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde());
+        assertNull(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde());
         assertEquals(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).keySerde(), mySerde);
         assertNull(((AbstractStream) stream1.leftJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).valueSerde());
 
-        assertEquals(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde(), null);
-        assertEquals(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).keySerde());
+        assertNull(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)))).valueSerde());
         assertEquals(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).keySerde(), mySerde);
         assertNull(((AbstractStream) stream1.outerJoin(stream1, joiner, JoinWindows.of(Duration.ofMillis(100L)), Joined.with(mySerde, mySerde, mySerde))).valueSerde());
 
         assertEquals(((AbstractStream) stream1.join(table1, joiner)).keySerde(), consumedInternal.keySerde());
-        assertEquals(((AbstractStream) stream1.join(table1, joiner)).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.join(table1, joiner)).valueSerde());
         assertEquals(((AbstractStream) stream1.join(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).keySerde(), mySerde);
-        assertEquals(((AbstractStream) stream1.join(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.join(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).valueSerde());
 
         assertEquals(((AbstractStream) stream1.leftJoin(table1, joiner)).keySerde(), consumedInternal.keySerde());
-        assertEquals(((AbstractStream) stream1.leftJoin(table1, joiner)).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.leftJoin(table1, joiner)).valueSerde());
         assertEquals(((AbstractStream) stream1.leftJoin(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).keySerde(), mySerde);
-        assertEquals(((AbstractStream) stream1.leftJoin(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.leftJoin(table1, joiner, Joined.with(mySerde, mySerde, mySerde))).valueSerde());
 
         assertEquals(((AbstractStream) stream1.join(table2, selector, joiner)).keySerde(), consumedInternal.keySerde());
-        assertEquals(((AbstractStream) stream1.join(table2, selector, joiner)).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.join(table2, selector, joiner)).valueSerde());
 
         assertEquals(((AbstractStream) stream1.leftJoin(table2, selector, joiner)).keySerde(), consumedInternal.keySerde());
-        assertEquals(((AbstractStream) stream1.leftJoin(table2, selector, joiner)).valueSerde(), null);
+        assertNull(((AbstractStream) stream1.leftJoin(table2, selector, joiner)).valueSerde());
     }
 
     @Test
@@ -273,10 +274,10 @@ public class KStreamImplTest {
 
         final ProcessorTopology processorTopology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build(null);
         assertThat(processorTopology.source("topic-6").getTimestampExtractor(), instanceOf(FailOnInvalidTimestamp.class));
-        assertEquals(processorTopology.source("topic-4").getTimestampExtractor(), null);
-        assertEquals(processorTopology.source("topic-3").getTimestampExtractor(), null);
-        assertEquals(processorTopology.source("topic-2").getTimestampExtractor(), null);
-        assertEquals(processorTopology.source("topic-1").getTimestampExtractor(), null);
+        assertNull(processorTopology.source("topic-4").getTimestampExtractor());
+        assertNull(processorTopology.source("topic-3").getTimestampExtractor());
+        assertNull(processorTopology.source("topic-2").getTimestampExtractor());
+        assertNull(processorTopology.source("topic-1").getTimestampExtractor());
     }
 
     @Test
@@ -289,7 +290,7 @@ public class KStreamImplTest {
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(input, "a", "b"));
         }
-        assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList("a:b")));
+        assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList("a:b (ts: 0)")));
     }
 
     @Test
@@ -303,7 +304,7 @@ public class KStreamImplTest {
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(input, "e", "f"));
         }
-        assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList("e:f")));
+        assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList("e:f (ts: 0)")));
     }
 
     @Test
@@ -322,8 +323,8 @@ public class KStreamImplTest {
             driver.pipeInput(recordFactory.create(input, "b", "v1"));
         }
         final List<MockProcessor<String, String>> mockProcessors = processorSupplier.capturedProcessors(2);
-        assertThat(mockProcessors.get(0).processed, equalTo(asList("a:v1", "a:v2")));
-        assertThat(mockProcessors.get(1).processed, equalTo(Collections.singletonList("b:v1")));
+        assertThat(mockProcessors.get(0).processed, equalTo(asList("a:v1 (ts: 0)", "a:v2 (ts: 0)")));
+        assertThat(mockProcessors.get(1).processed, equalTo(Collections.singletonList("b:v1 (ts: 0)")));
     }
 
     @SuppressWarnings("deprecation") // specifically testing the deprecated variant
@@ -334,12 +335,7 @@ public class KStreamImplTest {
         final ValueJoiner<String, String, String> valueJoiner = MockValueJoiner.instance(":");
         final long windowSize = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS);
         final KStream<String, String> stream = kStream
-            .map(new KeyValueMapper<String, String, KeyValue<? extends String, ? extends String>>() {
-                @Override
-                public KeyValue<? extends String, ? extends String> apply(final String key, final String value) {
-                    return KeyValue.pair(value, value);
-                }
-            });
+            .map((key, value) -> KeyValue.pair(value, value));
         stream.join(kStream,
                     valueJoiner,
                     JoinWindows.of(ofMillis(windowSize)).grace(ofMillis(3 * windowSize)),
@@ -368,12 +364,7 @@ public class KStreamImplTest {
         final ValueJoiner<String, String, String> valueJoiner = MockValueJoiner.instance(":");
         final long windowSize = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS);
         final KStream<String, String> stream = kStream
-            .map(new KeyValueMapper<String, String, KeyValue<? extends String, ? extends String>>() {
-                @Override
-                public KeyValue<? extends String, ? extends String> apply(final String key, final String value) {
-                    return KeyValue.pair(value, value);
-                }
-            });
+            .map((key, value) -> KeyValue.pair(value, value));
         stream.join(
             kStream,
             valueJoiner,
@@ -559,7 +550,7 @@ public class KStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullTableOnJoinWithGlobalTable() {
         testStream.join((GlobalKTable) null,
-                        MockMapper.<String, String>selectValueMapper(),
+                        MockMapper.selectValueMapper(),
                         MockValueJoiner.TOSTRING_JOINER);
     }
 
@@ -573,14 +564,14 @@ public class KStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullJoinerOnJoinWithGlobalTable() {
         testStream.join(builder.globalTable("global", stringConsumed),
-                        MockMapper.<String, String>selectValueMapper(),
+                        MockMapper.selectValueMapper(),
                         null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullTableOnJLeftJoinWithGlobalTable() {
         testStream.leftJoin((GlobalKTable) null,
-                        MockMapper.<String, String>selectValueMapper(),
+                        MockMapper.selectValueMapper(),
                         MockValueJoiner.TOSTRING_JOINER);
     }
 
@@ -594,7 +585,7 @@ public class KStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTable() {
         testStream.leftJoin(builder.globalTable("global", stringConsumed),
-                        MockMapper.<String, String>selectValueMapper(),
+                        MockMapper.selectValueMapper(),
                         null);
     }
 
@@ -667,7 +658,7 @@ public class KStreamImplTest {
             driver.pipeInput(recordFactory.create(topic1, "D", "dd"));
         }
 
-        assertEquals(asList("A:aa", "B:bb", "C:cc", "D:dd"), processorSupplier.theCapturedProcessor().processed);
+        assertEquals(asList("A:aa (ts: 0)", "B:bb (ts: 0)", "C:cc (ts: 0)", "D:dd (ts: 0)"), processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test
@@ -696,7 +687,7 @@ public class KStreamImplTest {
             driver.pipeInput(recordFactory.create(topic1, "H", "hh"));
         }
 
-        assertEquals(asList("A:aa", "B:bb", "C:cc", "D:dd", "E:ee", "F:ff", "G:gg", "H:hh"),
+        assertEquals(asList("A:aa (ts: 0)", "B:bb (ts: 0)", "C:cc (ts: 0)", "D:dd (ts: 0)", "E:ee (ts: 0)", "F:ff (ts: 0)", "G:gg (ts: 0)", "H:hh (ts: 0)"),
                      processorSupplier.theCapturedProcessor().processed);
     }
 
@@ -714,7 +705,7 @@ public class KStreamImplTest {
             driver.pipeInput(recordFactory.create("topic-7", "E", "ee"));
         }
 
-        assertEquals(asList("A:aa", "B:bb", "C:cc", "D:dd", "E:ee"),
+        assertEquals(asList("A:aa (ts: 0)", "B:bb (ts: 0)", "C:cc (ts: 0)", "D:dd (ts: 0)", "E:ee (ts: 0)"),
                 processorSupplier.theCapturedProcessor().processed);
     }
 
@@ -737,7 +728,7 @@ public class KStreamImplTest {
             driver.pipeInput(recordFactory.create(topic3, "E", "ee"));
         }
 
-        assertEquals(asList("A:aa", "B:bb", "C:cc", "D:dd", "E:ee"),
+        assertEquals(asList("A:aa (ts: 0)", "B:bb (ts: 0)", "C:cc (ts: 0)", "D:dd (ts: 0)", "E:ee (ts: 0)"),
                 processorSupplier.theCapturedProcessor().processed);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -43,12 +43,12 @@ import static java.time.Duration.ofMillis;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamKStreamLeftJoinTest {
-
     final private String topic1 = "topic1";
     final private String topic2 = "topic2";
 
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<Integer, String> recordFactory =
+        new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @Test
@@ -64,19 +64,20 @@ public class KStreamKStreamLeftJoinTest {
         stream1 = builder.stream(topic1, consumed);
         stream2 = builder.stream(topic2, consumed);
 
-        joined = stream1.leftJoin(stream2,
-                                  MockValueJoiner.TOSTRING_JOINER,
-                                  JoinWindows.of(ofMillis(100)),
-                                  Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+        joined = stream1.leftJoin(
+            stream2,
+            MockValueJoiner.TOSTRING_JOINER,
+            JoinWindows.of(ofMillis(100)),
+            Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
         joined.process(supplier);
 
-        final Collection<Set<String>> copartitionGroups = TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
-
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final MockProcessor<Integer, String> processor = supplier.theCapturedProcessor();
 
             // push two items to the primary stream. the other window is empty
@@ -84,56 +85,50 @@ public class KStreamKStreamLeftJoinTest {
             // w2 {}
             // --> w1 = { 0:X0, 1:X1 }
             // --> w2 = {}
-
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i]));
             }
-            processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
+            processor.checkAndClearProcessResult("0:X0+null (ts: 0)", "1:X1+null (ts: 0)");
 
             // push two items to the other stream. this should produce two items.
             // w1 = { 0:X0, 1:X1 }
             // w2 {}
             // --> w1 = { 0:X0, 1:X1 }
             // --> w2 = { 0:Y0, 1:Y1 }
-
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], "Y" + expectedKeys[i]));
             }
-
-            processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1");
+            processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)");
 
             // push three items to the primary stream. this should produce four items.
             // w1 = { 0:X0, 1:X1 }
             // w2 = { 0:Y0, 1:Y1 }
             // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
             // --> w2 = { 0:Y0, 1:Y1 }
-
             for (int i = 0; i < 3; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i]));
             }
-            processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1", "2:X2+null");
+            processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)", "2:X2+null (ts: 0)");
 
             // push all items to the other stream. this should produce 5 items
             // w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
             // w2 = { 0:Y0, 1:Y1 }
             // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
             // --> w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
-
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKey, "YY" + expectedKey));
             }
-            processor.checkAndClearProcessResult("0:X0+YY0", "0:X0+YY0", "1:X1+YY1", "1:X1+YY1", "2:X2+YY2");
+            processor.checkAndClearProcessResult("0:X0+YY0 (ts: 0)", "0:X0+YY0 (ts: 0)", "1:X1+YY1 (ts: 0)", "1:X1+YY1 (ts: 0)", "2:X2+YY2 (ts: 0)");
 
             // push all four items to the primary stream. this should produce six items.
             // w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
             // w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
             // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2, 0:XX0, 1:XX1, 2:XX2, 3:XX3 }
             // --> w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
-
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "0:XX0+YY0", "1:XX1+Y1", "1:XX1+YY1", "2:XX2+YY2", "3:XX3+YY3");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 0)", "0:XX0+YY0 (ts: 0)", "1:XX1+Y1 (ts: 0)", "1:XX1+YY1 (ts: 0)", "2:XX2+YY2 (ts: 0)", "3:XX3+YY3 (ts: 0)");
         }
     }
 
@@ -141,7 +136,6 @@ public class KStreamKStreamLeftJoinTest {
     public void testWindowing() {
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
-        long time = 0L;
 
         final KStream<Integer, String> stream1;
         final KStream<Integer, String> stream2;
@@ -150,42 +144,42 @@ public class KStreamKStreamLeftJoinTest {
         stream1 = builder.stream(topic1, consumed);
         stream2 = builder.stream(topic2, consumed);
 
-        joined = stream1.leftJoin(stream2,
-                                  MockValueJoiner.TOSTRING_JOINER,
-                                  JoinWindows.of(ofMillis(100)),
-                                  Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+        joined = stream1.leftJoin(
+            stream2,
+            MockValueJoiner.TOSTRING_JOINER,
+            JoinWindows.of(ofMillis(100)),
+            Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
         joined.process(supplier);
 
-        final Collection<Set<String>> copartitionGroups = TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, time)) {
-
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final MockProcessor<Integer, String> processor = supplier.theCapturedProcessor();
+            long time = 0L;
 
             // push two items to the primary stream. the other window is empty. this should produce two items
             // w1 = {}
             // w2 = {}
             // --> w1 = { 0:X0, 1:X1 }
             // --> w2 = {}
-
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i], time));
             }
-            processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
+            processor.checkAndClearProcessResult("0:X0+null (ts: 0)", "1:X1+null (ts: 0)");
 
             // push two items to the other stream. this should produce no items.
             // w1 = { 0:X0, 1:X1 }
             // w2 = {}
             // --> w1 = { 0:X0, 1:X1 }
             // --> w2 = { 0:Y0, 1:Y1 }
-
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], "Y" + expectedKeys[i], time));
             }
-            processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1");
+            processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)");
 
             // clear logically
             time = 1000L;
@@ -205,36 +199,35 @@ public class KStreamKStreamLeftJoinTest {
             // w2 = {}
             // --> w1 = {}
             // --> w2 = { 0:Y0, 1:Y1, 2:Y2, 3:Y3 }
-
             time = 1000L + 100L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 1100)", "1:XX1+Y1 (ts: 1100)", "2:XX2+Y2 (ts: 1100)", "3:XX3+Y3 (ts: 1100)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+            processor.checkAndClearProcessResult("0:XX0+null (ts: 1101)", "1:XX1+Y1 (ts: 1101)", "2:XX2+Y2 (ts: 1101)", "3:XX3+Y3 (ts: 1101)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+Y2", "3:XX3+Y3");
+            processor.checkAndClearProcessResult("0:XX0+null (ts: 1102)", "1:XX1+null (ts: 1102)", "2:XX2+Y2 (ts: 1102)", "3:XX3+Y3 (ts: 1102)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+Y3");
+            processor.checkAndClearProcessResult("0:XX0+null (ts: 1103)", "1:XX1+null (ts: 1103)", "2:XX2+null (ts: 1103)", "3:XX3+Y3 (ts: 1103)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+            processor.checkAndClearProcessResult("0:XX0+null (ts: 1104)", "1:XX1+null (ts: 1104)", "2:XX2+null (ts: 1104)", "3:XX3+null (ts: 1104)");
 
             // go back to the time before expiration
 
@@ -242,31 +235,31 @@ public class KStreamKStreamLeftJoinTest {
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+            processor.checkAndClearProcessResult("0:XX0+null (ts: 899)", "1:XX1+null (ts: 899)", "2:XX2+null (ts: 899)", "3:XX3+null (ts: 899)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 900)", "1:XX1+null (ts: 900)", "2:XX2+null (ts: 900)", "3:XX3+null (ts: 900)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+null", "3:XX3+null");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 901)", "1:XX1+Y1 (ts: 901)", "2:XX2+null (ts: 901)", "3:XX3+null (ts: 901)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+null");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 902)", "1:XX1+Y1 (ts: 902)", "2:XX2+Y2 (ts: 902)", "3:XX3+null (ts: 902)");
 
             time += 1L;
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey, time));
             }
-            processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+            processor.checkAndClearProcessResult("0:XX0+Y0 (ts: 903)", "1:XX1+Y1 (ts: 903)", "2:XX2+Y2 (ts: 903)", "3:XX3+Y3 (ts: 903)");
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -43,11 +43,11 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamKTableLeftJoinTest {
-
     final private String streamTopic = "streamTopic";
     final private String tableTopic = "tableTopic";
 
-    private final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<Integer, String> recordFactory =
+        new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer(), 0L);
     private TopologyTestDriver driver;
     private MockProcessor<Integer, String> processor;
 
@@ -57,7 +57,6 @@ public class KStreamKTableLeftJoinTest {
     @Before
     public void setUp() {
         builder = new StreamsBuilder();
-
 
         final KStream<Integer, String> stream;
         final KTable<Integer, String> table;
@@ -69,7 +68,7 @@ public class KStreamKTableLeftJoinTest {
         stream.leftJoin(table, MockValueJoiner.TOSTRING_JOINER).process(supplier);
 
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
-        driver = new TopologyTestDriver(builder.build(), props, 0L);
+        driver = new TopologyTestDriver(builder.build(), props);
 
         processor = supplier.theCapturedProcessor();
     }
@@ -93,14 +92,14 @@ public class KStreamKTableLeftJoinTest {
 
     private void pushNullValueToTable(final int messageCount) {
         for (int i = 0; i < messageCount; i++) {
-            driver.pipeInput(recordFactory.create(tableTopic, expectedKeys[i], (String) null));
+            driver.pipeInput(recordFactory.create(tableTopic, expectedKeys[i], null));
         }
     }
 
     @Test
     public void shouldRequireCopartitionedStreams() {
-
-        final Collection<Set<String>> copartitionGroups = TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(streamTopic, tableTopic)), copartitionGroups.iterator().next());
@@ -108,84 +107,67 @@ public class KStreamKTableLeftJoinTest {
 
     @Test
     public void shouldJoinWithEmptyTableOnStreamUpdates() {
-
         // push two items to the primary stream. the table is empty
-
         pushToStream(2, "X");
-        processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
+        processor.checkAndClearProcessResult("0:X0+null (ts: 0)", "1:X1+null (ts: 0)");
     }
 
     @Test
     public void shouldNotJoinOnTableUpdates() {
-
         // push two items to the primary stream. the table is empty
-
         pushToStream(2, "X");
-        processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
+        processor.checkAndClearProcessResult("0:X0+null (ts: 0)", "1:X1+null (ts: 0)");
 
         // push two items to the table. this should not produce any item.
-
         pushToTable(2, "Y");
         processor.checkAndClearProcessResult();
 
         // push all four items to the primary stream. this should produce four items.
-
         pushToStream(4, "X");
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1", "2:X2+null", "3:X3+null");
+        processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)", "2:X2+null (ts: 0)", "3:X3+null (ts: 0)");
 
         // push all items to the table. this should not produce any item
-
         pushToTable(4, "YY");
         processor.checkAndClearProcessResult();
 
         // push all four items to the primary stream. this should produce four items.
-
         pushToStream(4, "X");
-        processor.checkAndClearProcessResult("0:X0+YY0", "1:X1+YY1", "2:X2+YY2", "3:X3+YY3");
+        processor.checkAndClearProcessResult("0:X0+YY0 (ts: 0)", "1:X1+YY1 (ts: 0)", "2:X2+YY2 (ts: 0)", "3:X3+YY3 (ts: 0)");
 
         // push all items to the table. this should not produce any item
-
         pushToTable(4, "YYY");
         processor.checkAndClearProcessResult();
     }
 
     @Test
     public void shouldJoinRegardlessIfMatchFoundOnStreamUpdates() {
-
         // push two items to the table. this should not produce any item.
-
         pushToTable(2, "Y");
         processor.checkAndClearProcessResult();
 
         // push all four items to the primary stream. this should produce four items.
-
         pushToStream(4, "X");
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1", "2:X2+null", "3:X3+null");
+        processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)", "2:X2+null (ts: 0)", "3:X3+null (ts: 0)");
 
     }
 
     @Test
     public void shouldClearTableEntryOnNullValueUpdates() {
-
         // push all four items to the table. this should not produce any item.
-
         pushToTable(4, "Y");
         processor.checkAndClearProcessResult();
 
         // push all four items to the primary stream. this should produce four items.
-
         pushToStream(4, "X");
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1", "2:X2+Y2", "3:X3+Y3");
+        processor.checkAndClearProcessResult("0:X0+Y0 (ts: 0)", "1:X1+Y1 (ts: 0)", "2:X2+Y2 (ts: 0)", "3:X3+Y3 (ts: 0)");
 
         // push two items with null to the table as deletes. this should not produce any item.
-
         pushNullValueToTable(2);
         processor.checkAndClearProcessResult();
 
         // push all four items to the primary stream. this should produce four items.
-
         pushToStream(4, "XX");
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+Y2", "3:XX3+Y3");
+        processor.checkAndClearProcessResult("0:XX0+null (ts: 0)", "1:XX1+null (ts: 0)", "2:XX2+Y2 (ts: 0)", "3:XX3+Y3 (ts: 0)");
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamMapTest.java
@@ -34,14 +34,14 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamMapTest {
-
-    private String topicName = "topic";
-    private final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<Integer, String> recordFactory =
+        new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
     @Test
     public void testMap() {
         final StreamsBuilder builder = new StreamsBuilder();
+        final String topicName = "topic";
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
 
         final MockProcessorSupplier<String, Integer> supplier = new MockProcessorSupplier<>();
@@ -54,10 +54,8 @@ public class KStreamMapTest {
             }
         }
 
+        final String[] expected = new String[]{"V0:0 (ts: 0)", "V1:1 (ts: 0)", "V2:2 (ts: 0)", "V3:3 (ts: 0)"};
         assertEquals(4, supplier.theCapturedProcessor().processed.size());
-
-        final String[] expected = new String[]{"V0:0", "V1:1", "V2:2", "V3:3"};
-
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed.get(i));
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSelectKeyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSelectKeyTest.java
@@ -19,12 +19,10 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -37,10 +35,9 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamSelectKeyTest {
-
-    private String topicName = "topic_key_select";
-
-    private final ConsumerRecordFactory<String, Integer> recordFactory = new ConsumerRecordFactory<>(topicName, new StringSerializer(), new IntegerSerializer());
+    private final String topicName = "topic_key_select";
+    private final ConsumerRecordFactory<String, Integer> recordFactory =
+        new ConsumerRecordFactory<>(topicName, new StringSerializer(), new IntegerSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
 
     @Test
@@ -52,22 +49,13 @@ public class KStreamSelectKeyTest {
         keyMap.put(2, "TWO");
         keyMap.put(3, "THREE");
 
-
-        final KeyValueMapper<Object, Number, String> selector = new KeyValueMapper<Object, Number, String>() {
-            @Override
-            public String apply(final Object key, final Number value) {
-                return keyMap.get(value);
-            }
-        };
-
-        final String[] expected = new String[]{"ONE:1", "TWO:2", "THREE:3"};
+        final String[] expected = new String[]{"ONE:1 (ts: 0)", "TWO:2 (ts: 0)", "THREE:3 (ts: 0)"};
         final int[] expectedValues = new int[]{1, 2, 3};
 
-        final KStream<String, Integer>  stream = builder.stream(topicName, Consumed.with(Serdes.String(), Serdes.Integer()));
-
+        final KStream<String, Integer>  stream =
+            builder.stream(topicName, Consumed.with(Serdes.String(), Serdes.Integer()));
         final MockProcessorSupplier<String, Integer> supplier = new MockProcessorSupplier<>();
-
-        stream.selectKey(selector).process(supplier);
+        stream.selectKey((key, value) -> keyMap.get(value)).process(supplier);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             for (final int expectedValue : expectedValues) {
@@ -76,7 +64,6 @@ public class KStreamSelectKeyTest {
         }
 
         assertEquals(3, supplier.theCapturedProcessor().processed.size());
-
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed.get(i));
         }
@@ -85,13 +72,8 @@ public class KStreamSelectKeyTest {
 
     @Test
     public void testTypeVariance() {
-        final ForeachAction<Number, Object> consume = new ForeachAction<Number, Object>() {
-            @Override
-            public void apply(final Number key, final Object value) {}
-        };
-
         new StreamsBuilder()
             .<Integer, String>stream("empty")
-            .foreach(consume);
+            .foreach((key, value) -> { });
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -61,8 +61,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamWindowAggregateTest {
-
-    private final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<String, String> recordFactory =
+        new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @Test
@@ -79,7 +79,7 @@ public class KStreamWindowAggregateTest {
         final MockProcessorSupplier<Windowed<String>, String> supplier = new MockProcessorSupplier<>();
         table2.toStream().process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic1, "A", "1", 0L));
             driver.pipeInput(recordFactory.create(topic1, "B", "2", 1L));
             driver.pipeInput(recordFactory.create(topic1, "C", "3", 2L));
@@ -100,23 +100,23 @@ public class KStreamWindowAggregateTest {
 
         assertEquals(
             asList(
-                "[A@0/10]:0+1",
-                "[B@0/10]:0+2",
-                "[C@0/10]:0+3",
-                "[D@0/10]:0+4",
-                "[A@0/10]:0+1+1",
+                "[A@0/10]:0+1 (ts: 0)",
+                "[B@0/10]:0+2 (ts: 1)",
+                "[C@0/10]:0+3 (ts: 2)",
+                "[D@0/10]:0+4 (ts: 3)",
+                "[A@0/10]:0+1+1 (ts: 4)",
 
-                "[A@0/10]:0+1+1+1", "[A@5/15]:0+1",
-                "[B@0/10]:0+2+2", "[B@5/15]:0+2",
-                "[D@0/10]:0+4+4", "[D@5/15]:0+4",
-                "[B@0/10]:0+2+2+2", "[B@5/15]:0+2+2",
-                "[C@0/10]:0+3+3", "[C@5/15]:0+3",
+                "[A@0/10]:0+1+1+1 (ts: 5)", "[A@5/15]:0+1 (ts: 5)",
+                "[B@0/10]:0+2+2 (ts: 6)", "[B@5/15]:0+2 (ts: 6)",
+                "[D@0/10]:0+4+4 (ts: 7)", "[D@5/15]:0+4 (ts: 7)",
+                "[B@0/10]:0+2+2+2 (ts: 8)", "[B@5/15]:0+2+2 (ts: 8)",
+                "[C@0/10]:0+3+3 (ts: 9)", "[C@5/15]:0+3 (ts: 9)",
 
-                "[A@5/15]:0+1+1", "[A@10/20]:0+1",
-                "[B@5/15]:0+2+2+2", "[B@10/20]:0+2",
-                "[D@5/15]:0+4+4", "[D@10/20]:0+4",
-                "[B@5/15]:0+2+2+2+2", "[B@10/20]:0+2+2",
-                "[C@5/15]:0+3+3", "[C@10/20]:0+3"
+                "[A@5/15]:0+1+1 (ts: 10)", "[A@10/20]:0+1 (ts: 10)",
+                "[B@5/15]:0+2+2+2 (ts: 11)", "[B@10/20]:0+2 (ts: 11)",
+                "[D@5/15]:0+4+4 (ts: 12)", "[D@10/20]:0+4 (ts: 12)",
+                "[B@5/15]:0+2+2+2+2 (ts: 13)", "[B@10/20]:0+2+2 (ts: 13)",
+                "[C@5/15]:0+3+3 (ts: 14)", "[C@10/20]:0+3 (ts: 14)"
             ),
             supplier.theCapturedProcessor().processed
         );
@@ -142,13 +142,11 @@ public class KStreamWindowAggregateTest {
             .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
             .windowedBy(TimeWindows.of(ofMillis(10)).advanceBy(ofMillis(5)))
             .aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, Materialized.<String, String, WindowStore<Bytes, byte[]>>as("topic2-Canonized").withValueSerde(Serdes.String()));
-
         table2.toStream().process(supplier);
-
 
         table1.join(table2, (p1, p2) -> p1 + "%" + p2).toStream().process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic1, "A", "1", 0L));
             driver.pipeInput(recordFactory.create(topic1, "B", "2", 1L));
             driver.pipeInput(recordFactory.create(topic1, "C", "3", 2L));
@@ -158,11 +156,11 @@ public class KStreamWindowAggregateTest {
             final List<MockProcessor<Windowed<String>, String>> processors = supplier.capturedProcessors(3);
 
             processors.get(0).checkAndClearProcessResult(
-                "[A@0/10]:0+1",
-                "[B@0/10]:0+2",
-                "[C@0/10]:0+3",
-                "[D@0/10]:0+4",
-                "[A@0/10]:0+1+1"
+                "[A@0/10]:0+1 (ts: 0)",
+                "[B@0/10]:0+2 (ts: 1)",
+                "[C@0/10]:0+3 (ts: 2)",
+                "[D@0/10]:0+4 (ts: 3)",
+                "[A@0/10]:0+1+1 (ts: 4)"
             );
             processors.get(1).checkAndClearProcessResult();
             processors.get(2).checkAndClearProcessResult();
@@ -174,11 +172,11 @@ public class KStreamWindowAggregateTest {
             driver.pipeInput(recordFactory.create(topic1, "C", "3", 9L));
 
             processors.get(0).checkAndClearProcessResult(
-                "[A@0/10]:0+1+1+1", "[A@5/15]:0+1",
-                "[B@0/10]:0+2+2", "[B@5/15]:0+2",
-                "[D@0/10]:0+4+4", "[D@5/15]:0+4",
-                "[B@0/10]:0+2+2+2", "[B@5/15]:0+2+2",
-                "[C@0/10]:0+3+3", "[C@5/15]:0+3"
+                "[A@0/10]:0+1+1+1 (ts: 5)", "[A@5/15]:0+1 (ts: 5)",
+                "[B@0/10]:0+2+2 (ts: 6)", "[B@5/15]:0+2 (ts: 6)",
+                "[D@0/10]:0+4+4 (ts: 7)", "[D@5/15]:0+4 (ts: 7)",
+                "[B@0/10]:0+2+2+2 (ts: 8)", "[B@5/15]:0+2+2 (ts: 8)",
+                "[C@0/10]:0+3+3 (ts: 9)", "[C@5/15]:0+3 (ts: 9)"
             );
             processors.get(1).checkAndClearProcessResult();
             processors.get(2).checkAndClearProcessResult();
@@ -191,18 +189,18 @@ public class KStreamWindowAggregateTest {
 
             processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
-                "[A@0/10]:0+a",
-                "[B@0/10]:0+b",
-                "[C@0/10]:0+c",
-                "[D@0/10]:0+d",
-                "[A@0/10]:0+a+a"
+                "[A@0/10]:0+a (ts: 0)",
+                "[B@0/10]:0+b (ts: 1)",
+                "[C@0/10]:0+c (ts: 2)",
+                "[D@0/10]:0+d (ts: 3)",
+                "[A@0/10]:0+a+a (ts: 4)"
             );
             processors.get(2).checkAndClearProcessResult(
-                "[A@0/10]:0+1+1+1%0+a",
-                "[B@0/10]:0+2+2+2%0+b",
-                "[C@0/10]:0+3+3%0+c",
-                "[D@0/10]:0+4+4%0+d",
-                "[A@0/10]:0+1+1+1%0+a+a");
+                "[A@0/10]:0+1+1+1%0+a (ts: 0)",
+                "[B@0/10]:0+2+2+2%0+b (ts: 1)",
+                "[C@0/10]:0+3+3%0+c (ts: 2)",
+                "[D@0/10]:0+4+4%0+d (ts: 3)",
+                "[A@0/10]:0+1+1+1%0+a+a (ts: 4)");
 
             driver.pipeInput(recordFactory.create(topic2, "A", "a", 5L));
             driver.pipeInput(recordFactory.create(topic2, "B", "b", 6L));
@@ -212,18 +210,18 @@ public class KStreamWindowAggregateTest {
 
             processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
-                "[A@0/10]:0+a+a+a", "[A@5/15]:0+a",
-                "[B@0/10]:0+b+b", "[B@5/15]:0+b",
-                "[D@0/10]:0+d+d", "[D@5/15]:0+d",
-                "[B@0/10]:0+b+b+b", "[B@5/15]:0+b+b",
-                "[C@0/10]:0+c+c", "[C@5/15]:0+c"
+                "[A@0/10]:0+a+a+a (ts: 5)", "[A@5/15]:0+a (ts: 5)",
+                "[B@0/10]:0+b+b (ts: 6)", "[B@5/15]:0+b (ts: 6)",
+                "[D@0/10]:0+d+d (ts: 7)", "[D@5/15]:0+d (ts: 7)",
+                "[B@0/10]:0+b+b+b (ts: 8)", "[B@5/15]:0+b+b (ts: 8)",
+                "[C@0/10]:0+c+c (ts: 9)", "[C@5/15]:0+c (ts: 9)"
             );
             processors.get(2).checkAndClearProcessResult(
-                "[A@0/10]:0+1+1+1%0+a+a+a", "[A@5/15]:0+1%0+a",
-                "[B@0/10]:0+2+2+2%0+b+b", "[B@5/15]:0+2+2%0+b",
-                "[D@0/10]:0+4+4%0+d+d", "[D@5/15]:0+4%0+d",
-                "[B@0/10]:0+2+2+2%0+b+b+b", "[B@5/15]:0+2+2%0+b+b",
-                "[C@0/10]:0+3+3%0+c+c", "[C@5/15]:0+3%0+c"
+                "[A@0/10]:0+1+1+1%0+a+a+a (ts: 5)", "[A@5/15]:0+1%0+a (ts: 5)",
+                "[B@0/10]:0+2+2+2%0+b+b (ts: 6)", "[B@5/15]:0+2+2%0+b (ts: 6)",
+                "[D@0/10]:0+4+4%0+d+d (ts: 7)", "[D@5/15]:0+4%0+d (ts: 7)",
+                "[B@0/10]:0+2+2+2%0+b+b+b (ts: 8)", "[B@5/15]:0+2+2%0+b+b (ts: 8)",
+                "[C@0/10]:0+3+3%0+c+c (ts: 9)", "[C@5/15]:0+3%0+c (ts: 9)"
             );
         }
     }
@@ -244,7 +242,7 @@ public class KStreamWindowAggregateTest {
             );
 
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic, null, "1"));
             LogCaptureAppender.unregister(appender);
 
@@ -273,7 +271,7 @@ public class KStreamWindowAggregateTest {
 
         LogCaptureAppender.setClassLoggerToDebug(KStreamWindowAggregate.class);
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic, "k", "100", 100L));
             driver.pipeInput(recordFactory.create(topic, "k", "0", 0L));
             driver.pipeInput(recordFactory.create(topic, "k", "1", 1L));
@@ -328,7 +326,7 @@ public class KStreamWindowAggregateTest {
 
         LogCaptureAppender.setClassLoggerToDebug(KStreamWindowAggregate.class);
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             driver.pipeInput(recordFactory.create(topic, "k", "100", 200L));
             driver.pipeInput(recordFactory.create(topic, "k", "0", 100L));
             driver.pipeInput(recordFactory.create(topic, "k", "1", 101L));
@@ -370,9 +368,7 @@ public class KStreamWindowAggregateTest {
                 mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
         );
-
         assertThat(driver.metrics().get(dropMetric).metricValue(), dropTotal);
-
 
         final MetricName dropRate = new MetricName(
             "late-record-drop-rate",
@@ -384,7 +380,6 @@ public class KStreamWindowAggregateTest {
                 mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
         );
-
         assertThat(driver.metrics().get(dropRate).metricValue(), not(0.0));
 
         final MetricName latenessMaxMetric = new MetricName(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -47,7 +47,6 @@ import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("deprecation")
 public class KTableAggregateTest {
-
     private final Serde<String> stringSerde = Serdes.String();
     private final Consumed<String, String> consumed = Consumed.with(stringSerde, stringSerde);
     private final Grouped<String, String> stringSerialzied = Grouped.with(stringSerde, stringSerde);
@@ -105,14 +104,14 @@ public class KTableAggregateTest {
 
         assertEquals(
             asList(
-                "A:0+1",
-                "B:0+2",
-                "A:0+1-1+3",
-                "B:0+2-2+4",
-                "C:0+5",
-                "D:0+6",
-                "B:0+2-2+4-4+7",
-                "C:0+5-5+8"),
+                "A:0+1 (ts: 0)",
+                "B:0+2 (ts: 0)",
+                "A:0+1-1+3 (ts: 0)",
+                "B:0+2-2+4 (ts: 0)",
+                "C:0+5 (ts: 0)",
+                "D:0+6 (ts: 0)",
+                "B:0+2-2+4-4+7 (ts: 0)",
+                "C:0+5-5+8 (ts: 0)"),
             supplier.theCapturedProcessor().processed);
     }
 
@@ -142,9 +141,8 @@ public class KTableAggregateTest {
         driver.process(topic1, "A", "4");
         driver.flushState();
 
-        assertEquals(Collections.singletonList("A:0+4"), supplier.theCapturedProcessor().processed);
+        assertEquals(Collections.singletonList("A:0+4 (ts: 0)"), supplier.theCapturedProcessor().processed);
     }
-
 
     @Test
     public void testAggRepartition() {
@@ -195,14 +193,14 @@ public class KTableAggregateTest {
 
         assertEquals(
             asList(
-                "1:0+1",
-                "1:0+1-1",
-                "1:0+1-1+1",
-                "2:0+2",
+                "1:0+1 (ts: 0)",
+                "1:0+1-1 (ts: 0)",
+                "1:0+1-1+1 (ts: 0)",
+                "2:0+2 (ts: 0)",
                   //noop
-                "2:0+2-2", "4:0+4",
+                "2:0+2-2 (ts: 0)", "4:0+4 (ts: 0)",
                   //noop
-                "4:0+4-4", "7:0+7"),
+                "4:0+4-4 (ts: 0)", "7:0+7 (ts: 0)"),
             supplier.theCapturedProcessor().processed);
     }
 
@@ -225,11 +223,11 @@ public class KTableAggregateTest {
 
         assertEquals(
             asList(
-                "green:1",
-                "green:2",
-                "green:1", "blue:1",
-                "yellow:1",
-                "green:2"),
+                "green:1 (ts: 0)",
+                "green:2 (ts: 0)",
+                "green:1 (ts: 0)", "blue:1 (ts: 0)",
+                "yellow:1 (ts: 0)",
+                "green:2 (ts: 0)"),
             supplier.theCapturedProcessor().processed);
     }
 
@@ -289,9 +287,9 @@ public class KTableAggregateTest {
 
         assertEquals(
             asList(
-                "blue:1",
-                "yellow:1",
-                "green:2"),
+                "blue:1 (ts: 0)",
+                "yellow:1 (ts: 0)",
+                "green:2 (ts: 0)"),
             proc.processed);
     }
 
@@ -332,10 +330,10 @@ public class KTableAggregateTest {
 
         assertEquals(
             asList(
-                "1:1",
-                "1:12",
-                "1:2",
-                "1:2"),
+                "1:1 (ts: 0)",
+                "1:12 (ts: 0)",
+                "1:2 (ts: 0)",
+                "1:2 (ts: 0)"),
             proc.processed);
     }
 
@@ -379,5 +377,4 @@ public class KTableAggregateTest {
         driver.process("tableOne", "1", "5");
         assertEquals(Long.valueOf(4L), reduceResults.get("2"));
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -58,13 +58,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class KTableKTableLeftJoinTest {
-
     final private String topic1 = "topic1";
     final private String topic2 = "topic2";
     final private String output = "output";
 
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(Serdes.Integer().serializer(), Serdes.String().serializer());
+    private final ConsumerRecordFactory<Integer, String> recordFactory =
+        new ConsumerRecordFactory<>(Serdes.Integer().serializer(), Serdes.String().serializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
     @Test
@@ -78,13 +78,13 @@ public class KTableKTableLeftJoinTest {
         final KTable<Integer, String> joined = table1.leftJoin(table2, MockValueJoiner.TOSTRING_JOINER);
         joined.toStream().to(output);
 
-        final Collection<Set<String>> copartitionGroups = TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
-
             // push two items to the primary stream. the other table is empty
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i]));
@@ -174,7 +174,6 @@ public class KTableKTableLeftJoinTest {
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
-
             final MockProcessor<Integer, String> proc = supplier.theCapturedProcessor();
 
             assertTrue(((KTableImpl<?, ?, ?>) table1).sendingOldValueEnabled());
@@ -185,43 +184,43 @@ public class KTableKTableLeftJoinTest {
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i]));
             }
-            proc.checkAndClearProcessResult("0:(X0+null<-null)", "1:(X1+null<-null)");
+            proc.checkAndClearProcessResult("0:(X0+null<-null) (ts: 0)", "1:(X1+null<-null) (ts: 0)");
 
             // push two items to the other stream. this should produce two items.
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], "Y" + expectedKeys[i]));
             }
-            proc.checkAndClearProcessResult("0:(X0+Y0<-null)", "1:(X1+Y1<-null)");
+            proc.checkAndClearProcessResult("0:(X0+Y0<-null) (ts: 0)", "1:(X1+Y1<-null) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "X" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+Y0<-null)", "1:(X1+Y1<-null)", "2:(X2+null<-null)", "3:(X3+null<-null)");
+            proc.checkAndClearProcessResult("0:(X0+Y0<-null) (ts: 0)", "1:(X1+Y1<-null) (ts: 0)", "2:(X2+null<-null) (ts: 0)", "3:(X3+null<-null) (ts: 0)");
 
             // push all items to the other stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKey, "YY" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+YY0<-null)", "1:(X1+YY1<-null)", "2:(X2+YY2<-null)", "3:(X3+YY3<-null)");
+            proc.checkAndClearProcessResult("0:(X0+YY0<-null) (ts: 0)", "1:(X1+YY1<-null) (ts: 0)", "2:(X2+YY2<-null) (ts: 0)", "3:(X3+YY3<-null) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "X" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+YY0<-null)", "1:(X1+YY1<-null)", "2:(X2+YY2<-null)", "3:(X3+YY3<-null)");
+            proc.checkAndClearProcessResult("0:(X0+YY0<-null) (ts: 0)", "1:(X1+YY1<-null) (ts: 0)", "2:(X2+YY2<-null) (ts: 0)", "3:(X3+YY3<-null) (ts: 0)");
 
             // push two items with null to the other stream as deletes. this should produce two item.
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], null));
             }
-            proc.checkAndClearProcessResult("0:(X0+null<-null)", "1:(X1+null<-null)");
+            proc.checkAndClearProcessResult("0:(X0+null<-null) (ts: 0)", "1:(X1+null<-null) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(XX0+null<-null)", "1:(XX1+null<-null)", "2:(XX2+YY2<-null)", "3:(XX3+YY3<-null)");
+            proc.checkAndClearProcessResult("0:(XX0+null<-null) (ts: 0)", "1:(XX1+null<-null) (ts: 0)", "2:(XX2+YY2<-null) (ts: 0)", "3:(XX3+YY3<-null) (ts: 0)");
         }
     }
 
@@ -246,7 +245,6 @@ public class KTableKTableLeftJoinTest {
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
         try (final TopologyTestDriver driver = new TopologyTestDriverWrapper(topology, props)) {
-
             final MockProcessor<Integer, String> proc = supplier.theCapturedProcessor();
 
             assertTrue(((KTableImpl<?, ?, ?>) table1).sendingOldValueEnabled());
@@ -257,43 +255,43 @@ public class KTableKTableLeftJoinTest {
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKeys[i], "X" + expectedKeys[i]));
             }
-            proc.checkAndClearProcessResult("0:(X0+null<-null)", "1:(X1+null<-null)");
+            proc.checkAndClearProcessResult("0:(X0+null<-null) (ts: 0)", "1:(X1+null<-null) (ts: 0)");
 
             // push two items to the other stream. this should produce two items.
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], "Y" + expectedKeys[i]));
             }
-            proc.checkAndClearProcessResult("0:(X0+Y0<-X0+null)", "1:(X1+Y1<-X1+null)");
+            proc.checkAndClearProcessResult("0:(X0+Y0<-X0+null) (ts: 0)", "1:(X1+Y1<-X1+null) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "X" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+Y0<-X0+Y0)", "1:(X1+Y1<-X1+Y1)", "2:(X2+null<-null)", "3:(X3+null<-null)");
+            proc.checkAndClearProcessResult("0:(X0+Y0<-X0+Y0) (ts: 0)", "1:(X1+Y1<-X1+Y1) (ts: 0)", "2:(X2+null<-null) (ts: 0)", "3:(X3+null<-null) (ts: 0)");
 
             // push all items to the other stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKey, "YY" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+YY0<-X0+Y0)", "1:(X1+YY1<-X1+Y1)", "2:(X2+YY2<-X2+null)", "3:(X3+YY3<-X3+null)");
+            proc.checkAndClearProcessResult("0:(X0+YY0<-X0+Y0) (ts: 0)", "1:(X1+YY1<-X1+Y1) (ts: 0)", "2:(X2+YY2<-X2+null) (ts: 0)", "3:(X3+YY3<-X3+null) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "X" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(X0+YY0<-X0+YY0)", "1:(X1+YY1<-X1+YY1)", "2:(X2+YY2<-X2+YY2)", "3:(X3+YY3<-X3+YY3)");
+            proc.checkAndClearProcessResult("0:(X0+YY0<-X0+YY0) (ts: 0)", "1:(X1+YY1<-X1+YY1) (ts: 0)", "2:(X2+YY2<-X2+YY2) (ts: 0)", "3:(X3+YY3<-X3+YY3) (ts: 0)");
 
             // push two items with null to the other stream as deletes. this should produce two item.
             for (int i = 0; i < 2; i++) {
                 driver.pipeInput(recordFactory.create(topic2, expectedKeys[i], null));
             }
-            proc.checkAndClearProcessResult("0:(X0+null<-X0+YY0)", "1:(X1+null<-X1+YY1)");
+            proc.checkAndClearProcessResult("0:(X0+null<-X0+YY0) (ts: 0)", "1:(X1+null<-X1+YY1) (ts: 0)");
 
             // push all four items to the primary stream. this should produce four items.
             for (final int expectedKey : expectedKeys) {
                 driver.pipeInput(recordFactory.create(topic1, expectedKey, "XX" + expectedKey));
             }
-            proc.checkAndClearProcessResult("0:(XX0+null<-X0+null)", "1:(XX1+null<-X1+null)", "2:(XX2+YY2<-X2+YY2)", "3:(XX3+YY3<-X3+YY3)");
+            proc.checkAndClearProcessResult("0:(XX0+null<-X0+null) (ts: 0)", "1:(XX1+null<-X1+null) (ts: 0)", "2:(XX2+YY2<-X2+YY2) (ts: 0)", "3:(XX3+YY3<-X3+YY3) (ts: 0)");
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -25,7 +24,6 @@ import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -38,14 +36,13 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 
 public class KTableMapKeysTest {
-
-    private final ConsumerRecordFactory<Integer, String> recordFactory = new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer());
+    private final ConsumerRecordFactory<Integer, String> recordFactory =
+        new ConsumerRecordFactory<>(new IntegerSerializer(), new StringSerializer(), 0L);
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
     @Test
     public void testMapKeysConvertingToStream() {
         final StreamsBuilder builder = new StreamsBuilder();
-
         final String topic1 = "topic_map_keys";
 
         final KTable<Integer, String> table1 = builder.table(topic1, Consumed.with(Serdes.Integer(), Serdes.String()));
@@ -55,21 +52,13 @@ public class KTableMapKeysTest {
         keyMap.put(2, "TWO");
         keyMap.put(3, "THREE");
 
-        final KeyValueMapper<Integer, String, String> keyMapper = new KeyValueMapper<Integer, String, String>() {
-            @Override
-            public  String apply(final Integer key, final String value) {
-                return keyMap.get(key);
-            }
-        };
+        final KStream<String, String> convertedStream = table1.toStream((key, value) -> keyMap.get(key));
 
-        final KStream<String, String> convertedStream = table1.toStream(keyMapper);
-
-        final String[] expected = new String[]{"ONE:V_ONE", "TWO:V_TWO", "THREE:V_THREE"};
+        final String[] expected = new String[]{"ONE:V_ONE (ts: 0)", "TWO:V_TWO (ts: 0)", "THREE:V_THREE (ts: 0)"};
         final int[] originalKeys = new int[]{1, 2, 3};
         final String[] values = new String[]{"V_ONE", "V_TWO", "V_THREE"};
 
         final MockProcessorSupplier<String, String> supplier = new MockProcessorSupplier<>();
-
         convertedStream.process(supplier);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
@@ -79,7 +68,6 @@ public class KTableMapKeysTest {
         }
 
         assertEquals(3, supplier.theCapturedProcessor().processed.size());
-
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed.get(i));
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -76,7 +76,7 @@ public class KTableTransformValuesTest {
     private static final Consumed<String, String> CONSUMED = Consumed.with(Serdes.String(), Serdes.String());
 
     private final ConsumerRecordFactory<String, String> recordFactory =
-        new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+        new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer(), 0L);
 
     private TopologyTestDriver driver;
     private MockProcessorSupplier<String, String> capture;
@@ -325,11 +325,11 @@ public class KTableTransformValuesTest {
 
         driver = new TopologyTestDriver(builder.build(), props());
 
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "B", "b", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "D", (String) null, 0L));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "B", "b"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "D", (String) null));
 
-        assertThat(output(), hasItems("A:A->a!", "B:B->b!", "D:D->null!"));
+        assertThat(output(), hasItems("A:A->a! (ts: 0)", "B:B->b! (ts: 0)", "D:D->null! (ts: 0)"));
         assertNull("Store should not be materialized", driver.getKeyValueStore(QUERYABLE_NAME));
     }
 
@@ -349,11 +349,11 @@ public class KTableTransformValuesTest {
 
         driver = new TopologyTestDriver(builder.build(), props());
 
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "B", "b", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "C", (String) null, 0L));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "B", "b"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "C", (String) null));
 
-        assertThat(output(), hasItems("A:A->a!", "B:B->b!", "C:C->null!"));
+        assertThat(output(), hasItems("A:A->a! (ts: 0)", "B:B->b! (ts: 0)", "C:C->null! (ts: 0)"));
 
         final KeyValueStore<String, String> keyValueStore = driver.getKeyValueStore(QUERYABLE_NAME);
         assertThat(keyValueStore.get("A"), is("A->a!"));
@@ -378,11 +378,11 @@ public class KTableTransformValuesTest {
 
         driver = new TopologyTestDriver(builder.build(), props());
 
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignore", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignored", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignored", 0L));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignore"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignored"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "ignored"));
 
-        assertThat(output(), hasItems("A:1", "A:0", "A:2", "A:0", "A:3"));
+        assertThat(output(), hasItems("A:1 (ts: 0)", "A:0 (ts: 0)", "A:2 (ts: 0)", "A:0 (ts: 0)", "A:3 (ts: 0)"));
 
         final KeyValueStore<String, Integer> keyValueStore = driver.getKeyValueStore(QUERYABLE_NAME);
         assertThat(keyValueStore.get("A"), is(3));
@@ -401,11 +401,11 @@ public class KTableTransformValuesTest {
 
         driver = new TopologyTestDriver(builder.build(), props());
 
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "aa", 0L));
-        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "aaa", 0L));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "a"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "aa"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC, "A", "aaa"));
 
-        assertThat(output(), hasItems("A:1", "A:0", "A:2", "A:0", "A:3"));
+        assertThat(output(), hasItems("A:1 (ts: 0)", "A:0 (ts: 0)", "A:2 (ts: 0)", "A:0 (ts: 0)", "A:3 (ts: 0)"));
     }
 
     private ArrayList<String> output() {
@@ -480,8 +480,7 @@ public class KTableTransformValuesTest {
         }
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 
     private static class NullSupplier implements ValueTransformerWithKeySupplier<String, String, String> {
@@ -502,8 +501,7 @@ public class KTableTransformValuesTest {
         private int counter;
 
         @Override
-        public void init(final ProcessorContext context) {
-        }
+        public void init(final ProcessorContext context) {}
 
         @Override
         public Integer transform(final String readOnlyKey, final String value) {
@@ -511,8 +509,7 @@ public class KTableTransformValuesTest {
         }
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 
     private static class StatelessTransformerSupplier implements ValueTransformerWithKeySupplier<String, String, Integer> {
@@ -524,8 +521,7 @@ public class KTableTransformValuesTest {
 
     private static class StatelessTransformer implements ValueTransformerWithKey<String, String, Integer> {
         @Override
-        public void init(final ProcessorContext context) {
-        }
+        public void init(final ProcessorContext context) {}
 
         @Override
         public Integer transform(final String readOnlyKey, final String value) {
@@ -533,7 +529,6 @@ public class KTableTransformValuesTest {
         }
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
@@ -51,7 +51,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TimeWindowedKStreamImplTest {
-
     private static final String TOPIC = "input";
     private final StreamsBuilder builder = new StreamsBuilder();
     private final ConsumerRecordFactory<String, String> recordFactory =
@@ -75,14 +74,13 @@ public class TimeWindowedKStreamImplTest {
             .toStream()
             .foreach(results::put);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
         }
         assertThat(results.get(new Windowed<>("1", new TimeWindow(0, 500))), equalTo(2L));
         assertThat(results.get(new Windowed<>("2", new TimeWindow(500, 1000))), equalTo(1L));
         assertThat(results.get(new Windowed<>("1", new TimeWindow(500, 1000))), equalTo(1L));
     }
-
 
     @Test
     public void shouldReduceWindowed() {
@@ -92,7 +90,7 @@ public class TimeWindowedKStreamImplTest {
             .toStream()
             .foreach(results::put);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
         }
         assertThat(results.get(new Windowed<>("1", new TimeWindow(0, 500))), equalTo("1+2"));
@@ -111,7 +109,7 @@ public class TimeWindowedKStreamImplTest {
             .toStream()
             .foreach(results::put);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
         }
         assertThat(results.get(new Windowed<>("1", new TimeWindow(0, 500))), equalTo("0+1+2"));
@@ -126,7 +124,7 @@ public class TimeWindowedKStreamImplTest {
                 .withKeySerde(Serdes.String())
                 .withValueSerde(Serdes.Long()));
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
             final WindowStore<String, Long> windowStore = driver.getWindowStore("count-store");
             final List<KeyValue<Windowed<String>, Long>> data =
@@ -147,7 +145,7 @@ public class TimeWindowedKStreamImplTest {
                 .withKeySerde(Serdes.String())
                 .withValueSerde(Serdes.String()));
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
             final WindowStore<String, String> windowStore = driver.getWindowStore("reduced");
             final List<KeyValue<Windowed<String>, String>> data =
@@ -169,7 +167,7 @@ public class TimeWindowedKStreamImplTest {
                 .withKeySerde(Serdes.String())
                 .withValueSerde(Serdes.String()));
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             processData(driver);
             final WindowStore<String, String> windowStore = driver.getWindowStore("aggregated");
             final List<KeyValue<Windowed<String>, String>> data =

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
@@ -77,8 +77,11 @@ public class MockProcessor<K, V> extends AbstractProcessor<K, V> {
     public void process(final K key, final V value) {
         processedKeys.add(key);
         processedValues.add(value);
-        processed.add((key == null ? "null" : key) + ":" +
-                (value == null ? "null" : value));
+        processed.add(
+            (key == null ? "null" : key) +
+            ":" + (value == null ? "null" : value) +
+            " (ts: " + context().timestamp() + ")"
+        );
 
         if (commitRequested) {
             context().commit();


### PR DESCRIPTION
To enable proper testing of timestamp propagation in the DSL, this PR updates `MockProcessor` to capture the record timestamp.

All tests using `MockProcessor` need to be updated accordingly. This PR only sets most timestamps to zero for now. When we update the DSL semantics, those test will gradually be updated accordingly.

Some code cleanup on the side (Java8 rewrites, reformatting, getting rid of warnings.)