### PR TITLE
[HOT FIX] in-memory store behavior should match rocksDB

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -134,9 +135,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
         removeExpiredSegments();
 
-        if (key == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        Objects.requireNonNull(key, "key cannot be null");
 
         // Only need to search if the record hasn't expired yet
         if (endTime > observedStreamTime - retentionPeriod) {
@@ -156,11 +155,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key,
                                                                   final long earliestSessionEndTime,
                                                                   final long latestSessionStartTime) {
-        removeExpiredSegments();
+        Objects.requireNonNull(key, "key cannot be null");
 
-        if (key == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        removeExpiredSegments();
 
         return registerNewIterator(key,
                                    key,
@@ -174,11 +171,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                                                                   final Bytes keyTo,
                                                                   final long earliestSessionEndTime,
                                                                   final long latestSessionStartTime) {
-        removeExpiredSegments();
+        Objects.requireNonNull(keyFrom, "from key cannot be null");
+        Objects.requireNonNull(keyTo, "to key cannot be null");
 
-        if (keyFrom == null || keyTo == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        removeExpiredSegments();
 
         if (keyFrom.compareTo(keyTo) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. "
@@ -195,22 +191,22 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes key) {
-        removeExpiredSegments();
 
-        if (key == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        Objects.requireNonNull(key, "key cannot be null");
+
+        removeExpiredSegments();
 
         return registerNewIterator(key, key, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from, final Bytes to) {
+
+        Objects.requireNonNull(from, "from key cannot be null");
+        Objects.requireNonNull(to, "to key cannot be null");
+
         removeExpiredSegments();
 
-        if (from == null || to == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
 
         return registerNewIterator(from, to, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -212,6 +212,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     @Override
     public void close() {
+        for (final InMemorySessionStoreIterator it : openIterators) {
+            it.close();
+        }
+
         endTimeMap.clear();
         openIterators.clear();
         open = false;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -228,8 +228,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     @Override
     public void close() {
-        for (final InMemorySessionStoreIterator it : openIterators) {
-            it.close();
+        if (openIterators.size() != 0) {
+            LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
+            for (final InMemorySessionStoreIterator it : openIterators) {
+                it.close();
+            }
         }
 
         endTimeMap.clear();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -134,6 +134,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
         removeExpiredSegments();
 
+        if (key == null) {
+            throw new NullPointerException("Tried to fetch with null key");
+        }
+
         // Only need to search if the record hasn't expired yet
         if (endTime > observedStreamTime - retentionPeriod) {
             final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(endTime);
@@ -154,6 +158,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                                                                   final long latestSessionStartTime) {
         removeExpiredSegments();
 
+        if (key == null) {
+            throw new NullPointerException("Tried to fetch with null key");
+        }
+
         return registerNewIterator(key,
                                    key,
                                    latestSessionStartTime,
@@ -167,6 +175,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                                                                   final long earliestSessionEndTime,
                                                                   final long latestSessionStartTime) {
         removeExpiredSegments();
+
+        if (keyFrom == null || keyTo == null) {
+            throw new NullPointerException("Tried to fetch with null key");
+        }
 
         if (keyFrom.compareTo(keyTo) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. "
@@ -185,12 +197,20 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes key) {
         removeExpiredSegments();
 
+        if (key == null) {
+            throw new NullPointerException("Tried to fetch with null key");
+        }
+
         return registerNewIterator(key, key, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from, final Bytes to) {
         removeExpiredSegments();
+
+        if (from == null || to == null) {
+            throw new NullPointerException("Tried to fetch with null key");
+        }
 
         return registerNewIterator(from, to, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
     }
@@ -307,6 +327,8 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
         @Override
         public void close() {
+            next = null;
+            recordIterator = null;
             callback.deregisterIterator(this);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -242,6 +242,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public void close() {
+        for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
+            it.close();
+        }
+
         segmentMap.clear();
         open = false;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -255,10 +255,13 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public void close() {
-        for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
-            it.close();
+        if (openIterators.size() != 0) {
+            LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
+            for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
+                it.close();
+            }
         }
-
+        
         segmentMap.clear();
         open = false;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -474,7 +474,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         private Windowed<Bytes> getWindowedKey() {
             final Bytes key = retainDuplicates ? getKey(super.next.key) : super.next.key;
-            final TimeWindow timeWindow = new TimeWindow(super.currentTime, super.currentTime + windowSize);
+            final long endTime = super.currentTime + windowSize;
+            final TimeWindow timeWindow = new TimeWindow(super.currentTime, endTime < 0 ? Long.MAX_VALUE : endTime);
             return new Windowed<>(key, timeWindow);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -146,11 +147,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     @Override
     public byte[] fetch(final Bytes key, final long windowStartTimestamp) {
-        removeExpiredSegments();
 
-        if (key == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        Objects.requireNonNull(key, "key cannot be null");
+
+        removeExpiredSegments();
 
         if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
             return null;
@@ -167,11 +167,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     @Deprecated
     @Override
     public WindowStoreIterator<byte[]> fetch(final Bytes key, final long timeFrom, final long timeTo) {
-        removeExpiredSegments();
 
-        if (key == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        Objects.requireNonNull(key, "key cannot be null");
+
+        removeExpiredSegments();
 
         // add one b/c records expire exactly retentionPeriod ms after created
         final long minTime = Math.max(timeFrom, observedStreamTime - retentionPeriod + 1);
@@ -190,11 +189,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
                                                            final Bytes to,
                                                            final long timeFrom,
                                                            final long timeTo) {
-        removeExpiredSegments();
+        Objects.requireNonNull(from, "from key cannot be null");
+        Objects.requireNonNull(to, "to key cannot be null");
 
-        if (from == null || to == null) {
-            throw new NullPointerException("Tried to fetch with null key");
-        }
+        removeExpiredSegments();
 
         if (from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. "

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -491,8 +491,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         private Windowed<Bytes> getWindowedKey() {
             final Bytes key = super.retainDuplicates ? getKey(super.next.key) : super.next.key;
-            final long endTime = super.currentTime + windowSize;
-            final TimeWindow timeWindow = new TimeWindow(super.currentTime, endTime < 0 ? Long.MAX_VALUE : endTime);
+            long endTime = super.currentTime + windowSize;
+
+            if (endTime < 0) {
+                LOG.warn("Warning: window end time was truncated to Long.MAX");
+                endTime = Long.MAX_VALUE;
+            }
+
+            final TimeWindow timeWindow = new TimeWindow(super.currentTime, endTime);
             return new Windowed<>(key, timeWindow);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
@@ -26,8 +26,12 @@ import org.apache.kafka.streams.state.StateSerdes;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowKeySchema.class);
 
     private static final int SEQNUM_SIZE = 4;
     private static final int TIMESTAMP_SIZE = 8;
@@ -99,8 +103,13 @@ public class WindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
      */
     static TimeWindow timeWindowForSize(final long startMs,
                                         final long windowSize) {
-        final long endMs = startMs + windowSize;
-        return new TimeWindow(startMs, endMs < 0 ? Long.MAX_VALUE : endMs);
+        long endMs = startMs + windowSize;
+
+        if (endMs < 0) {
+            LOG.warn("Warning: window end time was truncated to Long.MAX");
+            endMs = Long.MAX_VALUE;
+        }
+        return new TimeWindow(startMs, endMs);
     }
 
     // for pipe serdes


### PR DESCRIPTION
While working on consolidating the various store unit tests I uncovered some minor "bugs" in the in-memory stores (inconsistencies with the behavior as established by the RocksDB stores).

- open iterators should be properly closed in the case the store is closed
- fetch/findSessions should *always* throw NPE if key is null
- window end time should be truncated at Long.MAX_VALUE rather than throw exception

(Verified in-memory stores pass all applicable rocksDB tests now, unified unit tests coming in another PR)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
