### PR TITLE
MINOR: Remove line for testing repartition topic name

### DIFF
--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
@@ -42,6 +42,5 @@ class JoinedTest extends FlatSpec with Matchers {
     joined.keySerde.getClass shouldBe Serdes.String.getClass
     joined.valueSerde.getClass shouldBe Serdes.Long.getClass
     joined.otherValueSerde.getClass shouldBe Serdes.Integer.getClass
-    joined.name() shouldBe repartitionTopicName
   }
 }


### PR DESCRIPTION
With KIP-307 `joined.name()` is deprecated plus we don't need to test for repartition topic names.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
