### PR TITLE
attempt to fix KAFKA-8154 buffer overflow exceptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -530,7 +530,7 @@ public class SslTransportLayer implements TransportLayer {
                     readFromNetwork = true;
             }
 
-            while (netReadBuffer.position() > 0) {
+            if (netReadBuffer.position() > 0) {
                 netReadBuffer.flip();
                 SSLEngineResult unwrapResult = sslEngine.unwrap(netReadBuffer, appReadBuffer);
                 netReadBuffer.compact();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8154

Replace the inner while loop with an if statement. The purpose of the loop if to retry the unwrap after resizing of emptying the AppReadBuffer, however, neither of those operations are currently guaranteed. 

The modified jar was used in an environment that reliably reproduced the problem when using an unmodified kafka library. The modified library did not manifest the problem. 
