### PR TITLE
Add KStream branch with fluent API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.internals.KBranchedStream;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
@@ -403,6 +404,8 @@ public interface KStream<K, V> {
      */
     @SuppressWarnings("unchecked")
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
+
+    KBranchedStream<K, V> branch();
 
     /**
      * Merge this stream and the given stream into one larger stream.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KBranchedStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KBranchedStream.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class KBranchedStream<K, V> {
+
+    private final ProcessorGraphNode<K, V> parentNode;
+    private final List<Predicate<K, V>> predicates;
+    private final List<String> childNames;
+    private final Serde<K> keySerde;
+    private final Serde<V> valSerde;
+    private final Set<String> sourceNodes;
+    private final boolean repartitionRequired;
+    private final InternalStreamsBuilder builder;
+
+    KBranchedStream(final ProcessorGraphNode<K, V> parentNode, final List<Predicate<K, V>> predicates,
+                    final List<String> childNames, final Serde<K> keySerde, final Serde<V> valSerde,
+                    final Set<String> sourceNodes, final boolean repartitionRequired, final InternalStreamsBuilder builder) {
+        this.parentNode = parentNode;
+        this.predicates = predicates;
+        this.childNames = childNames;
+        this.keySerde = keySerde;
+        this.valSerde = valSerde;
+        this.sourceNodes = sourceNodes;
+        this.repartitionRequired = repartitionRequired;
+        this.builder = builder;
+    }
+
+    public KBranchedStream<K, V> addBranch(final Predicate<K, V> predicate, final Consumer<KStream<K, V>> streamBranch) {
+        add(predicate, streamBranch);
+        return this;
+    }
+
+    public void defaultBranch(final Predicate<K, V> predicate, final Consumer<KStream<K, V>> streamBranch) {
+        add(predicate, streamBranch);
+    }
+
+    private void add(final Predicate<K, V> predicate, final Consumer<KStream<K, V>> streamBranch) {
+        final String branchChildName = builder.newProcessorName("***BRANCH_CHILD***");
+        predicates.add(predicate);
+        childNames.add(branchChildName);
+
+        final ProcessorParameters<K, V> parameters = new ProcessorParameters<>(new KStreamPassThrough<>(), branchChildName);
+        final ProcessorGraphNode<K, V> branchChildNode = new ProcessorGraphNode<>(branchChildName, parameters);
+
+        builder.addGraphNode(parentNode, branchChildNode);
+        final KStreamImpl<K, V> newStream = new KStreamImpl<>(branchChildName, keySerde, valSerde, sourceNodes, repartitionRequired, branchChildNode, builder);
+        streamBranch.accept(newStream);
+    }
+}
+

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamLazyBranch.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamLazyBranch.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.To;
+
+import java.util.List;
+
+class KStreamLazyBranch<K, V> implements ProcessorSupplier<K, V> {
+
+    private final List<Predicate<K, V>> predicates;
+    private final List<String> childNodes;
+
+    KStreamLazyBranch(final List<Predicate<K, V>> predicates,
+                      final List<String> childNodes) {
+        this.predicates = predicates;
+        this.childNodes = childNodes;
+    }
+
+    @Override
+    public Processor<K, V> get() {
+        return new KStreamBranchLazyProcessor();
+    }
+
+    private class KStreamBranchLazyProcessor extends AbstractProcessor<K, V> {
+        @Override
+        public void process(final K key, final V value) {
+            for (int i = 0; i < predicates.size(); i++) {
+                if (predicates.get(i).test(key, value)) {
+                    // use forward with child here and then break the loop
+                    // so that no record is going to be piped to multiple streams
+                    context().forward(key, value, To.child(childNodes.get(i)));
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - stream.branch() (with no arguments) returns a KBranchedStream rather
 than array of KStreams, allowing for a more fluent definition of
 branches off of an original stream.

This is intended only as a proof of concept for discussion for a fluent branching API on KStream, in discussion in KIP 418.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
