### PR TITLE
KAFKA-8130:The consumer is not closed in GetOffsetShell, will exhausted socket channel when frequent calls

### DIFF
--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -97,9 +97,16 @@ object GetOffsetShell {
               val consumer = new SimpleConsumer(leader.host, leader.port, 10000, 100000, clientId)
               val topicAndPartition = TopicAndPartition(topic, partitionId)
               val request = OffsetRequest(Map(topicAndPartition -> PartitionOffsetRequestInfo(time, nOffsets)))
-              val offsets = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets
+              try {
+                val offsets = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets
 
-              println("%s:%d:%s".format(topic, partitionId, offsets.mkString(",")))
+                println("%s:%d:%s".format(topic, partitionId, offsets.mkString(",")))
+              } catch {
+                case e: Throwable =>
+                  throw e
+              } finally {
+                consumer.close()
+              }
             case None => System.err.println("Error: partition %d does not have a leader. Skip getting offsets".format(partitionId))
           }
         case None => System.err.println("Error: partition %d does not exist".format(partitionId))


### PR DESCRIPTION
When use command "bin/kafka-run-class.sh kafka.tools.GetOffsetShell --topic test --time -2 --broker-list 127.0.0.1:9092 --partitions 1" frequently, or use code call kafka.tools.GetOffsetShell method more then socket limit. It will show us  "Too many open files" error.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
