### PR TITLE
MINOR: Allow specifying auto.offset.reset in the ConsumeBenchSpec for Trogdor

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -98,6 +98,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     private final List<String> activeTopics;
     private final String consumerGroup;
     private final int threadsPerWorker;
+    private final String autoOffsetReset;
 
     @JsonCreator
     public ConsumeBenchSpec(@JsonProperty("startMs") long startMs,
@@ -111,7 +112,8 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                             @JsonProperty("threadsPerWorker") Integer threadsPerWorker,
-                            @JsonProperty("activeTopics") List<String> activeTopics) {
+                            @JsonProperty("activeTopics") List<String> activeTopics,
+                            @JsonProperty("autoOffsetReset") String autoOffsetReset) {
         super(startMs, durationMs);
         this.consumerNode = (consumerNode == null) ? "" : consumerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
@@ -123,6 +125,7 @@ public class ConsumeBenchSpec extends TaskSpec {
         this.activeTopics = activeTopics == null ? new ArrayList<>() : activeTopics;
         this.consumerGroup = consumerGroup == null ? "" : consumerGroup;
         this.threadsPerWorker = threadsPerWorker == null ? 1 : threadsPerWorker;
+        this.autoOffsetReset = autoOffsetReset == null ? "earliest" : autoOffsetReset;
     }
 
     @JsonProperty
@@ -183,6 +186,11 @@ public class ConsumeBenchSpec extends TaskSpec {
     @Override
     public TaskWorker newTaskWorker(String id) {
         return new ConsumeBenchWorker(id, this);
+    }
+
+    @JsonProperty
+    public String autoOffsetReset() {
+        return autoOffsetReset;
     }
 
     /**

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -153,7 +153,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.bootstrapServers());
             props.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
             props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
-            props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+            props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, spec.autoOffsetReset());
             props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 100000);
             // these defaults maybe over-written by the user-specified commonClientConf or consumerConf
             WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.consumerConf());

--- a/tools/src/test/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpecTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpecTest.java
@@ -73,6 +73,7 @@ public class ConsumeBenchSpecTest {
     private ConsumeBenchSpec consumeBenchSpec(List<String> activeTopics) {
         return new ConsumeBenchSpec(0, 0, "node", "localhost",
             123, 1234, "cg-1",
-            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), 1, activeTopics);
+            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), 1,
+                activeTopics, "latest");
     }
 }


### PR DESCRIPTION
This patch allows specifying `auto.offset.reset` for the Trogdor consumers, allowing benchmarks that start reading at the beginning of the log. 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
