### PR TITLE
 KAFKA-6647 KafkaStreams.cleanUp creates .lock file in directory its trying to clean (Windows OS) 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -329,7 +329,7 @@ public class StateDirectory {
 
 
     /**
-     * Delete Task Dir with retry option and handle Exceptions.
+     * Delete Task Dir with retry option and exception handling.
      * In Windows TaskDir is not empty due to lock file in it
      * First call with indicateRetryIfDirectoryNotEmpty = true to indicate possibility to try it again after unlock
      *

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -328,7 +328,8 @@ public class StateDirectory {
     }
 
 
-    /** Delete Task Dir with retry option and handle Exceptions.
+    /**
+     * Delete Task Dir with retry option and handle Exceptions.
      * In Windows TaskDir is not empty due to lock file in it
      * First call with indicateRetryIfDirectoryNotEmpty = true to indicate possibility to try it again after unlock
      *

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -328,7 +328,7 @@ public class StateDirectory {
     }
 
 
-    /** Delete Task Dir and handle Exceptions.
+    /** Delete Task Dir with retry option and handle Exceptions.
      * In Windows TaskDir is not empty due to lock file in it
      * First call with indicateRetryIfDirectoryNotEmpty = true to indicate possibility to try it again after unlock
      *

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -324,6 +324,8 @@ public class StateDirectoryTest {
         thread.join(30000);
         assertNull("should not have had an exception during locking on other thread", exceptionOnThread.get());
         assertFalse(directory.lock(taskId));
+        //This test (@After method) is still failing in Windows due to existing lock file in directory see KAFKA-6647
+        //There is no way to unlock task of already dead thread without adding extra code to StateDirectory class
     }
 
     @Test
@@ -354,6 +356,7 @@ public class StateDirectoryTest {
 
         assertNull("should not have had an exception on other thread", exceptionOnThread.get());
         assertTrue(directory.lock(taskId));
+        directory.unlock(taskId);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -324,7 +324,7 @@ public class StateDirectoryTest {
         thread.join(30000);
         assertNull("should not have had an exception during locking on other thread", exceptionOnThread.get());
         assertFalse(directory.lock(taskId));
-        //This test (@After method) is still failing in Windows due to existing lock file in directory see KAFKA-6647
+        //This test (@After cleanup method) is still failing in Windows due to existing lock file in directory see KAFKA-6647
         //There is no way to unlock task of already dead thread without adding extra code to StateDirectory class
     }
 


### PR DESCRIPTION
This KAFKA-6647 KafkaStreams.cleanUp creates .lock file in directory its trying to clean (Windows OS) has been open for a while, and long conversation in previous Pull Requests. Anyway this problems is causing the TopologyTestDriver driver based unit test failing in Windows if not adding extra exception handling in there.

This PR version is trying to keep the general functionality as similar as earlier. Only add one extra retry of delete, if first failed due to DirectoryNotExmptyException. When added the retry logic only at the end of finally, caused checkstyle CyclomaticComplexity and NPathComplexity to go above threshold.
After it extracted cleanRemovedTaskDir and deleteTaskDir methods to avoid complexity.
Also time condition evaluation changed to be first before locking, so no need to lock if inner block is doing nothing.


No external functionality changed, so no additional test cases added.

Following five test in StateDirectoryTest failed earlier in Windows.
StateDirectoryTest.shouldCleanUpTaskStateDirectoriesThatAreNotCurrentlyLocked
StateDirectoryTest.shouldCleanupStateDirectoriesWhenLastModifiedIsLessThanNowMinusCleanupDelay
StateDirectoryTest.shouldNotLockStateDirLockedByAnotherThread
StateDirectoryTest.shouldNotUnLockStateDirLockedByAnotherThread
StateDirectoryTest.shouldCleanupAllTaskDirectoriesIncludingGlobalOne

Test shouldNotLockStateDirLockedByAnotherThread is still failing due to
there is no way to unlock task of already dead thread without adding extra code to StateDirectory class.
The test left as is, but explanatory comment added. The rest four of those five tests are now successful also in Windows.


Also shouldUseSerdesDefinedInMaterializedToConsumeGlobalTable test in StreamsBuilderTest failed in Windows before this change. After the change all the tests in StreamsBuilderTest are succesful.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
