### PR TITLE
KAFKA-8164: Add unitTestWithFlakyRetry and testWithFlakyRetry tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,9 +147,8 @@ if (file('.git').exists()) {
 def shouldFilterFlakyTests = gradle.startParameter.taskNames.any{it.contains("FlakyRetry")}
 if (shouldFilterFlakyTests) {
   logger.warn('''************************************************************************
-  a FlakyRetry task was included in task list ->
-  Failing tests will not cause a build failure. Test classes with failures will be run again to
-  filter out flaky tests. Failures in this second run will cause build failure.
+  a FlakyRetry task was included in task list. Therefore failing tests will be retried once 
+  in order to test whether they are flaky.
 ************************************************************************''')
 } else {
   logger.info("unitTestWithFlakyRetry was not included in task list, no anti-flaky steps are done, proceeding as normal upstream build")
@@ -297,7 +296,7 @@ subprojects {
     logTestStdout.rehydrate(delegate, owner, this)()
 
     afterTest { TestDescriptor desc , TestResult result ->
-      if (TestResult.ResultType.FAILURE == result.resultType) {
+      if (shouldFilterFlakyTests && TestResult.ResultType.FAILURE == result.resultType) {
         logger.warn("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
         failedTestsInFirstTestRun << desc
       }
@@ -319,7 +318,7 @@ subprojects {
       exceptionFormat = testExceptionFormat
     }
 
-    def oldResultsToOverwite = []
+    def oldResultsToOverwrite = []
 
     doFirst {
       if (!failedTestsInFirstTestRun.isEmpty()) {
@@ -331,7 +330,7 @@ subprojects {
           it.className.replaceAll('\\.', '/') + ".*"
         } as Set
         // re-running complete classes to keep the integrity of the test results
-        logger.warn("Re-running $failedTestClasses")
+        logger.warn("Re-running ${failedTestClasses.size()} failing test classes")
         setIncludes(failedTestClasses)
       } else {
         logger.info("Yay, no failing tests, no need for a second run!")
@@ -350,16 +349,16 @@ subprojects {
         // no need to overwrite anything in this case
         if (testClassName != null) {
           logger.info("Second execution of $testClassName was successful, previous failures seem to be flaky. Marking test result to be overwritten.")
-          oldResultsToOverwite << testClassName
+          oldResultsToOverwrite << testClassName
         }
       }
     }
 
     doLast {
-      if (oldResultsToOverwite.isEmpty()) {
+      if (oldResultsToOverwrite.isEmpty()) {
         logger.info("No flaky tests were detected, no need to overwrite previous test results")
       } else {
-        oldResultsToOverwite.each { testClassName ->
+        oldResultsToOverwrite.each { testClassName ->
           def oldReportFile = "$testResultsDir/TEST-${testClassName}.xml"
           def newReportsFile = "$reports.junitXml.destination/TEST-${testClassName}.xml"
           logger.warn("Overwriting old test result at $oldReportFile with $newReportsFile")

--- a/build.gradle
+++ b/build.gradle
@@ -146,13 +146,13 @@ if (file('.git').exists()) {
 
 def shouldFilterFlakyTests = gradle.startParameter.taskNames.any{it.contains("FlakyRetry")}
 if (shouldFilterFlakyTests) {
-  println('''************************************************************************
+  logger.warn('''************************************************************************
   a FlakyRetry task was included in task list ->
   Failing tests will not cause a build failure. Test classes with failures will be run again to
   filter out flaky tests. Failures in this second run will cause build failure.
 ************************************************************************''')
 } else {
-  println("unitTestWithFlakyRetry was not included in task list, no anti-flaky steps are done, proceeding as normal upstream build")
+  logger.info("unitTestWithFlakyRetry was not included in task list, no anti-flaky steps are done, proceeding as normal upstream build")
 }
 
 subprojects {
@@ -298,7 +298,7 @@ subprojects {
 
     afterTest { TestDescriptor desc , TestResult result ->
       if (TestResult.ResultType.FAILURE == result.resultType) {
-        println("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
+        logger.warn("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
         failedTestsInFirstTestRun << desc
       }
     }
@@ -323,18 +323,18 @@ subprojects {
 
     doFirst {
       if (!failedTestsInFirstTestRun.isEmpty()) {
-        println("Executing failed tests again to filter out flaky tests")
-        println("Failed tests: " + failedTestsInFirstTestRun)
+        logger.warn("Executing failed tests again to filter out flaky tests")
+        logger.warn("Failed tests: " + failedTestsInFirstTestRun)
 
-        println("Successful results will overwrite stale failed test results from $testResultsDir to avoid jenkins reporting an UNSTABLE build")
+        logger.warn("Successful results will overwrite stale failed test results from $testResultsDir to avoid jenkins reporting an UNSTABLE build")
         def failedTestClasses = failedTestsInFirstTestRun.collect{
           it.className.replaceAll('\\.', '/') + ".*"
         } as Set
         // re-running complete classes to keep the integrity of the test results
-        println("Re-running $failedTestClasses")
+        logger.warn("Re-running $failedTestClasses")
         setIncludes(failedTestClasses)
       } else {
-        println("Yay, no failing tests, no need for a second run!")
+        logger.info("Yay, no failing tests, no need for a second run!")
         setExcludes(["**/*"])
       }
     }
@@ -349,7 +349,7 @@ subprojects {
         // Gradle seems to call afterSuite not only after suites but also when the executor finishes
         // no need to overwrite anything in this case
         if (testClassName != null) {
-          println("Second execution of $testClassName was successful, previous failures seem to be flaky. Marking test result to be overwritten.")
+          logger.info("Second execution of $testClassName was successful, previous failures seem to be flaky. Marking test result to be overwritten.")
           oldResultsToOverwite << testClassName
         }
       }
@@ -357,12 +357,12 @@ subprojects {
 
     doLast {
       if (oldResultsToOverwite.isEmpty()) {
-        println("No flaky tests were detected, no need to overwrite previous test results")
+        logger.info("No flaky tests were detected, no need to overwrite previous test results")
       } else {
         oldResultsToOverwite.each { testClassName ->
           def oldReportFile = "$testResultsDir/TEST-${testClassName}.xml"
           def newReportsFile = "$reports.junitXml.destination/TEST-${testClassName}.xml"
-          println("Overwriting old test result at $oldReportFile with $newReportsFile")
+          logger.warn("Overwriting old test result at $oldReportFile with $newReportsFile")
           Files.copy(Paths.get(newReportsFile), Paths.get(oldReportFile), StandardCopyOption.REPLACE_EXISTING)
         }
       }
@@ -411,7 +411,7 @@ subprojects {
 
     afterTest { TestDescriptor desc , TestResult result ->
       if (TestResult.ResultType.FAILURE == result.resultType) {
-        println("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
+        logger.warn("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
         failedTestsInFirstUnitRun << desc
       }
     }
@@ -433,16 +433,16 @@ subprojects {
 
     doFirst {
       if (!failedTestsInFirstUnitRun.isEmpty()) {
-        println("Executing failed tests again to filter out flaky tests")
-        println("Failed tests: " + failedTestsInFirstUnitRun)
+        logger.warn("Executing failed tests again to filter out flaky tests")
+        logger.warn("Failed tests: " + failedTestsInFirstUnitRun)
         def failedTestClasses = failedTestsInFirstUnitRun.collect{
           it.className.replaceAll('\\.', '/') + ".*"
         } as Set
         // re-running complete classes to keep the integrity of the test results
-        println("Re-running $failedTestClasses")
+        logger.warn("Re-running $failedTestClasses")
         setIncludes(failedTestClasses)
       } else {
-        println("Yay, no failing tests, no need for a second run!")
+        logger.info("Yay, no failing tests, no need for a second run!")
         setExcludes(["**/*"])
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@
 
 import org.ajoberstar.grgit.Grgit
 
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import java.nio.charset.StandardCharsets
 
 buildscript {
@@ -141,6 +144,16 @@ if (file('.git').exists()) {
   }
 }
 
+def shouldFilterFlakyTests = gradle.startParameter.taskNames.any{it.contains("FlakyRetry")}
+if (shouldFilterFlakyTests) {
+  println('''************************************************************************
+  a FlakyRetry task was included in task list ->
+  Failing tests will not cause a build failure. Test classes with failures will be run again to
+  filter out flaky tests. Failures in this second run will cause build failure.
+************************************************************************''')
+} else {
+  println("unitTestWithFlakyRetry was not included in task list, no anti-flaky steps are done, proceeding as normal upstream build")
+}
 
 subprojects {
   apply plugin: 'java'
@@ -267,6 +280,9 @@ subprojects {
     }
   }
 
+  def failedTestsInFirstTestRun = []
+  def testResultsDir = null
+
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
@@ -279,6 +295,78 @@ subprojects {
       exceptionFormat = testExceptionFormat
     }
     logTestStdout.rehydrate(delegate, owner, this)()
+
+    afterTest { TestDescriptor desc , TestResult result ->
+      if (TestResult.ResultType.FAILURE == result.resultType) {
+        println("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
+        failedTestsInFirstTestRun << desc
+      }
+    }
+    testResultsDir = reports.junitXml.destination
+
+    ignoreFailures = shouldFilterFlakyTests
+  }
+
+  task testWithFlakyRetry(type: Test, dependsOn: test) {
+    maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+
+    minHeapSize = "256m"
+    maxHeapSize = "2048m"
+
+    testLogging {
+      events = userTestLoggingEvents ?: testLoggingEvents
+      showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
+      exceptionFormat = testExceptionFormat
+    }
+
+    def oldResultsToOverwite = []
+
+    doFirst {
+      if (!failedTestsInFirstTestRun.isEmpty()) {
+        println("Executing failed tests again to filter out flaky tests")
+        println("Failed tests: " + failedTestsInFirstTestRun)
+
+        println("Successful results will overwrite stale failed test results from $testResultsDir to avoid jenkins reporting an UNSTABLE build")
+        def failedTestClasses = failedTestsInFirstTestRun.collect{
+          it.className.replaceAll('\\.', '/') + ".*"
+        } as Set
+        // re-running complete classes to keep the integrity of the test results
+        println("Re-running $failedTestClasses")
+        setIncludes(failedTestClasses)
+      } else {
+        println("Yay, no failing tests, no need for a second run!")
+        setExcludes(["**/*"])
+      }
+    }
+
+    afterSuite { TestDescriptor desc , TestResult result ->
+      if (TestResult.ResultType.FAILURE != result.resultType) {
+        // In case of flaky tests old results should be overwritten to avoid Jenkins considering a successful build
+        // UNSTABLE due to failed tests
+        // Unfortunately at this point new result files are not ready, so we need to defer overwrites to a later time,
+        // see doLast below
+        def testClassName = desc.className
+        // Gradle seems to call afterSuite not only after suites but also when the executor finishes
+        // no need to overwrite anything in this case
+        if (testClassName != null) {
+          println("Second execution of $testClassName was successful, previous failures seem to be flaky. Marking test result to be overwritten.")
+          oldResultsToOverwite << testClassName
+        }
+      }
+    }
+
+    doLast {
+      if (oldResultsToOverwite.isEmpty()) {
+        println("No flaky tests were detected, no need to overwrite previous test results")
+      } else {
+        oldResultsToOverwite.each { testClassName ->
+          def oldReportFile = "$testResultsDir/TEST-${testClassName}.xml"
+          def newReportsFile = "$reports.junitXml.destination/TEST-${testClassName}.xml"
+          println("Overwriting old test result at $oldReportFile with $newReportsFile")
+          Files.copy(Paths.get(newReportsFile), Paths.get(oldReportFile), StandardCopyOption.REPLACE_EXISTING)
+        }
+      }
+    }
   }
 
   task integrationTest(type: Test, dependsOn: compileJava) {
@@ -300,6 +388,8 @@ subprojects {
 
   }
 
+  def failedTestsInFirstUnitRun = []
+
   task unitTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
@@ -318,7 +408,46 @@ subprojects {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }
     }
+
+    afterTest { TestDescriptor desc , TestResult result ->
+      if (TestResult.ResultType.FAILURE == result.resultType) {
+        println("Found failing test $desc.parent - $desc.name, trying again in next turn of test execution")
+        failedTestsInFirstUnitRun << desc
+      }
+    }
+
+    ignoreFailures = shouldFilterFlakyTests
   }
+
+  task unitTestWithFlakyRetry(type: Test, dependsOn: unitTest) {
+    maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+
+    minHeapSize = "256m"
+    maxHeapSize = "2048m"
+
+    testLogging {
+      events = userTestLoggingEvents ?: testLoggingEvents
+      showStandardStreams = userShowStandardStreams ?: testShowStandardStreams
+      exceptionFormat = testExceptionFormat
+    }
+
+    doFirst {
+      if (!failedTestsInFirstUnitRun.isEmpty()) {
+        println("Executing failed tests again to filter out flaky tests")
+        println("Failed tests: " + failedTestsInFirstUnitRun)
+        def failedTestClasses = failedTestsInFirstUnitRun.collect{
+          it.className.replaceAll('\\.', '/') + ".*"
+        } as Set
+        // re-running complete classes to keep the integrity of the test results
+        println("Re-running $failedTestClasses")
+        setIncludes(failedTestClasses)
+      } else {
+        println("Yay, no failing tests, no need for a second run!")
+        setExcludes(["**/*"])
+      }
+    }
+  }
+
 
   jar {
     from "$rootDir/LICENSE"


### PR DESCRIPTION
These tasks run the tests and collect failures without failing the build. Failed tests are run again in a second turn and the build is failed only if there are test failures in this second run.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
