### PR TITLE
MINOR: Move KTable source topic for changelog to optimization framework

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -109,11 +109,12 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
             // only add state store if the source KTable should be materialized
             final KTableSource<K, V> ktableSource = (KTableSource<K, V>) processorParameters.processorSupplier();
             if (ktableSource.queryableName() != null) {
-                topologyBuilder.addStateStore(storeBuilder, nodeName());
-
                 if (shouldReuseSourceTopicForChangelog) {
                     storeBuilder.withLoggingDisabled();
+                    topologyBuilder.addStateStore(storeBuilder, nodeName());
                     topologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topicName);
+                } else {
+                    topologyBuilder.addStateStore(storeBuilder, nodeName());
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -109,12 +109,11 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
             // only add state store if the source KTable should be materialized
             final KTableSource<K, V> ktableSource = (KTableSource<K, V>) processorParameters.processorSupplier();
             if (ktableSource.queryableName() != null) {
+                topologyBuilder.addStateStore(storeBuilder, nodeName());
+
                 if (shouldReuseSourceTopicForChangelog) {
                     storeBuilder.withLoggingDisabled();
-                    topologyBuilder.addStateStore(storeBuilder, nodeName());
                     topologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topicName);
-                } else {
-                    topologyBuilder.addStateStore(storeBuilder, nodeName());
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -123,9 +123,6 @@ public class InternalTopologyBuilder {
 
     private Map<Integer, Set<String>> nodeGroups = null;
 
-    // TODO: this is only temporary for 2.0 and should be removed
-    private final Map<StoreBuilder, String> storeToSourceChangelogTopic = new HashMap<>();
-
     public static class StateStoreFactory {
         private final StoreBuilder builder;
         private final Set<String> users = new HashSet<>();
@@ -358,10 +355,6 @@ public class InternalTopologyBuilder {
         for (final StoreBuilder storeBuilder : globalStateBuilders.values()) {
             globalStateStores.put(storeBuilder.name(), storeBuilder.build());
         }
-
-        // adjust the topology if optimization is turned on.
-        // TODO: to be removed post 2.0
-        adjust(config);
 
         return this;
     }
@@ -606,20 +599,12 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
-    private void connectSourceStoreAndTopic(final String sourceStoreName,
+    public void connectSourceStoreAndTopic(final String sourceStoreName,
                                             final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {
             throw new TopologyException("Source store " + sourceStoreName + " is already added.");
         }
         storeToChangelogTopic.put(sourceStoreName, topic);
-    }
-
-    public final void markSourceStoreAndTopic(final StoreBuilder storeBuilder,
-                                              final String topic) {
-        if (storeToSourceChangelogTopic.containsKey(storeBuilder)) {
-            throw new TopologyException("Source store " + storeBuilder.name() + " is already used.");
-        }
-        storeToSourceChangelogTopic.put(storeBuilder, topic);
     }
 
     public final void addInternalTopic(final String topicName) {
@@ -1069,25 +1054,6 @@ public class InternalTopologyBuilder {
         }
 
         return Collections.unmodifiableMap(topicGroups);
-    }
-
-    // Adjust the generated topology based on the configs.
-    // Not exposed as public API and should be removed post 2.0
-    private void adjust(final StreamsConfig config) {
-        final boolean enableOptimization20 =
-            config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION).equals(StreamsConfig.OPTIMIZE);
-
-        if (enableOptimization20) {
-            for (final Map.Entry<StoreBuilder, String> entry : storeToSourceChangelogTopic.entrySet()) {
-                final StoreBuilder storeBuilder = entry.getKey();
-                final String topicName = entry.getValue();
-
-                // update store map to disable logging for this store
-                storeBuilder.withLoggingDisabled();
-                addStateStore(storeBuilder, true);
-                connectSourceStoreAndTopic(storeBuilder.name(), topicName);
-            }
-        }
     }
 
     private void setRegexMatchedTopicsToSourceNodes() {

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -349,9 +349,9 @@ public class StreamsBuilderTest {
     public void shouldReuseSourceTopicAsChangelogsWithOptimization20() {
         final String topic = "topic";
         builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store"));
-        final Topology topology = builder.build();
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+        final Topology topology = builder.build(props);
 
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
         internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -146,7 +146,7 @@ public class RestoreIntegrationTest {
                     }
                 });
 
-        kafkaStreams = new KafkaStreams(builder.build(), props);
+        kafkaStreams = new KafkaStreams(builder.build(props), props);
         kafkaStreams.setStateListener((newState, oldState) -> {
             if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
                 startupLatch.countDown();


### PR DESCRIPTION
Since we've added Kafka Streams optimizations in `2.1` we need to move the optimization for source `KTable` nodes (use source topic as changelog) to the optimization framework.

Updated streams tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
