### PR TITLE
[MINOR] RocksDBConfigSetter docs: warn users to (re)set Filter 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -23,6 +23,9 @@ import java.util.Map;
 /**
  * An interface to that allows developers to customize the RocksDB settings for a given Store.
  * Please read the <a href="https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide">RocksDB Tuning Guide</a>.
+ *
+ * Note: if you choose to set options.setTableFormatConfig(tableConfig) with a new BlockBasedTableConfig you should
+ * probably also set the filter for that tableConfig, most likely with tableConfig.setFilter(new BloomFilter());
  */
 public interface RocksDBConfigSetter {
 


### PR DESCRIPTION
Currently when opening a new instance of RocksDB, we first set the default options before reading in any user supplied ones through RocksDBConfigSetter. One such option is the TableFormatConfig, for which we create a new BlockBasedTableConfig object, set its specific options, and then pass to the options#setTableFormatConfig.

A new TableFormatConfig has its filter parameter initialized to null, which we set to a new BloomFilter() by default and which most users probably want to keep even if they override the other defaults. The problem is if they do override other defaults involving tableConfig, they must do so by making a new BlockBasedTableConfig and then calling options#setTableFormatConfig with it. 

If they only change e.g. the block cache size through this parameter, they override the default tableConfig with their custom one which has its filter set to null. So we should warn users whose RocksDBConfigSetter involves setting a new BlockBasedTableConfig that they should probably also set the filter on this object as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
