### PR TITLE
KAFKA-8171: Set callback to null in addStopReplicaRequestForBrokers when replica …

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -357,7 +357,7 @@ class ControllerBrokerRequestBatch(controller: KafkaController, stateChangeLogge
       stopReplicaRequestMap.getOrElseUpdate(brokerId, Seq.empty[StopReplicaRequestInfo])
       val v = stopReplicaRequestMap(brokerId)
       stopReplicaRequestMap(brokerId) = v :+ StopReplicaRequestInfo(PartitionAndReplica(topicPartition, brokerId),
-        deletePartition, (r: AbstractResponse) => callback(r, brokerId))
+        deletePartition, if (callback != null) (r: AbstractResponse) => callback(r, brokerId) else null)
     }
   }
 

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -202,9 +202,11 @@ class ReplicaStateMachine(config: KafkaConfig,
           replicaState.put(replica, OnlineReplica)
         }
       case OfflineReplica =>
+        // Set callback to null so that controller will send one grouped request instead of one request for
+        // each topic partition
         validReplicas.foreach { replica =>
           controllerBrokerRequestBatch.addStopReplicaRequestForBrokers(Seq(replicaId), replica.topicPartition,
-            deletePartition = false, (_, _) => ())
+            deletePartition = false, null)
         }
         val (replicasWithLeadershipInfo, replicasWithoutLeadershipInfo) = validReplicas.partition { replica =>
           controllerContext.partitionLeadershipInfo.contains(replica.topicPartition)


### PR DESCRIPTION
Problem: 

In ControllerChannelManager.sendRequestsToBrokers, for STOP_REPLICA requests, it will try to group the requests based on deletePartition flag and callback:

> val (replicasToGroup, replicasToNotGroup) = replicaInfoList.partition(r => !r.deletePartition && r.callback == null)

When both conditions meet, controller is expected to only send one request to destionation broker. However, when adding the requests in ReplicaStateMachine, it's putting in non-null callback **_(_,_)=>()_**. Therefore, replicasToGroup is always empty and controller will always first sends an empty request followed by #partitions requests.


Fix: set the callback to null in addStopReplicaRequestForBrokers when replica state transits to offline.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
