### PR TITLE
KAFKA-8299: Add generic-safe getConfiguredInstance() methods to AbstractConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -952,6 +952,8 @@ project(':clients') {
     testRuntime libs.jacksonDatabind
     testRuntime libs.jacksonJDK8Datatypes
     testCompile libs.jacksonJaxrsJsonProvider
+
+    compile 'org.apache.commons:commons-lang3:3.9'
   }
 
   task determineCommitId {

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -54,6 +54,7 @@
     <allow pkg="org.apache.kafka.common.config" exact-match="true" />
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
     <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.apache.commons.lang3" />
 
     <subpackage name="acl">
       <allow pkg="org.apache.kafka.common.annotation" />

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -326,7 +326,7 @@ public class AbstractConfigTest {
 
     @Test
     public void testGenericClassInstantiation() {
-        TypeLiteral<Consumer<String>> stringConsumerType = new TypeLiteral<Consumer<String>>() {};
+        TypeLiteral<Consumer<String>> stringConsumerType = new TypeLiteral<Consumer<String>>() { };
         String stringConsumerConfig = "string.consumer.class";
         ConfigDef testConfigDef = new ConfigDef()
             .define(


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-8299)

The changes here add four new methods to the `AbstractConfig` class that mirror the existing `getConfiguredInstance(...)` and `getConfiguredInstances(...)` methods; the only difference is that any parameter of type `Class<T>` is changed to `TypeLiteral<T>` and that type checking is done with `TypeUtils.isInstance(...)` instead of `Class.isInstance(...)`

A new unit test (`AbstractConfigTest.testGenericClassInstantiation()`) confirms this behavior, including the lack of unchecked cast warnings and the throwing of a runtime exception when an attempt is made to instantiate a class that extends from/implements the proper raw type but with improper type parameters.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
