### PR TITLE
KAFKA-8316: Remove deprecated usage of Slf4jRequestLog, SslContextFactory

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -60,7 +60,7 @@ public class RestClient {
         HttpClient client;
 
         if (url.startsWith("https://")) {
-            client = new HttpClient(SSLUtils.createSslContextFactory(config, true));
+            client = new HttpClient(SSLUtils.createClientSideSslContextFactory(config));
         } else {
             client = new HttpClient();
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -148,7 +148,7 @@ public class RestServer {
         ServerConnector connector;
 
         if (PROTOCOL_HTTPS.equals(protocol)) {
-            SslContextFactory ssl = SSLUtils.createSslContextFactory(config);
+            SslContextFactory ssl = SSLUtils.createServerSideSslContextFactory(config);
             connector = new ServerConnector(jettyServer, ssl);
             connector.setName(String.format("%s_%s%d", PROTOCOL_HTTPS, hostname, port));
         } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -32,9 +32,11 @@ import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
 import org.apache.kafka.connect.runtime.rest.resources.RootResource;
 import org.apache.kafka.connect.runtime.rest.util.SSLUtils;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
@@ -181,7 +183,6 @@ public class RestServer {
         log.info("REST server listening at " + jettyServer.getURI() + ", advertising URL " + advertisedUrl());
     }
 
-    @SuppressWarnings("deprecation")
     public void initializeResources(Herder herder) {
         log.info("Initializing REST resources");
 
@@ -217,10 +218,9 @@ public class RestServer {
         }
 
         RequestLogHandler requestLogHandler = new RequestLogHandler();
-        // Use fully qualified name to avoid deprecation warning
-        org.eclipse.jetty.server.Slf4jRequestLog requestLog = new org.eclipse.jetty.server.Slf4jRequestLog();
-        requestLog.setLoggerName(RestServer.class.getCanonicalName());
-        requestLog.setLogLatency(true);
+        Slf4jRequestLogWriter slf4jRequestLogWriter = new Slf4jRequestLogWriter();
+        slf4jRequestLogWriter.setLoggerName(RestServer.class.getCanonicalName());
+        CustomRequestLog requestLog = new CustomRequestLog(slf4jRequestLogWriter, CustomRequestLog.EXTENDED_NCSA_FORMAT + " %msT");
         requestLogHandler.setRequestLog(requestLog);
 
         handlers.setHandlers(new Handler[]{context, new DefaultHandler(), requestLogHandler});

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -35,28 +35,33 @@ public class SSLUtils {
     private static final Pattern COMMA_WITH_WHITESPACE = Pattern.compile("\\s*,\\s*");
 
     /**
-     * Configures SSL/TLS for HTTPS Jetty Server / Client
+     * Configures SSL/TLS for HTTPS Jetty Server
      */
-    public static SslContextFactory createSslContextFactory(WorkerConfig config) {
-        return createSslContextFactory(config, false);
-    }
-
-    /**
-     * Configures SSL/TLS for HTTPS Jetty Server / Client
-     */
-    @SuppressWarnings("deprecation")
-    public static SslContextFactory createSslContextFactory(WorkerConfig config, boolean client) {
+    public static SslContextFactory createServerSideSslContextFactory(WorkerConfig config) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
 
-        SslContextFactory ssl = new SslContextFactory();
+        final SslContextFactory.Server ssl = new SslContextFactory.Server();
 
         configureSslContextFactoryKeyStore(ssl, sslConfigValues);
         configureSslContextFactoryTrustStore(ssl, sslConfigValues);
         configureSslContextFactoryAlgorithms(ssl, sslConfigValues);
         configureSslContextFactoryAuthentication(ssl, sslConfigValues);
 
-        if (client)
-            configureSslContextFactoryEndpointIdentification(ssl, sslConfigValues);
+        return ssl;
+    }
+
+    /**
+     * Configures SSL/TLS for HTTPS Jetty Client
+     */
+    public static SslContextFactory createClientSideSslContextFactory(WorkerConfig config) {
+        Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
+
+        final SslContextFactory.Client ssl = new SslContextFactory.Client();
+
+        configureSslContextFactoryKeyStore(ssl, sslConfigValues);
+        configureSslContextFactoryTrustStore(ssl, sslConfigValues);
+        configureSslContextFactoryAlgorithms(ssl, sslConfigValues);
+        configureSslContextFactoryEndpointIdentification(ssl, sslConfigValues);
 
         return ssl;
     }
@@ -141,8 +146,7 @@ public class SSLUtils {
     /**
      * Configures Authentication related settings in SslContextFactory
      */
-    @SuppressWarnings("deprecation")
-    protected static void configureSslContextFactoryAuthentication(SslContextFactory ssl, Map<String, Object> sslConfigValues) {
+    protected static void configureSslContextFactoryAuthentication(SslContextFactory.Server ssl, Map<String, Object> sslConfigValues) {
         String sslClientAuth = (String) getOrDefault(sslConfigValues, BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
         switch (sslClientAuth) {
             case "requested":

--- a/tools/src/main/java/org/apache/kafka/trogdor/rest/JsonRestServer.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/rest/JsonRestServer.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.ThreadUtils;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
@@ -84,7 +86,6 @@ public class JsonRestServer {
      *
      * @param resources         The path handling resources to register.
      */
-    @SuppressWarnings("deprecation")
     public void start(Object... resources) {
         log.info("Starting REST server");
         ResourceConfig resourceConfig = new ResourceConfig();
@@ -101,10 +102,9 @@ public class JsonRestServer {
         context.addServlet(servletHolder, "/*");
 
         RequestLogHandler requestLogHandler = new RequestLogHandler();
-        // Use fully qualified name to avoid deprecation warning in import statement
-        org.eclipse.jetty.server.Slf4jRequestLog requestLog = new org.eclipse.jetty.server.Slf4jRequestLog();
-        requestLog.setLoggerName(JsonRestServer.class.getCanonicalName());
-        requestLog.setLogLatency(true);
+        Slf4jRequestLogWriter slf4jRequestLogWriter = new Slf4jRequestLogWriter();
+        slf4jRequestLogWriter.setLoggerName(JsonRestServer.class.getCanonicalName());
+        CustomRequestLog requestLog = new CustomRequestLog(slf4jRequestLogWriter, CustomRequestLog.EXTENDED_NCSA_FORMAT + " %msT");
         requestLogHandler.setRequestLog(requestLog);
 
         HandlerCollection handlers = new HandlerCollection();
@@ -157,21 +157,6 @@ public class JsonRestServer {
         while (!shutdownExecutor.isShutdown()) {
             shutdownExecutor.awaitTermination(1, TimeUnit.DAYS);
         }
-    }
-
-    /**
-     * Make an HTTP request.
-     *
-     * @param url               HTTP connection will be established with this url.
-     * @param method            HTTP method ("GET", "POST", "PUT", etc.)
-     * @param requestBodyData   Object to serialize as JSON and send in the request body.
-     * @param responseFormat    Expected format of the response to the HTTP request.
-     * @param <T>               The type of the deserialized response to the HTTP request.
-     * @return The deserialized response to the HTTP request, or null if no data is expected.
-     */
-    public static <T> HttpResponse<T> httpRequest(String url, String method, Object requestBodyData,
-                                                  TypeReference<T> responseFormat) throws IOException {
-        return httpRequest(log, url, method, requestBodyData, responseFormat);
     }
 
     /**


### PR DESCRIPTION
This PR resolves [KAFKA-8316](https://issues.apache.org/jira/browse/KAFKA-8316) following the method described [here](https://github.com/eclipse/jetty.project/issues/3502), along with [KAFKA-8308](https://issues.apache.org/jira/browse/KAFKA-8308).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
