### PR TITLE
KAFKA-8277: Fix NPEs in several methods of ConnectHeaders

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -274,7 +274,7 @@ public class ConnectHeaders implements Headers {
     @Override
     public Headers remove(String key) {
         checkKey(key);
-        if (!headers.isEmpty()) {
+        if (!isEmpty()) {
             Iterator<Header> iterator = iterator();
             while (iterator.hasNext()) {
                 if (iterator.next().key().equals(key)) {
@@ -287,7 +287,7 @@ public class ConnectHeaders implements Headers {
 
     @Override
     public Headers retainLatest() {
-        if (!headers.isEmpty()) {
+        if (!isEmpty()) {
             Set<String> keys = new HashSet<>();
             ListIterator<Header> iter = headers.listIterator(headers.size());
             while (iter.hasPrevious()) {
@@ -304,7 +304,7 @@ public class ConnectHeaders implements Headers {
     @Override
     public Headers retainLatest(String key) {
         checkKey(key);
-        if (!headers.isEmpty()) {
+        if (!isEmpty()) {
             boolean found = false;
             ListIterator<Header> iter = headers.listIterator(headers.size());
             while (iter.hasPrevious()) {
@@ -322,7 +322,7 @@ public class ConnectHeaders implements Headers {
     @Override
     public Headers apply(String key, HeaderTransform transform) {
         checkKey(key);
-        if (!headers.isEmpty()) {
+        if (!isEmpty()) {
             ListIterator<Header> iter = headers.listIterator();
             while (iter.hasNext()) {
                 Header orig = iter.next();
@@ -341,7 +341,7 @@ public class ConnectHeaders implements Headers {
 
     @Override
     public Headers apply(HeaderTransform transform) {
-        if (!headers.isEmpty()) {
+        if (!isEmpty()) {
             ListIterator<Header> iter = headers.listIterator();
             while (iter.hasNext()) {
                 Header orig = iter.next();

--- a/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
@@ -119,6 +119,14 @@ public class ConnectHeadersTest {
     }
 
     @Test
+    public void shouldRetainLatestWhenEmpty() {
+        headers.retainLatest(other);
+        headers.retainLatest(key);
+        headers.retainLatest();
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
     public void shouldAddMultipleHeadersWithSameKeyAndRetainLatest() {
         populate(headers);
 
@@ -180,6 +188,12 @@ public class ConnectHeadersTest {
     }
 
     @Test
+    public void shouldRemoveAllHeadersWithSameKeyWhenEmpty() {
+        headers.remove(key);
+        assertNoHeaderWithKey(key);
+    }
+
+    @Test
     public void shouldRemoveAllHeadersWithSameKey() {
         populate(headers);
 
@@ -208,6 +222,13 @@ public class ConnectHeadersTest {
         assertNoHeaderWithKey(key);
         assertNoHeaderWithKey(other);
         assertEquals(0, headers.size());
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void shouldTransformHeadersWhenEmpty() {
+        headers.apply(appendToKey("-suffix"));
+        headers.apply(key, appendToKey("-suffix"));
         assertTrue(headers.isEmpty());
     }
 


### PR DESCRIPTION
Replace `headers.isEmpty()` by calls to `isEmpty()` as the
latter does a null check on heathers (that is lazily created).

Testing strategy: extending the existing unit tests for the case in which headers is null.

No need to change docs because not throwing NPEs is what the user expects from the docs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
