### PR TITLE
[MINOR] Allow specifying an optional adminClientBootstrapServers in Trogdor

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -61,6 +61,7 @@ import java.util.Optional;
 public class ProduceBenchSpec extends TaskSpec {
     private final String producerNode;
     private final String bootstrapServers;
+    private final String adminClientBootstrapServers;
     private final int targetMessagesPerSec;
     private final long maxMessages;
     private final PayloadGenerator keyGenerator;
@@ -77,6 +78,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("durationMs") long durationMs,
                          @JsonProperty("producerNode") String producerNode,
                          @JsonProperty("bootstrapServers") String bootstrapServers,
+                         @JsonProperty("adminClientBootstrapServers") String adminClientBootstrapServers,
                          @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
                          @JsonProperty("maxMessages") long maxMessages,
                          @JsonProperty("keyGenerator") PayloadGenerator keyGenerator,
@@ -90,6 +92,13 @@ public class ProduceBenchSpec extends TaskSpec {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
+        if (adminClientBootstrapServers != null) {
+            this.adminClientBootstrapServers = adminClientBootstrapServers;
+        } else if (bootstrapServers != null) {
+            this.adminClientBootstrapServers = bootstrapServers;
+        } else {
+            this.adminClientBootstrapServers = "";
+        }
         this.targetMessagesPerSec = targetMessagesPerSec;
         this.maxMessages = maxMessages;
         this.keyGenerator = keyGenerator == null ?
@@ -114,6 +123,11 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public String bootstrapServers() {
         return bootstrapServers;
+    }
+
+    @JsonProperty
+    public String adminClientBootstrapServers() {
+        return adminClientBootstrapServers;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -118,7 +118,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     newTopics.put(topicName, partSpec.newTopic(topicName));
                 }
                 status.update(new TextNode("Creating " + newTopics.keySet().size() + " topic(s)"));
-                WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
+                WorkerUtils.createTopics(log, spec.adminClientBootstrapServers(), spec.commonClientConf(),
                                          spec.adminClientConf(), newTopics, false);
                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
                 executor.submit(new SendRecords(active));

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -146,7 +146,8 @@ public class RoundTripWorker implements TaskWorker {
                     throw new RuntimeException("You must specify at least one active topic.");
                 }
                 status.update(new TextNode("Creating " + newTopics.keySet().size() + " topic(s)"));
-                WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
+                WorkerUtils.createTopics(log, spec.adminClientBootstrapServers(),
+                        spec.commonClientConf(),
                     spec.adminClientConf(), newTopics, true);
                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
                 toSendTracker = new ToSendTracker(spec.maxMessages());

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -33,6 +33,7 @@ import java.util.Map;
 public class RoundTripWorkloadSpec extends TaskSpec {
     private final String clientNode;
     private final String bootstrapServers;
+    private final String adminClientBootstrapServers;
     private final int targetMessagesPerSec;
     private final PayloadGenerator valueGenerator;
     private final TopicsSpec activeTopics;
@@ -47,6 +48,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
              @JsonProperty("durationMs") long durationMs,
              @JsonProperty("clientNode") String clientNode,
              @JsonProperty("bootstrapServers") String bootstrapServers,
+             @JsonProperty("adminClientBootstrapServers") String adminClientBootstrapServers,
              @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
              @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
              @JsonProperty("consumerConf") Map<String, String> consumerConf,
@@ -58,6 +60,13 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         super(startMs, durationMs);
         this.clientNode = clientNode == null ? "" : clientNode;
         this.bootstrapServers = bootstrapServers == null ? "" : bootstrapServers;
+        if (adminClientBootstrapServers != null) {
+            this.adminClientBootstrapServers = adminClientBootstrapServers;
+        } else if (bootstrapServers != null) {
+            this.adminClientBootstrapServers = bootstrapServers;
+        } else {
+            this.adminClientBootstrapServers = "";
+        }
         this.targetMessagesPerSec = targetMessagesPerSec;
         this.valueGenerator = valueGenerator == null ?
             new UniformRandomPayloadGenerator(32, 123, 10) : valueGenerator;
@@ -83,6 +92,11 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     @JsonProperty
     public int targetMessagesPerSec() {
         return targetMessagesPerSec;
+    }
+
+    @JsonProperty
+    public String adminClientBootstrapServers() {
+        return adminClientBootstrapServers;
     }
 
     @JsonProperty

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -54,9 +54,9 @@ public class JsonSerializationTest {
         verify(new WorkerDone(null, null, 0, 0, null, null));
         verify(new WorkerRunning(null, null, 0, null));
         verify(new WorkerStopping(null, null, 0, null));
-        verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, Optional.empty(), null, null, null, null, null));
-        verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null,
+        verify(new ProduceBenchSpec(0, 0, null, null, null,
+                0, 0, null, null, Optional.empty(), null, null, null, null, null));
+        verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null, null,
             0, null, null, 0));
         verify(new TopicsSpec());
         verify(new PartitionsSpec(0, (short) 0, null, null));


### PR DESCRIPTION
Allow specifying an optional adminClientBootstrapServers when launching Trogdor workloads which use the AdminClient to create topics.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
