### PR TITLE
MINOR: Update scoverage so bootstrapping build works with Gradle 5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     // For Apache Rat plugin to ignore non-Git files
     classpath "org.ajoberstar:grgit:1.9.3"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
-    classpath 'org.scoverage:gradle-scoverage:2.1.0'
+    classpath 'org.scoverage:gradle-scoverage:2.5.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
   }
 }


### PR DESCRIPTION
Trying to bootstrap the build with the gradle command with Gradle 5.2 fails to apply the scoverage plugin. Upgrading to the most recent 2.x version of the plugin fixes this build issue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
