### PR TITLE
KAFKA-8127 It may need to import scala.io

### DIFF
--- a/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
+++ b/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
@@ -19,6 +19,7 @@ package kafka.tools
 
 import joptsimple._
 
+import scala.io
 import scala.util.matching.Regex
 import collection.mutable
 import java.util.Date


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/KAFKA-8127](url)

It may get error when compile kafka if no scala.io imported