### PR TITLE
add break keyword, when globalGroups has already updated.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -830,6 +830,7 @@ public class InternalTopologyBuilder {
             for (final String node : nodes) {
                 if (isGlobalSource(node)) {
                     globalGroups.addAll(nodes);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
1. Just add break keyword, when globalGroups has already updated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
