### PR TITLE
KAFKA-7841: Implement KIP-419 adding SourceTask.stopped method

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -102,4 +102,18 @@ public abstract class SourceTask implements Task {
     public void commitRecord(SourceRecord record) throws InterruptedException {
         // This space intentionally left blank.
     }
+
+    /**
+     * <p>
+     * This task has stopped and can safely release resources.
+     * </p>
+     * <p>
+     * SourceTasks are not required to implement this functionality. This hook is provided
+     * for systems that have resources such as network connections that need to be
+     * released safely once the SourceTask has indeed stopped.
+     * </p>
+     */
+    public void stopped() {
+        // This space intentionally left blank.
+    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -215,6 +215,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
 
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
+
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();
 
@@ -263,6 +266,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         sourceTask.stop();
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
+
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
 
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();
@@ -316,6 +322,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
 
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
+
         producer.close(EasyMock.anyObject(Duration.class));
         EasyMock.expectLastCall();
 
@@ -356,6 +365,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         sourceTask.stop();
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
+
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
 
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();
@@ -401,6 +413,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         sourceTask.stop();
         EasyMock.expectLastCall();
         expectOffsetFlush(false);
+
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
 
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();
@@ -591,6 +606,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         sourceTask.stop();
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
+
+        sourceTask.stopped();
+        EasyMock.expectLastCall();
 
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();


### PR DESCRIPTION
Add a new SourceTask.stopped method called as the last method in the lifecycle of a SourceTask.
Called just as the resources are cleaned up in the Kafka Connect runtime.

Testing by adding checks that the new method is called as expected in the existing Kafka Connect runtime tests.

The contribution is my original work and I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)