### PR TITLE
KAFKA-8231: Expansion of ConnectClusterState interface

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
@@ -25,7 +25,7 @@ public interface ConnectClusterDetails {
 
     /**
      * Get the cluster ID of the Kafka cluster backing this Connect cluster.
-     * @return the cluster ID of the Kafka cluster backing this connect cluster
+     * @return the cluster ID of the Kafka cluster backing this Connect cluster
      **/
     String kafkaClusterId();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
@@ -23,9 +23,9 @@ package org.apache.kafka.connect.health;
  */
 public interface ConnectClusterDetails {
 
-  /**
-   * Get the cluster ID of the Kafka cluster backing this Connect cluster.
-   * @return the cluster ID of the Kafka cluster backing this connect cluster
-   **/
-  public String kafkaClusterId();
+    /**
+     * Get the cluster ID of the Kafka cluster backing this Connect cluster.
+     * @return the cluster ID of the Kafka cluster backing this connect cluster
+     **/
+    String kafkaClusterId();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.health;
+
+/**
+ * Provides immutable connect cluster information, such as the ID of the backing Kafka cluster. The
+ * Connect framework provides the implementation for this interface.
+ */
+public interface ConnectClusterDetails {
+
+  /**
+   * Get the cluster ID of the Kafka cluster backing this Connect cluster.
+   * @return the cluster ID of the Kafka cluster backing this connect cluster
+   **/
+  public String kafkaClusterId();
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
@@ -18,13 +18,14 @@
 package org.apache.kafka.connect.health;
 
 /**
- * Provides immutable connect cluster information, such as the ID of the backing Kafka cluster. The
+ * Provides immutable Connect cluster information, such as the ID of the backing Kafka cluster. The
  * Connect framework provides the implementation for this interface.
  */
 public interface ConnectClusterDetails {
 
     /**
      * Get the cluster ID of the Kafka cluster backing this Connect cluster.
+     * 
      * @return the cluster ID of the Kafka cluster backing this Connect cluster
      **/
     String kafkaClusterId();

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.connect.health;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Provides the ability to lookup connector metadata and its health. This is made available to the {@link org.apache.kafka.connect.rest.ConnectRestExtension}
@@ -43,4 +44,32 @@ public interface ConnectClusterState {
      * @throws org.apache.kafka.connect.errors.NotFoundException if the requested connector can't be found
      */
     ConnectorHealth connectorHealth(String connName);
+
+    /**
+     * Lookup the current configuration of a connector. This provides the current snapshot of configuration by querying the underlying
+     * herder. A connector returned by previous invocation of {@link #connectors()} may no longer be available and could result in {@link
+     * org.apache.kafka.connect.errors.NotFoundException}.
+     *
+     * @param connName name of the connector
+     * @return the configuration of the connector for the connector name
+     * @throws org.apache.kafka.connect.errors.NotFoundException if the requested connector can't be found
+     */
+    Map<String, String> connectorConfig(String connName);
+
+    /**
+     * Lookup the current task configurations of a connector. This provides the current snapshot of configuration by querying the underlying
+     * herder. A connector returned by previous invocation of {@link #connectors()} may no longer be available and could result in {@link
+     * org.apache.kafka.connect.errors.NotFoundException}.
+     *
+     * @param connName name of the connector
+     * @return the configuration for each task ID
+     * @throws org.apache.kafka.connect.errors.NotFoundException if the requested connector can't be found
+     **/
+    Map<Integer, Map<String, String>> taskConfigs(String connName);
+
+    /**
+     * Get the cluster ID of the Kafka cluster backing this Connect cluster.
+     * @return the cluster ID of the Kafka cluster backing this connect cluster
+     **/
+    String kafkaClusterId();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
@@ -21,8 +21,10 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Provides the ability to lookup connector metadata and its health. This is made available to the {@link org.apache.kafka.connect.rest.ConnectRestExtension}
- * implementations. The Connect framework provides the implementation for this interface.
+ * Provides the ability to lookup connector metadata, including status and configurations, as well
+ * as immutable cluster information such as Kafka cluster ID. This is made available to
+ * {@link org.apache.kafka.connect.rest.ConnectRestExtension} implementations. The Connect framework
+ * provides the implementation for this interface.
  */
 public interface ConnectClusterState {
 
@@ -53,23 +55,18 @@ public interface ConnectClusterState {
      * @param connName name of the connector
      * @return the configuration of the connector for the connector name
      * @throws org.apache.kafka.connect.errors.NotFoundException if the requested connector can't be found
+     * @throws java.lang.UnsupportedOperationException if the default implementation has not been overridden
      */
-    Map<String, String> connectorConfig(String connName);
+    default Map<String, String> connectorConfig(String connName) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
-     * Lookup the current task configurations of a connector. This provides the current snapshot of configuration by querying the underlying
-     * herder. A connector returned by previous invocation of {@link #connectors()} may no longer be available and could result in {@link
-     * org.apache.kafka.connect.errors.NotFoundException}.
-     *
-     * @param connName name of the connector
-     * @return the configuration for each task ID
-     * @throws org.apache.kafka.connect.errors.NotFoundException if the requested connector can't be found
+     * Get details about the setup of the Connect cluster.
+     * @return a {@link ConnectClusterDetails} object containing information about the cluster
+     * @throws java.lang.UnsupportedOperationException if the default implementation has not been overridden
      **/
-    Map<Integer, Map<String, String>> taskConfigs(String connName);
-
-    /**
-     * Get the cluster ID of the Kafka cluster backing this Connect cluster.
-     * @return the cluster ID of the Kafka cluster backing this connect cluster
-     **/
-    String kafkaClusterId();
+    default ConnectClusterDetails clusterDetails() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.runtime.health;
+
+import org.apache.kafka.connect.health.ConnectClusterDetails;
+
+public class ConnectClusterDetailsImpl implements ConnectClusterDetails {
+
+  private final String kafkaClusterId;
+
+  public ConnectClusterDetailsImpl(String kafkaClusterId) {
+    this.kafkaClusterId = kafkaClusterId;
+  }
+
+  @Override
+  public String kafkaClusterId() {
+    return kafkaClusterId;
+  }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
@@ -21,14 +21,14 @@ import org.apache.kafka.connect.health.ConnectClusterDetails;
 
 public class ConnectClusterDetailsImpl implements ConnectClusterDetails {
 
-  private final String kafkaClusterId;
+    private final String kafkaClusterId;
 
-  public ConnectClusterDetailsImpl(String kafkaClusterId) {
-    this.kafkaClusterId = kafkaClusterId;
-  }
+    public ConnectClusterDetailsImpl(String kafkaClusterId) {
+        this.kafkaClusterId = kafkaClusterId;
+    }
 
-  @Override
-  public String kafkaClusterId() {
-    return kafkaClusterId;
-  }
+    @Override
+    public String kafkaClusterId() {
+        return kafkaClusterId;
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -19,10 +19,12 @@ package org.apache.kafka.connect.runtime.rest;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.health.ConnectClusterDetails;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.health.ConnectClusterDetailsImpl;
 import org.apache.kafka.connect.runtime.health.ConnectClusterStateImpl;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectExceptionMapper;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResource;
@@ -328,10 +330,14 @@ public class RestServer {
             herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());
         }
 
+        ConnectClusterDetails connectClusterDetails = new ConnectClusterDetailsImpl(
+            herder.kafkaClusterId()
+        );
+
         ConnectRestExtensionContext connectRestExtensionContext =
             new ConnectRestExtensionContextImpl(
                 new ConnectRestConfigurable(resourceConfig),
-                new ConnectClusterStateImpl(herderRequestTimeoutMs, herder)
+                new ConnectClusterStateImpl(herderRequestTimeoutMs, connectClusterDetails, herder)
             );
         for (ConnectRestExtension connectRestExtension : connectRestExtensions) {
             connectRestExtension.register(connectRestExtensionContext);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/health/ConnectClusterStateImplTest.java
@@ -46,9 +46,11 @@ public class ConnectClusterStateImplTest {
     protected Herder herder;
     protected ConnectClusterStateImpl connectClusterState;
     protected long herderRequestTimeoutMs = TimeUnit.SECONDS.toMillis(10);
+    protected Collection<String> expectedConnectors;
     
     @Before
     public void setUp() {
+        expectedConnectors = Arrays.asList("sink1", "source1", "source2");
         connectClusterState = new ConnectClusterStateImpl(
             herderRequestTimeoutMs,
             new ConnectClusterDetailsImpl(KAFKA_CLUSTER_ID),
@@ -58,7 +60,6 @@ public class ConnectClusterStateImplTest {
     
     @Test
     public void connectors() {
-        final Collection<String> expectedConnectors = Arrays.asList("sink1", "source1", "source2");
         Capture<Callback<Collection<String>>> callback = EasyMock.newCapture();
         herder.connectors(EasyMock.capture(callback));
         EasyMock.expectLastCall().andAnswer(new IAnswer<Void>() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -166,6 +166,7 @@ public class RestServerTest {
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,
@@ -202,6 +203,7 @@ public class RestServerTest {
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
 
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                                            workerConfig,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -262,7 +262,7 @@ public class RestServerTest {
         workerProps.put("offset.storage.file.filename", "/tmp");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
 
-
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -62,6 +62,8 @@ public class RestServerTest {
     private Plugins plugins;
     private RestServer server;
 
+    protected static final String KAFKA_CLUSTER_ID = "Xbafgnagvar";
+
     @After
     public void tearDown() {
         server.stop();
@@ -166,7 +168,7 @@ public class RestServerTest {
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,
@@ -203,7 +205,7 @@ public class RestServerTest {
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                                            workerConfig,
@@ -262,7 +264,7 @@ public class RestServerTest {
         workerProps.put("offset.storage.file.filename", "/tmp");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(null);
+        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-8231) and [KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-454%3A+Expansion+of+the+ConnectClusterState+interface)

The changes here add new methods to the `ConnectClusterState` interface so that Connect REST extensions can be more aware of the current state of the Connect cluster they are added to. The new methods allow extensions to query for connector and task configurations, as well as the ID of the Kafka cluster targeted by the Connect cluster.

All new methods have new unit tests added for their implementations in the `ConnectClusterStateImpl` class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
