### PR TITLE
MINOR: Fix directory name inconsistency in the Kafka Streams tutorial

### DIFF
--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -48,7 +48,7 @@
             -DarchetypeArtifactId=streams-quickstart-java \
             -DarchetypeVersion={{fullDotVersion}} \
             -DgroupId=streams.examples \
-            -DartifactId=streams.examples \
+            -DartifactId=streams-quickstart \
             -Dversion=0.1 \
             -Dpackage=myapps
     </pre>
@@ -59,7 +59,7 @@
     </p>
 
     <pre class="brush: bash;">
-        &gt; tree streams.examples
+        &gt; tree streams-quickstart
         streams-quickstart
         |-- pom.xml
         |-- src


### PR DESCRIPTION
In the Kafka Streams tutorial, "streams.examples" is specified
for `mvn archetype:generate`'s `artifactId` parameter.
So the project directory is created as the same name, but it's
changed to "streams-quickstart" in the following explanations.