### PR TITLE
Removed Avro topic from TOC on kafka

### DIFF
--- a/docs/streams/developer-guide/datatypes.html
+++ b/docs/streams/developer-guide/datatypes.html
@@ -47,7 +47,6 @@
           <li><a class="reference internal" href="#available-serdes" id="id3">Available SerDes</a></li>
           <ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
-              <li><a class="reference internal" href="#avro" id="id5">Avro</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
               <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
           </ul>


### PR DESCRIPTION
## Description

- Removed TOC entry in Streams Developer Guide for Avro, since we have no content for this

## Related

- Jira Ticket: https://issues.apache.org/jira/browse/KAFKA-8181
- PR on `kafka-site`: https://github.com/apache/kafka-site/pull/195


### Committer Checklist (excluded from commit message)

- [ ] Verify documentation (including upgrade notes)

cc: 
@guozhangwang, @joel-hamill 


Signed-off-by: Victoria Bialas <vicky@confluent.io>


