### PR TITLE
MINOR: make LogCleaner.shouldRetainRecord more clear to read

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -735,9 +735,9 @@ private[log] class Cleaner(val id: Int,
        *   1) if there exists a message with the same key but higher offset
        *   2) if the message is a delete "tombstone" marker and enough time has passed
        */
-      val redundant = foundOffset >= 0 && record.offset < foundOffset
+      val latest = record.offset() >= foundOffset
       val obsoleteDelete = !retainDeletes && !record.hasValue
-      !redundant && !obsoleteDelete
+      latest && !obsoleteDelete
     } else {
       stats.invalidMessage()
       false

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -735,9 +735,9 @@ private[log] class Cleaner(val id: Int,
        *   1) if there exists a message with the same key but higher offset
        *   2) if the message is a delete "tombstone" marker and enough time has passed
        */
-      val latest = record.offset() >= foundOffset
+      val latestOffsetForKey = record.offset() >= foundOffset
       val obsoleteDelete = !retainDeletes && !record.hasValue
-      latest && !obsoleteDelete
+      latestOffsetForKey && !obsoleteDelete
     } else {
       stats.invalidMessage()
       false

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -731,13 +731,14 @@ private[log] class Cleaner(val id: Int,
     if (record.hasKey) {
       val key = record.key
       val foundOffset = map.get(key)
-      /* two cases in which we can get rid of a message:
-       *   1) if there exists a message with the same key but higher offset
-       *   2) if the message is a delete "tombstone" marker and enough time has passed
+      /* First,the message must have the latest offset for the key
+       * then there are two cases in which we can retain a message:
+       *   1) The message has value
+       *   2) The message doesn't has value but it can't be deleted now.
        */
       val latestOffsetForKey = record.offset() >= foundOffset
-      val obsoleteDelete = !retainDeletes && !record.hasValue
-      latestOffsetForKey && !obsoleteDelete
+      val isRetainedValue = record.hasValue || retainDeletes
+      latestOffsetForKey && isRetainedValue
     } else {
       stats.invalidMessage()
       false


### PR DESCRIPTION
The comments of LogCleaner.shouldRetainRecord are pretty clear to tell us when to retain a record.
However, I think the code is not so clear as the comments so that i make some changes:
`val redundant = foundOffset >= 0 && record.offset < foundOffset`
--->
`val latest= foundOffset < 0 || record.offset >= foundOffset`

if there dose not exist a message with the key, foundOffset will be -1, record.offset is larger than -1:
`val latest = record.offset() >= foundOffset`