### PR TITLE
MINOR: Add logging for the case when a topic is automatically created upon receiving a MetadataRequest

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -959,10 +959,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     topicMetadata.headOption.getOrElse(createInternalTopic(topic))
   }
 
-  private def getTopicMetadata(allowAutoTopicCreation: Boolean, topics: Set[String], listenerName: ListenerName,
+  private def getTopicMetadata(allowAutoTopicCreation: Boolean, topics: Set[String], requestContext: RequestContext,
                                errorUnavailableEndpoints: Boolean,
                                errorUnavailableListeners: Boolean): Seq[MetadataResponse.TopicMetadata] = {
-    val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
+    val topicResponses = metadataCache.getTopicMetadata(topics, requestContext.listenerName,
         errorUnavailableEndpoints, errorUnavailableListeners)
     if (topics.isEmpty || topicResponses.size == topics.size) {
       topicResponses
@@ -976,6 +976,12 @@ class KafkaApis(val requestChannel: RequestChannel,
           else
             topicMetadata
         } else if (allowAutoTopicCreation && config.autoCreateTopicsEnable) {
+          val msg =  "Automatically creating topic: " + topic + " with " + config.numPartitions +
+            " partitions and replication factor " + config.defaultReplicationFactor +
+            " due to request from " + requestContext.principal + " at IP address " +
+            requestContext.clientAddress + " and header " + requestContext.header
+          info(msg)
+
           createTopic(topic, config.numPartitions, config.defaultReplicationFactor)
         } else {
           new MetadataResponse.TopicMetadata(Errors.UNKNOWN_TOPIC_OR_PARTITION, topic, false, java.util.Collections.emptyList())
@@ -1037,7 +1043,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponse.TopicMetadata]
       else
-        getTopicMetadata(metadataRequest.allowAutoTopicCreation, authorizedTopics, request.context.listenerName,
+        getTopicMetadata(metadataRequest.allowAutoTopicCreation, authorizedTopics, request.context,
           errorUnavailableEndpoints, errorUnavailableListeners)
 
     var clusterAuthorizedOperations = 0


### PR DESCRIPTION
When Kafka receives a metadata request to get metadata for some non-existent topic and if `auto.create.topics.enable` is true, it automatically creates that non-existent topic with the default number of partitions and replication factor. The current logging provides minimum information when this automatic topic creation happens.

In some situations, knowing which application/client triggers the auto-topic creation would be very useful. For example, for a Kafka cluster with `auto.create.topics.enable` being true, some Kafka users might have their business log relies on the fact that this configuration property is true. However, `auto.create.topics.enable` is required to be set to false for some reason, knowing which applications/clients trigger the auto-topic creation would help cluster operators identify who are potentially going to be affected by this configuration change a so that some actions could be taken ahead of time.