### PR TITLE
attempt to fix KAFKA-8154 buffer overflow exceptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -544,6 +544,7 @@ public class SslTransportLayer implements TransportLayer {
 
                 if (unwrapResult.getStatus() == Status.OK) {
                     read += readFromAppBuffer(dst);
+                    break;
                 } else if (unwrapResult.getStatus() == Status.BUFFER_OVERFLOW) {
                     int currentApplicationBufferSize = applicationBufferSize();
                     appReadBuffer = Utils.ensureCapacity(appReadBuffer, currentApplicationBufferSize);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8154

Break the inner while loop after a successful unwrap operation. This allows the function to return if dst is full. 

The modified jar was used in an environment that reliably reproduced the problem when using an unmodified kafka library. The modified library did not manifest the problem. 
