### PR TITLE
KAFKA-8106:Reducing the allocation and copying of ByteBuffer  when logValidator  do validation.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -18,6 +18,8 @@ package org.apache.kafka.common.record;
 
 abstract class AbstractRecordBatch implements RecordBatch {
 
+    public boolean isSimplified = false;
+
     @Override
     public boolean hasProducerId() {
         return RecordBatch.NO_PRODUCER_ID < producerId();
@@ -31,6 +33,16 @@ abstract class AbstractRecordBatch implements RecordBatch {
     @Override
     public boolean isCompressed() {
         return compressionType() != CompressionType.NONE;
+    }
+
+    @Override
+    public void setSimplified(boolean isSimplified){
+        this.isSimplified = isSimplified;
+    }
+
+    @Override
+    public  boolean isSimplified() {
+        return isSimplified;
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -36,7 +36,7 @@ abstract class AbstractRecordBatch implements RecordBatch {
     }
 
     @Override
-    public void setSimplified(boolean isSimplified){
+    public void setSimplified(boolean isSimplified) {
         this.isSimplified = isSimplified;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -421,7 +421,12 @@ public class DefaultRecord implements Record {
             }
             skipBytes += ByteUtils.sizeOfVarlong(keySize);
 
-            input.skipBytes(sizeOfBodyInBytes - skipBytes);
+            skipBytes = sizeOfBodyInBytes - skipBytes;
+            if (skipBytes > 0) {
+                int currentSkipBytes = input.skipBytes(skipBytes);
+                if (currentSkipBytes != skipBytes)
+                    throw new InvalidRecordException("Found invalid record structure , skipBytes expected is " + skipBytes + ", actually is " + currentSkipBytes);
+            }
 
             return new SimplifiedDefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, hasKey);
         } catch (BufferUnderflowException | IllegalArgumentException e) {

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -28,7 +28,11 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
 
@@ -313,7 +317,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         if (!isCompressed())
             return uncompressedIterator();
 
-        if(isSimplified()) {
+        if (isSimplified()) {
             return simplifiedIterator();
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -313,6 +313,10 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         if (!isCompressed())
             return uncompressedIterator();
 
+        if(isSimplified()) {
+            return simplifiedIterator();
+        }
+
         // for a normal iterator, we cannot ensure that the underlying compression stream is closed,
         // so we decompress the full record set here. Use cases which call for a lower memory footprint
         // can use `streamingIterator` at the cost of additional complexity
@@ -329,7 +333,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
      *
      * @return
      */
-    public Iterator<Record> simplifiedIterator() {
+    private Iterator<Record> simplifiedIterator() {
         if (count() == 0)
             return Collections.emptyIterator();
         try (CloseableIterator<Record> iterator = simplifiedCompressedIterator(BufferSupplier.NO_CACHING)) {

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordBatch.java
@@ -198,6 +198,10 @@ public interface RecordBatch extends Iterable<Record> {
      */
     boolean isCompressed();
 
+    void setSimplified(boolean isSimplified);
+
+    boolean isSimplified();
+
     /**
      * Write this record batch into a buffer.
      * @param buffer The buffer to write the batch to

--- a/clients/src/main/java/org/apache/kafka/common/record/SimplifiedDefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/SimplifiedDefaultRecord.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.header.Header;
+
+import java.nio.ByteBuffer;
+
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
+
+/**
+ *
+ * @Flower.min
+ */
+public class SimplifiedDefaultRecord implements Record {
+
+    private final int sizeInBytes;
+    private final byte attributes;
+    private final long offset;
+    private final long timestamp;
+    private final int sequence;
+    private final boolean isHasKey;
+
+    public SimplifiedDefaultRecord(int sizeInBytes,
+                                   byte attributes,
+                                   long offset,
+                                   long timestamp,
+                                   int sequence,
+                                   boolean isHasKey) {
+        this.sizeInBytes = sizeInBytes;
+        this.attributes = attributes;
+        this.offset = offset;
+        this.timestamp = timestamp;
+        this.sequence = sequence;
+        this.isHasKey = isHasKey;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public int sequence() {
+        return sequence;
+    }
+
+    public int sizeInBytes() {
+        return sizeInBytes;
+    }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public Long checksumOrNull() {
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+    @Override
+    public void ensureValid() {
+
+    }
+
+    @Override
+    public int keySize() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasKey() {
+        return isHasKey;
+    }
+
+    @Override
+    public ByteBuffer key() {
+        return null;
+    }
+
+    @Override
+    public int valueSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return false;
+    }
+
+    @Override
+    public ByteBuffer value() {
+        return null;
+    }
+
+    @Override
+    public boolean hasMagic(byte magic) {
+        return magic >= MAGIC_VALUE_V2;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return false;
+    }
+
+    @Override
+    public boolean hasTimestampType(TimestampType timestampType) {
+        return false;
+    }
+
+    @Override
+    public Header[] headers() {
+        return new Header[0];
+    }
+
+    public byte attributes() {
+        return attributes;
+    }
+
+    public boolean isHasKey() {
+        return isHasKey;
+    }
+
+}

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -23,7 +23,7 @@ import kafka.common.LongRef
 import kafka.message.{CompressionCodec, NoCompressionCodec, ZStdCompressionCodec}
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.{InvalidTimestampException, UnsupportedCompressionTypeException, UnsupportedForMessageFormatException}
-import org.apache.kafka.common.record.{AbstractRecords, CompressionType, InvalidRecordException, MemoryRecords, Record, RecordBatch, RecordConversionStats, TimestampType}
+import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.Time
 
 import scala.collection.mutable
@@ -266,7 +266,7 @@ private[kafka] object LogValidator extends Logging {
         if (sourceCodec == NoCompressionCodec && batch.isControlBatch)
           inPlaceAssignment = true
 
-        for (record <- batch.asScala) {
+        for (record <- batch.asInstanceOf[DefaultRecordBatch].simplifiedIterator().asScala) {
           if (sourceCodec != NoCompressionCodec && record.isCompressed)
             throw new InvalidRecordException("Compressed outer record should not have an inner record with a " +
               s"compression attribute set: $record")
@@ -379,9 +379,9 @@ private[kafka] object LogValidator extends Logging {
   }
 
   /**
-   * This method validates the timestamps of a message.
-   * If the message is using create time, this method checks if it is within acceptable range.
-   */
+    * This method validates the timestamps of a message.
+    * If the message is using create time, this method checks if it is within acceptable range.
+    */
   private def validateTimestamp(batch: RecordBatch,
                                 record: Record,
                                 now: Long,


### PR DESCRIPTION
We suggest that reducing the allocation and copying of ByteBuffer when logValidator do validation when magic value to use is above 1 and no format conversion or value overwriting is required for compressed messages.And improved code is as follows.
1. Adding a class **SimplifiedDefaultRecord** implement class Record which define  various attributes of a message. 
2. Adding Function **simplifiedreadFrom**() at class **DefaultRecord** .This function will not read data from DataInput to  ByteBuffer which need newly creating .**This will reduce the allocation and copying of ByteBuffer** when logValidator do validation .This will reduces GC frequency. We offer a simple read function to read data from **DataInput** whithout create ByteBuffer.Of course this opertion can not avoid deconmpression to data.
3. Adding Function **simplifiedIterator**() and **simplifiedCompressedIterator**() at class **DefaultRecordBatch**.This two functions will return iterator of instance belongs to class **SimplifiedDefaultRecord**.
4. Modify code of function **validateMessagesAndAssignOffsetsCompressed**() at class  LogValidator.

    **After modifing code wich  reducing the allocation and copying of ByteBuffer**, the test performance is greatly improved, and the CPU's stable usage is below 60%. The following is a comparison of different code test performance under the same conditions.
**Result of performance testing**
Main config of Kafka: Single Message:1024B;TopicPartitions:200;linger.ms:1000ms,
**1.Before modified code(Source code):**
Network inflow rate:600M/s;CPU(%)(97%);production:25,000,000 messages/s
**2.After modified code(remove allocation of ByteBuffer):**
Network inflow rate:1G/s;CPU(%)(<60%);production:41,000,000 messages/s
 **1.Before modified code(Source code) GC:**
![](https://i.loli.net/2019/05/07/5cd16df163ad3.png)
**2.After modified code(remove allocation of ByteBuffer) GC:**
![](https://i.loli.net/2019/05/07/5cd16dae1dbc2.png)
