### PR TITLE
KAFKA-8225 & KIP-345 part-2: fencing static member instances with conflicting group.instance.id

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -674,15 +674,18 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.clientId = clientId;
             this.groupId = config.getString(ConsumerConfig.GROUP_ID_CONFIG);
 
+            LogContext logContext;
+            // If group.instance.id is set, we will append it to the log context.
             String groupInstanceId = config.getString(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
             if (groupInstanceId != null) {
                 JoinGroupRequest.validateGroupInstanceId(groupInstanceId);
                 this.groupInstanceId = Optional.of(groupInstanceId);
+                logContext = new LogContext("[Consumer groupInstanceId=" + groupInstanceId + ", clientId=" + clientId + ", groupId=" + groupId + "] ");
             } else {
                 this.groupInstanceId = Optional.empty();
+                logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");
             }
 
-            LogContext logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");
             this.log = logContext.logger(getClass());
             boolean enableAutoCommit = config.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
             if (groupId == null) { // overwrite in case of default group id where the config is not explicitly provided

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -680,7 +680,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             if (groupInstanceId != null) {
                 JoinGroupRequest.validateGroupInstanceId(groupInstanceId);
                 this.groupInstanceId = Optional.of(groupInstanceId);
-                logContext = new LogContext("[Consumer groupInstanceId=" + groupInstanceId + ", clientId=" + clientId + ", groupId=" + groupId + "] ");
+                logContext = new LogContext("[Consumer instanceId=" + groupInstanceId + ", clientId=" + clientId + ", groupId=" + groupId + "] ");
             } else {
                 this.groupInstanceId = Optional.empty();
                 logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1141,7 +1141,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @throws java.lang.IllegalArgumentException if the timeout value is negative
      * @throws java.lang.IllegalStateException if the consumer is not subscribed to any topics or manually assigned any
      *             partitions to consume from
-     *
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      *
      * @deprecated Since 2.0. Use {@link #poll(Duration)}, which does not block beyond the timeout awaiting partition
      *             assignment. See <a href="https://cwiki.apache.org/confluence/x/5kiHB">KIP-266</a> for more information.
@@ -1187,6 +1187,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @throws java.lang.ArithmeticException if the timeout is greater than {@link Long#MAX_VALUE} milliseconds.
      * @throws org.apache.kafka.common.errors.InvalidTopicException if the current subscription contains any invalid
      *             topic (per {@link org.apache.kafka.common.internals.Topic#validate(String)})
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public ConsumerRecords<K, V> poll(final Duration timeout) {
@@ -1315,6 +1316,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             is too large or if the topic does not exist).
      * @throws org.apache.kafka.common.errors.TimeoutException if the timeout specified by {@code default.api.timeout.ms} expires
      *            before successful completion of the offset commit
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitSync() {
@@ -1349,6 +1351,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             is too large or if the topic does not exist).
      * @throws org.apache.kafka.common.errors.TimeoutException if the timeout expires before successful completion
      *            of the offset commit
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitSync(Duration timeout) {
@@ -1395,6 +1398,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             is too large or if the topic does not exist).
      * @throws org.apache.kafka.common.errors.TimeoutException if the timeout expires before successful completion
      *            of the offset commit
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
@@ -1432,6 +1436,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     *             is too large or if the topic does not exist).
     * @throws org.apache.kafka.common.errors.TimeoutException if the timeout expires before successful completion
     *            of the offset commit
+    * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
     */
     @Override
     public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout) {
@@ -1451,6 +1456,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     /**
      * Commit offsets returned on the last {@link #poll(Duration)} for all the subscribed list of topics and partition.
      * Same as {@link #commitAsync(OffsetCommitCallback) commitAsync(null)}
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitAsync() {
@@ -1473,6 +1479,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * (and variants) returns.
      *
      * @param callback Callback to invoke when the commit completes
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitAsync(OffsetCommitCallback callback) {
@@ -1498,6 +1505,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param offsets A map of offsets by partition with associate metadata. This map will be copied internally, so it
      *                is safe to mutate the map after returning.
      * @param callback Callback to invoke when the commit completes
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
      */
     @Override
     public void commitAsync(final Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1144,6 +1144,7 @@ public abstract class AbstractCoordinator implements Closeable {
                                         } else if (e instanceof FencedInstanceIdException) {
                                             log.error("Caught fenced group.instance.id {} error in heartbeat thread", groupInstanceId);
                                             heartbeatThread.failed.set(e);
+                                            heartbeatThread.disable();
                                         } else {
                                             heartbeat.failHeartbeat();
                                             // wake up the thread if it's sleeping to reschedule the heartbeat

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1142,7 +1142,7 @@ public abstract class AbstractCoordinator implements Closeable {
                                             // however, then the session timeout may expire before we can rejoin.
                                             heartbeat.receiveHeartbeat();
                                         } else if (e instanceof FencedInstanceIdException) {
-                                            log.error("Caught fenced group.instance.id {} error in heartbeat thread", groupInstanceId, e);
+                                            log.error("Caught fenced group.instance.id {} error in heartbeat thread", groupInstanceId);
                                             heartbeatThread.failed.set(e);
                                         } else {
                                             heartbeat.failHeartbeat();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -559,7 +559,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 log.debug("Attempt to join group failed due to obsolete coordinator information: {}", error.message());
                 future.raise(error);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
+                log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
                 future.raise(error);
             } else if (error == Errors.INCONSISTENT_GROUP_PROTOCOL
                     || error == Errors.INVALID_SESSION_TIMEOUT
@@ -662,7 +662,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     log.debug("SyncGroup failed because the group began another rebalance");
                     future.raise(error);
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
-                    log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
+                    log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
                     future.raise(error);
                 } else if (error == Errors.UNKNOWN_MEMBER_ID
                         || error == Errors.ILLEGAL_GENERATION) {
@@ -930,7 +930,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetGeneration();
                 future.raise(Errors.ILLEGAL_GENERATION);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
+                log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
                 future.raise(error);
             } else if (error == Errors.UNKNOWN_MEMBER_ID) {
                 log.info("Attempt to heartbeat failed for since member id {} is not valid.", generation.memberId);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -575,6 +575,10 @@ public abstract class AbstractCoordinator implements Closeable {
                 } else {
                     future.raise(error);
                 }
+            } else if (error == Errors.UNSUPPORTED_VERSION) {
+                log.error("Attempt to join group failed due to unsupported version error. Please unset field group.instance.id and retry" +
+                        "to see if the problem resolves");
+                future.raise(error);
             } else if (error == Errors.MEMBER_ID_REQUIRED) {
                 // Broker requires a concrete member id to be allowed to join the group. Update member id
                 // and send another join group request in next cycle.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -559,7 +559,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 log.debug("Attempt to join group failed due to obsolete coordinator information: {}", error.message());
                 future.raise(error);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
+                log.error("Received fatal exception: group.instance.id gets fenced");
                 future.raise(error);
             } else if (error == Errors.INCONSISTENT_GROUP_PROTOCOL
                     || error == Errors.INVALID_SESSION_TIMEOUT
@@ -666,7 +666,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     log.debug("SyncGroup failed because the group began another rebalance");
                     future.raise(error);
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
-                    log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
+                    log.error("Received fatal exception: group.instance.id gets fenced");
                     future.raise(error);
                 } else if (error == Errors.UNKNOWN_MEMBER_ID
                         || error == Errors.ILLEGAL_GENERATION) {
@@ -935,7 +935,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetGeneration();
                 future.raise(Errors.ILLEGAL_GENERATION);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
+                log.error("Received fatal exception: group.instance.id gets fenced");
                 future.raise(error);
             } else if (error == Errors.UNKNOWN_MEMBER_ID) {
                 log.info("Attempt to heartbeat failed for since member id {} is not valid.", generation.memberId);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -602,6 +602,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         new SyncGroupRequestData()
                                 .setGroupId(groupId)
                                 .setMemberId(generation.memberId)
+                                .setGroupInstanceId(this.groupInstanceId.orElse(null))
                                 .setGenerationId(generation.generationId)
                                 .setAssignments(Collections.emptyList())
                 );
@@ -628,6 +629,7 @@ public abstract class AbstractCoordinator implements Closeable {
                             new SyncGroupRequestData()
                                     .setGroupId(groupId)
                                     .setMemberId(generation.memberId)
+                                    .setGroupInstanceId(this.groupInstanceId.orElse(null))
                                     .setGenerationId(generation.generationId)
                                     .setAssignments(groupAssignmentList)
                     );

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -902,6 +902,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 new HeartbeatRequest.Builder(new HeartbeatRequestData()
                         .setGroupId(groupId)
                         .setGenerationid(this.generation.generationId)
+                        .setGroupInstanceId(this.groupInstanceId.orElse(null))
                         .setMemberId(this.generation.memberId));
         return client.send(coordinator, requestBuilder)
                 .compose(new HeartbeatResponseHandler());
@@ -1137,6 +1138,7 @@ public abstract class AbstractCoordinator implements Closeable {
                                             // however, then the session timeout may expire before we can rejoin.
                                             heartbeat.receiveHeartbeat();
                                         } else if (e instanceof FencedInstanceIdException) {
+                                            log.error("Caught fenced group.instance.id error in heartbeat thread", e);
                                             heartbeatThread.failed.set(e);
                                         } else {
                                             heartbeat.failHeartbeat();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -134,8 +134,6 @@ public abstract class AbstractCoordinator implements Closeable {
 
     private RequestFuture<Void> findCoordinatorFuture = null;
 
-    protected final String fencedInstanceErrorMessage = "Received fatal exception: group.instance.id {} get fenced in {}";
-
     /**
      * Initialize the coordination manager.
      */
@@ -561,7 +559,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 log.debug("Attempt to join group failed due to obsolete coordinator information: {}", error.message());
                 future.raise(error);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error(fencedInstanceErrorMessage, groupInstanceId, this.getClass().getName());
+                log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
                 future.raise(error);
             } else if (error == Errors.INCONSISTENT_GROUP_PROTOCOL
                     || error == Errors.INVALID_SESSION_TIMEOUT
@@ -664,7 +662,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     log.debug("SyncGroup failed because the group began another rebalance");
                     future.raise(error);
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
-                    log.error(fencedInstanceErrorMessage, groupInstanceId, this.getClass().getName());
+                    log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
                     future.raise(error);
                 } else if (error == Errors.UNKNOWN_MEMBER_ID
                         || error == Errors.ILLEGAL_GENERATION) {
@@ -932,7 +930,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetGeneration();
                 future.raise(Errors.ILLEGAL_GENERATION);
             } else if (error == Errors.FENCED_INSTANCE_ID) {
-                log.error(fencedInstanceErrorMessage, groupInstanceId, this.getClass().getName());
+                log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
                 future.raise(error);
             } else if (error == Errors.UNKNOWN_MEMBER_ID) {
                 log.info("Attempt to heartbeat failed for since member id {} is not valid.", generation.memberId);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1138,7 +1138,7 @@ public abstract class AbstractCoordinator implements Closeable {
                                             // however, then the session timeout may expire before we can rejoin.
                                             heartbeat.receiveHeartbeat();
                                         } else if (e instanceof FencedInstanceIdException) {
-                                            log.error("Caught fenced group.instance.id error in heartbeat thread", e);
+                                            log.error("Caught fenced group.instance.id {} error in heartbeat thread", groupInstanceId, e);
                                             heartbeatThread.failed.set(e);
                                         } else {
                                             heartbeat.failHeartbeat();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -134,7 +134,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
     private RequestFuture<Void> findCoordinatorFuture = null;
 
-    protected final String fencedInstanceErrorMessage = "Received fatal exception: duplicate group.instance.id {} detected in {}";
+    protected final String fencedInstanceErrorMessage = "Received fatal exception: group.instance.id {} get fenced in {}";
 
     /**
      * Initialize the coordination manager.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -599,11 +599,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             OffsetCommitCompletion completion = completedOffsetCommits.poll();
             if (completion == null) {
                 break;
-            } else if (completion.exception instanceof FencedInstanceIdException) {
-                throw (FencedInstanceIdException) completion.exception;
-            } else {
-                completion.invoke();
             }
+            completion.invoke();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -887,7 +887,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             future.raise(error);
                             return;
                         } else if (error == Errors.FENCED_INSTANCE_ID) {
-                            log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
+                            log.error("Received fatal exception: group.instance.id gets fenced");
                             future.raise(error);
                             return;
                         } else if (error == Errors.UNKNOWN_MEMBER_ID

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -880,7 +880,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             future.raise(error);
                             return;
                         } else if (error == Errors.FENCED_INSTANCE_ID) {
-                            log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
+                            log.error("Received fatal exception: group.instance.id {} gets fenced", groupInstanceId);
                             future.raise(error);
                             return;
                         } else if (error == Errors.UNKNOWN_MEMBER_ID

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -872,6 +872,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             markCoordinatorUnknown();
                             future.raise(error);
                             return;
+                        } else if (error == Errors.FENCED_INSTANCE_ID) {
+                            log.error(fencedInstanceErrorMessage, groupInstanceId);
+                            future.raise(error);
+                            return;
                         } else if (error == Errors.UNKNOWN_MEMBER_ID
                                 || error == Errors.ILLEGAL_GENERATION
                                 || error == Errors.REBALANCE_IN_PROGRESS) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -880,7 +880,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             future.raise(error);
                             return;
                         } else if (error == Errors.FENCED_INSTANCE_ID) {
-                            log.error(fencedInstanceErrorMessage, groupInstanceId, this.getClass().getName());
+                            log.error("Received fatal exception: group.instance.id {} get fenced", groupInstanceId);
                             future.raise(error);
                             return;
                         } else if (error == Errors.UNKNOWN_MEMBER_ID

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -818,6 +818,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                         .setGroupId(this.groupId)
                         .setGenerationId(generation.generationId)
                         .setMemberId(generation.memberId)
+                        .setGroupInstanceId(groupInstanceId.orElse(null))
                         .setTopics(new ArrayList<>(requestTopicDataMap.values()))
         );
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -873,7 +873,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             future.raise(error);
                             return;
                         } else if (error == Errors.FENCED_INSTANCE_ID) {
-                            log.error(fencedInstanceErrorMessage, groupInstanceId);
+                            log.error(fencedInstanceErrorMessage, groupInstanceId, this.getClass().getName());
                             future.raise(error);
                             return;
                         } else if (error == Errors.UNKNOWN_MEMBER_ID

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -305,7 +305,7 @@ public enum Errors {
             PreferredLeaderNotAvailableException::new),
     GROUP_MAX_SIZE_REACHED(81, "The consumer group has reached its max size.", GroupMaxSizeReachedException::new),
     FENCED_INSTANCE_ID(82, "The broker rejected this static consumer since " +
-            "another consumer with the same group.instance.id has registered with a more recent timestamp.",
+            "another consumer with the same group.instance.id has registered with a different member.id.",
             FencedInstanceIdException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -304,7 +304,8 @@ public enum Errors {
     PREFERRED_LEADER_NOT_AVAILABLE(80, "The preferred leader was not available",
             PreferredLeaderNotAvailableException::new),
     GROUP_MAX_SIZE_REACHED(81, "The consumer group has reached its max size.", GroupMaxSizeReachedException::new),
-    FENCED_INSTANCE_ID(82, "The coordinator reports a more recent member.id associated with the consumer's group.instance.id.",
+    FENCED_INSTANCE_ID(82, "The broker rejected this static consumer since " +
+            "another consumer with the same group.instance.id has registered with a more recent timestamp.",
             FencedInstanceIdException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -68,6 +68,7 @@ public class HeartbeatRequest extends AbstractRequest {
                 return new HeartbeatResponse(response);
             case 1:
             case 2:
+            case 3:
                 response.setThrottleTimeMs(throttleTimeMs);
                 return new HeartbeatResponse(response);
             default:

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -37,6 +38,10 @@ public class HeartbeatRequest extends AbstractRequest {
 
         @Override
         public HeartbeatRequest build(short version) {
+            if (data.groupInstanceId() != null && version < 3) {
+                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                        "Please unset consumer config group.instance.id field to proceed.");
+            }
             return new HeartbeatRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -39,7 +39,7 @@ public class HeartbeatRequest extends AbstractRequest {
         @Override
         public HeartbeatRequest build(short version) {
             if (data.groupInstanceId() != null && version < 3) {
-                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                throw new UnsupportedVersionException("The broker heartbeat protocol version " + version + " doesn't support static membership." +
                         "Please unset consumer config group.instance.id field to proceed.");
             }
             return new HeartbeatRequest(data, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -39,8 +39,8 @@ public class HeartbeatRequest extends AbstractRequest {
         @Override
         public HeartbeatRequest build(short version) {
             if (data.groupInstanceId() != null && version < 3) {
-                throw new UnsupportedVersionException("The broker heartbeat protocol version " + version + " doesn't support static membership." +
-                        "Please unset consumer config group.instance.id field to proceed.");
+                throw new UnsupportedVersionException("The broker heartbeat protocol version " +
+                        version + " does not support usage of config group.instance.id.");
             }
             return new HeartbeatRequest(data, version);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -41,8 +41,8 @@ public class JoinGroupRequest extends AbstractRequest {
         @Override
         public JoinGroupRequest build(short version) {
             if (data.groupInstanceId() != null && version < 5) {
-                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
-                        "Please unset consumer config group.instance.id field to proceed.");
+                throw new UnsupportedVersionException("The broker join group protocol version " +
+                        version + " does not support usage of config group.instance.id.");
             }
             return new JoinGroupRequest(data, version);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -39,6 +40,10 @@ public class JoinGroupRequest extends AbstractRequest {
 
         @Override
         public JoinGroupRequest build(short version) {
+            if (data.groupInstanceId() != null && version < 5) {
+                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                        "Please unset consumer config group.instance.id field to proceed.");
+            }
             return new JoinGroupRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -53,6 +54,10 @@ public class OffsetCommitRequest extends AbstractRequest {
 
         @Override
         public OffsetCommitRequest build(short version) {
+            if (data.groupInstanceId() != null && version < 7) {
+                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                        "Please unset consumer config group.instance.id field to proceed.");
+            }
             return new OffsetCommitRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -131,6 +131,7 @@ public class OffsetCommitRequest extends AbstractRequest {
             case 4:
             case 5:
             case 6:
+            case 7:
                 return new OffsetCommitResponse(
                         new OffsetCommitResponseData()
                                 .setTopics(responseTopicData)

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -55,7 +55,7 @@ public class OffsetCommitRequest extends AbstractRequest {
         @Override
         public OffsetCommitRequest build(short version) {
             if (data.groupInstanceId() != null && version < 7) {
-                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                throw new UnsupportedVersionException("The broker offset commit protocol version " + version + " doesn't support static membership. " +
                         "Please unset consumer config group.instance.id field to proceed.");
             }
             return new OffsetCommitRequest(data, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -55,8 +55,8 @@ public class OffsetCommitRequest extends AbstractRequest {
         @Override
         public OffsetCommitRequest build(short version) {
             if (data.groupInstanceId() != null && version < 7) {
-                throw new UnsupportedVersionException("The broker offset commit protocol version " + version + " doesn't support static membership. " +
-                        "Please unset consumer config group.instance.id field to proceed.");
+                throw new UnsupportedVersionException("The broker offset commit protocol version " +
+                        version + " does not support usage of config group.instance.id.");
             }
             return new OffsetCommitRequest(data, version);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -39,6 +40,10 @@ public class SyncGroupRequest extends AbstractRequest {
 
         @Override
         public SyncGroupRequest build(short version) {
+            if (data.groupInstanceId() != null && version < 3) {
+                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                        "Please unset consumer config group.instance.id field to proceed.");
+            }
             return new SyncGroupRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -41,8 +41,8 @@ public class SyncGroupRequest extends AbstractRequest {
         @Override
         public SyncGroupRequest build(short version) {
             if (data.groupInstanceId() != null && version < 3) {
-                throw new UnsupportedVersionException("The broker sync group protocol version " + version + " doesn't support static membership." +
-                        "Please unset consumer config group.instance.id field to proceed.");
+                throw new UnsupportedVersionException("The broker sync group protocol version " +
+                        version + " does not support usage of config group.instance.id.");
             }
             return new SyncGroupRequest(data, version);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -41,7 +41,7 @@ public class SyncGroupRequest extends AbstractRequest {
         @Override
         public SyncGroupRequest build(short version) {
             if (data.groupInstanceId() != null && version < 3) {
-                throw new UnsupportedVersionException("The broker join group protocol version " + version + " doesn't support static membership." +
+                throw new UnsupportedVersionException("The broker sync group protocol version " + version + " doesn't support static membership." +
                         "Please unset consumer config group.instance.id field to proceed.");
             }
             return new SyncGroupRequest(data, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -72,6 +72,7 @@ public class SyncGroupRequest extends AbstractRequest {
                        );
             case 1:
             case 2:
+            case 3:
                 return new SyncGroupResponse(
                         new SyncGroupResponseData()
                             .setErrorCode(Errors.forException(e).code())

--- a/clients/src/main/resources/common/message/HeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/HeartbeatRequest.json
@@ -18,13 +18,16 @@
   "type": "request",
   "name": "HeartbeatRequest",
   // Version 1 and version 2 are the same as version 0.
-  "validVersions": "0-2",
+  // Starting from version 3, we add a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-3",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The group id." },
     { "name": "Generationid", "type": "int32", "versions": "0+",
       "about": "The generation of the group." },
     { "name": "MemberId", "type": "string", "versions": "0+",
-      "about": "The member ID." }
+      "about": "The member ID." },
+    { "name": "GroupInstanceId", "type": "string", "versions": "3+", "nullableVersions": "3+",
+      "about": "The unique identifier of the consumer instance provided by end user." }
   ]
 }

--- a/clients/src/main/resources/common/message/HeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/HeartbeatResponse.json
@@ -19,7 +19,8 @@
   "name": "HeartbeatResponse",
   // Version 1 adds throttle time.
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-2",
+  // Starting from version 3, heartbeatRequest supports a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-3",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/OffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/OffsetCommitRequest.json
@@ -26,7 +26,8 @@
   // Version 5 removes the retention time, which is now controlled only by a broker configuration.
   //
   // Version 6 adds the leader epoch for fencing.
-  "validVersions": "0-6",
+  // version 7 adds a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-7",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The unique group identifier." },
@@ -34,6 +35,8 @@
       "about": "The generation of the group." },
     { "name": "MemberId", "type": "string", "versions": "1+", "ignorable": true,
       "about": "The member ID assigned by the group coordinator." },
+    { "name": "GroupInstanceId", "type": "string", "versions": "7+", "ignorable": true, "nullableVersions": "7+",
+      "about": "The unique identifier of the consumer instance provided by end user." },
     { "name": "RetentionTimeMs", "type": "int64", "versions": "2-4", "default": "-1", "ignorable": true,
       "about": "The time period in ms to retain the offset." },
     { "name": "Topics", "type": "[]OffsetCommitRequestTopic", "versions": "0+",

--- a/clients/src/main/resources/common/message/OffsetCommitResponse.json
+++ b/clients/src/main/resources/common/message/OffsetCommitResponse.json
@@ -24,7 +24,8 @@
   // Starting in version 4, on quota violation, brokers send out responses before throttling.
   //
   // Versions 5 and 6 are the same as version 4.
-  "validVersions": "0-6",
+  // Version 7 offsetCommitRequest supports a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-7",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/SyncGroupRequest.json
+++ b/clients/src/main/resources/common/message/SyncGroupRequest.json
@@ -18,7 +18,8 @@
   "type": "request",
   "name": "SyncGroupRequest",
   // Versions 1 and 2 are the same as version 0.
-  "validVersions": "0-2",
+  // Starting from version 3, we add a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-3",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The unique group identifier." },
@@ -26,10 +27,14 @@
       "about": "The generation of the group." },
     { "name": "MemberId", "type": "string", "versions": "0+",
       "about": "The member ID assigned by the group." },
+    { "name": "GroupInstanceId", "type": "string", "versions": "3+", "nullableVersions": "3+",
+      "about": "The unique identifier of the consumer instance provided by end user." },
     { "name": "Assignments", "type": "[]SyncGroupRequestAssignment", "versions": "0+",
       "about": "Each assignment.", "fields": [
       { "name": "MemberId", "type": "string", "versions": "0+",
         "about": "The ID of the member to assign." },
+      { "name": "GroupInstanceId", "type": "string", "versions": "3+", "nullableVersions": "3+",
+        "about": "The identifier of the member provided by end user." },
       { "name": "Assignment", "type": "bytes", "versions": "0+",
         "about": "The member assignment." }
     ]}

--- a/clients/src/main/resources/common/message/SyncGroupRequest.json
+++ b/clients/src/main/resources/common/message/SyncGroupRequest.json
@@ -33,8 +33,6 @@
       "about": "Each assignment.", "fields": [
       { "name": "MemberId", "type": "string", "versions": "0+",
         "about": "The ID of the member to assign." },
-      { "name": "GroupInstanceId", "type": "string", "versions": "3+", "nullableVersions": "3+",
-        "about": "The identifier of the member provided by end user." },
       { "name": "Assignment", "type": "bytes", "versions": "0+",
         "about": "The member assignment." }
     ]}

--- a/clients/src/main/resources/common/message/SyncGroupResponse.json
+++ b/clients/src/main/resources/common/message/SyncGroupResponse.json
@@ -19,7 +19,8 @@
   "name": "SyncGroupResponse",
   // Version 1 adds throttle time.
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-2",
+  // Starting from version 3, syncGroupRequest supports a new field called groupInstanceId to indicate member identity across restarts.
+  "validVersions": "0-3",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -274,8 +274,8 @@ public class AbstractCoordinatorTest {
         try {
             coordinator.ensureActiveGroup();
             fail("Failed to catch expected FencedInstanceIdException");
-        } catch (FencedInstanceIdException e) {
-            assertEquals(Errors.FENCED_INSTANCE_ID.message(), e.getMessage());
+        } catch (RuntimeException e) {
+            assertTrue("Sync group request was fenced due to duplicate instance id", e instanceof FencedInstanceIdException);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -2078,6 +2078,20 @@ public class ConsumerCoordinatorTest {
 
     @Test(expected = FencedInstanceIdException.class)
     public void testCommitOffsetRequestAsyncWithFencedInstanceIdException() {
+        receiveFencedInstanceIdException();
+    }
+
+    @Test
+    public void testCommitOffsetRequestAsyncAlwaysReceiveFencedException() {
+       // Once we get fenced exception once, we should always hit fencing case.
+       assertThrows(FencedInstanceIdException.class, this::receiveFencedInstanceIdException);
+       assertThrows(FencedInstanceIdException.class, () ->
+               coordinator.commitOffsetsAsync(singletonMap(t1p, new OffsetAndMetadata(100L)), new MockCommitCallback()));
+       assertThrows(FencedInstanceIdException.class, () ->
+               coordinator.commitOffsetsSync(singletonMap(t1p, new OffsetAndMetadata(100L)), time.timer(Long.MAX_VALUE)));
+    }
+
+    private void receiveFencedInstanceIdException() {
         subscriptions.assignFromUser(singleton(t1p));
 
         client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -2076,7 +2076,7 @@ public class ConsumerCoordinatorTest {
         coordinator.commitOffsetsSync(singletonMap(t1p, new OffsetAndMetadata(100L)), time.timer(Long.MAX_VALUE));
     }
 
-    @Test
+    @Test(expected = FencedInstanceIdException.class)
     public void testCommitOffsetRequestAsyncWithFencedInstanceIdException() {
         subscriptions.assignFromUser(singleton(t1p));
 
@@ -2085,11 +2085,8 @@ public class ConsumerCoordinatorTest {
 
         prepareOffsetCommitRequest(singletonMap(t1p, 100L), Errors.FENCED_INSTANCE_ID);
 
-        AtomicBoolean matchingException = new AtomicBoolean(false);
-        coordinator.commitOffsetsAsync(singletonMap(t1p, new OffsetAndMetadata(100L)), callback(
-                Errors.FENCED_INSTANCE_ID.message(), matchingException));
+        coordinator.commitOffsetsAsync(singletonMap(t1p, new OffsetAndMetadata(100L)), new MockCommitCallback());
         coordinator.invokeCompletedOffsetCommitCallbacks();
-        assertTrue(matchingException.get());
     }
 
     private ConsumerCoordinator prepareCoordinatorForCloseTest(final boolean useGroupManagement,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -2083,12 +2083,12 @@ public class ConsumerCoordinatorTest {
 
     @Test
     public void testCommitOffsetRequestAsyncAlwaysReceiveFencedException() {
-       // Once we get fenced exception once, we should always hit fencing case.
-       assertThrows(FencedInstanceIdException.class, this::receiveFencedInstanceIdException);
-       assertThrows(FencedInstanceIdException.class, () ->
-               coordinator.commitOffsetsAsync(singletonMap(t1p, new OffsetAndMetadata(100L)), new MockCommitCallback()));
-       assertThrows(FencedInstanceIdException.class, () ->
-               coordinator.commitOffsetsSync(singletonMap(t1p, new OffsetAndMetadata(100L)), time.timer(Long.MAX_VALUE)));
+        // Once we get fenced exception once, we should always hit fencing case.
+        assertThrows(FencedInstanceIdException.class, this::receiveFencedInstanceIdException);
+        assertThrows(FencedInstanceIdException.class, () ->
+                coordinator.commitOffsetsAsync(singletonMap(t1p, new OffsetAndMetadata(100L)), new MockCommitCallback()));
+        assertThrows(FencedInstanceIdException.class, () ->
+                coordinator.commitOffsetsSync(singletonMap(t1p, new OffsetAndMetadata(100L)), time.timer(Long.MAX_VALUE)));
     }
 
     private void receiveFencedInstanceIdException() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -2292,17 +2292,6 @@ public class ConsumerCoordinatorTest {
         };
     }
 
-    private OffsetCommitCallback callback(final Map<TopicPartition, OffsetAndMetadata> expectedOffsets,
-                                          final AtomicBoolean success) {
-        return new OffsetCommitCallback() {
-            @Override
-            public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
-                if (expectedOffsets.equals(offsets) && exception == null)
-                    success.set(true);
-            }
-        };
-    }
-
     private void joinAsFollowerAndReceiveAssignment(String consumerId,
                                                     ConsumerCoordinator coordinator,
                                                     List<TopicPartition> assignment) {
@@ -2361,6 +2350,17 @@ public class ConsumerCoordinatorTest {
                     }
                 }
                 return true;
+            }
+        };
+    }
+
+    private OffsetCommitCallback callback(final Map<TopicPartition, OffsetAndMetadata> expectedOffsets,
+                                          final AtomicBoolean success) {
+        return new OffsetCommitCallback() {
+            @Override
+            public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
+                if (expectedOffsets.equals(offsets) && exception == null)
+                    success.set(true);
             }
         };
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -2303,16 +2303,6 @@ public class ConsumerCoordinatorTest {
         };
     }
 
-    private OffsetCommitCallback callback(final String expectedMessage, final AtomicBoolean success) {
-        return new OffsetCommitCallback() {
-            @Override
-            public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
-                if (exception != null && expectedMessage.equals(exception.getMessage()))
-                    success.set(true);
-            }
-        };
-    }
-
     private void joinAsFollowerAndReceiveAssignment(String consumerId,
                                                     ConsumerCoordinator coordinator,
                                                     List<TopicPartition> assignment) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.junit.Test;
+
+public class HeartbeatRequestTest {
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testRequestVersionCompatibilityFailBuild() {
+        new HeartbeatRequest.Builder(
+                new HeartbeatRequestData()
+                        .setGroupId("groupId")
+                        .setMemberId("consumerId")
+                        .setGroupInstanceId("groupInstanceId")
+        ).build((short) 2);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
@@ -61,5 +63,16 @@ public class JoinGroupRequestTest {
             String instanceId = "Is " + c + "illegal";
             assertFalse(JoinGroupRequest.containsValidPattern(instanceId));
         }
+    }
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testRequestVersionCompatibilityFailBuild() {
+        new JoinGroupRequest.Builder(
+                new JoinGroupRequestData()
+                        .setGroupId("groupId")
+                        .setMemberId("consumerId")
+                        .setGroupInstanceId("groupInstanceId")
+                        .setProtocolType("consumer")
+        ).build((short) 4);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.junit.Test;
+
+public class OffsetCommitRequestTest {
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testRequestVersionCompatibilityFailBuild() {
+        new OffsetCommitRequest.Builder(
+                new OffsetCommitRequestData()
+                        .setGroupId("groupId")
+                        .setMemberId("consumerId")
+                        .setGroupInstanceId("groupInstanceId")
+        ).build((short) 6);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -797,8 +797,20 @@ public class RequestResponseTest {
                             .setGroupId("group1")
                             .setSessionTimeoutMs(30000)
                             .setMemberId("consumer1")
+                            .setGroupInstanceId(null)
                             .setProtocolType("consumer")
                             .setProtocols(protocols))
+                    .build((short) version);
+        } else if (version <= 4) {
+            return new JoinGroupRequest.Builder(
+                    new JoinGroupRequestData()
+                            .setGroupId("group1")
+                            .setSessionTimeoutMs(30000)
+                            .setMemberId("consumer1")
+                            .setGroupInstanceId(null)
+                            .setProtocolType("consumer")
+                            .setProtocols(protocols)
+                            .setRebalanceTimeoutMs(60000)) // v1 and above contains rebalance timeout
                     .build((short) version);
         } else {
             return new JoinGroupRequest.Builder(
@@ -806,6 +818,7 @@ public class RequestResponseTest {
                             .setGroupId("group1")
                             .setSessionTimeoutMs(30000)
                             .setMemberId("consumer1")
+                            .setGroupInstanceId("groupInstanceId") // v5 and above could set group instance id
                             .setProtocolType("consumer")
                             .setProtocols(protocols)
                             .setRebalanceTimeoutMs(60000)) // v1 and above contains rebalance timeout
@@ -955,6 +968,7 @@ public class RequestResponseTest {
         return new OffsetCommitRequest.Builder(new OffsetCommitRequestData()
                 .setGroupId("group1")
                 .setMemberId("consumer1")
+                .setGroupInstanceId(null)
                 .setGenerationId(100)
                 .setTopics(Collections.singletonList(
                         new OffsetCommitRequestData.OffsetCommitRequestTopic()

--- a/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.junit.Test;
+
+public class SyncGroupRequestTest {
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testRequestVersionCompatibilityFailBuild() {
+        new SyncGroupRequest.Builder(
+                new SyncGroupRequestData()
+                        .setGroupId("groupId")
+                        .setMemberId("consumerId")
+                        .setGroupInstanceId("groupInstanceId")
+        ).build((short) 2);
+    }
+}

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -181,7 +181,7 @@ class GroupCoordinator(val brokerId: Int,
           val oldMemberId = group.getStaticMemberId(groupInstanceId)
 
           if (group.is(Stable)) {
-            info(s"Static member $groupInstanceId with unknown member id rejoins, assigning new member id $newMemberId, while" +
+            info(s"Static member $groupInstanceId with unknown member id rejoins, assigning new member id $newMemberId, while " +
               s"old member $oldMemberId will be removed. No rebalance will be triggered.")
 
             val oldMember = group.replaceGroupInstance(oldMemberId, newMemberId, groupInstanceId)
@@ -258,8 +258,6 @@ class GroupCoordinator(val brokerId: Int,
         if (staticMemberId.isDefined && staticMemberId.get != memberId) {
           // given member id doesn't match with the groupInstanceId. Inform duplicate instance to shut down immediately.
           group.logFencingInstanceIdError(memberId, groupInstanceId, staticMemberId.get)
-          error(s"given member.id $memberId is identified as a known static member ${groupInstanceId.get}," +
-            s"but not matching the expected member.id ${staticMemberId.get}")
           responseCallback(joinError(memberId, Errors.FENCED_INSTANCE_ID))
         } else if (!group.has(memberId) || groupInstanceIdNotFound) {
             // If the dynamic member trying to register with an unrecognized id, or

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -356,19 +356,19 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   }
 
   /**
-    * Verify the member.id is up to date for static members. Return false if both conditions met:
+    * Verify the member.id is up to date for static members. Return true if both conditions met:
     *   1. given member is a known static member to group
     *   2. group stored member.id doesn't match with given member.id
     */
-  def validateMemberIdIfStatic(memberId: String,
-                               groupInstanceId: Option[String]): Boolean = {
+  def isStaticMemberFenced(memberId: String,
+                           groupInstanceId: Option[String]): Boolean = {
     if (hasStaticMember(groupInstanceId)
       && getStaticMemberId(groupInstanceId) != memberId) {
         error(s"given member.id $memberId is identified as a known static member ${groupInstanceId.get}," +
           s"but not matching the expected member.id ${getStaticMemberId(groupInstanceId)}")
-        false
+        true
     } else
-      true
+      false
   }
 
   def canRebalance = GroupMetadata.validPreviousStates(PreparingRebalance).contains(state)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -363,7 +363,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     // Member id must have formatted with valid delimiter as [prefix]-[suffix] to
     // be validated.
     if (delimiterIdx == -1) {
-      info(s"given member.id $memberId was ill-formatted without delimiter '-'.")
+      error(s"given member.id $memberId was ill-formatted without delimiter '-'.")
       true
     } else {
       val memberIdPrefix = Some(memberId.substring(0, delimiterIdx))

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -193,6 +193,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   // Static membership mapping [key: group.instance.id, value: member.id]
   private val staticMembers = new mutable.HashMap[String, String]
   private val pendingMembers = new mutable.HashSet[String]
+  private final val MEMBER_ID_DELIMITER = "-"
   private var numMembersAwaitingJoin = 0
   private val supportedProtocols = new mutable.HashMap[String, Integer]().withDefaultValue(0)
   private val offsets = new mutable.HashMap[TopicPartition, CommitRecordMetadataAndOffset]
@@ -343,7 +344,52 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     timeout.max(member.rebalanceTimeoutMs)
   }
 
-  def generateMemberIdSuffix = UUID.randomUUID().toString
+  def generateMemberId(clientId: String,
+                       groupInstanceId: Option[String]): String = {
+    groupInstanceId match {
+      case None =>
+        clientId + MEMBER_ID_DELIMITER + UUID.randomUUID().toString
+      case Some(instanceId) =>
+        instanceId + MEMBER_ID_DELIMITER + currentStateTimestamp.get
+    }
+  }
+
+  // This validation doesn't handle the case where a static member changes
+  // its group.instance.id while maintains the same member.id. That edge case should
+  // be handled by session timeout old static member registration
+  // with associated old member.id, so that the flipped member will be evicted and
+  // ask to rejoin due to UNKNOWN_MEMBER_ID.
+  def validateMemberIdIfStatic(memberId: String): Boolean = {
+    val delimiterIdx = memberId.lastIndexOf(MEMBER_ID_DELIMITER)
+    // Member id must have formatted with valid delimiter as [prefix]-[suffix] to
+    // be validated.
+    if (delimiterIdx == -1) {
+      info(s"given member.id $memberId was ill-formatted without delimiter '-'.")
+      true
+    } else {
+      val memberIdPrefix = Some(memberId.substring(0, delimiterIdx))
+      val isKnownStaticMember = hasStaticMember(memberIdPrefix)
+
+      if (isKnownStaticMember) {
+        val storedMemberId = getStaticMemberId(memberIdPrefix)
+        if (memberId != storedMemberId) {
+          logFencingInstanceIdError(memberId, memberIdPrefix, storedMemberId)
+          false
+        } else {
+          true
+        }
+      } else {
+        true
+      }
+    }
+  }
+
+  def logFencingInstanceIdError(newMemberId: String,
+                                groupInstanceId: Option[String],
+                                oldMemberId: String) {
+    error(s"given member.id $newMemberId is identified as a known static member ${groupInstanceId.get}," +
+      s"but not matching the expected member.id $oldMemberId")
+  }
 
   def canRebalance = GroupMetadata.validPreviousStates(PreparingRebalance).contains(state)
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -368,8 +368,9 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     } else {
       val memberIdPrefix = Some(memberId.substring(0, delimiterIdx))
       val isKnownStaticMember = hasStaticMember(memberIdPrefix)
+      val hasValidTimestamp = isValidTimestamp(memberId.substring(delimiterIdx + 1))
 
-      if (isKnownStaticMember) {
+      if (isKnownStaticMember && hasValidTimestamp) {
         val storedMemberId = getStaticMemberId(memberIdPrefix)
         if (memberId != storedMemberId) {
           logFencingInstanceIdError(memberId, memberIdPrefix, storedMemberId)
@@ -380,6 +381,15 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       } else {
         true
       }
+    }
+  }
+
+  def isValidTimestamp(str: String): Boolean = {
+    try {
+      val longValue = str.toLong
+      longValue.toString == str
+    } catch {
+      case _: NumberFormatException => false
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -193,7 +193,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   // Static membership mapping [key: group.instance.id, value: member.id]
   private val staticMembers = new mutable.HashMap[String, String]
   private val pendingMembers = new mutable.HashSet[String]
-  private final val MEMBER_ID_DELIMITER = "-"
+  private val MEMBER_ID_DELIMITER = "-"
   private var numMembersAwaitingJoin = 0
   private val supportedProtocols = new mutable.HashMap[String, Integer]().withDefaultValue(0)
   private val offsets = new mutable.HashMap[TopicPartition, CommitRecordMetadataAndOffset]
@@ -356,9 +356,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   // This validation doesn't handle the case where a static member changes
   // its group.instance.id while maintains the same member.id. That edge case should
-  // be handled by session timeout old static member registration
-  // with associated old member.id, so that the flipped member will be evicted and
-  // ask to rejoin due to UNKNOWN_MEMBER_ID.
+  // be caused by a hacked consumer client since current client logic doesn't
+  // support group.instance.id change on runtime.
   def validateMemberIdIfStatic(memberId: String): Boolean = {
     val delimiterIdx = memberId.lastIndexOf(MEMBER_ID_DELIMITER)
     // Member id must have formatted with valid delimiter as [prefix]-[suffix] to

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -327,12 +327,6 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     }
   }
 
-  def isUnknownMember(memberId: String,
-                      groupInstanceId: Option[String]): Boolean = {
-    val groupInstanceIdNotFound = groupInstanceId.isDefined && !hasStaticMember(groupInstanceId)
-    groupInstanceIdNotFound || has(memberId)
-  }
-
   def currentState = state
 
   def notYetRejoinedMembers = members.values.filter(!_.isAwaitingJoin).toList
@@ -363,8 +357,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   /**
     * Verify the member.id is up to date for static members. Return false if both conditions met:
-    *   1. given member is static
-    *   2. corresponding member.id doesn't match
+    *   1. given member is a known static member to group
+    *   2. group stored member.id doesn't match with given member.id
     */
   def validateMemberIdIfStatic(memberId: String,
                                groupInstanceId: Option[String]): Boolean = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1343,25 +1343,25 @@ class KafkaApis(val requestChannel: RequestChannel,
         )
       )
     } else {
-      val groupInstanceId = getGroupInstanceId(joinGroupRequest.data().groupInstanceId)
+      val groupInstanceId = getGroupInstanceId(joinGroupRequest.data.groupInstanceId)
 
       // Only return MEMBER_ID_REQUIRED error if joinGroupRequest version is >= 4
       // and groupInstanceId is configured to unknown.
       val requireKnownMemberId = joinGroupRequest.version >= 4 && groupInstanceId.isEmpty
 
       // let the coordinator handle join-group
-      val protocols = joinGroupRequest.data().protocols().valuesList.asScala.map(protocol =>
+      val protocols = joinGroupRequest.data.protocols.valuesList.asScala.map(protocol =>
         (protocol.name, protocol.metadata)).toList
       groupCoordinator.handleJoinGroup(
-        joinGroupRequest.data().groupId,
-        joinGroupRequest.data().memberId,
+        joinGroupRequest.data.groupId,
+        joinGroupRequest.data.memberId,
         groupInstanceId,
         requireKnownMemberId,
         request.header.clientId,
         request.session.clientAddress.toString,
-        joinGroupRequest.data().rebalanceTimeoutMs,
-        joinGroupRequest.data().sessionTimeoutMs,
-        joinGroupRequest.data().protocolType,
+        joinGroupRequest.data.rebalanceTimeoutMs,
+        joinGroupRequest.data.sessionTimeoutMs,
+        joinGroupRequest.data.protocolType,
         protocols,
         sendResponseCallback)
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1334,7 +1334,21 @@ class KafkaApis(val requestChannel: RequestChannel,
         new JoinGroupResponse(
           new JoinGroupResponseData()
             .setThrottleTimeMs(requestThrottleMs)
-            .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())
+            .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code)
+            .setGenerationId(JoinGroupResponse.UNKNOWN_GENERATION_ID)
+            .setProtocolName(JoinGroupResponse.UNKNOWN_PROTOCOL)
+            .setLeader(JoinGroupResponse.UNKNOWN_MEMBER_ID)
+            .setMemberId(JoinGroupResponse.UNKNOWN_MEMBER_ID)
+            .setMembers(Collections.emptyList())
+        )
+      )
+    } else if (joinGroupRequest.data.groupInstanceId != null && config.interBrokerProtocolVersion < KAFKA_2_3_IV0) {
+      // Reject client request if client is using static membership while IBP is < 2.3.
+      sendResponseMaybeThrottle(request, requestThrottleMs =>
+        new JoinGroupResponse(
+          new JoinGroupResponseData()
+            .setThrottleTimeMs(requestThrottleMs)
+            .setErrorCode(Errors.UNSUPPORTED_VERSION.code)
             .setGenerationId(JoinGroupResponse.UNKNOWN_GENERATION_ID)
             .setProtocolName(JoinGroupResponse.UNKNOWN_PROTOCOL)
             .setLeader(JoinGroupResponse.UNKNOWN_MEMBER_ID)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -399,9 +399,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
         // call coordinator to handle commit offset
         groupCoordinator.handleCommitOffsets(
-          offsetCommitRequest.data().groupId(),
-          offsetCommitRequest.data().memberId(),
-          offsetCommitRequest.data().generationId(),
+          offsetCommitRequest.data.groupId,
+          offsetCommitRequest.data.memberId,
+          getGroupInstanceId(offsetCommitRequest.data.groupInstanceId),
+          offsetCommitRequest.data.generationId,
           partitionData,
           sendResponseCallback)
       }
@@ -1397,6 +1398,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         syncGroupRequest.data.groupId,
         syncGroupRequest.data.generationId,
         syncGroupRequest.data.memberId,
+        getGroupInstanceId(syncGroupRequest.data.groupInstanceId),
         assignmentMap.result,
         sendResponseCallback
       )
@@ -1446,9 +1448,18 @@ class KafkaApis(val requestChannel: RequestChannel,
       groupCoordinator.handleHeartbeat(
         heartbeatRequest.data.groupId,
         heartbeatRequest.data.memberId,
+        getGroupInstanceId(heartbeatRequest.data.groupInstanceId),
         heartbeatRequest.data.generationid,
         sendResponseCallback)
     }
+  }
+
+  def getGroupInstanceId(rawInstanceId: String): Option[String] = {
+      if (rawInstanceId == null ||
+        config.interBrokerProtocolVersion < KAFKA_2_3_IV0)
+        None
+      else
+        Some(rawInstanceId)
   }
 
   def handleLeaveGroupRequest(request: RequestChannel.Request) {

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -180,10 +180,10 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     override def runWithCallback(member: GroupMember, responseCallback: SyncGroupCallback): Unit = {
       if (member.leader) {
         groupCoordinator.handleSyncGroup(member.groupId, member.generationId, member.memberId,
-            member.group.assignment, responseCallback)
+          member.groupInstanceId, member.group.assignment, responseCallback)
       } else {
-         groupCoordinator.handleSyncGroup(member.groupId, member.generationId, member.memberId,
-             Map.empty[String, Array[Byte]], responseCallback)
+        groupCoordinator.handleSyncGroup(member.groupId, member.generationId, member.memberId,
+          member.groupInstanceId, Map.empty[String, Array[Byte]], responseCallback)
       }
     }
     override def awaitAndVerify(member: GroupMember): Unit = {
@@ -198,7 +198,8 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
       callback
     }
     override def runWithCallback(member: GroupMember, responseCallback: HeartbeatCallback): Unit = {
-      groupCoordinator.handleHeartbeat( member.groupId, member.memberId,  member.generationId, responseCallback)
+      groupCoordinator.handleHeartbeat(member.groupId, member.memberId,
+        member.groupInstanceId, member.generationId, responseCallback)
     }
     override def awaitAndVerify(member: GroupMember): Unit = {
        val error = await(member, DefaultSessionTimeout)
@@ -213,8 +214,8 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     override def runWithCallback(member: GroupMember, responseCallback: CommitOffsetCallback): Unit = {
       val tp = new TopicPartition("topic", 0)
       val offsets = immutable.Map(tp -> OffsetAndMetadata(1, "", Time.SYSTEM.milliseconds()))
-      groupCoordinator.handleCommitOffsets(member.groupId, member.memberId, member.generationId,
-          offsets, responseCallback)
+      groupCoordinator.handleCommitOffsets(member.groupId, member.memberId,
+        member.groupInstanceId, member.generationId, offsets, responseCallback)
     }
     override def awaitAndVerify(member: GroupMember): Unit = {
        val offsets = await(member, 500)
@@ -307,6 +308,7 @@ object GroupCoordinatorConcurrencyTest {
 
   class GroupMember(val group: Group, val groupPartitionId: Int, val leader: Boolean) extends CoordinatorMember {
     @volatile var memberId: String = JoinGroupRequest.UNKNOWN_MEMBER_ID
+    @volatile var groupInstanceId: Option[String] = None
     @volatile var generationId: Int = -1
     def groupId: String = group.groupId
   }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -735,19 +735,6 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def staticMemberSyncWithInvalidMemberId() {
-    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
-
-    val invalidMemberIdList = List("no_delimiter", followerInstanceId.get + "-123x")
-    for (invalidMemberId <- invalidMemberIdList) {
-      EasyMock.reset(replicaManager)
-      // The fencing won't happen because the member.id is ill-formatted or last portion is not a timestamp.
-      val syncGroupResult = syncGroupFollower(groupId, rebalanceResult.generation, invalidMemberId)
-      assertEquals(Errors.UNKNOWN_MEMBER_ID, syncGroupResult._2)
-    }
-  }
-
-  @Test
   def staticMemberJoinWithUnknownInstanceIdAndKnownMemberId() {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -740,6 +740,19 @@ class GroupCoordinatorTest {
   }
 
   @Test
+  def staticMemberSyncWithInvalidMemberId() {
+    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
+
+    val invalidMemberIdList = List("no_delimiter", followerInstanceId.get + "-123x")
+    for (invalidMemberId <- invalidMemberIdList) {
+      EasyMock.reset(replicaManager)
+      // The fencing won't happen because the member.id is ill-formatted or last portion is not a timestamp.
+      val syncGroupResult = syncGroupFollower(groupId, rebalanceResult.generation, invalidMemberId)
+      assertEquals(Errors.UNKNOWN_MEMBER_ID, syncGroupResult._2)
+    }
+  }
+
+  @Test
   def staticMemberJoinWithUnknownInstanceIdAndKnownMemberId() {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -76,7 +76,6 @@ class GroupCoordinatorTest {
   private val leaderInstanceId = Some("leader")
   private val followerInstanceId = Some("follower")
   private val invalidMemberId = "invalidMember"
-
   private val metadata = Array[Byte]()
   private val protocols = List(("range", metadata))
   private val protocolSuperset = List(("range", metadata), ("roundrobin", metadata))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -621,7 +621,7 @@ class KafkaApisTest {
                 .setPartitionIndex(0)
                 .setCommittedOffset(100)
                 .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
-                .setCommittedMetadata(""),
+                .setCommittedMetadata("")
             ))
         ))
     ))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -48,9 +48,8 @@ import org.apache.kafka.common.requests.{FetchMetadata => JFetchMetadata, _}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.easymock.{Capture, EasyMock, IAnswer}
 import EasyMock._
-import org.apache.kafka.common.message.JoinGroupRequestData
+import org.apache.kafka.common.message.{HeartbeatRequestData, JoinGroupRequestData, OffsetCommitRequestData, OffsetCommitResponseData, SyncGroupRequestData}
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol
-import org.apache.kafka.common.message.OffsetCommitRequestData
 import org.junit.Assert.{assertEquals, assertNull, assertTrue}
 import org.junit.{After, Test}
 
@@ -546,7 +545,7 @@ class KafkaApisTest {
   }
 
   @Test
-  def rejectRequestWhenStaticMembershipNotSupported() {
+  def rejectJoinGroupRequestWhenStaticMembershipNotSupported() {
     val capturedResponse = expectNoThrottling()
     EasyMock.replay(clientRequestQuotaManager, requestChannel)
 
@@ -556,11 +555,90 @@ class KafkaApisTest {
         .setMemberId("test")
         .setGroupInstanceId("instanceId")
         .setProtocolType("consumer")
-        .setProtocols(new JoinGroupRequestData.JoinGroupRequestProtocolCollection)))
+        .setProtocols(new JoinGroupRequestData.JoinGroupRequestProtocolCollection)
+    ))
     createKafkaApis(KAFKA_2_2_IV1).handleJoinGroupRequest(requestChannelRequest)
 
     val response = readResponse(ApiKeys.JOIN_GROUP, joinGroupRequest, capturedResponse).asInstanceOf[JoinGroupResponse]
     assertEquals(Errors.UNSUPPORTED_VERSION, response.error())
+    EasyMock.replay(groupCoordinator)
+  }
+
+  @Test
+  def rejectSyncGroupRequestWhenStaticMembershipNotSupported() {
+    val capturedResponse = expectNoThrottling()
+    EasyMock.replay(clientRequestQuotaManager, requestChannel)
+
+    val (syncGroupRequest, requestChannelRequest) = buildRequest(new SyncGroupRequest.Builder(
+      new SyncGroupRequestData()
+        .setGroupId("test")
+        .setMemberId("test")
+        .setGroupInstanceId("instanceId")
+        .setGenerationId(1)
+    ))
+    createKafkaApis(KAFKA_2_2_IV1).handleSyncGroupRequest(requestChannelRequest)
+
+    val response = readResponse(ApiKeys.SYNC_GROUP, syncGroupRequest, capturedResponse).asInstanceOf[SyncGroupResponse]
+    assertEquals(Errors.UNSUPPORTED_VERSION, response.error())
+    EasyMock.replay(groupCoordinator)
+  }
+
+  @Test
+  def rejectHeartbeatRequestWhenStaticMembershipNotSupported() {
+    val capturedResponse = expectNoThrottling()
+    EasyMock.replay(clientRequestQuotaManager, requestChannel)
+
+    val (heartbeatRequest, requestChannelRequest) = buildRequest(new HeartbeatRequest.Builder(
+      new HeartbeatRequestData()
+        .setGroupId("test")
+        .setMemberId("test")
+        .setGroupInstanceId("instanceId")
+        .setGenerationid(1)
+    ))
+    createKafkaApis(KAFKA_2_2_IV1).handleHeartbeatRequest(requestChannelRequest)
+
+    val response = readResponse(ApiKeys.HEARTBEAT, heartbeatRequest, capturedResponse).asInstanceOf[HeartbeatResponse]
+    assertEquals(Errors.UNSUPPORTED_VERSION, response.error())
+    EasyMock.replay(groupCoordinator)
+  }
+
+  @Test
+  def rejectOffsetCommitRequestWhenStaticMembershipNotSupported() {
+    val capturedResponse = expectNoThrottling()
+    EasyMock.replay(clientRequestQuotaManager, requestChannel)
+
+    val (offsetCommitRequest, requestChannelRequest) = buildRequest(new OffsetCommitRequest.Builder(
+      new OffsetCommitRequestData()
+        .setGroupId("test")
+        .setMemberId("test")
+        .setGroupInstanceId("instanceId")
+        .setGenerationId(100)
+        .setTopics(Collections.singletonList(
+          new OffsetCommitRequestData.OffsetCommitRequestTopic()
+            .setName("test")
+            .setPartitions(Collections.singletonList(
+              new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                .setPartitionIndex(0)
+                .setCommittedOffset(100)
+                .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                .setCommittedMetadata(""),
+            ))
+        ))
+    ))
+    createKafkaApis(KAFKA_2_2_IV1).handleOffsetCommitRequest(requestChannelRequest)
+
+    val response = readResponse(ApiKeys.OFFSET_COMMIT, offsetCommitRequest, capturedResponse).asInstanceOf[OffsetCommitResponse]
+
+    val expectedTopicErrors = Collections.singletonList(
+      new OffsetCommitResponseData.OffsetCommitResponseTopic()
+        .setName("test")
+        .setPartitions(Collections.singletonList(
+          new OffsetCommitResponseData.OffsetCommitResponsePartition()
+            .setPartitionIndex(0)
+            .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+        ))
+    )
+    assertEquals(expectedTopicErrors, response.data.topics())
     EasyMock.replay(groupCoordinator)
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -627,8 +627,6 @@ class KafkaApisTest {
     ))
     createKafkaApis(KAFKA_2_2_IV1).handleOffsetCommitRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.OFFSET_COMMIT, offsetCommitRequest, capturedResponse).asInstanceOf[OffsetCommitResponse]
-
     val expectedTopicErrors = Collections.singletonList(
       new OffsetCommitResponseData.OffsetCommitResponseTopic()
         .setName("test")
@@ -638,6 +636,7 @@ class KafkaApisTest {
             .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
         ))
     )
+    val response = readResponse(ApiKeys.OFFSET_COMMIT, offsetCommitRequest, capturedResponse).asInstanceOf[OffsetCommitResponse]
     assertEquals(expectedTopicErrors, response.data.topics())
     EasyMock.replay(groupCoordinator)
   }

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -39,6 +39,7 @@ import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.consumer.RoundRobinAssignor;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Exit;
@@ -213,6 +214,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         } catch (WakeupException e) {
             // we only call wakeup() once to close the consumer, so this recursion should be safe
             commitSync(offsets);
+            throw e;
+        } catch (FencedInstanceIdException e) {
             throw e;
         } catch (Exception e) {
             onComplete(offsets, e);


### PR DESCRIPTION
For static members join/rejoin, we encode the current timestamp in the new `member.id`. The format looks like `group.instance.id-timestamp`.

During consumer/broker interaction logic (Join, Sync, Heartbeat, Commit), we shall check the whether `group.instance.id` is known on group. If yes, we shall match the `member.id` stored on static membership map with the request `member.id`. If mismatching, this indicates a conflict consumer has used same group.instance.id, and it will receive a fatal exception to shut down.

Right now the only missing part is the system test. Will work on it offline while getting the major logic changes reviewed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
