### PR TITLE
Fix with resize

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -546,7 +546,7 @@ public class SslTransportLayer implements TransportLayer {
                     read += readFromAppBuffer(dst);
                 } else if (unwrapResult.getStatus() == Status.BUFFER_OVERFLOW) {
                     int currentApplicationBufferSize = applicationBufferSize();
-                    appReadBuffer = Utils.ensureCapacity(appReadBuffer, currentApplicationBufferSize);
+                    appReadBuffer = Utils.ensureCapacity(appReadBuffer, currentApplicationBufferSize + appReadBuffer.position());
                     if (appReadBuffer.position() >= currentApplicationBufferSize) {
                         throw new IllegalStateException("Buffer overflow when available data size (" + appReadBuffer.position() +
                                                         ") >= application buffer size (" + currentApplicationBufferSize + ")");

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -547,18 +547,19 @@ public class SslTransportLayer implements TransportLayer {
                 } else if (unwrapResult.getStatus() == Status.BUFFER_OVERFLOW) {
                     int currentApplicationBufferSize = applicationBufferSize();
                     appReadBuffer = Utils.ensureCapacity(appReadBuffer, currentApplicationBufferSize + appReadBuffer.position());
-                    if (appReadBuffer.position() >= currentApplicationBufferSize) {
-                        throw new IllegalStateException("Buffer overflow when available data size (" + appReadBuffer.position() +
-                                                        ") >= application buffer size (" + currentApplicationBufferSize + ")");
-                    }
 
-                    // appReadBuffer will extended upto currentApplicationBufferSize
-                    // we need to read the existing content into dst before we can do unwrap again. If there are no space in dst
-                    // we can break here.
-                    if (dst.hasRemaining())
-                        read += readFromAppBuffer(dst);
-                    else
-                        break;
+//                    if (appReadBuffer.position() >= currentApplicationBufferSize) {
+//                        throw new IllegalStateException("Buffer overflow when available data size (" + appReadBuffer.position() +
+//                                                        ") >= application buffer size (" + currentApplicationBufferSize + ")");
+//                    }
+//
+//                    // appReadBuffer will extended upto currentApplicationBufferSize
+//                    // we need to read the existing content into dst before we can do unwrap again. If there are no space in dst
+//                    // we can break here.
+//                    if (dst.hasRemaining())
+//                        read += readFromAppBuffer(dst);
+//                    else
+//                        break;
                 } else if (unwrapResult.getStatus() == Status.BUFFER_UNDERFLOW) {
                     int currentNetReadBufferSize = netReadBufferSize();
                     netReadBuffer = Utils.ensureCapacity(netReadBuffer, currentNetReadBufferSize);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8154

Resize the appReadBuffer on buffer overflow and continue to the next iteration of the loop to retry the unwrap operation. 

The modified jar was used in an environment that reliably reproduced the problem when using an unmodified kafka library. The modified library did not manifest the problem. 
