### PR TITLE
MINOR: Add support for Standalone Connect configs in Rest Server extensions

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -329,6 +329,10 @@ public class WorkerConfig extends AbstractConfig {
         }
     }
 
+    public Integer getRebalanceTimeout() {
+        return null;
+    }
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -268,6 +268,11 @@ public class DistributedConfig extends WorkerConfig {
                         STATUS_STORAGE_REPLICATION_FACTOR_CONFIG_DOC);
     }
 
+    @Override
+    public Integer getRebalanceTimeout() {
+        return getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+    }
+
     public DistributedConfig(Map<String, String> props) {
         super(CONFIG, props);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -309,7 +309,11 @@ public class RestServer {
             config, ConnectRestExtension.class);
 
         long herderRequestTimeoutMs = ConnectorsResource.REQUEST_TIMEOUT_MS;
-        Integer rebalanceTimeoutMs = config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+
+        Integer rebalanceTimeoutMs =
+            config.typeOf(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG) == null ? null :
+            config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+
         if (rebalanceTimeoutMs != null) {
             herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.HerderProvider;
 import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.health.ConnectClusterStateImpl;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectExceptionMapper;
@@ -310,9 +309,7 @@ public class RestServer {
 
         long herderRequestTimeoutMs = ConnectorsResource.REQUEST_TIMEOUT_MS;
 
-        Integer rebalanceTimeoutMs =
-            config.typeOf(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG) == null ? null :
-            config.getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
+        Integer rebalanceTimeoutMs = config.getRebalanceTimeout();
 
         if (rebalanceTimeoutMs != null) {
             herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.runtime.HerderProvider;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -247,5 +248,36 @@ public class RestServerTest {
                 response.getFirstHeader("Access-Control-Allow-Methods").getValue());
         }
         PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testStandaloneConfig() throws IOException  {
+        Map<String, String> workerProps = baseWorkerProps();
+        workerProps.put("offset.storage.file.filename", "/tmp");
+        WorkerConfig workerConfig = new StandaloneConfig(workerProps);
+
+
+      EasyMock.expect(herder.plugins()).andStubReturn(plugins);
+      EasyMock.expect(plugins.newPlugins(Collections.EMPTY_LIST,
+          workerConfig,
+          ConnectRestExtension.class)).andStubReturn(Collections.EMPTY_LIST);
+
+      final Capture<Callback<Collection<String>>> connectorsCallback = EasyMock.newCapture();
+      herder.connectors(EasyMock.capture(connectorsCallback));
+      PowerMock.expectLastCall().andAnswer(() -> {
+        connectorsCallback.getValue().onCompletion(null, Arrays.asList("a", "b"));
+        return null;
+      });
+
+      PowerMock.replayAll();
+
+      server = new RestServer(workerConfig);
+      server.start(new HerderProvider(herder), herder.plugins());
+      HttpRequest request = new HttpGet("/connectors");
+      CloseableHttpClient httpClient = HttpClients.createMinimal();
+      HttpHost httpHost = new HttpHost(server.advertisedUrl().getHost(), server.advertisedUrl().getPort());
+      CloseableHttpResponse response = httpClient.execute(httpHost, request);
+
+      Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     }
 }


### PR DESCRIPTION
A bug was introduced in 7a42750d which was caught in system tests:
The rest extensions fail if a Standalone worker config is passed,
which does not have a definition for rebalance timeout.

The code will now check that the config is defined before parsing
the value

A new unit test is added to cover Standalone mode for quick testing.
