### PR TITLE
KAFKA-7652: Restrict range of fetch/findSessions in cache

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -36,7 +36,7 @@ import java.util.ArrayDeque;
  */
 public class RecordQueue {
 
-    static final long UNKNOWN = ConsumerRecord.NO_TIMESTAMP;
+    public static final long UNKNOWN = ConsumerRecord.NO_TIMESTAMP;
 
     private final Logger log;
     private final SourceNode source;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -323,6 +323,8 @@ class CachingSessionStore
             }
 
             setCacheKeyRange(currentSegmentBeginTime(), currentSegmentLastTime());
+
+            current.close();
             current = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -338,7 +338,7 @@ class CachingSessionStore
 
         private void setCacheKeyRange(final long lowerRangeEndTime, final long upperRangeEndTime) {
             if (cacheFunction.segmentId(lowerRangeEndTime) != cacheFunction.segmentId(upperRangeEndTime)) {
-                throw new IllegalStateException();
+                throw new IllegalStateException("Error iterating over segments: segment interval has changed");
             }
 
             if (keyFrom == keyTo) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.RecordQueue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 
@@ -49,7 +50,7 @@ class CachingSessionStore
         super(bytesStore);
         this.keySchema = new SessionKeySchema();
         this.cacheFunction = new SegmentedCacheFunction(keySchema, segmentInterval);
-        this.maxObservedTimestamp = -1;
+        this.maxObservedTimestamp = RecordQueue.UNKNOWN;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -142,7 +142,12 @@ class CachingSessionStore
                                                                   final long latestSessionStartTime) {
         validateStoreOpen();
 
-        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(key, earliestSessionEndTime, latestSessionStartTime);
+        final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
+            new CacheIteratorWrapper(key, earliestSessionEndTime, latestSessionStartTime) :
+            cache.range(cacheName,
+                        cacheFunction.cacheKey(keySchema.lowerRangeFixedSize(key, earliestSessionEndTime)),
+                        cacheFunction.cacheKey(keySchema.upperRangeFixedSize(key, latestSessionStartTime))
+            );
 
         final KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator = wrapped().findSessions(key,
                                                                                                earliestSessionEndTime,
@@ -163,7 +168,12 @@ class CachingSessionStore
                                                                   final long latestSessionStartTime) {
         validateStoreOpen();
 
-        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
+            new CacheIteratorWrapper(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime) :
+            cache.range(cacheName,
+                        cacheFunction.cacheKey(keySchema.lowerRange(keyFrom, earliestSessionEndTime)),
+                        cacheFunction.cacheKey(keySchema.upperRange(keyTo, latestSessionStartTime))
+            );
 
         final KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator = wrapped().findSessions(
             keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -168,12 +168,9 @@ class CachingSessionStore
                                                                   final long latestSessionStartTime) {
         validateStoreOpen();
 
-        final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
-            new CacheIteratorWrapper(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime) :
-            cache.range(cacheName,
-                        cacheFunction.cacheKey(keySchema.lowerRange(keyFrom, earliestSessionEndTime)),
-                        cacheFunction.cacheKey(keySchema.upperRange(keyTo, latestSessionStartTime))
-            );
+        final Bytes cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRange(keyFrom, earliestSessionEndTime));
+        final Bytes cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRange(keyTo, latestSessionStartTime));
+        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
 
         final KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator = wrapped().findSessions(
             keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -16,8 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.NoSuchElementException;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -39,11 +42,14 @@ class CachingSessionStore
     private CacheFlushListener<byte[], byte[]> flushListener;
     private boolean sendOldValues;
 
+    private long maxObservedTimestamp; // Refers to the window end time (determines segmentId)
+
     CachingSessionStore(final SessionStore<Bytes, byte[]> bytesStore,
                         final long segmentInterval) {
         super(bytesStore);
         this.keySchema = new SessionKeySchema();
         this.cacheFunction = new SegmentedCacheFunction(keySchema, segmentInterval);
+        this.maxObservedTimestamp = -1;
     }
 
     @Override
@@ -119,6 +125,8 @@ class CachingSessionStore
                 context.partition(),
                 context.topic());
         cache.put(cacheName, cacheFunction.cacheKey(binaryKey), entry);
+
+        maxObservedTimestamp = Math.max(keySchema.segmentTimestamp(binaryKey), maxObservedTimestamp);
     }
 
     @Override
