### PR TITLE
KAFKA 8311: better handle timeout exception on Stream thread

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1776,7 +1776,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     Collections.singleton(partition), time.timer(timeout));
             if (offsets == null) {
                 throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the last " +
-                        "committed offset for partition " + partition + " could be determined");
+                        "committed offset for partition " + partition + " could be determined. User could tune default.api.timeout.ms " +
+                        "larger to relax the threshold.");
             } else {
                 offsets.forEach(this::updateLastSeenEpochIfNewer);
                 return offsets.get(partition);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1776,7 +1776,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     Collections.singleton(partition), time.timer(timeout));
             if (offsets == null) {
                 throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the last " +
-                        "committed offset for partition " + partition + " could be determined. User could tune default.api.timeout.ms " +
+                        "committed offset for partition " + partition + " could be determined. Try tuning default.api.timeout.ms " +
                         "larger to relax the threshold.");
             } else {
                 offsets.forEach(this::updateLastSeenEpochIfNewer);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -498,9 +498,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             }
         } catch (final CommitFailedException | ProducerFencedException error) {
             throw new TaskMigratedException(this, error);
-        } catch (final TimeoutException error) {
-            log.error("Main thread times out while doing commit.");
-            throw error;
         }
 
         commitNeeded = false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -498,6 +498,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             }
         } catch (final CommitFailedException | ProducerFencedException error) {
             throw new TaskMigratedException(this, error);
+        } catch (final TimeoutException error) {
+            log.error("Main thread times out while doing commit.");
+            throw error;
         }
 
         commitNeeded = false;


### PR DESCRIPTION
The goals for this small diff are:

1. Give user guidance if they want to relax commit timeout threshold
2. Indicate the code path where timeout exception was caught

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
