### PR TITLE
KAFKA-8204: fix Streams store flush order (#6555)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/FixedOrderMap.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FixedOrderMap.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An ordered map (LinkedHashMap) implementation for which the order is immutable.
+ * To accomplish this, all methods of removing mappings are disabled (they are marked
+ * deprecated and throw an exception).
+ *
+ * This class is final to prevent subclasses from violating the desired property.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+public final class FixedOrderMap<K, V> extends LinkedHashMap<K, V> {
+    private static final long serialVersionUID = -6504110858733236170L;
+
+    @Deprecated
+    @Override
+    protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
+        return false;
+    }
+
+    @Deprecated
+    @Override
+    public V remove(final Object key) {
+        throw new UnsupportedOperationException("Removing from registeredStores is not allowed");
+    }
+
+    @Deprecated
+    @Override
+    public boolean remove(final Object key, final Object value) {
+        throw new UnsupportedOperationException("Removing from registeredStores is not allowed");
+    }
+
+    @Deprecated
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Removing from registeredStores is not allowed");
+    }
+
+    @Override
+    public FixedOrderMap<K, V> clone() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class FixedOrderMapTest {
+    @Test
+    public void shouldMaintainOrderWhenAdding() {
+        final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
+        map.put("a", 0);
+        map.put("b", 1);
+        map.put("c", 2);
+        map.put("b", 3);
+        final Iterator<Map.Entry<String, Integer>> iterator = map.entrySet().iterator();
+        assertThat(iterator.next(), is(mkEntry("a", 0)));
+        assertThat(iterator.next(), is(mkEntry("b", 3)));
+        assertThat(iterator.next(), is(mkEntry("c", 2)));
+        assertThat(iterator.hasNext(), is(false));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldForbidRemove() {
+        final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
+        map.put("a", 0);
+        try {
+            map.remove("a");
+            fail("expected exception");
+        } catch (final RuntimeException e) {
+            assertThat(e, CoreMatchers.instanceOf(UnsupportedOperationException.class));
+        }
+        assertThat(map.get("a"), is(0));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldForbidConditionalRemove() {
+        final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
+        map.put("a", 0);
+        try {
+            map.remove("a", 0);
+            fail("expected exception");
+        } catch (final RuntimeException e) {
+            assertThat(e, CoreMatchers.instanceOf(UnsupportedOperationException.class));
+        }
+        assertThat(map.get("a"), is(0));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldForbidConditionalClear() {
+        final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
+        map.put("a", 0);
+        try {
+            map.clear();
+            fail("expected exception");
+        } catch (final RuntimeException e) {
+            assertThat(e, CoreMatchers.instanceOf(UnsupportedOperationException.class));
+        }
+        assertThat(map.get("a"), is(0));
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractStateManager.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.FixedOrderMap;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateStore;
@@ -28,8 +29,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 abstract class AbstractStateManager implements StateManager {
@@ -40,8 +41,7 @@ abstract class AbstractStateManager implements StateManager {
     OffsetCheckpoint checkpoint;
 
     final Map<TopicPartition, Long> checkpointableOffsets = new HashMap<>();
-    final Map<String, StateStore> stores = new LinkedHashMap<>();
-    final Map<String, StateStore> globalStores = new LinkedHashMap<>();
+    final FixedOrderMap<String, Optional<StateStore>> globalStores = new FixedOrderMap<>();
 
     AbstractStateManager(final File baseDir,
                          final boolean eosEnabled) {
@@ -51,17 +51,16 @@ abstract class AbstractStateManager implements StateManager {
     }
 
     public void reinitializeStateStoresForPartitions(final Logger log,
-                                                     final Map<String, StateStore> stateStores,
+                                                     final FixedOrderMap<String, Optional<StateStore>> stateStores,
                                                      final Map<String, String> storeToChangelogTopic,
                                                      final Collection<TopicPartition> partitions,
                                                      final InternalProcessorContext processorContext) {
         final Map<String, String> changelogTopicToStore = inverseOneToOneMap(storeToChangelogTopic);
-        final Set<String> storeToBeReinitialized = new HashSet<>();
-        final Map<String, StateStore> storesCopy = new HashMap<>(stateStores);
+        final Set<String> storesToBeReinitialized = new HashSet<>();
 
         for (final TopicPartition topicPartition : partitions) {
             checkpointableOffsets.remove(topicPartition);
-            storeToBeReinitialized.add(changelogTopicToStore.get(topicPartition.topic()));
+            storesToBeReinitialized.add(changelogTopicToStore.get(topicPartition.topic()));
         }
 
         if (!eosEnabled) {
@@ -73,36 +72,44 @@ abstract class AbstractStateManager implements StateManager {
             }
         }
 
-        for (final Map.Entry<String, StateStore> entry : storesCopy.entrySet()) {
-            final StateStore stateStore = entry.getValue();
-            final String storeName = stateStore.name();
-            if (storeToBeReinitialized.contains(storeName)) {
-                try {
-                    stateStore.close();
-                } catch (final RuntimeException ignoreAndSwallow) { /* ignore */ }
-                processorContext.uninitialize();
-                stateStores.remove(entry.getKey());
-
-                // TODO remove this eventually
-                // -> (only after we are sure, we don't need it for backward compatibility reasons anymore; maybe 2.0 release?)
-                // this is an ugly "hack" that is required because RocksDBStore does not follow the pattern to put the
-                // store directory as <taskDir>/<storeName> but nests it with an intermediate <taskDir>/rocksdb/<storeName>
-                try {
-                    Utils.delete(new File(baseDir + File.separator + "rocksdb" + File.separator + storeName));
-                } catch (final IOException fatalException) {
-                    log.error("Failed to reinitialize store {}.", storeName, fatalException);
-                    throw new StreamsException(String.format("Failed to reinitialize store %s.", storeName), fatalException);
-                }
-
-                try {
-                    Utils.delete(new File(baseDir + File.separator + storeName));
-                } catch (final IOException fatalException) {
-                    log.error("Failed to reinitialize store {}.", storeName, fatalException);
-                    throw new StreamsException(String.format("Failed to reinitialize store %s.", storeName), fatalException);
-                }
-
-                stateStore.init(processorContext, stateStore);
+        for (final String storeName : storesToBeReinitialized) {
+            if (!stateStores.containsKey(storeName)) {
+                // the store has never been registered; carry on...
+                continue;
             }
+            final StateStore stateStore = stateStores
+                .get(storeName)
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        "Re-initializing store that has not been initialized. This is a bug in Kafka Streams."
+                    )
+                );
+
+            try {
+                stateStore.close();
+            } catch (final RuntimeException ignoreAndSwallow) { /* ignore */ }
+            processorContext.uninitialize();
+            stateStores.put(storeName, Optional.empty());
+
+            // TODO remove this eventually
+            // -> (only after we are sure, we don't need it for backward compatibility reasons anymore; maybe 2.0 release?)
+            // this is an ugly "hack" that is required because RocksDBStore does not follow the pattern to put the
+            // store directory as <taskDir>/<storeName> but nests it with an intermediate <taskDir>/rocksdb/<storeName>
+            try {
+                Utils.delete(new File(baseDir + File.separator + "rocksdb" + File.separator + storeName));
+            } catch (final IOException fatalException) {
+                log.error("Failed to reinitialize store {}.", storeName, fatalException);
+                throw new StreamsException(String.format("Failed to reinitialize store %s.", storeName), fatalException);
+            }
+
+            try {
+                Utils.delete(new File(baseDir + File.separator + storeName));
+            } catch (final IOException fatalException) {
+                log.error("Failed to reinitialize store {}.", storeName, fatalException);
+                throw new StreamsException(String.format("Failed to reinitialize store %s.", storeName), fatalException);
+            }
+
+            stateStore.init(processorContext, stateStore);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -139,7 +140,7 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
 
     @Override
     public StateStore getGlobalStore(final String name) {
-        return globalStores.get(name);
+        return globalStores.getOrDefault(name, Optional.empty()).orElse(null);
     }
 
     @Override
@@ -196,7 +197,7 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
         }
         try {
             restoreState(stateRestoreCallback, topicPartitions, highWatermarks, store.name());
-            globalStores.put(store.name(), store);
+            globalStores.put(store.name(), Optional.of(store));
         } finally {
             globalConsumer.unsubscribe();
         }
@@ -298,12 +299,20 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
     @Override
     public void flush() {
         log.debug("Flushing all global globalStores registered in the state manager");
-        for (final StateStore store : this.globalStores.values()) {
-            try {
-                log.trace("Flushing global store={}", store.name());
-                store.flush();
-            } catch (final Exception e) {
-                throw new ProcessorStateException(String.format("Failed to flush global state store %s", store.name()), e);
+        for (final Map.Entry<String, Optional<StateStore>> entry : globalStores.entrySet()) {
+            if (entry.getValue().isPresent()) {
+                final StateStore store = entry.getValue().get();
+                try {
+                    log.trace("Flushing global store={}", store.name());
+                    store.flush();
+                } catch (final Exception e) {
+                    throw new ProcessorStateException(
+                        String.format("Failed to flush global state store %s", store.name()),
+                        e
+                    );
+                }
+            } else {
+                throw new IllegalStateException("Expected " + entry.getKey() + " to have been initialized");
             }
         }
     }
@@ -316,20 +325,24 @@ public class GlobalStateManagerImpl extends AbstractStateManager implements Glob
                 return;
             }
             final StringBuilder closeFailed = new StringBuilder();
-            for (final Map.Entry<String, StateStore> entry : globalStores.entrySet()) {
-                log.debug("Closing global storage engine {}", entry.getKey());
-                try {
-                    entry.getValue().close();
-                } catch (final Exception e) {
-                    log.error("Failed to close global state store {}", entry.getKey(), e);
-                    closeFailed.append("Failed to close global state store:")
-                            .append(entry.getKey())
-                            .append(". Reason: ")
-                            .append(e.toString())
-                            .append("\n");
+            for (final Map.Entry<String, Optional<StateStore>> entry : globalStores.entrySet()) {
+                if (entry.getValue().isPresent()) {
+                    log.debug("Closing global storage engine {}", entry.getKey());
+                    try {
+                        entry.getValue().get().close();
+                    } catch (final Exception e) {
+                        log.error("Failed to close global state store {}", entry.getKey(), e);
+                        closeFailed.append("Failed to close global state store:")
+                                   .append(entry.getKey())
+                                   .append(". Reason: ")
+                                   .append(e.toString())
+                                   .append("\n");
+                    }
+                    globalStores.put(entry.getKey(), Optional.empty());
+                } else {
+                    log.info("Skipping to close non-initialized store {}", entry.getKey());
                 }
             }
-            globalStores.clear();
             if (closeFailed.length() > 0) {
                 throw new ProcessorStateException("Exceptions caught during close of 1 or more global state globalStores\n" + closeFailed);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.FixedOrderMap;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
@@ -33,7 +34,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import static java.util.Collections.unmodifiableList;
 import static org.apache.kafka.streams.processor.internals.StateRestoreCallbackAdapter.adapt;
 
 
@@ -49,6 +52,10 @@ public class ProcessorStateManager extends AbstractStateManager {
     private final Map<TopicPartition, Long> standbyRestoredOffsets;
     private final Map<String, StateRestoreCallback> restoreCallbacks; // used for standby tasks, keyed by state topic name
     private final Map<String, String> storeToChangelogTopic;
+
+    // must be maintained in topological order
+    private final FixedOrderMap<String, Optional<StateStore>> registeredStores = new FixedOrderMap<>();
+
     private final List<TopicPartition> changelogPartitions = new ArrayList<>();
 
     // TODO: this map does not work with customized grouper where multiple partitions
@@ -82,7 +89,7 @@ public class ProcessorStateManager extends AbstractStateManager {
         standbyRestoredOffsets = new HashMap<>();
         this.isStandby = isStandby;
         restoreCallbacks = isStandby ? new HashMap<>() : null;
-        this.storeToChangelogTopic = storeToChangelogTopic;
+        this.storeToChangelogTopic = new HashMap<>(storeToChangelogTopic);
 
         // load the checkpoint information
         checkpointableOffsets.putAll(checkpoint.read());
@@ -115,20 +122,19 @@ public class ProcessorStateManager extends AbstractStateManager {
             throw new IllegalArgumentException(String.format("%sIllegal store name: %s", logPrefix, CHECKPOINT_FILE_NAME));
         }
 
-        if (stores.containsKey(storeName)) {
+        if (registeredStores.containsKey(storeName) && registeredStores.get(storeName).isPresent()) {
             throw new IllegalArgumentException(String.format("%sStore %s has already been registered.", logPrefix, storeName));
         }
 
         // check that the underlying change log topic exist or not
         final String topic = storeToChangelogTopic.get(storeName);
         if (topic == null) {
-            stores.put(storeName, store);
-            return;
-        }
+            registeredStores.put(storeName, Optional.of(store));
+        } else {
 
-        final TopicPartition storePartition = new TopicPartition(topic, getPartition(topic));
+            final TopicPartition storePartition = new TopicPartition(topic, getPartition(topic));
 
-        if (isStandby) {
+            if (isStandby) {
             log.trace("Preparing standby replica of persistent state store {} with changelog topic {}", storeName, topic);
             restoreCallbacks.put(topic, stateRestoreCallback);
         } else {
@@ -140,19 +146,20 @@ public class ProcessorStateManager extends AbstractStateManager {
                                                              store.persistent(),
                                                              storeName);
 
-            changelogReader.register(restorer);
-        }
-        changelogPartitions.add(storePartition);
+                changelogReader.register(restorer);
+            }
+            changelogPartitions.add(storePartition);
 
-        stores.put(storeName, store);
+            registeredStores.put(storeName, Optional.of(store));
+        }
     }
 
     @Override
     public void reinitializeStateStoresForPartitions(final Collection<TopicPartition> partitions,
                                                      final InternalProcessorContext processorContext) {
-        super.reinitializeStateStoresForPartitions(
+        reinitializeStateStoresForPartitions(
             log,
-            stores,
+            registeredStores,
             storeToChangelogTopic,
             partitions,
             processorContext);
@@ -202,24 +209,29 @@ public class ProcessorStateManager extends AbstractStateManager {
 
     @Override
     public StateStore getStore(final String name) {
-        return stores.get(name);
+        return registeredStores.getOrDefault(name, Optional.empty()).orElse(null);
     }
 
     @Override
     public void flush() {
         ProcessorStateException firstException = null;
         // attempting to flush the stores
-        if (!stores.isEmpty()) {
+        if (!registeredStores.isEmpty()) {
             log.debug("Flushing all stores registered in the state manager");
-            for (final StateStore store : stores.values()) {
-                log.trace("Flushing store {}", store.name());
-                try {
-                    store.flush();
-                } catch (final Exception e) {
-                    if (firstException == null) {
-                        firstException = new ProcessorStateException(String.format("%sFailed to flush state store %s", logPrefix, store.name()), e);
+            for (final Map.Entry<String, Optional<StateStore>> entry : registeredStores.entrySet()) {
+                if (entry.getValue().isPresent()) {
+                    final StateStore store = entry.getValue().get();
+                    log.trace("Flushing store {}", store.name());
+                    try {
+                        store.flush();
+                    } catch (final Exception e) {
+                        if (firstException == null) {
+                            firstException = new ProcessorStateException(String.format("%sFailed to flush state store %s", logPrefix, store.name()), e);
+                        }
+                        log.error("Failed to flush state store {}: ", store.name(), e);
                     }
-                    log.error("Failed to flush state store {}: ", store.name(), e);
+                } else {
+                    throw new IllegalStateException("Expected " + entry.getKey() + " to have been initialized");
                 }
             }
         }
@@ -239,24 +251,31 @@ public class ProcessorStateManager extends AbstractStateManager {
         ProcessorStateException firstException = null;
         // attempting to close the stores, just in case they
         // are not closed by a ProcessorNode yet
-        if (!stores.isEmpty()) {
+        if (!registeredStores.isEmpty()) {
             log.debug("Closing its state manager and all the registered state stores");
-            for (final StateStore store : stores.values()) {
-                log.debug("Closing storage engine {}", store.name());
-                try {
-                    store.close();
-                } catch (final Exception e) {
-                    if (firstException == null) {
-                        firstException = new ProcessorStateException(String.format("%sFailed to close state store %s", logPrefix, store.name()), e);
+            for (final Map.Entry<String, Optional<StateStore>> entry : registeredStores.entrySet()) {
+                if (entry.getValue().isPresent()) {
+                    final StateStore store = entry.getValue().get();
+                    log.debug("Closing storage engine {}", store.name());
+                    try {
+                        store.close();
+                    } catch (final Exception e) {
+                        if (firstException == null) {
+                            firstException = new ProcessorStateException(String.format("%sFailed to close state store %s", logPrefix, store.name()), e);
+                        }
+                        log.error("Failed to close state store {}: ", store.name(), e);
                     }
-                    log.error("Failed to close state store {}: ", store.name(), e);
+                } else {
+                    log.info("Skipping to close non-initialized store {}", entry.getKey());
                 }
             }
 
             if (ackedOffsets != null) {
                 checkpoint(ackedOffsets);
             }
-            stores.clear();
+            for (final String storeName : registeredStores.keySet()) {
+                registeredStores.put(storeName, Optional.empty());
+            }
         }
 
         if (firstException != null) {
@@ -268,18 +287,21 @@ public class ProcessorStateManager extends AbstractStateManager {
     @Override
     public void checkpoint(final Map<TopicPartition, Long> checkpointableOffsets) {
         this.checkpointableOffsets.putAll(changelogReader.restoredOffsets());
-        for (final StateStore store : stores.values()) {
-            final String storeName = store.name();
-            // only checkpoint the offset to the offsets file if
-            // it is persistent AND changelog enabled
-            if (store.persistent() && storeToChangelogTopic.containsKey(storeName)) {
-                final String changelogTopic = storeToChangelogTopic.get(storeName);
-                final TopicPartition topicPartition = new TopicPartition(changelogTopic, getPartition(storeName));
-                if (checkpointableOffsets.containsKey(topicPartition)) {
-                    // store the last offset + 1 (the log position after restoration)
-                    this.checkpointableOffsets.put(topicPartition, checkpointableOffsets.get(topicPartition) + 1);
-                } else if (standbyRestoredOffsets.containsKey(topicPartition)) {
-                    this.checkpointableOffsets.put(topicPartition, standbyRestoredOffsets.get(topicPartition));
+        for (final Map.Entry<String, Optional<StateStore>> entry : registeredStores.entrySet()) {
+            if (entry.getValue().isPresent()) {
+                final StateStore store = entry.getValue().get();
+                final String storeName = store.name();
+                // only checkpoint the offset to the offsets file if
+                // it is persistent AND changelog enabled
+                if (store.persistent() && storeToChangelogTopic.containsKey(storeName)) {
+                    final String changelogTopic = storeToChangelogTopic.get(storeName);
+                    final TopicPartition topicPartition = new TopicPartition(changelogTopic, getPartition(storeName));
+                    if (checkpointableOffsets.containsKey(topicPartition)) {
+                        // store the last offset + 1 (the log position after restoration)
+                        this.checkpointableOffsets.put(topicPartition, checkpointableOffsets.get(topicPartition) + 1);
+                    } else if (standbyRestoredOffsets.containsKey(topicPartition)) {
+                        this.checkpointableOffsets.put(topicPartition, standbyRestoredOffsets.get(topicPartition));
+                    }
                 }
             }
         }
@@ -304,16 +326,26 @@ public class ProcessorStateManager extends AbstractStateManager {
     void registerGlobalStateStores(final List<StateStore> stateStores) {
         log.debug("Register global stores {}", stateStores);
         for (final StateStore stateStore : stateStores) {
-            globalStores.put(stateStore.name(), stateStore);
+            globalStores.put(stateStore.name(), Optional.of(stateStore));
         }
     }
 
     @Override
     public StateStore getGlobalStore(final String name) {
-        return globalStores.get(name);
+        return globalStores.getOrDefault(name, Optional.empty()).orElse(null);
     }
 
     Collection<TopicPartition> changelogPartitions() {
-        return changelogPartitions;
+        return unmodifiableList(changelogPartitions);
+    }
+
+    void ensureStoresRegistered() {
+        for (final Map.Entry<String, Optional<StateStore>> entry : registeredStores.entrySet()) {
+            if (!entry.getValue().isPresent()) {
+                throw new IllegalStateException(
+                    "store [" + entry.getKey() + "] has not been correctly registered. This is a bug in Kafka Streams."
+                );
+            }
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -135,16 +135,16 @@ public class ProcessorStateManager extends AbstractStateManager {
             final TopicPartition storePartition = new TopicPartition(topic, getPartition(topic));
 
             if (isStandby) {
-            log.trace("Preparing standby replica of persistent state store {} with changelog topic {}", storeName, topic);
-            restoreCallbacks.put(topic, stateRestoreCallback);
-        } else {
-            log.trace("Restoring state store {} from changelog topic {}", storeName, topic);
-            final StateRestorer restorer = new StateRestorer(storePartition,
-                                                             new CompositeRestoreListener(stateRestoreCallback),
-                                                             checkpointableOffsets.get(storePartition),
-                                                             offsetLimit(storePartition),
-                                                             store.persistent(),
-                                                             storeName);
+                log.trace("Preparing standby replica of persistent state store {} with changelog topic {}", storeName, topic);
+                restoreCallbacks.put(topic, stateRestoreCallback);
+            } else {
+                log.trace("Restoring state store {} from changelog topic {}", storeName, topic);
+                final StateRestorer restorer = new StateRestorer(storePartition,
+                                                                 new CompositeRestoreListener(stateRestoreCallback),
+                                                                 checkpointableOffsets.get(storePartition),
+                                                                 offsetLimit(storePartition),
+                                                                 store.persistent(),
+                                                                 storeName);
 
                 changelogReader.register(restorer);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -34,77 +34,19 @@ public class ProcessorTopology {
     private final Map<String, String> storeToChangelogTopic;
     private final Set<String> repartitionTopics;
 
-    public static ProcessorTopology with(final List<ProcessorNode> processorNodes,
-                                         final Map<String, SourceNode> sourcesByTopic,
-                                         final List<StateStore> stateStoresByName,
-                                         final Map<String, String> storeToChangelogTopic) {
-        return new ProcessorTopology(processorNodes,
-                sourcesByTopic,
-                Collections.<String, SinkNode>emptyMap(),
-                stateStoresByName,
-                Collections.<StateStore>emptyList(),
-                storeToChangelogTopic,
-                Collections.<String>emptySet());
-    }
-
-    static ProcessorTopology withSources(final List<ProcessorNode> processorNodes,
-                                         final Map<String, SourceNode> sourcesByTopic) {
-        return new ProcessorTopology(processorNodes,
-                sourcesByTopic,
-                Collections.<String, SinkNode>emptyMap(),
-                Collections.<StateStore>emptyList(),
-                Collections.<StateStore>emptyList(),
-                Collections.<String, String>emptyMap(),
-                Collections.<String>emptySet());
-    }
-
-    static ProcessorTopology withLocalStores(final List<StateStore> stateStores,
-                                             final Map<String, String> storeToChangelogTopic) {
-        return new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
-                Collections.<String, SourceNode>emptyMap(),
-                Collections.<String, SinkNode>emptyMap(),
-                stateStores,
-                Collections.<StateStore>emptyList(),
-                storeToChangelogTopic,
-                Collections.<String>emptySet());
-    }
-
-    static ProcessorTopology withGlobalStores(final List<StateStore> stateStores,
-                                              final Map<String, String> storeToChangelogTopic) {
-        return new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
-                Collections.<String, SourceNode>emptyMap(),
-                Collections.<String, SinkNode>emptyMap(),
-                Collections.<StateStore>emptyList(),
-                stateStores,
-                storeToChangelogTopic,
-                Collections.<String>emptySet());
-    }
-
-    static ProcessorTopology withRepartitionTopics(final List<ProcessorNode> processorNodes,
-                                                   final Map<String, SourceNode> sourcesByTopic,
-                                                   final Set<String> repartitionTopics) {
-        return new ProcessorTopology(processorNodes,
-                sourcesByTopic,
-                Collections.<String, SinkNode>emptyMap(),
-                Collections.<StateStore>emptyList(),
-                Collections.<StateStore>emptyList(),
-                Collections.<String, String>emptyMap(),
-                repartitionTopics);
-    }
-
     public ProcessorTopology(final List<ProcessorNode> processorNodes,
                              final Map<String, SourceNode> sourcesByTopic,
                              final Map<String, SinkNode> sinksByTopic,
                              final List<StateStore> stateStores,
                              final List<StateStore> globalStateStores,
-                             final Map<String, String> stateStoreToChangelogTopic,
+                             final Map<String, String> storeToChangelogTopic,
                              final Set<String> repartitionTopics) {
         this.processorNodes = Collections.unmodifiableList(processorNodes);
         this.sourcesByTopic = Collections.unmodifiableMap(sourcesByTopic);
         this.sinksByTopic = Collections.unmodifiableMap(sinksByTopic);
         this.stateStores = Collections.unmodifiableList(stateStores);
         this.globalStateStores = Collections.unmodifiableList(globalStateStores);
-        this.storeToChangelogTopic = Collections.unmodifiableMap(stateStoreToChangelogTopic);
+        this.storeToChangelogTopic = Collections.unmodifiableMap(storeToChangelogTopic);
         this.repartitionTopics = Collections.unmodifiableSet(repartitionTopics);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -280,6 +280,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         taskInitialized = true;
 
         idleStartTime = RecordQueue.UNKNOWN;
+
+        stateMgr.ensureStoresRegistered();
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.kafka.streams.processor.internals.ProcessorTopologyFactories.withLocalStores;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,6 +97,8 @@ public class AbstractTaskTest {
     public void shouldThrowLockExceptionIfFailedToLockStateDirectoryWhenTopologyHasStores() throws IOException {
         final Consumer consumer = EasyMock.createNiceMock(Consumer.class);
         final StateStore store = EasyMock.createNiceMock(StateStore.class);
+        expect(store.name()).andReturn("dummy-store-name").anyTimes();
+        EasyMock.replay(store);
         expect(stateDirectory.lock(id)).andReturn(false);
         EasyMock.replay(stateDirectory);
 
@@ -232,9 +235,13 @@ public class AbstractTaskTest {
 
         return new AbstractTask(id,
                                 storeTopicPartitions,
-                                ProcessorTopology.withLocalStores(new ArrayList<>(stateStoresToChangelogTopics.keySet()), storeNamesToChangelogTopics),
+                                withLocalStores(new ArrayList<>(stateStoresToChangelogTopics.keySet()),
+                                                storeNamesToChangelogTopics),
                                 consumer,
-                                new StoreChangelogReader(consumer, Duration.ZERO, new MockStateRestoreListener(), new LogContext("stream-task-test ")),
+                                new StoreChangelogReader(consumer,
+                                                         Duration.ZERO,
+                                                         new MockStateRestoreListener(),
+                                                         new LogContext("stream-task-test ")),
                                 false,
                                 stateDirectory,
                                 config) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -89,6 +89,17 @@ public class GlobalStateManagerImplTest {
     private ProcessorTopology topology;
     private InternalMockProcessorContext processorContext;
 
+    static ProcessorTopology withGlobalStores(final List<StateStore> stateStores,
+                                              final Map<String, String> storeToChangelogTopic) {
+        return new ProcessorTopology(Collections.emptyList(),
+                                     Collections.emptyMap(),
+                                     Collections.emptyMap(),
+                                     Collections.emptyList(),
+                                     stateStores,
+                                     storeToChangelogTopic,
+                                     Collections.emptySet());
+    }
+
     @Before
     public void before() throws IOException {
         final Map<String, String> storeToTopic = new HashMap<>();
@@ -103,7 +114,7 @@ public class GlobalStateManagerImplTest {
         store3 = new NoOpReadOnlyStore<>(storeName3);
         store4 = new NoOpReadOnlyStore<>(storeName4);
 
-        topology = ProcessorTopology.withGlobalStores(Utils.<StateStore>mkList(store1, store2, store3, store4), storeToTopic);
+        topology = withGlobalStores(Utils.<StateStore>mkList(store1, store2, store3, store4), storeToTopic);
 
         streamsConfig = new StreamsConfig(new Properties() {
             {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
@@ -83,7 +83,7 @@ public class GlobalStateTaskTest {
         final Map<String, String> storeToTopic = new HashMap<>();
         storeToTopic.put("t1-store", topic1);
         storeToTopic.put("t2-store", topic2);
-        topology = ProcessorTopology.with(
+        topology = ProcessorTopologyFactories.with(
             Utils.mkList(sourceOne, sourceTwo, processorOne, processorTwo),
             sourceByTopics,
             Collections.<StateStore>emptyList(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyFactories.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyFactories.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.processor.StateStore;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class ProcessorTopologyFactories {
+    private ProcessorTopologyFactories() {}
+
+
+    public static ProcessorTopology with(final List<ProcessorNode> processorNodes,
+                                         final Map<String, SourceNode> sourcesByTopic,
+                                         final List<StateStore> stateStoresByName,
+                                         final Map<String, String> storeToChangelogTopic) {
+        return new ProcessorTopology(processorNodes,
+                                     sourcesByTopic,
+                                     Collections.emptyMap(),
+                                     stateStoresByName,
+                                     Collections.emptyList(),
+                                     storeToChangelogTopic,
+                                     Collections.emptySet());
+    }
+
+    static ProcessorTopology withLocalStores(final List<StateStore> stateStores,
+                                             final Map<String, String> storeToChangelogTopic) {
+        return new ProcessorTopology(Collections.emptyList(),
+                                     Collections.emptyMap(),
+                                     Collections.emptyMap(),
+                                     stateStores,
+                                     Collections.emptyList(),
+                                     storeToChangelogTopic,
+                                     Collections.emptySet());
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -50,9 +50,9 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import org.apache.kafka.streams.state.internals.WindowKeySchema;
 import org.apache.kafka.test.MockKeyValueStore;
+import org.apache.kafka.test.MockKeyValueStoreBuilder;
 import org.apache.kafka.test.MockRestoreConsumer;
 import org.apache.kafka.test.MockStateRestoreListener;
-import org.apache.kafka.test.MockKeyValueStoreBuilder;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -105,8 +105,9 @@ public class StandbyTaskTest {
     private final MockStateRestoreListener stateRestoreListener = new MockStateRestoreListener();
 
     private final Set<TopicPartition> topicPartitions = Collections.emptySet();
-    private final ProcessorTopology topology = ProcessorTopology.withLocalStores(
-        mkList(new MockKeyValueStoreBuilder(storeName1, false).build(), new MockKeyValueStoreBuilder(storeName2, true).build()),
+    private final ProcessorTopology topology = ProcessorTopologyFactories.withLocalStores(
+        mkList(new MockKeyValueStoreBuilder(storeName1, false).build(),
+               new MockKeyValueStoreBuilder(storeName2, true).build()),
         mkMap(
             mkEntry(storeName1, storeChangelogTopicName1),
             mkEntry(storeName2, storeChangelogTopicName2)
@@ -114,8 +115,9 @@ public class StandbyTaskTest {
     );
     private final TopicPartition globalTopicPartition = new TopicPartition(globalStoreName, 0);
     private final Set<TopicPartition> ktablePartitions = Utils.mkSet(globalTopicPartition);
-    private final ProcessorTopology ktableTopology = ProcessorTopology.withLocalStores(
-        singletonList(new MockKeyValueStoreBuilder(globalTopicPartition.topic(), true).withLoggingDisabled().build()),
+    private final ProcessorTopology ktableTopology = ProcessorTopologyFactories.withLocalStores(
+        singletonList(new MockKeyValueStoreBuilder(globalTopicPartition.topic(), true)
+                          .withLoggingDisabled().build()),
         mkMap(
             mkEntry(globalStoreName, globalTopicPartition.topic())
         )
@@ -363,7 +365,7 @@ public class StandbyTaskTest {
             singletonList(makeWindowedConsumerRecord(changelogName, 10, 1, 0L, 60_000L))
         );
 
-        task.closeStateManager(true);
+        task.close(true, false);
 
         final File taskDir = stateDirectory.directoryForTask(taskId);
         final OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
@@ -26,8 +26,13 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MockKeyValueStore implements KeyValueStore {
+    // keep a global counter of flushes and a local reference to which store had which
+    // flush, so we can reason about the order in which stores get flushed.
+    private static final AtomicInteger GLOBAL_FLUSH_COUNTER = new AtomicInteger(0);
+    private final AtomicInteger instanceLastFlushCount = new AtomicInteger(-1);
     private final String name;
     private final boolean persistent;
 
@@ -57,7 +62,12 @@ public class MockKeyValueStore implements KeyValueStore {
 
     @Override
     public void flush() {
+        instanceLastFlushCount.set(GLOBAL_FLUSH_COUNTER.getAndIncrement());
         flushed = true;
+    }
+
+    public int getLastFlushCount() {
+        return instanceLastFlushCount.get();
     }
 
     @Override


### PR DESCRIPTION
Streams previously flushed stores in the order of their registration, which is arbitrary. Because stores may forward values upon flush (as in cached state stores), we must flush stores in topological order.

Cherry-picked from #6555 / 58d6043d4

Reviewers: Bill Bejeck <bbejeck@gmail.com>, Guozhang Wang <wangguoz@gmail.com>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
