### PR TITLE
KAFKA-8315: fix the JoinWindows retention deprecation doc

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
@@ -246,7 +246,7 @@ public final class JoinWindows extends Windows<Window> {
      * @param durationMs the window retention time in milliseconds
      * @return itself
      * @throws IllegalArgumentException if {@code durationMs} is smaller than the window size
-     * @deprecated since 2.1. Use {@link Materialized#withRetention(Duration)} instead.
+     * @deprecated since 2.1. Use {@link JoinWindows#grace(Duration)} instead.
      */
     @Override
     @Deprecated
@@ -263,7 +263,8 @@ public final class JoinWindows extends Windows<Window> {
      * For {@link TimeWindows} the maintain duration is at least as small as the window size.
      *
      * @return the window maintain duration
-     * @deprecated since 2.1. This function should not be used anymore as retention period can be specified via {@link Materialized#withRetention(Duration)}.
+     * @deprecated since 2.1. This function should not be used anymore, since {@link JoinWindows#until(long)}
+     *             is deprecated in favor of {@link JoinWindows#grace(Duration)}.
      */
     @Override
     @Deprecated


### PR DESCRIPTION
Fix a javadoc mistake introduced in https://github.com/apache/kafka/pull/5911/files#diff-35e3523474fa277a63e36a3fe9e22af8 .

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
