### PR TITLE
KAFKA-7502: Cleanup KTable materialization logic in a single place (doMapValues)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -28,7 +28,6 @@ public class TableProcessorNode<K, V> extends StreamsGraphNode {
     private final ProcessorParameters<K, V> processorParameters;
     private final StoreBuilder<KeyValueStore<K, V>> storeBuilder;
     private final String[] storeNames;
-    private final StoreBuilder<KeyValueStore<K, V>> storeBuilder;
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V> processorParameters,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -28,6 +28,7 @@ public class TableProcessorNode<K, V> extends StreamsGraphNode {
     private final ProcessorParameters<K, V> processorParameters;
     private final StoreBuilder<KeyValueStore<K, V>> storeBuilder;
     private final String[] storeNames;
+    private final StoreBuilder<KeyValueStore<K, V>> storeBuilder;
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V> processorParameters,


### PR DESCRIPTION
This PR is the final part of KAFKA-7502, which cleans up `KTableImpl#doMapValues` method. (follow up of #6174, #6453, and #6519)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