@@ -132,9 +140,8 @@ class CachingSessionStore
                                                                   final long earliestSessionEndTime,
                                                                   final long latestSessionStartTime) {
         validateStoreOpen();
-        final Bytes cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRangeFixedSize(key, earliestSessionEndTime));
-        final Bytes cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRangeFixedSize(key, latestSessionStartTime));
-        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
+
+        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(key, earliestSessionEndTime, latestSessionStartTime);
 
         final KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator = wrapped().findSessions(key,
                                                                                                earliestSessionEndTime,
@@ -155,9 +162,7 @@ class CachingSessionStore
                                                                   final long latestSessionStartTime) {
         validateStoreOpen();
 
-        final Bytes cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRange(keyFrom, earliestSessionEndTime));
-        final Bytes cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRange(keyTo, latestSessionStartTime));
-        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
+        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
 
         final KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator = wrapped().findSessions(
             keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime
@@ -212,5 +217,137 @@ class CachingSessionStore
         flush();
         cache.close(cacheName);
         super.close();
+    }
+
+    private class CacheIteratorWrapper implements PeekingKeyValueIterator<Bytes, LRUCacheEntry> {
+
+        private final long segmentInterval;
+
+        private final Bytes keyFrom;
+        private final Bytes keyTo;
+        private final long latestSessionStartTime;
+        private long lastSegmentId;
+
+        private long currentSegmentId;
+        private Bytes cacheKeyFrom;
+        private Bytes cacheKeyTo;
+
+        private ThreadCache.MemoryLRUCacheBytesIterator current;
+
+        private CacheIteratorWrapper(final Bytes key,
+                                     final long earliestSessionEndTime,
+                                     final long latestSessionStartTime) {
+            this(key, key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        private CacheIteratorWrapper(final Bytes keyFrom,
+                                     final Bytes keyTo,
+                                     final long earliestSessionEndTime,
+                                     final long latestSessionStartTime) {
+            this.keyFrom = keyFrom;
+            this.keyTo = keyTo;
+            this.latestSessionStartTime = latestSessionStartTime;
+            this.lastSegmentId = cacheFunction.segmentId(maxObservedTimestamp);
+            this.segmentInterval = cacheFunction.getSegmentInterval();
+
+            this.currentSegmentId = cacheFunction.segmentId(earliestSessionEndTime);
+
+            setCacheKeyRange(earliestSessionEndTime, currentSegmentLastTime());
+
+            this.current = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (current == null) {
+                return false;
+            }
+
+            if (current.hasNext()) {
+                return true;
+            }
+
+            while (!current.hasNext()) {
+                getNextSegmentIterator();
+                if (current == null) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public Bytes peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return current.peekNextKey();
+        }
+
+        @Override
+        public KeyValue<Bytes, LRUCacheEntry> peekNext() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return current.peekNext();
+        }
+
+        @Override
+        public KeyValue<Bytes, LRUCacheEntry> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return current.next();
+        }
+
+        @Override
+        public void close() {
+            current.close();
+        }
+
+        private long currentSegmentBeginTime() {
+            return currentSegmentId * segmentInterval;
+        }
+
+        private long currentSegmentLastTime() {
+            return currentSegmentBeginTime() + segmentInterval - 1;
+        }
+
+        private void getNextSegmentIterator() {
+            ++currentSegmentId;
+            lastSegmentId = cacheFunction.segmentId(maxObservedTimestamp);
+
+            if (currentSegmentId > lastSegmentId) {
+                current = null;
+                return;
+            }
+
+            setCacheKeyRange(currentSegmentBeginTime(), currentSegmentLastTime());
+            current = cache.range(cacheName, cacheKeyFrom, cacheKeyTo);
+        }
+
+        private void setCacheKeyRange(final long lowerRangeEndTime, final long upperRangeEndTime) {
+            if (cacheFunction.segmentId(lowerRangeEndTime) != cacheFunction.segmentId(upperRangeEndTime)) {
+                throw new IllegalStateException();
+            }
+
+            if (keyFrom == keyTo) {
+                cacheKeyFrom = cacheFunction.cacheKey(segmentLowerRangeFixedSize(keyFrom, lowerRangeEndTime));
+                cacheKeyTo = cacheFunction.cacheKey(segmentUpperRangeFixedSize(keyTo, upperRangeEndTime));
+            } else {
+                cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRange(keyFrom, lowerRangeEndTime), currentSegmentId);
+                cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRange(keyTo, latestSessionStartTime), currentSegmentId);
+            }
+        }
+
+        private Bytes segmentLowerRangeFixedSize(final Bytes key, final long segmentBeginTime) {
+            final Windowed<Bytes> sessionKey = new Windowed<>(key, new SessionWindow(0, Math.max(0, segmentBeginTime)));
+            return SessionKeySchema.toBinary(sessionKey);
+        }
+
+        private Bytes segmentUpperRangeFixedSize(final Bytes key, final long segmentEndTime) {
+            final Windowed<Bytes> sessionKey = new Windowed<>(key, new SessionWindow(Math.min(latestSessionStartTime, segmentEndTime), segmentEndTime));
+            return SessionKeySchema.toBinary(sessionKey);
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -379,6 +379,8 @@ class CachingWindowStore
             }
 
             setCacheKeyRange(currentSegmentBeginTime(), currentSegmentLastTime());
