### PR TITLE
KAFKA-8119; Ensure KafkaConfig listener accessors work during update

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1349,12 +1349,13 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def logRetentionTimeMillis: Long = {
     val millisInMinute = 60L * 1000L
     val millisInHour = 60L * millisInMinute
+    val config = currentConfig
 
     val millis: java.lang.Long =
-      Option(getLong(KafkaConfig.LogRetentionTimeMillisProp)).getOrElse(
-        Option(getInt(KafkaConfig.LogRetentionTimeMinutesProp)) match {
+      Option(config.getLong(KafkaConfig.LogRetentionTimeMillisProp)).getOrElse(
+        Option(config.getInt(KafkaConfig.LogRetentionTimeMinutesProp)) match {
           case Some(mins) => millisInMinute * mins
-          case None => getInt(KafkaConfig.LogRetentionTimeHoursProp) * millisInHour
+          case None => config.getInt(KafkaConfig.LogRetentionTimeHoursProp) * millisInHour
         })
 
     if (millis < 0) return -1
@@ -1372,21 +1373,24 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   // If the user did not define listeners but did define host or port, let's use them in backward compatible way
   // If none of those are defined, we default to PLAINTEXT://:9092
   def listeners: Seq[EndPoint] = {
-    Option(getString(KafkaConfig.ListenersProp)).map { listenerProp =>
-      CoreUtils.listenerListToEndPoints(listenerProp, listenerSecurityProtocolMap)
-    }.getOrElse(CoreUtils.listenerListToEndPoints("PLAINTEXT://" + hostName + ":" + port, listenerSecurityProtocolMap))
+    val config = currentConfig
+    Option(config.getString(KafkaConfig.ListenersProp)).map { listenerProp =>
+      CoreUtils.listenerListToEndPoints(listenerProp, config.listenerSecurityProtocolMap)
+    }.getOrElse(CoreUtils.listenerListToEndPoints(s"PLAINTEXT://${config.hostName}:${config.port}", config.listenerSecurityProtocolMap))
   }
 
   def controlPlaneListener: Option[EndPoint] = {
-    controlPlaneListenerName.map { listenerName =>
-      listeners.filter(endpoint => endpoint.listenerName.value() == listenerName.value()).head
+    val config = currentConfig
+    config.controlPlaneListenerName.map { listenerName =>
+      config.listeners.filter(endpoint => endpoint.listenerName.value() == listenerName.value()).head
     }
   }
 
   def dataPlaneListeners: Seq[EndPoint] = {
-    Option(getString(KafkaConfig.ControlPlaneListenerNameProp)) match {
-      case Some(controlPlaneListenerName) => listeners.filterNot(_.listenerName.value() == controlPlaneListenerName)
-      case None => listeners
+    val config = currentConfig
+    Option(config.getString(KafkaConfig.ControlPlaneListenerNameProp)) match {
+      case Some(controlPlaneListenerName) => config.listeners.filterNot(_.listenerName.value() == controlPlaneListenerName)
+      case None => config.listeners
     }
   }
 
@@ -1394,44 +1398,47 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   // If he didn't but did define advertised host or port, we'll use those and fill in the missing value from regular host / port or defaults
   // If none of these are defined, we'll use the listeners
   def advertisedListeners: Seq[EndPoint] = {
-    val advertisedListenersProp = getString(KafkaConfig.AdvertisedListenersProp)
+    val config = currentConfig
+    val advertisedListenersProp = config.getString(KafkaConfig.AdvertisedListenersProp)
     if (advertisedListenersProp != null)
-      CoreUtils.listenerListToEndPoints(advertisedListenersProp, listenerSecurityProtocolMap)
-    else if (getString(KafkaConfig.AdvertisedHostNameProp) != null || getInt(KafkaConfig.AdvertisedPortProp) != null)
-      CoreUtils.listenerListToEndPoints("PLAINTEXT://" + advertisedHostName + ":" + advertisedPort, listenerSecurityProtocolMap)
+      CoreUtils.listenerListToEndPoints(advertisedListenersProp, config.listenerSecurityProtocolMap)
+    else if (config.getString(KafkaConfig.AdvertisedHostNameProp) != null || config.getInt(KafkaConfig.AdvertisedPortProp) != null)
+      CoreUtils.listenerListToEndPoints(s"PLAINTEXT://${config.advertisedHostName}:${config.advertisedPort}", config.listenerSecurityProtocolMap)
     else
       listeners
   }
 
   private def getInterBrokerListenerNameAndSecurityProtocol: (ListenerName, SecurityProtocol) = {
-    Option(getString(KafkaConfig.InterBrokerListenerNameProp)) match {
-      case Some(_) if originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) =>
+    val config = currentConfig
+    Option(config.getString(KafkaConfig.InterBrokerListenerNameProp)) match {
+      case Some(_) if config.originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) =>
         throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} and " +
           s"${KafkaConfig.InterBrokerSecurityProtocolProp} should be set.")
       case Some(name) =>
         val listenerName = ListenerName.normalised(name)
-        val securityProtocol = listenerSecurityProtocolMap.getOrElse(listenerName,
+        val securityProtocol = config.listenerSecurityProtocolMap.getOrElse(listenerName,
           throw new ConfigException(s"Listener with name ${listenerName.value} defined in " +
             s"${KafkaConfig.InterBrokerListenerNameProp} not found in ${KafkaConfig.ListenerSecurityProtocolMapProp}."))
         (listenerName, securityProtocol)
       case None =>
-        val securityProtocol = getSecurityProtocol(getString(KafkaConfig.InterBrokerSecurityProtocolProp),
+        val securityProtocol = config.getSecurityProtocol(config.getString(KafkaConfig.InterBrokerSecurityProtocolProp),
           KafkaConfig.InterBrokerSecurityProtocolProp)
         (ListenerName.forSecurityProtocol(securityProtocol), securityProtocol)
     }
   }
 
   private def getControlPlaneListenerNameAndSecurityProtocol: Option[(ListenerName, SecurityProtocol)] = {
-    Option(getString(KafkaConfig.ControlPlaneListenerNameProp)) match {
+    val config = currentConfig
+    Option(config.getString(KafkaConfig.ControlPlaneListenerNameProp)) match {
       case Some(name) =>
         val listenerName = ListenerName.normalised(name)
-        val securityProtocol = listenerSecurityProtocolMap.getOrElse(listenerName,
+        val securityProtocol = config.listenerSecurityProtocolMap.getOrElse(listenerName,
           throw new ConfigException(s"Listener with ${listenerName.value} defined in " +
             s"${KafkaConfig.ControlPlaneListenerNameProp} not found in ${KafkaConfig.ListenerSecurityProtocolMapProp}."))
         Some(listenerName, securityProtocol)
 
       case None => None
-   }
+    }
   }
 
   private def getSecurityProtocol(protocolName: String, configName: String): SecurityProtocol = {

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -23,6 +23,7 @@ import kafka.api.{ApiVersion, KAFKA_0_8_2}
 import kafka.cluster.EndPoint
 import kafka.message._
 import kafka.utils.{CoreUtils, TestUtils}
+import kafka.utils.Implicits._
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.metrics.Sensor
 import org.apache.kafka.common.network.ListenerName
@@ -827,6 +828,62 @@ class KafkaConfigTest {
     assertTrue(isValidKafkaConfig(props))
     props.put(KafkaConfig.MaxConnectionsPerIpOverridesProp, "127.0.0.0#:100")
     assertFalse(isValidKafkaConfig(props))
+  }
+
+  @Test
+  def testListenerUpdate(): Unit = {
+    val initialProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+    val initialListeners = Set("INTERNAL://:9092", "EXTERNAL://:9093", "REPLICATION://:9094", "CONTROL://:9095")
+    val initialAdvertisedListeners = Set("INTERNAL://host1:9092", "EXTERNAL://host2:9093", "REPLICATION://host3:9094", "CONTROL://host3:9095")
+    initialProps.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "INTERNAL:SASL_PLAINTEXT,EXTERNAL:SASL_SSL,REPLICATION:PLAINTEXT,CONTROL:SSL")
+    initialProps.setProperty(KafkaConfig.ListenersProp, initialListeners.mkString(","))
+    initialProps.setProperty(KafkaConfig.AdvertisedListenersProp, initialAdvertisedListeners.mkString(","))
+    initialProps.setProperty(KafkaConfig.InterBrokerListenerNameProp, "REPLICATION")
+    initialProps.setProperty(KafkaConfig.ControlPlaneListenerNameProp, "CONTROL")
+    val initialConfig = new KafkaConfig(initialProps)
+
+    val newProps = new Properties()
+    newProps ++= initialProps
+    val newListeners = Set("EXTERNAL://:9093", "REPLICATION://:9094", "CONTROL://:9095")
+    val newAdvertisedListeners = Set("EXTERNAL://host2:9093", "REPLICATION://host3:9094", "CONTROL://host3:9095")
+    newProps.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "EXTERNAL:SASL_SSL,REPLICATION:SSL,CONTROL:SSL")
+    newProps.setProperty(KafkaConfig.ListenersProp, newListeners.mkString(","))
+    newProps.setProperty(KafkaConfig.AdvertisedListenersProp, newAdvertisedListeners.mkString(","))
+    val newConfig = new KafkaConfig(newProps)
+
+    var configUpdateOpt: Option[KafkaConfig] = None
+    val config = new KafkaConfig(initialProps) {
+      override def listenerSecurityProtocolMap: collection.Map[ListenerName, SecurityProtocol] = {
+        configUpdateOpt.foreach(updateCurrentConfig)
+        super.listenerSecurityProtocolMap
+      }
+    }
+    config.updateCurrentConfig(initialConfig)
+    assertEquals(initialListeners, config.listeners.map(_.connectionString).toSet)
+    assertEquals(initialAdvertisedListeners, config.advertisedListeners.map(_.connectionString).toSet)
+
+    def setupConfigUpdate(startConfig: KafkaConfig, updatedConfig: KafkaConfig): Unit = {
+      config.updateCurrentConfig(startConfig)
+      configUpdateOpt = Some(updatedConfig)
+    }
+
+    setupConfigUpdate(initialConfig, newConfig)
+    assertEquals(initialListeners, config.listeners.map(_.connectionString).toSet)
+    setupConfigUpdate(initialConfig, newConfig)
+    assertEquals(initialAdvertisedListeners, config.advertisedListeners.map(_.connectionString).toSet)
+    setupConfigUpdate(initialConfig, newConfig)
+    assertEquals(Some("CONTROL://:9095"), config.controlPlaneListener.map(_.connectionString))
+    setupConfigUpdate(initialConfig, newConfig)
+    assertEquals(Set("INTERNAL://:9092", "EXTERNAL://:9093", "REPLICATION://:9094"), config.dataPlaneListeners.map(_.connectionString).toSet)
+
+    setupConfigUpdate(newConfig, initialConfig)
+    assertEquals(newListeners, config.listeners.map(_.connectionString).toSet)
+    setupConfigUpdate(newConfig, initialConfig)
+    assertEquals(newAdvertisedListeners, config.advertisedListeners.map(_.connectionString).toSet)
+    setupConfigUpdate(newConfig, initialConfig)
+    assertEquals(Some("CONTROL://:9095"), config.controlPlaneListener.map(_.connectionString))
+    setupConfigUpdate(newConfig, initialConfig)
+    assertEquals(Set("EXTERNAL://:9093", "REPLICATION://:9094"), config.dataPlaneListeners.map(_.connectionString).toSet)
   }
 
   private def assertPropertyInvalid(validRequiredProps: => Properties, name: String, values: Any*) {


### PR DESCRIPTION
Use the same config to obtain all properties used in each KafkaConfig accessor method to ensure that validation doesn't fail if config was updated during the method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
