### PR TITLE
Allow Transformer/ProcessorSuppliers to declare store usage (proof of concept only)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/StateStoresSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/StateStoresSupplier.java
@@ -1,0 +1,12 @@
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.state.StoreBuilder;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public interface StateStoresSupplier {
+    default Collection<StoreBuilder> stateStores() {
+        return Collections.emptyList();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TransformerSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TransformerSupplier.java
@@ -30,7 +30,7 @@ package org.apache.kafka.streams.kstream;
  * @see ValueTransformerSupplier
  * @see KStream#transformValues(ValueTransformerSupplier, String...)
  */
-public interface TransformerSupplier<K, V, R> {
+public interface TransformerSupplier<K, V, R> extends StateStoresSupplier {
 
     /**
      * Return a new {@link Transformer} instance.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerSupplier.java
@@ -31,7 +31,7 @@ package org.apache.kafka.streams.kstream;
  * @see TransformerSupplier
  * @see KStream#transform(TransformerSupplier, String...)
  */
-public interface ValueTransformerSupplier<V, VR> {
+public interface ValueTransformerSupplier<V, VR> extends StateStoresSupplier {
 
     /**
      * Return a new {@link ValueTransformer} instance.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -28,6 +28,6 @@ package org.apache.kafka.streams.kstream;
  * @see TransformerSupplier
  * @see KStream#transform(TransformerSupplier, String...)
  */
-public interface ValueTransformerWithKeySupplier<K, V, VR> {
+public interface ValueTransformerWithKeySupplier<K, V, VR> extends StateStoresSupplier {
     ValueTransformerWithKey<K, V, VR> get();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TransformerSupplierAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TransformerSupplierAdapter.java
@@ -16,12 +16,14 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.Collection;
 import java.util.Collections;
 
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.StoreBuilder;
 
 public class TransformerSupplierAdapter<KIn, VIn, KOut, VOut> implements TransformerSupplier<KIn, VIn, Iterable<KeyValue<KOut, VOut>>> {
 
@@ -56,5 +58,10 @@ public class TransformerSupplierAdapter<KIn, VIn, KOut, VOut> implements Transfo
                 transformer.close();
             }
         };
+    }
+
+    @Override
+    public Collection<StoreBuilder> stateStores() {
+        return transformerSupplier.stateStores();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorSupplier.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.StateStoresSupplier;
 
 /**
  * A processor supplier that can create one or more {@link Processor} instances.
@@ -28,7 +29,7 @@ import org.apache.kafka.streams.Topology;
  * @param <K> the type of keys
  * @param <V> the type of values
  */
-public interface ProcessorSupplier<K, V> {
+public interface ProcessorSupplier<K, V> extends StateStoresSupplier {
 
     /**
      * Return a new {@link Processor} instance.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -523,8 +523,10 @@ public class InternalTopologyBuilder {
                                     final boolean allowOverride,
                                     final String... processorNames) {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
-        if (!allowOverride && stateFactories.containsKey(storeBuilder.name())) {
-            throw new TopologyException("StateStore " + storeBuilder.name() + " is already added.");
+
+        StateStoreFactory stateFactory = stateFactories.get(storeBuilder.name());
+        if (!allowOverride && stateFactory != null && stateFactory.builder != storeBuilder) {
+            throw new TopologyException("A different StateStore has already been added with the name " + storeBuilder.name());
         }
 
         stateFactories.put(storeBuilder.name(), new StateStoreFactory(storeBuilder));


### PR DESCRIPTION
 - All public and private Transformer/ProcessorSupplier interfaces now
 extend StateStoresSupplier, which allows them to specify what state
 stores they use.  This eliminates the need for users defining a
 topology with KStream::process/transform to give state store names in
 while defining the topology.

This is intended only as demonstration of a possible API for KIP 401 (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=97553756)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
