### PR TITLE
MINOR: Allow scripts to be symlinked

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -20,7 +20,11 @@ then
         exit 1
 fi
 
-base_dir=$(dirname $0)
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
@@ -42,4 +46,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"
+exec $base_dir/bin/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -20,7 +20,11 @@ then
         exit 1
 fi
 
-base_dir=$(dirname $0)
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
@@ -42,4 +46,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"
+exec $base_dir/bin/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"

--- a/bin/kafka-acls.sh
+++ b/bin/kafka-acls.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.AclCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.AclCommand "$@"

--- a/bin/kafka-broker-api-versions.sh
+++ b/bin/kafka-broker-api-versions.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.BrokerApiVersionsCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.BrokerApiVersionsCommand "$@"

--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConfigCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.ConfigCommand "$@"

--- a/bin/kafka-console-consumer.sh
+++ b/bin/kafka-console-consumer.sh
@@ -18,4 +18,10 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleConsumer "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.ConsoleConsumer "$@"

--- a/bin/kafka-console-producer.sh
+++ b/bin/kafka-console-producer.sh
@@ -17,4 +17,11 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"

--- a/bin/kafka-consumer-groups.sh
+++ b/bin/kafka-consumer-groups.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConsumerGroupCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.ConsumerGroupCommand "$@"

--- a/bin/kafka-consumer-perf-test.sh
+++ b/bin/kafka-consumer-perf-test.sh
@@ -17,4 +17,11 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerPerformance "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.ConsumerPerformance "$@"

--- a/bin/kafka-delegation-tokens.sh
+++ b/bin/kafka-delegation-tokens.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.DelegationTokenCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.DelegationTokenCommand "$@"

--- a/bin/kafka-delete-records.sh
+++ b/bin/kafka-delete-records.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.DeleteRecordsCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.DeleteRecordsCommand "$@"

--- a/bin/kafka-dump-log.sh
+++ b/bin/kafka-dump-log.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.DumpLogSegments "$@"

--- a/bin/kafka-log-dirs.sh
+++ b/bin/kafka-log-dirs.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.LogDirsCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.LogDirsCommand "$@"

--- a/bin/kafka-mirror-maker.sh
+++ b/bin/kafka-mirror-maker.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.MirrorMaker "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.MirrorMaker "$@"

--- a/bin/kafka-preferred-replica-election.sh
+++ b/bin/kafka-preferred-replica-election.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.PreferredReplicaLeaderElectionCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.PreferredReplicaLeaderElectionCommand "$@"

--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -17,4 +17,11 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"

--- a/bin/kafka-reassign-partitions.sh
+++ b/bin/kafka-reassign-partitions.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ReassignPartitionsCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.ReassignPartitionsCommand "$@"

--- a/bin/kafka-replica-verification.sh
+++ b/bin/kafka-replica-verification.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ReplicaVerificationTool "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.ReplicaVerificationTool "$@"

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -20,7 +20,7 @@ then
   exit 1
 fi
 
-# CYGWIN == 1 if Cygwin is detected, else 0.
+# CYGINW == 1 if Cygwin is detected, else 0.
 if [[ $(uname -a) =~ "CYGWIN" ]]; then
   CYGWIN=1
 else
@@ -45,7 +45,11 @@ should_include_file() {
   fi
 }
 
-base_dir=$(dirname $0)/..
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
 
 if [ -z "$SCALA_VERSION" ]; then
   SCALA_VERSION=2.12.8

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -19,7 +19,12 @@ then
 	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
 	exit 1
 fi
-base_dir=$(dirname $0)
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
@@ -41,4 +46,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"
+exec $base_dir/bin/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"

--- a/bin/kafka-streams-application-reset.sh
+++ b/bin/kafka-streams-application-reset.sh
@@ -18,4 +18,10 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.StreamsResetter "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.tools.StreamsResetter "$@"

--- a/bin/kafka-topics.sh
+++ b/bin/kafka-topics.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.TopicCommand "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.TopicCommand "$@"

--- a/bin/kafka-verifiable-consumer.sh
+++ b/bin/kafka-verifiable-consumer.sh
@@ -17,4 +17,11 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"

--- a/bin/kafka-verifiable-producer.sh
+++ b/bin/kafka-verifiable-producer.sh
@@ -17,4 +17,11 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"

--- a/bin/trogdor.sh
+++ b/bin/trogdor.sh
@@ -47,4 +47,11 @@ case ${action} in
 esac
 
 export INCLUDE_TEST_JARS=1
-exec $(dirname $0)/kafka-run-class.sh "${CLASS}" "$@"
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh "${CLASS}" "$@"

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -111,7 +111,7 @@ IF ["%JMX_PORT%"] NEQ [""] (
 
 rem Log directory to use
 IF ["%LOG_DIR%"] EQU [""] (
-    set LOG_DIR=%BASE_DIR%/logs
+    set LOG_DIR="%BASE_DIR%/logs"
 )
 
 rem Log4j settings

--- a/bin/zookeeper-security-migration.sh
+++ b/bin/zookeeper-security-migration.sh
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"

--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -19,7 +19,12 @@ then
 	echo "USAGE: $0 [-daemon] zookeeper.properties"
 	exit 1
 fi
-base_dir=$(dirname $0)
+
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
@@ -41,4 +46,4 @@ case $COMMAND in
      ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"
+exec $base_dir/bin/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -20,4 +20,10 @@ then
 	exit 1
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMain -server "$@"
+if [ -z "$(readlink $0)" ]; then
+  base_dir=$(dirname $0)/..
+else
+  base_dir=$(dirname $(readlink $0))/..
+fi
+
+exec $base_dir/bin/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMain -server "$@"


### PR DESCRIPTION
Scripts now support one level of symlinking, for example from /usr/bin to your Kafka install directory.

Previously the scripts would break if you didn't run them directly from the installation directory.

I installed this on a test system and ran every script from both the installation directory and as a symlink from /usr/bin/
