### PR TITLE
MINOR: Remove erroring lock.unlock() call from RoundTripWorker

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -385,8 +385,6 @@ public class RoundTripWorker implements TaskWorker {
                         log.debug("{}: Consumer got WakeupException", id, e);
                     } catch (TimeoutException e) {
                         log.debug("{}: Consumer got TimeoutException", id, e);
-                    } finally {
-                        lock.unlock();
                     }
                 }
             } catch (Throwable e) {


### PR DESCRIPTION
Commit 62171781396b613b6be8e13a2541ab0895b9bb6b added a ReentrantLock to the Trogdor RoundTripWorker, but includes an extra lock.unlock() which was causing system tests to fail with java.lang.IllegalMonitorStateException. This patch removes the offending call. Tested by running system test.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
