### PR TITLE
[MINOR] In-memory stores cleanup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -33,20 +33,18 @@ import org.slf4j.LoggerFactory;
 
 public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private final String name;
-    private final ConcurrentNavigableMap<Bytes, byte[]> map;
+    private final ConcurrentNavigableMap<Bytes, byte[]> map = new ConcurrentSkipListMap<>();
     private volatile boolean open = false;
 
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryKeyValueStore.class);
 
     public InMemoryKeyValueStore(final String name) {
         this.name = name;
-
-        this.map = new ConcurrentSkipListMap<>();
     }
 
     @Override
     public String name() {
-        return this.name;
+        return name;
     }
 
     @Override
@@ -65,7 +63,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
             });
         }
 
-        this.open = true;
+        open = true;
     }
 
     @Override
@@ -75,20 +73,20 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public boolean isOpen() {
-        return this.open;
+        return open;
     }
 
     @Override
     public byte[] get(final Bytes key) {
-        return this.map.get(key);
+        return map.get(key);
     }
 
     @Override
     public void put(final Bytes key, final byte[] value) {
         if (value == null) {
-            this.map.remove(key);
+            map.remove(key);
         } else {
-            this.map.put(key, value);
+            map.put(key, value);
         }
     }
 
@@ -110,7 +108,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public byte[] delete(final Bytes key) {
-        return this.map.remove(key);
+        return map.remove(key);
     }
 
     @Override
@@ -125,19 +123,19 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
         return new DelegatingPeekingKeyValueIterator<>(
             name,
-            new InMemoryKeyValueIterator(this.map.subMap(from, true, to, true).entrySet().iterator()));
+            new InMemoryKeyValueIterator(map.subMap(from, true, to, true).entrySet().iterator()));
     }
 
     @Override
     public KeyValueIterator<Bytes, byte[]> all() {
         return new DelegatingPeekingKeyValueIterator<>(
             name,
-            new InMemoryKeyValueIterator(this.map.entrySet().iterator()));
+            new InMemoryKeyValueIterator(map.entrySet().iterator()));
     }
 
     @Override
     public long approximateNumEntries() {
-        return this.map.size();
+        return map.size();
     }
 
     @Override
@@ -147,8 +145,8 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public void close() {
-        this.map.clear();
-        this.open = false;
+        map.clear();
+        open = false;
     }
 
     private static class InMemoryKeyValueIterator implements KeyValueIterator<Bytes, byte[]> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -63,8 +63,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     private final long windowSize;
     private final boolean retainDuplicates;
 
-    private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap;
-    private final Set<InMemoryWindowStoreIteratorWrapper> openIterators;
+    private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap = new ConcurrentSkipListMap<>();
+    private final Set<InMemoryWindowStoreIteratorWrapper> openIterators = ConcurrentHashMap.newKeySet();
 
     private volatile boolean open = false;
 
@@ -78,14 +78,11 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         this.windowSize = windowSize;
         this.retainDuplicates = retainDuplicates;
         this.metricScope = metricScope;
-
-        this.openIterators = ConcurrentHashMap.newKeySet();
-        this.segmentMap = new ConcurrentSkipListMap<>();
     }
 
     @Override
     public String name() {
-        return this.name;
+        return name;
     }
 
     @Override
@@ -113,7 +110,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
                 put(Bytes.wrap(extractStoreKeyBytes(key)), value, extractStoreTimestamp(key));
             });
         }
-        this.open = true;
+        open = true;
     }
 
     @Override
