### PR TITLE
KAFKA-8162: IBM JDK Class not found error when handling SASL

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
@@ -49,7 +49,7 @@ public enum KerberosError {
 
     static {
         try {
-            if (Java.isIbmJdk()) {
+            if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.internal.KrbException")) {
                 KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.internal.KrbException");
             } else {
                 KRB_EXCEPTION_CLASS = Class.forName("sun.security.krb5.KrbException");
@@ -57,6 +57,15 @@ public enum KerberosError {
             KRB_EXCEPTION_RETURN_CODE_METHOD = KRB_EXCEPTION_CLASS.getMethod("returnCode");
         } catch (Exception e) {
             throw new KafkaException("Kerberos exceptions could not be initialized", e);
+        }
+    }
+
+    private static boolean canLoad(String clazz) {
+        try {
+            Class.forName(clazz);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
@@ -49,7 +49,9 @@ public enum KerberosError {
 
     static {
         try {
-            if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.internal.KrbException")) {
+            if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.KrbException")) {
+                KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.KrbException");
+            } else if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.internal.KrbException")) {
                 KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.internal.KrbException");
             } else {
                 KRB_EXCEPTION_CLASS = Class.forName("sun.security.krb5.KrbException");

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosError.java
@@ -49,6 +49,7 @@ public enum KerberosError {
 
     static {
         try {
+            // different IBM JDKs versions include different security implementations
             if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.KrbException")) {
                 KRB_EXCEPTION_CLASS = Class.forName("com.ibm.security.krb5.KrbException");
             } else if (Java.isIbmJdk() && canLoad("com.ibm.security.krb5.internal.KrbException")) {


### PR DESCRIPTION
Attempt to load the IBM internal class but fallback on loading the Sun
class if the IBM one is not found.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