+
+            current.close();
             current = cache.range(name, cacheKeyFrom, cacheKeyTo);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -185,9 +185,8 @@ class CachingWindowStore
         if (cache == null) {
             return underlyingIterator;
         }
-        final Bytes cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRangeFixedSize(key, timeFrom));
-        final Bytes cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRangeFixedSize(key, timeTo));
-        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(name, cacheKeyFrom, cacheKeyTo);
+
+        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(key, timeFrom, timeTo);
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(key, key, timeFrom, timeTo);
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> filteredCacheIterator = new FilteredCacheIterator(
@@ -212,9 +211,7 @@ class CachingWindowStore
         if (cache == null) {
             return underlyingIterator;
         }
-        final Bytes cacheKeyFrom = cacheFunction.cacheKey(keySchema.lowerRange(from, timeFrom));
-        final Bytes cacheKeyTo = cacheFunction.cacheKey(keySchema.upperRange(to, timeTo));
-        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(name, cacheKeyFrom, cacheKeyTo);
+        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(from, to, timeFrom, timeTo);
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(from, to, timeFrom, timeTo);
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> filteredCacheIterator = new FilteredCacheIterator(cacheIterator, hasNextCondition, cacheFunction);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -398,7 +398,7 @@ class CachingWindowStore
 
         private void setCacheKeyRange(final long lowerRangeEndTime, final long upperRangeEndTime) {
             if (cacheFunction.segmentId(lowerRangeEndTime) != cacheFunction.segmentId(upperRangeEndTime)) {
-                throw new IllegalStateException();
+                throw new IllegalStateException("Error iterating over segments: segment interval has changed");
             }
 
             if (keyFrom == keyTo) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -186,7 +186,12 @@ class CachingWindowStore
             return underlyingIterator;
         }
 
-        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(key, timeFrom, timeTo);
+        final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
+            new CacheIteratorWrapper(key, timeFrom, timeTo) :
+            cache.range(name,
+                        cacheFunction.cacheKey(keySchema.lowerRangeFixedSize(key, timeFrom)),
+                        cacheFunction.cacheKey(keySchema.upperRangeFixedSize(key, timeTo))
+                        );
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(key, key, timeFrom, timeTo);
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> filteredCacheIterator = new FilteredCacheIterator(
@@ -211,7 +216,13 @@ class CachingWindowStore
         if (cache == null) {
             return underlyingIterator;
         }
-        final CacheIteratorWrapper cacheIterator = new CacheIteratorWrapper(from, to, timeFrom, timeTo);
+
+        final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
+            new CacheIteratorWrapper(from, to, timeFrom, timeTo) :
+            cache.range(name,
+                cacheFunction.cacheKey(keySchema.lowerRange(from, timeFrom)),
+                cacheFunction.cacheKey(keySchema.upperRange(to, timeTo))
+            );
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(from, to, timeFrom, timeTo);
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> filteredCacheIterator = new FilteredCacheIterator(cacheIterator, hasNextCondition, cacheFunction);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -192,7 +192,7 @@ class CachingWindowStore
             cache.range(name,
                         cacheFunction.cacheKey(keySchema.lowerRangeFixedSize(key, timeFrom)),
                         cacheFunction.cacheKey(keySchema.upperRangeFixedSize(key, timeTo))
-                        );
+            );
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(key, key, timeFrom, timeTo);
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> filteredCacheIterator = new FilteredCacheIterator(
@@ -221,8 +221,8 @@ class CachingWindowStore
         final PeekingKeyValueIterator<Bytes, LRUCacheEntry> cacheIterator = wrapped().persistent() ?
             new CacheIteratorWrapper(from, to, timeFrom, timeTo) :
             cache.range(name,
-                cacheFunction.cacheKey(keySchema.lowerRange(from, timeFrom)),
-                cacheFunction.cacheKey(keySchema.upperRange(to, timeTo))
+                        cacheFunction.cacheKey(keySchema.lowerRange(from, timeFrom)),
+                        cacheFunction.cacheKey(keySchema.upperRange(to, timeTo))
             );
 
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(from, to, timeFrom, timeTo);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.RecordQueue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.WindowStore;
@@ -55,7 +56,7 @@ class CachingWindowStore
         super(underlying);
         this.windowSize = windowSize;
         this.cacheFunction = new SegmentedCacheFunction(keySchema, segmentInterval);
-        this.maxObservedTimestamp = -1;
+        this.maxObservedTimestamp = RecordQueue.UNKNOWN;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
@@ -57,12 +57,12 @@ class SegmentedCacheFunction implements CacheFunction {
         return binaryKey;
     }
 
-    long segmentId(final long timestamp) {
-        return timestamp / segmentInterval;
+    public long segmentId(final Bytes key) {
+        return segmentId(keySchema.segmentTimestamp(key));
     }
 
-    long segmentId(final Bytes key) {
-        return segmentId(keySchema.segmentTimestamp(key));
+    long segmentId(final long timestamp) {
+        return timestamp / segmentInterval;
     }
 
     long getSegmentInterval() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
@@ -41,9 +41,13 @@ class SegmentedCacheFunction implements CacheFunction {
 
     @Override
     public Bytes cacheKey(final Bytes key) {
+        return cacheKey(key, segmentId(key));
+    }
+
+    Bytes cacheKey(final Bytes key, final long segmentId) {
         final byte[] keyBytes = key.get();
         final ByteBuffer buf = ByteBuffer.allocate(SEGMENT_ID_BYTES + keyBytes.length);
-        buf.putLong(segmentId(key)).put(keyBytes);
+        buf.putLong(segmentId).put(keyBytes);
         return Bytes.wrap(buf.array());
     }
 
@@ -52,9 +56,17 @@ class SegmentedCacheFunction implements CacheFunction {
         System.arraycopy(cacheKey.get(), SEGMENT_ID_BYTES, binaryKey, 0, binaryKey.length);
         return binaryKey;
     }
-    
-    public long segmentId(final Bytes key) {
-        return keySchema.segmentTimestamp(key) / segmentInterval;
+
+    long segmentId(final long timestamp) {
+        return timestamp / segmentInterval;
+    }
+
+    long segmentId(final Bytes key) {
+        return segmentId(keySchema.segmentTimestamp(key));
+    }
+
+    long getSegmentInterval() {
+        return segmentInterval;
     }
 
     int compareSegmentedKeys(final Bytes cacheKey, final Bytes storeKey) {


### PR DESCRIPTION
Reduce the total key space cache iterators have to search for segmented byte stores by wrapping several single-segment iterators.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
