### PR TITLE
KAFKA-8220 & KIP-345 part-3: Avoid kicking out members through rebalance timeout

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -919,17 +919,7 @@ class GroupCoordinator(val brokerId: Int,
 
   def onCompleteJoin(group: GroupMetadata) {
     group.inLock {
-      val leaderId = group.leaderOrNull
-      if (leaderId != null) {
-        val leader = group.get(group.leaderOrNull)
-        if (!leader.isAwaitingJoin) {
-          removeHeartbeatForLeavingMember(group, leader)
-          group.remove(leaderId)
-          group.removeStaticMember(leader.groupInstanceId)
-          info(s"Group leader [member.id: $leaderId, group.instance.id: ${leader.groupInstanceId}] " +
-            s"failed to join before rebalance timeout. New leader ${group.leaderOrNull} was elected.")
-        }
-      }
+      group.maybeElectNewLeader()
 
       if (!group.is(Dead)) {
         group.initNextGeneration()

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -928,16 +928,15 @@ class GroupCoordinator(val brokerId: Int,
       }
 
       if (group.is(Dead)) {
-        info(s"group ${group.groupId} is dead, skipping rebalance stage")
-      } else if (group.maybeElectNewJoinedLeader().isEmpty
-        && group.allMembers.nonEmpty) {
+        info(s"Group ${group.groupId} is dead, skipping rebalance stage")
+      } else if (!group.maybeElectNewJoinedLeader() && group.allMembers.nonEmpty) {
         // If all members are not rejoining, we will postpone the completion
-        // of rebalance preparing stage, and send out another dummy delayed operation
+        // of rebalance preparing stage, and send out another delayed operation
         // until session timeout removes all the non-responsive members.
-        error(s"group could not complete rebalance because no members rejoined")
+        error(s"Group ${group.groupId} could not complete rebalance because no members rejoined")
         joinPurgatory.tryCompleteElseWatch(
           new DelayedJoin(this, group, group.rebalanceTimeoutMs),
-          Seq("dummy-key"))
+          Seq(GroupKey(group.groupId)))
       } else {
         group.initNextGeneration()
         if (group.is(Empty)) {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -919,45 +919,61 @@ class GroupCoordinator(val brokerId: Int,
 
   def onCompleteJoin(group: GroupMetadata) {
     group.inLock {
-      group.maybeElectNewLeader()
+      // remove dynamic members who haven't joined the group yet
+      group.notYetRejoinedMembers.filter(!_.isStaticMember) foreach { failedMember =>
+        removeHeartbeatForLeavingMember(group, failedMember)
+        group.remove(failedMember.memberId)
+        group.removeStaticMember(failedMember.groupInstanceId)
+        // TODO: cut the socket connection to the client
+      }
 
-      if (!group.is(Dead)) {
-        group.initNextGeneration()
-        if (group.is(Empty)) {
-          info(s"Group ${group.groupId} with generation ${group.generationId} is now empty " +
-            s"(${Topic.GROUP_METADATA_TOPIC_NAME}-${partitionFor(group.groupId)})")
+      group.maybeElectNewJoinedLeader() match {
+        // If all static members are not rejoining, we will postpone the completion
+        // of rebalance preparing stage, and send out another dummy delayed operation
+        // until session timeout removes all the non-responsive members.
+        case None => joinPurgatory.tryCompleteElseWatch(
+          new DelayedJoin(this, group, group.rebalanceTimeoutMs),
+          Seq(group.allMembers.headOption)
+        )
+        case Some(_) =>
+          if (!group.is(Dead)) {
+            group.initNextGeneration()
+            if (group.is(Empty)) {
+              info(s"Group ${group.groupId} with generation ${group.generationId} is now empty " +
+                s"(${Topic.GROUP_METADATA_TOPIC_NAME}-${partitionFor(group.groupId)})")
 
-          groupManager.storeGroup(group, Map.empty, error => {
-            if (error != Errors.NONE) {
-              // we failed to write the empty group metadata. If the broker fails before another rebalance,
-              // the previous generation written to the log will become active again (and most likely timeout).
-              // This should be safe since there are no active members in an empty generation, so we just warn.
-              warn(s"Failed to write empty metadata for group ${group.groupId}: ${error.message}")
+              groupManager.storeGroup(group, Map.empty, error => {
+                if (error != Errors.NONE) {
+                  // we failed to write the empty group metadata. If the broker fails before another rebalance,
+                  // the previous generation written to the log will become active again (and most likely timeout).
+                  // This should be safe since there are no active members in an empty generation, so we just warn.
+                  warn(s"Failed to write empty metadata for group ${group.groupId}: ${error.message}")
+                }
+              })
+            } else {
+              info(s"Stabilized group ${group.groupId} generation ${group.generationId} " +
+                s"(${Topic.GROUP_METADATA_TOPIC_NAME}-${partitionFor(group.groupId)})")
+
+              // trigger the awaiting join group response callback for all the members after rebalancing
+              for (member <- group.allMemberMetadata) {
+                val joinResult = JoinGroupResult(
+                  members = if (group.isLeader(member.memberId)) {
+                    group.currentMemberMetadata
+                  } else {
+                    List.empty
+                  },
+                  memberId = member.memberId,
+                  generationId = group.generationId,
+                  subProtocol = group.protocolOrNull,
+                  leaderId = group.leaderOrNull,
+                  error = Errors.NONE)
+
+                group.maybeInvokeJoinCallback(member, joinResult)
+                completeAndScheduleNextHeartbeatExpiration(group, member)
+                member.isNew = false
+              }
             }
-          })
-        } else {
-          info(s"Stabilized group ${group.groupId} generation ${group.generationId} " +
-            s"(${Topic.GROUP_METADATA_TOPIC_NAME}-${partitionFor(group.groupId)})")
-
-          // trigger the awaiting join group response callback for all the members after rebalancing
-          for (member <- group.allMemberMetadata) {
-            val joinResult = JoinGroupResult(
-              members = if (group.isLeader(member.memberId)) {
-                group.currentMemberMetadata
-              } else {
-                List.empty
-              },
-              memberId = member.memberId,
-              generationId = group.generationId,
-              subProtocol = group.protocolOrNull,
-              leaderId = group.leaderOrNull,
-              error = Errors.NONE)
-
-            group.maybeInvokeJoinCallback(member, joinResult)
-            completeAndScheduleNextHeartbeatExpiration(group, member)
-            member.isNew = false
           }
-        }
       }
     }
   }

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -251,7 +251,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     *   2. no member rejoined
     */
   def maybeElectNewJoinedLeader(): Boolean = {
-    leaderId.fold (false) { currentLeaderId => {
+    leaderId.map { currentLeaderId =>
       val currentLeader = get(currentLeaderId)
       if (!currentLeader.isAwaitingJoin) {
         members.find(_._2.isAwaitingJoin) match {
@@ -272,8 +272,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       } else {
         true
       }
-    }
-    }
+    }.getOrElse(false)
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -244,6 +244,25 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       leaderId = members.keys.headOption
   }
 
+  def maybeElectNewLeader() {
+    leaderId match {
+      case Some(currentLeaderId) =>
+        val oldLeader = get(currentLeaderId)
+        if (!oldLeader.isAwaitingJoin) {
+          members.find(_._2.isAwaitingJoin) match {
+            case Some(anyJoinedMember) => {
+              leaderId = Option(anyJoinedMember._1)
+              info(s"Group leader [member.id: ${oldLeader.memberId}, " +
+                s"group.instance.id: ${oldLeader.groupInstanceId}] failed to join " +
+                s"before rebalance timeout, while new leader $leaderId was elected.")
+            }
+            case _ =>
+          }
+        }
+      case _ =>
+    }
+  }
+
   /**
     * [For static members only]: Replace the old member id with the new one,
     * keep everything else unchanged and return the updated member.

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -190,8 +190,6 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private var protocol: Option[String] = None
 
   private val members = new mutable.HashMap[String, MemberMetadata]
-  // Visible for testing
-  val dummyMember = new MemberMetadata("", "", None, "", "", 0, 0, "", List.empty)
   // Static membership mapping [key: group.instance.id, value: member.id]
   private val staticMembers = new mutable.HashMap[String, String]
   private val pendingMembers = new mutable.HashSet[String]
@@ -264,7 +262,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
         } else {
           Some(oldLeader)
         }
-      case _ => Some(dummyMember)
+      case _ => None
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -296,8 +296,6 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def currentState = state
 
-  def notYetRejoinedMembers = members.values.filter(!_.isAwaitingJoin).toList
-
   def hasAllMembersJoined = members.size == numMembersAwaitingJoin && pendingMembers.isEmpty
 
   def allMembers = members.keySet
@@ -377,7 +375,6 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   }
 
   def initNextGeneration() = {
-    assert(notYetRejoinedMembers == List.empty[MemberMetadata])
     if (members.nonEmpty) {
       generationId += 1
       protocol = Some(selectProtocol)

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -139,5 +139,4 @@ private[group] class MemberMetadata(var memberId: String,
       s"supportedProtocols=${supportedProtocols.map(_._1)}, " +
       ")"
   }
-
 }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -755,8 +755,6 @@ class GroupCoordinatorTest extends JUnitSuite {
     EasyMock.reset(replicaManager)
     val followerLeaveGroupResult = leaveGroup(groupId, rebalanceResult.followerId)
     assertEquals(Errors.NONE, followerLeaveGroupResult)
-    EasyMock.reset(replicaManager)
-    sendJoinGroup(groupId, memberId, protocolType, protocols, groupInstanceId)
     timer.advanceClock(DefaultRebalanceTimeout + 1)
     // Only rejoined leader is maintained
     assertEquals(Set(rebalanceResult.leaderId), getGroup(groupId).allMembers)


### PR DESCRIPTION
To make consumer group members more persist, we want to avoid kick-out unjoined members through rebalance timeout. The only exception is when leader fails to join, because we will at risk of no assignment computed during sync stage. The choice will be kicking off non-responsive leader and choose a new leader if possible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
