### PR TITLE
KAFKA-8215: Pt I. Share block cache between instances

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -433,6 +433,9 @@ public class StreamsConfig extends AbstractConfig {
     public static final String ROCKSDB_CONFIG_SETTER_CLASS_CONFIG = "rocksdb.config.setter";
     private static final String ROCKSDB_CONFIG_SETTER_CLASS_DOC = "A Rocks DB config setter class or class name that implements the <code>org.apache.kafka.streams.state.RocksDBConfigSetter</code> interface";
 
+    /** {@code rocksdb.shared.block.cache} */
+    public static final String ROCKSDB_SHARED_BLOCK_CACHE = "rocksdb.shared.block.cache";
+
     /** {@code security.protocol} */
     @SuppressWarnings("WeakerAccess")
     public static final String SECURITY_PROTOCOL_CONFIG = CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -34,4 +34,15 @@ public interface RocksDBConfigSetter {
      * @param configs       the configuration supplied to {@link org.apache.kafka.streams.StreamsConfig}
      */
     void setConfig(final String storeName, final Options options, final Map<String, Object> configs);
+
+    /**
+     * Turn on/off sharing of the block cache between all RocksDB instances within a process. Override this to share
+     * the cache and limit memory usage. Note that the default shared block cache size is the same as the default
+     * for individual block caches (50 MB) so you may want to set this value in setConfig()
+     *
+     * @return              true means share the block cache
+     */
+    default boolean shareBlockCache() {
+        return false;
+    }
 }


### PR DESCRIPTION
As of v5.12, RocksDB provides an API for sharing the block cache across all instances in a single process. Because it involves passing the same cache to the Rocks Options, this ability is not supported by the current Streams configs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
