### PR TITLE
KAFKA-8172: Fix to close file handlers before renaming files/directories

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -49,7 +49,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
 
     // mutable state
     private final AtomicInteger size;
-    private final FileChannel channel;
+    private volatile FileChannel channel;
     private volatile File file;
 
     /**
@@ -187,6 +187,15 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public void closeHandlers() throws IOException {
         channel.close();
+    }
+
+    /**
+     * Re-opens the channel if it not already open.
+     */
+    public void reopenHandler() throws IOException {
+        if(!channel.isOpen()) {
+            channel = openChannel(this.file, true, true, 0, false);
+        }
     }
 
     /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -783,6 +783,17 @@ class Log(@volatile var dir: File,
   }
 
   /**
+    * Re-Open handlers
+    */
+  def reopenHandlers() {
+    debug("Re-Opening handlers")
+    lock synchronized {
+      logSegments.foreach(_.reopenHandlers())
+      isMemoryMappedBufferClosed = false
+    }
+  }
+
+  /**
    * Append this message set to the active segment of the log, assigning offsets and Partition Leader Epochs
    *
    * @param records The records to append
@@ -1921,6 +1932,8 @@ class Log(@volatile var dir: File,
    * @throws IOException if the file can't be renamed and still exists
    */
   private def asyncDeleteSegment(segment: LogSegment) {
+    // Since we are deleting the segment, lets close its handlers
+    segment.closeHandlers()
     segment.changeFileSuffixes("", Log.DeletedFileSuffix)
     def deleteSeg() {
       info(s"Deleting segment ${segment.baseOffset}")
@@ -1972,6 +1985,10 @@ class Log(@volatile var dir: File,
       val sortedOldSegments = oldSegments.filter(seg => segments.containsKey(seg.baseOffset)).sortBy(_.baseOffset)
 
       checkIfMemoryMappedBufferClosed()
+
+      // Close the handlers of the new segments as we are renaming the files
+      sortedNewSegments.foreach(_.closeHandlers())
+
       // need to do this in two phases to be crash safe AND do the delete asynchronously
       // if we crash in the middle of this we complete the swap in loadSegments()
       if (!isRecoveredSwapFile)
@@ -1988,6 +2005,9 @@ class Log(@volatile var dir: File,
       }
       // okay we are safe now, remove the swap suffix
       sortedNewSegments.foreach(_.changeFileSuffixes(Log.SwapFileSuffix, ""))
+
+      // Re-Open the handlers since we closed them for renaming
+      sortedNewSegments.foreach(_.reopenHandlers())
     }
   }
 

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -595,6 +595,16 @@ class LogSegment private[log] (val log: FileRecords,
   }
 
   /**
+    * Re-Open the file handlers
+    */
+  def reopenHandlers() {
+    offsetIndex.reopenHandler()
+    timeIndex.reopenHandler()
+    log.reopenHandler()
+    txnIndex.reopenHandler()
+  }
+
+  /**
    * Delete this log segment from the filesystem.
    */
   def deleteIfExists() {

--- a/core/src/main/scala/kafka/log/TransactionIndex.scala
+++ b/core/src/main/scala/kafka/log/TransactionIndex.scala
@@ -102,6 +102,14 @@ class TransactionIndex(val startOffset: Long, @volatile var file: File) extends 
     maybeChannel = None
   }
 
+  /**
+    * Re-opens the channel if it not already open.
+    */
+  def reopenHandler(): Unit = {
+    if(maybeChannel == None)
+      openChannel()
+  }
+
   def renameTo(f: File): Unit = {
     try {
       if (file.exists)

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -67,6 +67,7 @@ class CheckpointFile[T](val file: File,
           fileOutputStream.getFD().sync()
         } finally {
           writer.close()
+          Utils.closeQuietly(fileOutputStream, tempPath.toString)
         }
 
         Utils.atomicMoveWithFallback(tempPath, path)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
@@ -88,6 +88,8 @@ public class OffsetCheckpoint {
 
                 writer.flush();
                 fileOutputStream.getFD().sync();
+            } finally {
+                Utils.closeQuietly(fileOutputStream, temp.getName());
             }
 
             Utils.atomicMoveWithFallback(temp.toPath(), file.toPath());


### PR DESCRIPTION
Fix to close file handlers before renaming files / directories and open them back if required

Following are the file renaming scenarios:
- Files are renamed to .deleted so they can be deleted
- .cleaned files are renamed to .swap as part of Log.replaceSegments flow
- .swap files are renamed to original files as part of Log.replaceSegments flow

Following are the folder renaming scenarios:
- When a topic is marked for deletion, folder is renamed
- As part of replacing current logs with future logs in LogManager

In above scenarios, if file handles are not closed, we get file access violation exception

Idea is to close the logs and file segments before doing a rename and open them back up if required.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