@@ -125,19 +122,19 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     public void put(final Bytes key, final byte[] value, final long windowStartTimestamp) {
         removeExpiredSegments();
         maybeUpdateSeqnumForDups();
-        this.observedStreamTime = Math.max(this.observedStreamTime, windowStartTimestamp);
+        observedStreamTime = Math.max(observedStreamTime, windowStartTimestamp);
 
         final Bytes keyBytes = retainDuplicates ? wrapForDups(key, seqnum) : key;
 
-        if (windowStartTimestamp <= this.observedStreamTime - this.retentionPeriod) {
+        if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
             expiredRecordSensor.record();
             LOG.warn("Skipping record for expired segment.");
         } else {
             if (value != null) {
-                this.segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
-                this.segmentMap.get(windowStartTimestamp).put(keyBytes, value);
+                segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
+                segmentMap.get(windowStartTimestamp).put(keyBytes, value);
             } else {
-                this.segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
+                segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
                     kvMap.remove(keyBytes);
                     return kvMap;
                 });
@@ -149,11 +146,11 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     public byte[] fetch(final Bytes key, final long windowStartTimestamp) {
         removeExpiredSegments();
 
-        if (windowStartTimestamp <= this.observedStreamTime - this.retentionPeriod) {
+        if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
             return null;
         }
 
-        final ConcurrentNavigableMap<Bytes, byte[]> kvMap = this.segmentMap.get(windowStartTimestamp);
+        final ConcurrentNavigableMap<Bytes, byte[]> kvMap = segmentMap.get(windowStartTimestamp);
         if (kvMap == null) {
             return null;
         } else {
@@ -167,14 +164,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         // add one b/c records expire exactly retentionPeriod ms after created
-        final long minTime = Math.max(timeFrom, this.observedStreamTime - this.retentionPeriod + 1);
+        final long minTime = Math.max(timeFrom, observedStreamTime - retentionPeriod + 1);
 
         if (timeTo < minTime) {
             return new WrappedInMemoryWindowStoreIterator();
         }
 
         return new WrappedInMemoryWindowStoreIterator(
-            key, key, this.segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
+            key, key, segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
     }
 
     @Deprecated
@@ -193,14 +190,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         }
 
         // add one b/c records expire exactly retentionPeriod ms after created
-        final long minTime = Math.max(timeFrom, this.observedStreamTime - this.retentionPeriod + 1);
+        final long minTime = Math.max(timeFrom, observedStreamTime - retentionPeriod + 1);
 
         if (timeTo < minTime) {
             return new WrappedWindowedKeyValueIterator();
         }
 
         return new WrappedWindowedKeyValueIterator(
-            from, to, this.segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
+            from, to, segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
     }
 
     @Deprecated
@@ -209,24 +206,24 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         // add one b/c records expire exactly retentionPeriod ms after created
-        final long minTime = Math.max(timeFrom, this.observedStreamTime - this.retentionPeriod + 1);
+        final long minTime = Math.max(timeFrom, observedStreamTime - retentionPeriod + 1);
 
         if (timeTo < minTime) {
             return new WrappedWindowedKeyValueIterator();
         }
 
         return new WrappedWindowedKeyValueIterator(
-            null, null, this.segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
+            null, null, segmentMap.subMap(minTime, true, timeTo, true).entrySet().iterator());
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> all() {
         removeExpiredSegments();
 
-        final long minTime = this.observedStreamTime - this.retentionPeriod;
+        final long minTime = observedStreamTime - retentionPeriod;
 
         return new WrappedWindowedKeyValueIterator(
-            null, null, this.segmentMap.tailMap(minTime, false).entrySet().iterator());
+            null, null, segmentMap.tailMap(minTime, false).entrySet().iterator());
     }
 
     @Override
@@ -236,7 +233,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public boolean isOpen() {
-        return this.open;
+        return open;
     }
 
     @Override
@@ -246,16 +243,16 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public void close() {
-        this.segmentMap.clear();
-        this.open = false;
+        segmentMap.clear();
+        open = false;
     }
 
     private void removeExpiredSegments() {
-        long minLiveTime = Math.max(0L, this.observedStreamTime - this.retentionPeriod + 1);
+        long minLiveTime = Math.max(0L, observedStreamTime - retentionPeriod + 1);
         for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
             minLiveTime = Math.min(minLiveTime, it.minTime());
         }
-        this.segmentMap.headMap(minLiveTime, false).clear();
+        segmentMap.headMap(minLiveTime, false).clear();
     }
 
     private void maybeUpdateSeqnumForDups() {
@@ -292,14 +289,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         // Default constructor sets up a dummy iterator when no results are returned (eg entire fetch range is expired)
         InMemoryWindowStoreIteratorWrapper() {
-            this.allKeys = false;
+            allKeys = false;
             recordIterator = null;
         }
 
         InMemoryWindowStoreIteratorWrapper(final Bytes keyFrom,
                                            final Bytes keyTo,
                                            final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator) {
-            this.allKeys = (keyFrom == null) && (keyTo == null);
+            allKeys = (keyFrom == null) && (keyTo == null);
             if (retainDuplicates && !allKeys) {
                 this.keyFrom = wrapForDups(keyFrom, 0);
                 this.keyTo = wrapForDups(keyTo, Integer.MAX_VALUE);
@@ -309,7 +306,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
             }
 
             this.segmentIterator = segmentIterator;
-            this.recordIterator = setRecordIterator();
+            recordIterator = setRecordIterator();
 
             openIterators.add(this);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -86,7 +86,6 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void init(final ProcessorContext context, final StateStore root) {
         this.context = (InternalProcessorContext) context;
 
@@ -276,7 +275,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     }
 
-    private abstract class InMemoryWindowStoreIteratorWrapper implements Comparable<InMemoryWindowStoreIteratorWrapper> {
+    private abstract class InMemoryWindowStoreIteratorWrapper {
 
         private Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator;
         private Iterator<Map.Entry<Bytes, byte[]>> recordIterator;
@@ -364,10 +363,6 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         Long minTime() {
             return currentTime;
-        }
-
-        public int compareTo(final InMemoryWindowStoreIteratorWrapper other) {
-            return (int) (minTime() - other.minTime());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -287,17 +287,15 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         return iterator;
     }
 
-    private WrappedWindowedKeyValueIterator registerNewWindowedKeyValueIterator(Bytes keyFrom,
-                                                                                   Bytes keyTo,
-                                                                                   final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator) {
-        if (retainDuplicates && !(keyFrom == null || keyTo == null)) {
-            keyFrom = wrapForDups(keyFrom, 0);
-            keyTo = wrapForDups(keyTo, Integer.MAX_VALUE);
-        }
+    private WrappedWindowedKeyValueIterator registerNewWindowedKeyValueIterator(final Bytes keyFrom,
+                                                                                final Bytes keyTo,
+                                                                                final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator) {
+        final Bytes from = (retainDuplicates && keyFrom != null) ? wrapForDups(keyFrom, 0) : keyFrom;
+        final Bytes to = (retainDuplicates && keyTo != null) ? wrapForDups(keyTo, Integer.MAX_VALUE) : keyTo;
 
         final WrappedWindowedKeyValueIterator iterator =
-            new WrappedWindowedKeyValueIterator(keyFrom,
-                                                keyTo,
+            new WrappedWindowedKeyValueIterator(from,
+                                                to,
                                                 segmentIterator,
                                                 openIterators::remove,
                                                 retainDuplicates,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -419,7 +419,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         }
 
         public static WrappedInMemoryWindowStoreIterator emptyIterator() {
-            return new WrappedInMemoryWindowStoreIterator(null, null, null, it -> {});
+            return new WrappedInMemoryWindowStoreIterator(null, null, null, it -> { });
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -412,7 +412,7 @@ public abstract class AbstractKeyValueStoreTest {
         LogCaptureAppender.setClassLoggerToDebug(InMemoryWindowStore.class);
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
 
-        final KeyValueIterator iterator = store.range(-1, 1);
+        final KeyValueIterator<Integer, String> iterator = store.range(-1, 1);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -439,7 +439,7 @@ public class CachingSessionStoreTest {
         final Bytes keyFrom = Bytes.wrap(Serdes.Integer().serializer().serialize("", -1));
         final Bytes keyTo = Bytes.wrap(Serdes.Integer().serializer().serialize("", 1));
 
-        final KeyValueIterator iterator = cachingStore.findSessions(keyFrom, keyTo, 0L, 10L);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.findSessions(keyFrom, keyTo, 0L, 10L);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -598,7 +598,7 @@ public class CachingWindowStoreTest {
         final Bytes keyFrom = Bytes.wrap(Serdes.Integer().serializer().serialize("", -1));
         final Bytes keyTo = Bytes.wrap(Serdes.Integer().serializer().serialize("", 1));
 
-        final KeyValueIterator iterator = cachingStore.fetch(keyFrom, keyTo, 0L, 10L);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.fetch(keyFrom, keyTo, 0L, 10L);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -605,7 +605,7 @@ public class InMemoryWindowStoreTest {
         LogCaptureAppender.setClassLoggerToDebug(InMemoryWindowStore.class);
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
 
-        final KeyValueIterator iterator = windowStore.fetch(-1, 1, 0L, 10L);
+        final KeyValueIterator<Windowed<Integer>, String> iterator = windowStore.fetch(-1, 1, 0L, 10L);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -290,7 +290,7 @@ public class RocksDBSessionStoreTest {
         final String keyFrom = Serdes.String().deserializer().deserialize("", Serdes.Integer().serializer().serialize("", -1));
         final String keyTo = Serdes.String().deserializer().deserialize("", Serdes.Integer().serializer().serialize("", 1));
 
-        final KeyValueIterator iterator = sessionStore.findSessions(keyFrom, keyTo, 0L, 10L);
+        final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions(keyFrom, keyTo, 0L, 10L);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -1426,7 +1426,7 @@ public class RocksDBWindowStoreTest {
         LogCaptureAppender.setClassLoggerToDebug(InMemoryWindowStore.class);
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
 
-        final KeyValueIterator iterator = windowStore.fetch(-1, 1, 0L, 10L);
+        final KeyValueIterator<Windowed<Integer>, String> iterator = windowStore.fetch(-1, 1, 0L, 10L);
         assertFalse(iterator.hasNext());
 
         final List<String> messages = appender.getMessages();


### PR DESCRIPTION
While going through the review of InMemorySessionStore I realized there is also some minor cleanup to be done for the other in-memory stores. This includes trivial changes such as removing unnecessary references to 'this' and moving collection initialization to the declaration. It also fixes some unsafe behavior (registering an iterator from inside its own constructor). In-memory window store iterator classes were made static and some instances of KeyValueIterator missing types were fixed across a handful of tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
