### PR TITLE
Minor: refactor list offsets usage in Fetcher

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.FetcherMetricsRegistry;
 import org.apache.kafka.clients.consumer.internals.Heartbeat;
+import org.apache.kafka.clients.consumer.internals.ListOffsetsClient;
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
@@ -796,7 +797,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.time,
                     this.retryBackoffMs,
                     this.requestTimeoutMs,
-                    isolationLevel);
+                    isolationLevel,
+                    new ListOffsetsClient(client, logContext));
 
             config.logUnused();
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -159,7 +159,8 @@ public class Fetcher<K, V> implements Closeable {
                    Time time,
                    long retryBackoffMs,
                    long requestTimeoutMs,
-                   IsolationLevel isolationLevel) {
+                   IsolationLevel isolationLevel,
+                   ListOffsetsClient listOffsetsClient) {
         this.log = logContext.logger(Fetcher.class);
         this.logContext = logContext;
         this.time = time;
@@ -181,7 +182,7 @@ public class Fetcher<K, V> implements Closeable {
         this.isolationLevel = isolationLevel;
         this.sessionHandlers = new HashMap<>();
         this.offsetsForLeaderEpochClient = new OffsetsForLeaderEpochClient(client, logContext);
-        this.listOffsetsClient = new ListOffsetsClient(client, logContext);
+        this.listOffsetsClient = listOffsetsClient;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -61,7 +61,6 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.requests.ListOffsetRequest;
-import org.apache.kafka.common.requests.ListOffsetResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -91,6 +90,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -138,6 +138,7 @@ public class Fetcher<K, V> implements Closeable {
     private final AtomicReference<RuntimeException> cachedListOffsetsException = new AtomicReference<>();
     private final AtomicReference<RuntimeException> cachedOffsetForLeaderException = new AtomicReference<>();
     private final OffsetsForLeaderEpochClient offsetsForLeaderEpochClient;
+    private final ListOffsetsClient listOffsetsClient;
 
     private PartitionRecords nextInLineRecords = null;
 
@@ -180,6 +181,7 @@ public class Fetcher<K, V> implements Closeable {
         this.isolationLevel = isolationLevel;
         this.sessionHandlers = new HashMap<>();
         this.offsetsForLeaderEpochClient = new OffsetsForLeaderEpochClient(client, logContext);
+        this.listOffsetsClient = new ListOffsetsClient(client, logContext);
     }
 
     /**
@@ -445,17 +447,17 @@ public class Fetcher<K, V> implements Closeable {
         metadata.addTransientTopics(topicsForPartitions(timestampsToSearch.keySet()));
 
         try {
-            Map<TopicPartition, ListOffsetData> fetchedOffsets = fetchOffsetsByTimes(timestampsToSearch,
+            Map<TopicPartition, ListOffsetsClient.ListOffsetData> fetchedOffsets = fetchOffsetsByTimes(timestampsToSearch,
                     timer, true).fetchedOffsets;
 
             HashMap<TopicPartition, OffsetAndTimestamp> offsetsByTimes = new HashMap<>(timestampsToSearch.size());
             for (Map.Entry<TopicPartition, Long> entry : timestampsToSearch.entrySet())
                 offsetsByTimes.put(entry.getKey(), null);
 
-            for (Map.Entry<TopicPartition, ListOffsetData> entry : fetchedOffsets.entrySet()) {
+            for (Map.Entry<TopicPartition, ListOffsetsClient.ListOffsetData> entry : fetchedOffsets.entrySet()) {
                 // 'entry.getValue().timestamp' will not be null since we are guaranteed
                 // to work with a v1 (or later) ListOffset request
-                ListOffsetData offsetData = entry.getValue();
+                ListOffsetsClient.ListOffsetData offsetData = entry.getValue();
                 offsetsByTimes.put(entry.getKey(), new OffsetAndTimestamp(offsetData.offset, offsetData.timestamp,
                         offsetData.leaderEpoch));
             }
@@ -466,23 +468,23 @@ public class Fetcher<K, V> implements Closeable {
         }
     }
 
-    private ListOffsetResult fetchOffsetsByTimes(Map<TopicPartition, Long> timestampsToSearch,
-                                                 Timer timer,
-                                                 boolean requireTimestamps) {
-        ListOffsetResult result = new ListOffsetResult();
+    private ListOffsetsClient.ResultData fetchOffsetsByTimes(Map<TopicPartition, Long> timestampsToSearch,
+                                                             Timer timer,
+                                                             boolean requireTimestamps) {
+        ListOffsetsClient.ResultData result = new ListOffsetsClient.ResultData();
         if (timestampsToSearch.isEmpty())
             return result;
 
         Map<TopicPartition, Long> remainingToSearch = new HashMap<>(timestampsToSearch);
         do {
-            RequestFuture<ListOffsetResult> future = sendListOffsetsRequests(remainingToSearch, requireTimestamps);
+            RequestFuture<ListOffsetsClient.ResultData> future = sendListOffsetsRequests(remainingToSearch, requireTimestamps);
             client.poll(future, timer);
 
             if (!future.isDone())
                 break;
 
             if (future.succeeded()) {
-                ListOffsetResult value = future.value();
+                ListOffsetsClient.ResultData value = future.value();
                 result.fetchedOffsets.putAll(value.fetchedOffsets);
                 if (value.partitionsToRetry.isEmpty())
                     return result;
@@ -517,7 +519,7 @@ public class Fetcher<K, V> implements Closeable {
             Map<TopicPartition, Long> timestampsToSearch = partitions.stream()
                     .collect(Collectors.toMap(Function.identity(), tp -> timestamp));
 
-            ListOffsetResult result = fetchOffsetsByTimes(timestampsToSearch, timer, false);
+            ListOffsetsClient.ResultData result = fetchOffsetsByTimes(timestampsToSearch, timer, false);
 
             return result.fetchedOffsets.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset));
@@ -635,7 +637,7 @@ public class Fetcher<K, V> implements Closeable {
         return emptyList();
     }
 
-    private void resetOffsetIfNeeded(TopicPartition partition, Long requestedResetTimestamp, ListOffsetData offsetData) {
+    private void resetOffsetIfNeeded(TopicPartition partition, Long requestedResetTimestamp, ListOffsetsClient.ListOffsetData offsetData) {
         // we might lose the assignment while fetching the offset, or the user might seek to a different offset,
         // so verify it is still assigned and still in need of the requested reset
         if (!subscriptions.isAssigned(partition)) {
@@ -661,18 +663,19 @@ public class Fetcher<K, V> implements Closeable {
             final Map<TopicPartition, ListOffsetRequest.PartitionData> resetTimestamps = entry.getValue();
             subscriptions.setNextAllowedRetry(resetTimestamps.keySet(), time.milliseconds() + requestTimeoutMs);
 
-            RequestFuture<ListOffsetResult> future = sendListOffsetRequest(node, resetTimestamps, false);
-            future.addListener(new RequestFutureListener<ListOffsetResult>() {
+            RequestFuture<ListOffsetsClient.ResultData> future = listOffsetsClient.sendAsyncRequest(node,
+                    new ListOffsetsClient.RequestData(resetTimestamps, false, isolationLevel));
+            future.addListener(new RequestFutureListener<ListOffsetsClient.ResultData>() {
                 @Override
-                public void onSuccess(ListOffsetResult result) {
+                public void onSuccess(ListOffsetsClient.ResultData result) {
                     if (!result.partitionsToRetry.isEmpty()) {
                         subscriptions.requestFailed(result.partitionsToRetry, time.milliseconds() + retryBackoffMs);
                         metadata.requestUpdate();
                     }
 
-                    for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
+                    for (Map.Entry<TopicPartition, ListOffsetsClient.ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
                         TopicPartition partition = fetchedOffset.getKey();
-                        ListOffsetData offsetData = fetchedOffset.getValue();
+                        ListOffsetsClient.ListOffsetData offsetData = fetchedOffset.getValue();
                         ListOffsetRequest.PartitionData requestedReset = resetTimestamps.get(partition);
                         resetOffsetIfNeeded(partition, requestedReset.timestamp, offsetData);
                     }
@@ -698,7 +701,7 @@ public class Fetcher<K, V> implements Closeable {
      */
     private void validateOffsetsAsync(Map<TopicPartition, SubscriptionState.FetchPosition> partitionsToValidate) {
         final Map<Node, Map<TopicPartition, SubscriptionState.FetchPosition>> regrouped =
-                regroupFetchPositionsByLeader(partitionsToValidate);
+                regroupPartitionMapByNode(partitionsToValidate, (tp, fetchPosition) -> fetchPosition.currentLeader.leader);
 
         regrouped.forEach((node, dataMap) -> {
             if (node.isEmpty()) {
@@ -782,30 +785,32 @@ public class Fetcher<K, V> implements Closeable {
      *                         not support fetching precise timestamps for offsets
      * @return A response which can be polled to obtain the corresponding timestamps and offsets.
      */
-    private RequestFuture<ListOffsetResult> sendListOffsetsRequests(final Map<TopicPartition, Long> timestampsToSearch,
-                                                                    final boolean requireTimestamps) {
+    private RequestFuture<ListOffsetsClient.ResultData> sendListOffsetsRequests(final Map<TopicPartition, Long> timestampsToSearch,
+                                                                                final boolean requireTimestamps) {
         final Set<TopicPartition> partitionsToRetry = new HashSet<>();
         Map<Node, Map<TopicPartition, ListOffsetRequest.PartitionData>> timestampsToSearchByNode =
                 groupListOffsetRequests(timestampsToSearch, partitionsToRetry);
         if (timestampsToSearchByNode.isEmpty())
             return RequestFuture.failure(new StaleMetadataException());
 
-        final RequestFuture<ListOffsetResult> listOffsetRequestsFuture = new RequestFuture<>();
-        final Map<TopicPartition, ListOffsetData> fetchedTimestampOffsets = new HashMap<>();
+        final RequestFuture<ListOffsetsClient.ResultData> listOffsetRequestsFuture = new RequestFuture<>();
+        final Map<TopicPartition, ListOffsetsClient.ListOffsetData> fetchedTimestampOffsets = new HashMap<>();
         final AtomicInteger remainingResponses = new AtomicInteger(timestampsToSearchByNode.size());
 
         for (Map.Entry<Node, Map<TopicPartition, ListOffsetRequest.PartitionData>> entry : timestampsToSearchByNode.entrySet()) {
-            RequestFuture<ListOffsetResult> future =
-                sendListOffsetRequest(entry.getKey(), entry.getValue(), requireTimestamps);
-            future.addListener(new RequestFutureListener<ListOffsetResult>() {
+
+            RequestFuture<ListOffsetsClient.ResultData> future = listOffsetsClient.sendAsyncRequest(
+                    entry.getKey(), new ListOffsetsClient.RequestData(entry.getValue(), requireTimestamps, isolationLevel));
+            future.addListener(new RequestFutureListener<ListOffsetsClient.ResultData>() {
                 @Override
-                public void onSuccess(ListOffsetResult partialResult) {
+                public void onSuccess(ListOffsetsClient.ResultData partialResult) {
                     synchronized (listOffsetRequestsFuture) {
                         fetchedTimestampOffsets.putAll(partialResult.fetchedOffsets);
                         partitionsToRetry.addAll(partialResult.partitionsToRetry);
 
                         if (remainingResponses.decrementAndGet() == 0 && !listOffsetRequestsFuture.isDone()) {
-                            ListOffsetResult result = new ListOffsetResult(fetchedTimestampOffsets, partitionsToRetry);
+                            ListOffsetsClient.ResultData result = new ListOffsetsClient.ResultData(
+                                    fetchedTimestampOffsets, partitionsToRetry);
                             listOffsetRequestsFuture.complete(result);
                         }
                     }
@@ -834,6 +839,7 @@ public class Fetcher<K, V> implements Closeable {
     private Map<Node, Map<TopicPartition, ListOffsetRequest.PartitionData>> groupListOffsetRequests(
             Map<TopicPartition, Long> timestampsToSearch,
             Set<TopicPartition> partitionsToRetry) {
+
         final Map<TopicPartition, ListOffsetRequest.PartitionData> partitionDataMap = new HashMap<>();
         for (Map.Entry<TopicPartition, Long> entry: timestampsToSearch.entrySet()) {
             TopicPartition tp  = entry.getKey();
@@ -860,137 +866,8 @@ public class Fetcher<K, V> implements Closeable {
                         new ListOffsetRequest.PartitionData(entry.getValue(), Optional.of(currentInfo.get().epoch())));
             }
         }
-        return regroupPartitionMapByNode(partitionDataMap);
-    }
 
-    /**
-     * Send the ListOffsetRequest to a specific broker for the partitions and target timestamps.
-     *
-     * @param node The node to send the ListOffsetRequest to.
-     * @param timestampsToSearch The mapping from partitions to the target timestamps.
-     * @param requireTimestamp  True if we require a timestamp in the response.
-     * @return A response which can be polled to obtain the corresponding timestamps and offsets.
-     */
-    private RequestFuture<ListOffsetResult> sendListOffsetRequest(final Node node,
-                                                                  final Map<TopicPartition, ListOffsetRequest.PartitionData> timestampsToSearch,
-                                                                  boolean requireTimestamp) {
-        ListOffsetRequest.Builder builder = ListOffsetRequest.Builder
-                .forConsumer(requireTimestamp, isolationLevel)
-                .setTargetTimes(timestampsToSearch);
-
-        log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
-        return client.send(node, builder)
-                .compose(new RequestFutureAdapter<ClientResponse, ListOffsetResult>() {
-                    @Override
-                    public void onSuccess(ClientResponse response, RequestFuture<ListOffsetResult> future) {
-                        ListOffsetResponse lor = (ListOffsetResponse) response.responseBody();
-                        log.trace("Received ListOffsetResponse {} from broker {}", lor, node);
-                        handleListOffsetResponse(timestampsToSearch, lor, future);
-                    }
-                });
-    }
-
-    /**
-     * Callback for the response of the list offset call above.
-     * @param timestampsToSearch The mapping from partitions to target timestamps
-     * @param listOffsetResponse The response from the server.
-     * @param future The future to be completed when the response returns. Note that any partition-level errors will
-     *               generally fail the entire future result. The one exception is UNSUPPORTED_FOR_MESSAGE_FORMAT,
-     *               which indicates that the broker does not support the v1 message format. Partitions with this
-     *               particular error are simply left out of the future map. Note that the corresponding timestamp
-     *               value of each partition may be null only for v0. In v1 and later the ListOffset API would not
-     *               return a null timestamp (-1 is returned instead when necessary).
-     */
-    @SuppressWarnings("deprecation")
-    private void handleListOffsetResponse(Map<TopicPartition, ListOffsetRequest.PartitionData> timestampsToSearch,
-                                          ListOffsetResponse listOffsetResponse,
-                                          RequestFuture<ListOffsetResult> future) {
-        Map<TopicPartition, ListOffsetData> fetchedOffsets = new HashMap<>();
-        Set<TopicPartition> partitionsToRetry = new HashSet<>();
-        Set<String> unauthorizedTopics = new HashSet<>();
-
-        for (Map.Entry<TopicPartition, ListOffsetRequest.PartitionData> entry : timestampsToSearch.entrySet()) {
-            TopicPartition topicPartition = entry.getKey();
-            ListOffsetResponse.PartitionData partitionData = listOffsetResponse.responseData().get(topicPartition);
-            Errors error = partitionData.error;
-            if (error == Errors.NONE) {
-                if (partitionData.offsets != null) {
-                    // Handle v0 response
-                    long offset;
-                    if (partitionData.offsets.size() > 1) {
-                        future.raise(new IllegalStateException("Unexpected partitionData response of length " +
-                                partitionData.offsets.size()));
-                        return;
-                    } else if (partitionData.offsets.isEmpty()) {
-                        offset = ListOffsetResponse.UNKNOWN_OFFSET;
-                    } else {
-                        offset = partitionData.offsets.get(0);
-                    }
-                    log.debug("Handling v0 ListOffsetResponse response for {}. Fetched offset {}",
-                            topicPartition, offset);
-                    if (offset != ListOffsetResponse.UNKNOWN_OFFSET) {
-                        ListOffsetData offsetData = new ListOffsetData(offset, null, Optional.empty());
-                        fetchedOffsets.put(topicPartition, offsetData);
-                    }
-                } else {
-                    // Handle v1 and later response
-                    log.debug("Handling ListOffsetResponse response for {}. Fetched offset {}, timestamp {}",
-                            topicPartition, partitionData.offset, partitionData.timestamp);
-                    if (partitionData.offset != ListOffsetResponse.UNKNOWN_OFFSET) {
-                        ListOffsetData offsetData = new ListOffsetData(partitionData.offset, partitionData.timestamp,
-                                partitionData.leaderEpoch);
-                        fetchedOffsets.put(topicPartition, offsetData);
-                    }
-                }
-            } else if (error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT) {
-                // The message format on the broker side is before 0.10.0, which means it does not
-                // support timestamps. We treat this case the same as if we weren't able to find an
-                // offset corresponding to the requested timestamp and leave it out of the result.
-                log.debug("Cannot search by timestamp for partition {} because the message format version " +
-                        "is before 0.10.0", topicPartition);
-            } else if (error == Errors.NOT_LEADER_FOR_PARTITION ||
-                       error == Errors.REPLICA_NOT_AVAILABLE ||
-                       error == Errors.KAFKA_STORAGE_ERROR ||
-                       error == Errors.OFFSET_NOT_AVAILABLE ||
-                       error == Errors.LEADER_NOT_AVAILABLE) {
-                log.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
-                        topicPartition, error);
-                partitionsToRetry.add(topicPartition);
-            } else if (error == Errors.FENCED_LEADER_EPOCH ||
-                       error == Errors.UNKNOWN_LEADER_EPOCH) {
-                log.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
-                        topicPartition, error);
-                partitionsToRetry.add(topicPartition);
-            } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-                log.warn("Received unknown topic or partition error in ListOffset request for partition {}", topicPartition);
-                partitionsToRetry.add(topicPartition);
-            } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
-                unauthorizedTopics.add(topicPartition.topic());
-            } else {
-                log.warn("Attempt to fetch offsets for partition {} failed due to: {}, retrying.", topicPartition, error.message());
-                partitionsToRetry.add(topicPartition);
-            }
-        }
-
-        if (!unauthorizedTopics.isEmpty())
-            future.raise(new TopicAuthorizationException(unauthorizedTopics));
-        else
-            future.complete(new ListOffsetResult(fetchedOffsets, partitionsToRetry));
-    }
-
-    static class ListOffsetResult {
-        private final Map<TopicPartition, ListOffsetData> fetchedOffsets;
-        private final Set<TopicPartition> partitionsToRetry;
-
-        public ListOffsetResult(Map<TopicPartition, ListOffsetData> fetchedOffsets, Set<TopicPartition> partitionsNeedingRetry) {
-            this.fetchedOffsets = fetchedOffsets;
-            this.partitionsToRetry = partitionsNeedingRetry;
-        }
-
-        public ListOffsetResult() {
-            this.fetchedOffsets = new HashMap<>();
-            this.partitionsToRetry = new HashSet<>();
-        }
+        return regroupPartitionMapByNode(partitionDataMap, (tp, partitionData) -> metadata.fetch().leaderFor(tp));
     }
 
     private List<TopicPartition> fetchablePartitions() {
@@ -1059,18 +936,20 @@ public class Fetcher<K, V> implements Closeable {
         return reqs;
     }
 
-    private Map<Node, Map<TopicPartition, SubscriptionState.FetchPosition>> regroupFetchPositionsByLeader(
-            Map<TopicPartition, SubscriptionState.FetchPosition> partitionMap) {
+    /**
+     * Regroup a map consisting of {@link TopicPartition} keys and generic values to an outer map of {@link Node}. This
+     * is generally used to group request data based on where it is going (the node).
+     * @param partitionMap
+     * @param groupingFunction
+     * @param <T>
+     * @return
+     */
+    private <T> Map<Node, Map<TopicPartition, T>> regroupPartitionMapByNode(
+            Map<TopicPartition, T> partitionMap,
+            BiFunction<TopicPartition, T, Node> groupingFunction) {
         return partitionMap.entrySet()
                 .stream()
-                .collect(Collectors.groupingBy(entry -> entry.getValue().currentLeader.leader,
-                        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
-    private <T> Map<Node, Map<TopicPartition, T>> regroupPartitionMapByNode(Map<TopicPartition, T> partitionMap) {
-        return partitionMap.entrySet()
-                .stream()
-                .collect(Collectors.groupingBy(entry -> metadata.fetch().leaderFor(entry.getKey()),
+                .collect(Collectors.groupingBy(entry -> groupingFunction.apply(entry.getKey(), entry.getValue()),
                         Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
@@ -40,7 +40,7 @@ public class ListOffsetsClient extends AsyncClient<
         ListOffsetsClient.ResultData> {
 
 
-    ListOffsetsClient(ConsumerNetworkClient client, LogContext logContext) {
+    public ListOffsetsClient(ConsumerNetworkClient client, LogContext logContext) {
         super(client, logContext);
     }
 
@@ -76,6 +76,11 @@ public class ListOffsetsClient extends AsyncClient<
         for (Map.Entry<TopicPartition, ListOffsetRequest.PartitionData> entry : requestData.timestampsToSearch.entrySet()) {
             TopicPartition topicPartition = entry.getKey();
             ListOffsetResponse.PartitionData partitionData = response.responseData().get(topicPartition);
+            if (partitionData == null) {
+                logger().warn("Missing partition {} from response, ignoring", topicPartition);
+                partitionsToRetry.add(topicPartition);
+                continue;
+            }
             Errors error = partitionData.error;
             if (error == Errors.NONE) {
                 handleOkPartitionResponse(topicPartition, partitionData, fetchedOffsets);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.IsolationLevel;
+import org.apache.kafka.common.requests.ListOffsetRequest;
+import org.apache.kafka.common.requests.ListOffsetResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class ListOffsetsClient extends AsyncClient<
+        ListOffsetsClient.RequestData,
+        ListOffsetRequest,
+        ListOffsetResponse,
+        ListOffsetsClient.ResultData> {
+
+
+    ListOffsetsClient(ConsumerNetworkClient client, LogContext logContext) {
+        super(client, logContext);
+    }
+
+    @Override
+    protected AbstractRequest.Builder<ListOffsetRequest> prepareRequest(Node node, RequestData requestData) {
+        ListOffsetRequest.Builder builder = ListOffsetRequest.Builder
+                .forConsumer(requestData.requireTimestamp, requestData.isolationLevel)
+                .setTargetTimes(requestData.timestampsToSearch);
+        return builder;
+    }
+
+    /**
+     * Callback for the response of list offset.
+     * @param requestData The request data including the mapping from partitions to target timestamps
+     * @param response The response from the server.
+     * @return The result of the request represented by a {@link ResultData} object. Note that any partition-level
+     *         errors will fail the entire response. The one exception is UNSUPPORTED_FOR_MESSAGE_FORMAT, which
+     *         indicates that the broker does not support the v1 message format. Partitions with this particular error
+     *         are simply left out of the result map. Note that the corresponding timestamp value of each partition may
+     *         be null only for v0. In v1 and later the ListOffset API would not return a null timestamp (-1 is returned
+     *         instead when necessary).
+     */
+    @Override
+    protected ResultData handleResponse(Node node, RequestData requestData, ListOffsetResponse response) {
+
+        // Handle the response, translate to something more usable
+        Map<TopicPartition, ListOffsetData> fetchedOffsets = new HashMap<>();
+        Set<TopicPartition> partitionsToRetry = new HashSet<>();
+        Set<String> unauthorizedTopics = new HashSet<>();
+
+        Logger log = logger();
+
+        for (Map.Entry<TopicPartition, ListOffsetRequest.PartitionData> entry : requestData.timestampsToSearch.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            ListOffsetResponse.PartitionData partitionData = response.responseData().get(topicPartition);
+            Errors error = partitionData.error;
+            if (error == Errors.NONE) {
+                handleOkPartitionResponse(topicPartition, partitionData, fetchedOffsets);
+            } else if (error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT) {
+                // The message format on the broker side is before 0.10.0, which means it does not
+                // support timestamps. We treat this case the same as if we weren't able to find an
+                // offset corresponding to the requested timestamp and leave it out of the result.
+                log.debug("Cannot search by timestamp for partition {} because the message format version " +
+                        "is before 0.10.0", topicPartition);
+            } else if (error == Errors.NOT_LEADER_FOR_PARTITION ||
+                    error == Errors.REPLICA_NOT_AVAILABLE ||
+                    error == Errors.KAFKA_STORAGE_ERROR ||
+                    error == Errors.OFFSET_NOT_AVAILABLE ||
+                    error == Errors.LEADER_NOT_AVAILABLE) {
+                log.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
+                        topicPartition, error);
+                partitionsToRetry.add(topicPartition);
+            } else if (error == Errors.FENCED_LEADER_EPOCH ||
+                    error == Errors.UNKNOWN_LEADER_EPOCH) {
+                log.debug("Attempt to fetch offsets for partition {} failed due to {}, retrying.",
+                        topicPartition, error);
+                partitionsToRetry.add(topicPartition);
+            } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
+                log.warn("Received unknown topic or partition error in ListOffset request for partition {}", topicPartition);
+                partitionsToRetry.add(topicPartition);
+            } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
+                unauthorizedTopics.add(topicPartition.topic());
+            } else {
+                log.warn("Attempt to fetch offsets for partition {} failed due to: {}, retrying.", topicPartition, error.message());
+                partitionsToRetry.add(topicPartition);
+            }
+        }
+
+        if (!unauthorizedTopics.isEmpty())
+            throw new TopicAuthorizationException(unauthorizedTopics);
+        else
+            return new ResultData(fetchedOffsets, partitionsToRetry);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void handleOkPartitionResponse(TopicPartition topicPartition,
+                            ListOffsetResponse.PartitionData partitionData,
+                            Map<TopicPartition, ListOffsetData> fetchedOffsets) {
+        Logger log = logger();
+        if (partitionData.offsets != null) {
+            // Handle v0 response
+            long offset;
+            if (partitionData.offsets.size() > 1) {
+                throw new IllegalStateException("Unexpected partitionData response of length " +
+                        partitionData.offsets.size());
+            } else if (partitionData.offsets.isEmpty()) {
+                offset = ListOffsetResponse.UNKNOWN_OFFSET;
+            } else {
+                offset = partitionData.offsets.get(0);
+            }
+            log.debug("Handling v0 ListOffsetResponse response for {}. Fetched offset {}",
+                    topicPartition, offset);
+            if (offset != ListOffsetResponse.UNKNOWN_OFFSET) {
+                ListOffsetData offsetData = new ListOffsetData(offset, null, Optional.empty());
+                fetchedOffsets.put(topicPartition, offsetData);
+            }
+        } else {
+            // Handle v1 and later response
+            log.debug("Handling ListOffsetResponse response for {}. Fetched offset {}, timestamp {}",
+                    topicPartition, partitionData.offset, partitionData.timestamp);
+            if (partitionData.offset != ListOffsetResponse.UNKNOWN_OFFSET) {
+                ListOffsetData offsetData = new ListOffsetData(partitionData.offset, partitionData.timestamp,
+                        partitionData.leaderEpoch);
+                fetchedOffsets.put(topicPartition, offsetData);
+            }
+        }
+    }
+
+
+    static class RequestData {
+        final Map<TopicPartition, ListOffsetRequest.PartitionData> timestampsToSearch;
+        final boolean requireTimestamp;
+        final IsolationLevel isolationLevel;
+
+        /**
+         * @param timestampsToSearch The mapping from partitions to the target timestamps.
+         * @param requireTimestamp  True if we require a timestamp in the response.
+         * @param isolationLevel The isolation level of the consumer making this request.
+         * @return A response which can be polled to obtain the corresponding timestamps and offsets.
+         */
+        RequestData(Map<TopicPartition, ListOffsetRequest.PartitionData> timestampsToSearch, boolean requireTimestamp,
+                    IsolationLevel isolationLevel) {
+            this.timestampsToSearch = timestampsToSearch;
+            this.requireTimestamp = requireTimestamp;
+            this.isolationLevel = isolationLevel;
+        }
+    }
+
+    static class ResultData {
+        final Map<TopicPartition, ListOffsetData> fetchedOffsets;
+        final Set<TopicPartition> partitionsToRetry;
+
+        public ResultData(Map<TopicPartition, ListOffsetData> fetchedOffsets, Set<TopicPartition> partitionsNeedingRetry) {
+            this.fetchedOffsets = fetchedOffsets;
+            this.partitionsToRetry = partitionsNeedingRetry;
+        }
+
+        public ResultData() {
+            this.fetchedOffsets = new HashMap<>();
+            this.partitionsToRetry = new HashSet<>();
+        }
+    }
+
+
+    static class ListOffsetData {
+        final long offset;
+        final Long timestamp; //  null if the broker does not support returning timestamps
+        final Optional<Integer> leaderEpoch; // empty if the leader epoch is not known
+
+        ListOffsetData(long offset, Long timestamp, Optional<Integer> leaderEpoch) {
+            this.offset = offset;
+            this.timestamp = timestamp;
+            this.leaderEpoch = leaderEpoch;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClient.java
@@ -33,6 +33,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Convenience class for making asynchronous requests to the ListOffsets API
+ */
 public class ListOffsetsClient extends AsyncClient<
         ListOffsetsClient.RequestData,
         ListOffsetRequest,
@@ -154,7 +157,6 @@ public class ListOffsetsClient extends AsyncClient<
         }
     }
 
-
     static class RequestData {
         final Map<TopicPartition, ListOffsetRequest.PartitionData> timestampsToSearch;
         final boolean requireTimestamp;
@@ -188,7 +190,6 @@ public class ListOffsetsClient extends AsyncClient<
             this.partitionsToRetry = new HashSet<>();
         }
     }
-
 
     static class ListOffsetData {
         final long offset;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
@@ -52,7 +52,6 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
         requestData.forEach((topicPartition, fetchPosition) -> fetchPosition.offsetEpoch.ifPresent(
             fetchEpoch -> partitionData.put(topicPartition,
                 new OffsetsForLeaderEpochRequest.PartitionData(fetchPosition.currentLeader.epoch, fetchEpoch))));
-
         return new OffsetsForLeaderEpochRequest.Builder(ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion(), partitionData);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.Heartbeat;
+import org.apache.kafka.clients.consumer.internals.ListOffsetsClient;
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
 import org.apache.kafka.common.Cluster;
@@ -1910,7 +1911,8 @@ public class KafkaConsumerTest {
                 time,
                 retryBackoffMs,
                 requestTimeoutMs,
-                IsolationLevel.READ_UNCOMMITTED);
+                IsolationLevel.READ_UNCOMMITTED,
+                new ListOffsetsClient(consumerClient, loggerFactory));
 
         return new KafkaConsumer<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -92,7 +92,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
@@ -118,7 +117,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.list;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClientTest.java
@@ -24,20 +24,15 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.EpochEndOffset;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.requests.ListOffsetRequest;
 import org.apache.kafka.common.requests.ListOffsetResponse;
-import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.test.TestUtils.assertOptional;
@@ -46,6 +41,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class ListOffsetsClientTest {
 
     private ConsumerNetworkClient consumerClient;
@@ -94,12 +90,12 @@ public class ListOffsetsClientTest {
     public void testOkV0Response() {
         ListOffsetsClient offsetClient = newClient();
         RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
-                Node.noNode(), new ListOffsetsClient.RequestData(
-                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.empty())),
-                        false, IsolationLevel.READ_COMMITTED));
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.empty())),
+                false, IsolationLevel.READ_COMMITTED));
 
         ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
-                new ListOffsetResponse.PartitionData(Errors.NONE, Collections.singletonList(10L))));
+            new ListOffsetResponse.PartitionData(Errors.NONE, Collections.singletonList(10L))));
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -115,12 +111,12 @@ public class ListOffsetsClientTest {
     public void testOkV1Response() {
         ListOffsetsClient offsetClient = newClient();
         RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
-                Node.noNode(), new ListOffsetsClient.RequestData(
-                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
-                        false, IsolationLevel.READ_COMMITTED));
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                false, IsolationLevel.READ_COMMITTED));
 
         ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
-                new ListOffsetResponse.PartitionData(Errors.NONE, -1, 10L, Optional.of(1))));
+            new ListOffsetResponse.PartitionData(Errors.NONE, -1, 10L, Optional.of(1))));
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -137,12 +133,12 @@ public class ListOffsetsClientTest {
     public void testErrorResponse() {
         ListOffsetsClient offsetClient = newClient();
         RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
-                Node.noNode(), new ListOffsetsClient.RequestData(
-                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
-                        false, IsolationLevel.READ_COMMITTED));
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                false, IsolationLevel.READ_COMMITTED));
 
         ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
-                new ListOffsetResponse.PartitionData(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, Optional.empty())));
+            new ListOffsetResponse.PartitionData(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, Optional.empty())));
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -155,13 +151,13 @@ public class ListOffsetsClientTest {
     public void testTimestampsNotSupportedByBroker() {
         ListOffsetsClient offsetClient = newClient();
         RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
-                Node.noNode(), new ListOffsetsClient.RequestData(
-                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
-                        false, IsolationLevel.READ_COMMITTED));
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                false, IsolationLevel.READ_COMMITTED));
 
         // When we get this error, we treat it as a valid empty response (no offsets returned)
         ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
-                new ListOffsetResponse.PartitionData(Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT, -1, -1, Optional.empty())));
+            new ListOffsetResponse.PartitionData(Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT, -1, -1, Optional.empty())));
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -174,12 +170,12 @@ public class ListOffsetsClientTest {
     public void testUnauthorizedTopic() {
         ListOffsetsClient offsetClient = newClient();
         RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
-                Node.noNode(), new ListOffsetsClient.RequestData(
-                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
-                        false, IsolationLevel.READ_COMMITTED));
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                false, IsolationLevel.READ_COMMITTED));
 
         ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
-                new ListOffsetResponse.PartitionData(Errors.TOPIC_AUTHORIZATION_FAILED, -1, -1, Optional.empty())));
+            new ListOffsetResponse.PartitionData(Errors.TOPIC_AUTHORIZATION_FAILED, -1, -1, Optional.empty())));
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ListOffsetsClientTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.EpochEndOffset;
+import org.apache.kafka.common.requests.IsolationLevel;
+import org.apache.kafka.common.requests.ListOffsetRequest;
+import org.apache.kafka.common.requests.ListOffsetResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.kafka.test.TestUtils.assertOptional;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ListOffsetsClientTest {
+
+    private ConsumerNetworkClient consumerClient;
+    private SubscriptionState subscriptions;
+    private Metadata metadata;
+    private MockClient client;
+    private Time time;
+
+    private TopicPartition tp0 = new TopicPartition("topic", 0);
+
+    @Test
+    public void testEmptyResponse() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.emptyMap(), false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.emptyMap());
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertTrue(result.partitionsToRetry.isEmpty());
+        assertTrue(result.fetchedOffsets.isEmpty());
+    }
+
+    @Test
+    public void testUnexpectedEmptyResponse() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+            Node.noNode(), new ListOffsetsClient.RequestData(
+                Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(0))),
+                    false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.emptyMap());
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertFalse(result.partitionsToRetry.isEmpty());
+        assertTrue(result.partitionsToRetry.contains(tp0));
+        assertTrue(result.fetchedOffsets.isEmpty());
+    }
+
+    @Test
+    public void testOkV0Response() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+                Node.noNode(), new ListOffsetsClient.RequestData(
+                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.empty())),
+                        false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
+                new ListOffsetResponse.PartitionData(Errors.NONE, Collections.singletonList(10L))));
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertTrue(result.partitionsToRetry.isEmpty());
+        assertFalse(result.fetchedOffsets.isEmpty());
+        assertEquals(result.fetchedOffsets.get(tp0).offset, 10L);
+        assertEquals(result.fetchedOffsets.get(tp0).leaderEpoch, Optional.empty());
+        assertNull(result.fetchedOffsets.get(tp0).timestamp);
+    }
+
+    @Test
+    public void testOkV1Response() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+                Node.noNode(), new ListOffsetsClient.RequestData(
+                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                        false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
+                new ListOffsetResponse.PartitionData(Errors.NONE, -1, 10L, Optional.of(1))));
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertTrue(result.partitionsToRetry.isEmpty());
+        assertFalse(result.fetchedOffsets.isEmpty());
+        assertEquals(result.fetchedOffsets.get(tp0).offset, 10L);
+        assertOptional(result.fetchedOffsets.get(tp0).leaderEpoch, epoch -> assertEquals(epoch.longValue(), 1));
+        assertEquals(result.fetchedOffsets.get(tp0).timestamp.longValue(), -1);
+    }
+
+
+    @Test
+    public void testErrorResponse() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+                Node.noNode(), new ListOffsetsClient.RequestData(
+                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                        false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
+                new ListOffsetResponse.PartitionData(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, Optional.empty())));
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertTrue(result.fetchedOffsets.isEmpty());
+        assertFalse(result.partitionsToRetry.isEmpty());
+    }
+
+    @Test
+    public void testTimestampsNotSupportedByBroker() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+                Node.noNode(), new ListOffsetsClient.RequestData(
+                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                        false, IsolationLevel.READ_COMMITTED));
+
+        // When we get this error, we treat it as a valid empty response (no offsets returned)
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
+                new ListOffsetResponse.PartitionData(Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT, -1, -1, Optional.empty())));
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        ListOffsetsClient.ResultData result = future.value();
+        assertTrue(result.fetchedOffsets.isEmpty());
+        assertTrue(result.partitionsToRetry.isEmpty());
+    }
+
+    @Test
+    public void testUnauthorizedTopic() {
+        ListOffsetsClient offsetClient = newClient();
+        RequestFuture<ListOffsetsClient.ResultData> future = offsetClient.sendAsyncRequest(
+                Node.noNode(), new ListOffsetsClient.RequestData(
+                        Collections.singletonMap(tp0, new ListOffsetRequest.PartitionData(-1, Optional.of(1))),
+                        false, IsolationLevel.READ_COMMITTED));
+
+        ListOffsetResponse resp = new ListOffsetResponse(Collections.singletonMap(tp0,
+                new ListOffsetResponse.PartitionData(Errors.TOPIC_AUTHORIZATION_FAILED, -1, -1, Optional.empty())));
+        client.prepareResponse(resp);
+        consumerClient.pollNoWakeup();
+
+        assertTrue(future.failed());
+        assertEquals(future.exception().getClass(), TopicAuthorizationException.class);
+        assertTrue(((TopicAuthorizationException) future.exception()).unauthorizedTopics().contains(tp0.topic()));
+    }
+
+    private ListOffsetsClient newClient() {
+        buildDependencies(OffsetResetStrategy.EARLIEST);
+        return new ListOffsetsClient(consumerClient, new LogContext());
+    }
+
+    private void buildDependencies(OffsetResetStrategy offsetResetStrategy) {
+        LogContext logContext = new LogContext();
+        time = new MockTime(1);
+        subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
+        metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
+                subscriptions, logContext, new ClusterResourceListeners());
+        client = new MockClient(time, metadata);
+        consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
+                100, 1000, Integer.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
This change introduces a ListOffsetsClient which decouples the Fetcher from the ListOffsets API. This was done as follow-on work to KAFKA-7747.
