### PR TITLE
Buffer overflow / Underflow exception handling. 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -547,7 +547,7 @@ public class SslTransportLayer implements TransportLayer {
                 } else if (unwrapResult.getStatus() == Status.BUFFER_OVERFLOW) {
                     int currentApplicationBufferSize = applicationBufferSize();
                     appReadBuffer = Utils.ensureCapacity(appReadBuffer, currentApplicationBufferSize);
-                    if (appReadBuffer.position() >= currentApplicationBufferSize) {
+                    if (appReadBuffer.position() > currentApplicationBufferSize) {
                         throw new IllegalStateException("Buffer overflow when available data size (" + appReadBuffer.position() +
                                                         ") >= application buffer size (" + currentApplicationBufferSize + ")");
                     }
@@ -562,7 +562,7 @@ public class SslTransportLayer implements TransportLayer {
                 } else if (unwrapResult.getStatus() == Status.BUFFER_UNDERFLOW) {
                     int currentNetReadBufferSize = netReadBufferSize();
                     netReadBuffer = Utils.ensureCapacity(netReadBuffer, currentNetReadBufferSize);
-                    if (netReadBuffer.position() >= currentNetReadBufferSize) {
+                    if (netReadBuffer.position() > currentNetReadBufferSize) {
                         throw new IllegalStateException("Buffer underflow when available data size (" + netReadBuffer.position() +
                                                         ") > packet buffer size (" + currentNetReadBufferSize + ")");
                     }


### PR DESCRIPTION
Hello, 


While testing 3 Node Kafka Cluster in our docker container (using Swarm) environment, we noticed buffer overflow issues when we enable SSL. We run into the exceptions shown below. We actually never ran into a scenario where the buffer exceeded the size of the application buffer size or packet buffer size. But, we see overflow/underflow where they exactly match the size. We noticed these exceptions with both 2.1.0 and 2.1.1. 

In our application we have consumers/producers that are Java and Go based.

While I am not aware of what the original reasoning was to actually generate an exception due to buffer over/underflow. As per SSLEngine documentation, one is supposed to resize respective buffers and retry the operation appropriately. 

https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLEngine.html

We have both Go (librdkafka) and Java (confluent) clients and these are the tracebacks we see on the brokers, very consistently. This is not even a very high traffic scenario.
We are using 2.1.0 Broker.
Java version is
openjdk version "1.8.0_191"
OpenJDK Runtime Environment (build 1.8.0_191-b12)
OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode

Inviting your comments and insights on the code changes in this PR. 

[2019-03-20 10:00:47,664] WARN [SocketServer brokerId=22] Unexpected error from /192.168.2.44; closing connection (org.apache.kafka.common.network.Selector)
java.lang.IllegalStateException: Buffer overflow when available data size (16384) >= application buffer size (16384)
at org.apache.kafka.common.network.SslTransportLayer.read(SslTransportLayer.java:550)
at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:94)
at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:381)
at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:342)
at org.apache.kafka.common.network.Selector.attemptRead(Selector.java:609)
at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:541)
at org.apache.kafka.common.network.Selector.poll(Selector.java:467)
at kafka.network.Processor.poll(SocketServer.scala:689)
at kafka.network.Processor.run(SocketServer.scala:594)
at java.lang.Thread.run(Thread.java:748)

[2019-03-20 10:01:53,423] WARN [ReplicaFetcher replicaId=22, leaderId=23, fetcherId=0] Unexpected error from /192.168.2.23; closing connection (org.apache.kafka.common.network.Selector)
java.lang.IllegalStateException: Buffer overflow when available data size (16384) >= application buffer size (16384)
at org.apache.kafka.common.network.SslTransportLayer.read(SslTransportLayer.java:550)
at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:94)
at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:381)
at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:342)
at org.apache.kafka.common.network.Selector.attemptRead(Selector.java:609)
at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:541)
at org.apache.kafka.common.network.Selector.poll(Selector.java:467)
at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:521)
at org.apache.kafka.clients.NetworkClientUtils.sendAndReceive(NetworkClientUtils.java:93)
at kafka.server.ReplicaFetcherBlockingSend.sendRequest(ReplicaFetcherBlockingSend.scala:97)
at kafka.server.ReplicaFetcherThread.fetchFromLeader(ReplicaFetcherThread.scala:190)
at kafka.server.AbstractFetcherThread.kafka$server$AbstractFetcherThread$$processFetchRequest(AbstractFetcherThread.scala:241)
at kafka.server.AbstractFetcherThread$$anonfun$maybeFetch$1.apply(AbstractFetcherThread.scala:130)
at kafka.server.AbstractFetcherThread$$anonfun$maybeFetch$1.apply(AbstractFetcherThread.scala:129)
at scala.Option.foreach(Option.scala:257)
at kafka.server.AbstractFetcherThread.maybeFetch(AbstractFetcherThread.scala:129)
at kafka.server.AbstractFetcherThread.doWork(AbstractFetcherThread.scala:111)
at kafka.utils.ShutdownableThread.run(ShutdownableThread.scala:82)


Unit Test:
Brought up the full cluster and verified that the buffer overflow exception is not seen any more. 
Cluster is up and running for a few days. 