### PR TITLE
KAFKA-6988: Reduce classpath via classpath jar

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -143,11 +143,9 @@ do
 done
 
 # classpath addition for release
-for file in "$base_dir"/libs/*;
+for file in "$base_dir"/libs/kafka_${SCALA_BINARY_VERSION}-classpath*.jar;
 do
-  if should_include_file "$file"; then
-    CLASSPATH="$CLASSPATH":"$file"
-  fi
+  CLASSPATH="$CLASSPATH":"$file"
 done
 
 for file in "$base_dir"/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -90,7 +90,7 @@ for %%p in (api runtime file json tools) do (
 )
 
 rem Classpath addition for release
-for %%i in ("%BASE_DIR%\libs\*") do (
+for %%i in ("%BASE_DIR%\libs\kafka_%SCALA_BINARY_VERSION%-classpath*.jar") do (
 	call :concat "%%i"
 )
 

--- a/build.gradle
+++ b/build.gradle
@@ -809,6 +809,11 @@ project(':core') {
     duplicatesStrategy 'exclude'
   }
 
+  task launcherJar(type: Jar) {
+    description = 'Create a Class-Path only Jar for launcher scripts and the application'
+    appendix = 'classpath'
+  }
+
   tasks.create(name: "releaseTarGz", dependsOn: configurations.archives.artifacts, type: Tar) {
     into "kafka_${versions.baseScala}-${version}"
     compression = Compression.GZIP
@@ -818,6 +823,7 @@ project(':core') {
     from "$rootDir/NOTICE"
     from(configurations.runtime) { into("libs/") }
     from(configurations.archives.artifacts.files) { into("libs/") }
+    from(launcherJar.outputs.files) { into("libs/") }
     from(project.siteDocsTar) { into("site-docs/") }
     from(project(':tools').jar) { into("libs/") }
     from(project(':tools').configurations.runtime) { into("libs/") }
@@ -842,6 +848,33 @@ project(':core') {
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtime) { into("libs/") }
     duplicatesStrategy 'exclude'
+  }
+
+  project.gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(launcherJar)) {
+      def jars = configurations.runtime +
+          configurations.archives.artifacts.files +
+          project(':tools').configurations.archives.artifacts.files +
+          project(':tools').configurations.runtime +
+          project(':connect:api').configurations.archives.artifacts.files +
+          project(':connect:api').configurations.runtime +
+          project(':connect:runtime').configurations.archives.artifacts.files +
+          project(':connect:runtime').configurations.runtime +
+          project(':connect:transforms').configurations.archives.artifacts.files +
+          project(':connect:transforms').configurations.runtime +
+          project(':connect:json').configurations.archives.artifacts.files +
+          project(':connect:json').configurations.runtime +
+          project(':connect:file').configurations.archives.artifacts.files +
+          project(':connect:file').configurations.runtime +
+          project(':streams').configurations.archives.artifacts.files +
+          project(':streams').configurations.runtime +
+          project(':streams:examples').configurations.archives.artifacts.files +
+          project(':streams:examples').configurations.runtime as Set
+
+      launcherJar.manifest.attributes("Class-Path": jars*.name.findAll { name ->
+        !(name =~ '(-(test|sources|test-sources|scaladoc|javadoc).jar|jar.asc)$')
+      }.join(' '))
+    }
   }
 
   jar {


### PR DESCRIPTION
Similar to #5960, we hit an issue with starting up Kafka on Windows when installed to a local with a very long file path; however, we came up with a slightly different solution that attempts to not pollute the classpath with unnecessary items.

Instead we build a classpath jar via Gradle and append it to the classpath.  The Gradle function handles the regex originally done by `should_include_file`.