### PR TITLE
KAFKA-8229: Only change nextCommit if and only if now >= to it

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -615,7 +615,7 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     // Visible for testing
-    public long getNextCommit() {
+    long getNextCommit() {
         return nextCommit;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -206,9 +206,7 @@ class WorkerSinkTask extends WorkerTask {
             // Maybe commit
             if (!committing && (context.isCommitRequested() || now >= nextCommit)) {
                 commitOffsets(now, false);
-                if (now >= nextCommit) {
-                    nextCommit += offsetCommitIntervalMs;
-                }
+                nextCommit = now + offsetCommitIntervalMs;
                 context.clearCommitRequest();
             }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -206,7 +206,9 @@ class WorkerSinkTask extends WorkerTask {
             // Maybe commit
             if (!committing && (context.isCommitRequested() || now >= nextCommit)) {
                 commitOffsets(now, false);
-                nextCommit += offsetCommitIntervalMs;
+                if (now >= nextCommit) {
+                    nextCommit += offsetCommitIntervalMs;
+                }
                 context.clearCommitRequest();
             }
 
@@ -610,6 +612,11 @@ class WorkerSinkTask extends WorkerTask {
 
     SinkTaskMetricsGroup sinkTaskMetricsGroup() {
         return sinkTaskMetricsGroup;
+    }
+
+    // Visible for testing
+    public long getNextCommit() {
+        return nextCommit;
     }
 
     private class HandleRebalance implements ConsumerRebalanceListener {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -577,7 +577,8 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("offset-commit-success-percentage", 0.0);
 
         // Grab the commit time prior to requesting a commit.
-        // This time should not advance after committing
+        // This time should advance slightly after committing.
+        // KAFKA-8229
         final long previousCommitValue = workerTask.getNextCommit();
         sinkTaskContext.getValue().requestCommit();
         assertTrue(sinkTaskContext.getValue().isCommitRequested());
@@ -588,10 +589,14 @@ public class WorkerSinkTaskTest {
         assertFalse(sinkTaskContext.getValue().isCommitRequested()); // should have been cleared
         assertEquals(offsets, Whitebox.<Map<TopicPartition, OffsetAndMetadata>>getInternalState(workerTask, "lastCommittedOffsets"));
         assertEquals(0, workerTask.commitFailures());
-        // Assert the next commit time hasn't advance just because
-        // we requested a commit.
+        // Assert the next commit time advances slightly, the amount it advances
+        // is the normal commit time less the two sleeps since it started each
+        // of those sleeps were 10 seconds.
         // KAFKA-8229
-        assertEquals(previousCommitValue, workerTask.getNextCommit());
+        assertEquals("Should have only advanced by 40 seconds",
+                     previousCommitValue  +
+                     (WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_DEFAULT - 10000L * 2),
+                     workerTask.getNextCommit());
 
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);


### PR DESCRIPTION
Summary
When using the commitRequest api within sink context, the next commit
timer should not advance. Timer should only advance when it is the
cause of the commit. Prior to this change, the time would advance
_each_ time a commit happens -- including when a commit happens
because it was requested by the `Task`. When a `Task` requests a
commit several times, the clock advances far into the future
preventing commits from happening.

This commit changes the behavior, if the `Task` requested a commit and
the `nextCommit` is in the _near_ future, `nextCommit` will not
advance.

KAFKA-8229

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
