### PR TITLE
KAFKA-8226: New MirrorMaker option partition.to.partition

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -75,4 +75,25 @@ class MirrorMakerTest {
     assertEquals("headerValue", new String(producerRecord.headers.lastHeader("headerKey").value))
     assertEquals(1, producerRecord.headers.asScala.size)
   }
+
+  @Test
+  def testDefaultMirrorMakerMessageHandlerWithPartitionToPartition() {
+    val now = 12345L
+    val consumerRecord = BaseConsumerRecord("topic", 123, 1L, now, TimestampType.CREATE_TIME, "key".getBytes,
+      "value".getBytes)
+
+    val oldSetting = MirrorMaker.partitionToPartition
+    MirrorMaker.partitionToPartition = true
+    val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
+    MirrorMaker.partitionToPartition = oldSetting
+
+    assertEquals(1, result.size)
+
+    val producerRecord = result.get(0)
+    assertEquals(now, producerRecord.timestamp)
+    assertEquals("topic", producerRecord.topic)
+    assertEquals(123, producerRecord.partition)
+    assertEquals("key", new String(producerRecord.key))
+    assertEquals("value", new String(producerRecord.value))
+  }
 }


### PR DESCRIPTION
When partition.to.partition=true MirrorMaker retains the partition number when mirroring records even without the keys. When partition.to.partition is disabled, records with null keys are shuffled between destination partitions.
When using this option - source and destination topics are assumed to have the same number of partitions.