### PR TITLE
KAFKA-9538: Flaky test: testResetOffsetsExportImportPlan

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -413,8 +413,8 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
     val cgcArgs = buildArgsForGroups(Seq(group1, group2), "--all-topics", "--to-offset", "2", "--export")
     val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
-    produceConsumeAndShutdown(topic = topic1, group = group1, totalMessages = 100, numConsumers = 2)
-    produceConsumeAndShutdown(topic = topic2, group = group2, totalMessages = 100, numConsumers = 5)
+    produceConsumeAndShutdown(topic = topic1, group = group1, totalMessages = 100)
+    produceConsumeAndShutdown(topic = topic2, group = group2, totalMessages = 100)
 
     awaitConsumerGroupInactive(consumerGroupCommand, group1)
     awaitConsumerGroupInactive(consumerGroupCommand, group2)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8211

Reduced offset-committing interval from 5 seconds to 1 second, hoping consumer#committed returns offset more quickly. Besides, enriched the output message for the exceptional case.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
