### PR TITLE
MINOR: trivial cleanups

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1228,7 +1228,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time) extends Logging {
 
   class ListenerConnectionQuota(lock: Object, listener: ListenerName) extends ListenerReconfigurable {
     @volatile private var _maxConnections = Int.MaxValue
-    private val listenerPropName = s"${listener.configPrefix}${KafkaConfig.MaxConnectionsProp}"
+
     def maxConnections: Int = _maxConnections
 
     override def listenerName(): ListenerName = listener


### PR DESCRIPTION
1. Remove `ListenerConnectionQuota#listenerPropName`: never used.
2. `MirrorMaker`: remove unused import, `java.util.concurrent.TimeUnit`.
3. `ConsumerBounceTest`: remove unused import, `util.control.Breaks._`.
4. `DynamicConnectionQuotaTest#[testDynamicConnectionQuota, testDynamicListenerConnectionQuota]`: remove unused local variables.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
