### PR TITLE
MINOR: Refactor SslFactory

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslClientAuth.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslClientAuth.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Describes whether the server should require or request client authentication.
+ */
+public enum SslClientAuth {
+    REQUIRED,
+    REQUESTED,
+    NONE;
+
+    public static final List<SslClientAuth> VALUES =
+        Collections.unmodifiableList(Arrays.asList(SslClientAuth.values()));
+
+    public static SslClientAuth forConfig(String key) {
+        if (key == null) {
+            return SslClientAuth.NONE;
+        }
+        String upperCaseKey = key.toUpperCase(Locale.ROOT);
+        for (SslClientAuth auth : VALUES) {
+            if (auth.name().equals(upperCaseKey)) {
+                return auth;
+            }
+        }
+        return null;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -147,4 +147,15 @@ public class SslConfigs {
             SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
             SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
             SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+
+    public static final Set<String> NON_RECONFIGURABLE_CONFIGS = Utils.mkSet(
+            BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,
+            SslConfigs.SSL_PROTOCOL_CONFIG,
+            SslConfigs.SSL_PROVIDER_CONFIG,
+            SslConfigs.SSL_CIPHER_SUITES_CONFIG,
+            SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
+            SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG,
+            SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,
+            SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG,
+            SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG);
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -863,7 +863,8 @@ public class SslTransportLayer implements TransportLayer {
     private void maybeProcessHandshakeFailure(SSLException sslException, boolean flush, IOException ioException) throws IOException {
         if (sslException instanceof SSLHandshakeException || sslException instanceof SSLProtocolException ||
                 sslException instanceof SSLPeerUnverifiedException || sslException instanceof SSLKeyException ||
-                sslException.getMessage().contains("Unrecognized SSL message"))
+                sslException.getMessage().contains("Unrecognized SSL message") ||
+                sslException.getMessage().contains("Received fatal alert: "))
             handshakeFailure(sslException, flush);
         else if (ioException == null)
             throw sslException;

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslEngineBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslEngineBuilder.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SslClientAuth;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.config.types.Password;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class SslEngineBuilder {
+    private static final Logger log = LoggerFactory.getLogger(SslEngineBuilder.class);
+
+    private final Map<String, ?> configs;
+    private final String protocol;
+    private final String provider;
+    private final String kmfAlgorithm;
+    private final String tmfAlgorithm;
+    private final SecurityStore keystore;
+    private final SecurityStore truststore;
+    private final String[] cipherSuites;
+    private final String[] enabledProtocols;
+    private final String endpointIdentification;
+    private final SecureRandom secureRandomImplementation;
+    private final SSLContext sslContext;
+    private final SslClientAuth sslClientAuth;
+
+    @SuppressWarnings("unchecked")
+    SslEngineBuilder(Map<String, ?> configs) {
+        this.configs = Collections.unmodifiableMap(configs);
+        this.protocol = (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
+        this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
+
+        List<String> cipherSuitesList = (List<String>) configs.get(SslConfigs.SSL_CIPHER_SUITES_CONFIG);
+        if (cipherSuitesList != null && !cipherSuitesList.isEmpty()) {
+            this.cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
+        } else {
+            this.cipherSuites = null;
+        }
+
+        List<String> enabledProtocolsList = (List<String>) configs.get(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG);
+        if (enabledProtocolsList != null && !enabledProtocolsList.isEmpty()) {
+            this.enabledProtocols = enabledProtocolsList.toArray(new String[enabledProtocolsList.size()]);
+        } else {
+            this.enabledProtocols = null;
+        }
+
+        this.endpointIdentification = (String) configs.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+
+        this.secureRandomImplementation = createSecureRandom((String)
+                configs.get(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG));
+
+        this.sslClientAuth = createSslClientAuth((String) configs.get(
+                BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG));
+
+        this.kmfAlgorithm = (String) configs.get(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG);
+        this.tmfAlgorithm = (String) configs.get(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
+
+        this.keystore = createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
+                (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+
+        this.truststore = createTruststore((String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
+                (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+
+        this.sslContext = createSSLContext();
+    }
+
+    private static SslClientAuth createSslClientAuth(String key) {
+        SslClientAuth auth = SslClientAuth.forConfig(key);
+        if (auth != null) {
+            return auth;
+        }
+        log.warn("Unrecognized client authentication configuration {}.  Falling " +
+                "back to NONE.  Recognized client authentication configurations are {}.",
+                key, String.join(", ", SslClientAuth.VALUES.stream().
+                        map(a -> a.name()).collect(Collectors.toList())));
+        return SslClientAuth.NONE;
+    }
+
+    private static SecureRandom createSecureRandom(String key) {
+        if (key == null) {
+            return null;
+        }
+        try {
+            return SecureRandom.getInstance(key);
+        } catch (GeneralSecurityException e) {
+            throw new KafkaException(e);
+        }
+    }
+
+    private SSLContext createSSLContext() {
+        try {
+            SSLContext sslContext;
+            if (provider != null)
+                sslContext = SSLContext.getInstance(protocol, provider);
+            else
+                sslContext = SSLContext.getInstance(protocol);
+
+            KeyManager[] keyManagers = null;
+            if (keystore != null || kmfAlgorithm != null) {
+                String kmfAlgorithm = this.kmfAlgorithm != null ?
+                        this.kmfAlgorithm : KeyManagerFactory.getDefaultAlgorithm();
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance(kmfAlgorithm);
+                if (keystore != null) {
+                    KeyStore ks = keystore.load();
+                    Password keyPassword = keystore.keyPassword != null ? keystore.keyPassword : keystore.password;
+                    kmf.init(ks, keyPassword.value().toCharArray());
+                } else {
+                    kmf.init(null, null);
+                }
+                keyManagers = kmf.getKeyManagers();
+            }
+
+            String tmfAlgorithm = this.tmfAlgorithm != null ? this.tmfAlgorithm : TrustManagerFactory.getDefaultAlgorithm();
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+            KeyStore ts = truststore == null ? null : truststore.load();
+            tmf.init(ts);
+
+            sslContext.init(keyManagers, tmf.getTrustManagers(), this.secureRandomImplementation);
+            log.debug("Created SSL context with keystore {}, truststore {}", keystore, truststore);
+            return sslContext;
+        } catch (Exception e) {
+            throw new KafkaException(e);
+        }
+    }
+
+    private static SecurityStore createKeystore(String type, String path, Password password, Password keyPassword) {
+        if (path == null && password != null) {
+            throw new KafkaException("SSL key store is not specified, but key store password is specified.");
+        } else if (path != null && password == null) {
+            throw new KafkaException("SSL key store is specified, but key store password is not specified.");
+        } else if (path != null && password != null) {
+            return new SecurityStore(type, path, password, keyPassword);
+        } else
+            return null; // path == null, clients may use this path with brokers that don't require client auth
+    }
+
+    private static SecurityStore createTruststore(String type, String path, Password password) {
+        if (path == null && password != null) {
+            throw new KafkaException("SSL trust store is not specified, but trust store password is specified.");
+        } else if (path != null) {
+            return new SecurityStore(type, path, password, null);
+        } else
+            return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> configs() {
+        return (Map<String, Object>) configs;
+    }
+
+    public SecurityStore keystore() {
+        return keystore;
+    }
+
+    public SecurityStore truststore() {
+        return truststore;
+    }
+
+    /**
+     * Create a new SSLEngine object.
+     *
+     * @param mode      Whether to use client or server mode.
+     * @param peerHost  The peer host to use.
+     * @param peerPort  The peer port to use.
+     * @return          The new SSLEngine.
+     */
+    public SSLEngine createSslEngine(Mode mode, String peerHost, int peerPort) {
+        SSLEngine sslEngine = sslContext.createSSLEngine(peerHost, peerPort);
+        if (cipherSuites != null) sslEngine.setEnabledCipherSuites(cipherSuites);
+        if (enabledProtocols != null) sslEngine.setEnabledProtocols(enabledProtocols);
+
+        if (mode == Mode.SERVER) {
+            sslEngine.setUseClientMode(false);
+            switch (sslClientAuth) {
+                case REQUIRED:
+                    sslEngine.setNeedClientAuth(true);
+                    break;
+                case REQUESTED:
+                    sslEngine.setWantClientAuth(true);
+                    break;
+                case NONE:
+                    break;
+            }
+            sslEngine.setUseClientMode(false);
+        } else {
+            sslEngine.setUseClientMode(true);
+            SSLParameters sslParams = sslEngine.getSSLParameters();
+            // SSLParameters#setEndpointIdentificationAlgorithm enables endpoint validation
+            // only in client mode. Hence, validation is enabled only for clients.
+            sslParams.setEndpointIdentificationAlgorithm(endpointIdentification);
+            sslEngine.setSSLParameters(sslParams);
+        }
+        return sslEngine;
+    }
+
+    public SSLContext sslContext() {
+        return sslContext;
+    }
+
+    /**
+     * Returns true if this SslEngineBuilder needs to be rebuilt.
+     *
+     * @param nextConfigs       The configuration we want to use.
+     * @return                  True only if this builder should be rebuilt.
+     */
+    public boolean shouldBeRebuilt(Map<String, Object> nextConfigs) {
+        if (!nextConfigs.equals(configs)) {
+            return true;
+        }
+        if (truststore != null && truststore.modified()) {
+            return true;
+        }
+        if (keystore != null && keystore.modified()) {
+            return true;
+        }
+        return false;
+    }
+
+    // package access for testing
+    static class SecurityStore {
+        private final String type;
+        private final String path;
+        private final Password password;
+        private final Password keyPassword;
+        private final Long fileLastModifiedMs;
+
+        SecurityStore(String type, String path, Password password, Password keyPassword) {
+            Objects.requireNonNull(type, "type must not be null");
+            this.type = type;
+            this.path = path;
+            this.password = password;
+            this.keyPassword = keyPassword;
+            fileLastModifiedMs = lastModifiedMs(path);
+        }
+
+        /**
+         * Loads this keystore
+         * @return the keystore
+         * @throws KafkaException if the file could not be read or if the keystore could not be loaded
+         *   using the specified configs (e.g. if the password or keystore type is invalid)
+         */
+        KeyStore load() {
+            try (InputStream in = Files.newInputStream(Paths.get(path))) {
+                KeyStore ks = KeyStore.getInstance(type);
+                // If a password is not set access to the truststore is still available, but integrity checking is disabled.
+                char[] passwordChars = password != null ? password.value().toCharArray() : null;
+                ks.load(in, passwordChars);
+                return ks;
+            } catch (GeneralSecurityException | IOException e) {
+                throw new KafkaException("Failed to load SSL keystore " + path + " of type " + type, e);
+            }
+        }
+
+        private Long lastModifiedMs(String path) {
+            try {
+                return Files.getLastModifiedTime(Paths.get(path)).toMillis();
+            } catch (IOException e) {
+                log.error("Modification time of key store could not be obtained: " + path, e);
+                return null;
+            }
+        }
+
+        boolean modified() {
+            Long modifiedMs = lastModifiedMs(path);
+            return modifiedMs != null && !Objects.equals(modifiedMs, this.fileLastModifiedMs);
+        }
+
+        @Override
+        public String toString() {
+            return "SecurityStore(" +
+                    "path=" + path +
+                    ", modificationTime=" + (fileLastModifiedMs == null ? null : new Date(fileLastModifiedMs)) + ")";
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -22,35 +22,24 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.network.Mode;
-import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.Principal;
-import java.security.SecureRandom;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,26 +52,24 @@ public class SslFactory implements Reconfigurable {
     private final Mode mode;
     private final String clientAuthConfigOverride;
     private final boolean keystoreVerifiableUsingTruststore;
-
-    private String protocol;
-    private String provider;
-    private String kmfAlgorithm;
-    private String tmfAlgorithm;
-    private SecurityStore keystore = null;
-    private SecurityStore truststore;
-    private String[] cipherSuites;
-    private String[] enabledProtocols;
-    private String endpointIdentification;
-    private SecureRandom secureRandomImplementation;
-    private SSLContext sslContext;
-    private boolean needClientAuth;
-    private boolean wantClientAuth;
+    private SslEngineBuilder sslEngineBuilder;
 
     public SslFactory(Mode mode) {
         this(mode, null, false);
     }
 
-    public SslFactory(Mode mode, String clientAuthConfigOverride, boolean keystoreVerifiableUsingTruststore) {
+    /**
+     * Create an SslFactory.
+     *
+     * @param mode                                  Whether to use client or server mode.
+     * @param clientAuthConfigOverride              The value to override ssl.client.auth with, or null
+     *                                              if we don't want to override it.
+     * @param keystoreVerifiableUsingTruststore     True if we should require the keystore to be verifiable
+     *                                              using the truststore.
+     */
+    public SslFactory(Mode mode,
+                      String clientAuthConfigOverride,
+                      boolean keystoreVerifiableUsingTruststore) {
         this.mode = mode;
         this.clientAuthConfigOverride = clientAuthConfigOverride;
         this.keystoreVerifiableUsingTruststore = keystoreVerifiableUsingTruststore;
@@ -90,59 +77,25 @@ public class SslFactory implements Reconfigurable {
 
     @Override
     public void configure(Map<String, ?> configs) throws KafkaException {
-        this.protocol =  (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
-        this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
-
-        @SuppressWarnings("unchecked")
-        List<String> cipherSuitesList = (List<String>) configs.get(SslConfigs.SSL_CIPHER_SUITES_CONFIG);
-        if (cipherSuitesList != null && !cipherSuitesList.isEmpty())
-            this.cipherSuites = cipherSuitesList.toArray(new String[cipherSuitesList.size()]);
-
-        @SuppressWarnings("unchecked")
-        List<String> enabledProtocolsList = (List<String>) configs.get(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG);
-        if (enabledProtocolsList != null && !enabledProtocolsList.isEmpty())
-            this.enabledProtocols = enabledProtocolsList.toArray(new String[enabledProtocolsList.size()]);
-
-        String endpointIdentification = (String) configs.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
-        if (endpointIdentification != null)
-            this.endpointIdentification = endpointIdentification;
-
-        String secureRandomImplementation = (String) configs.get(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG);
-        if (secureRandomImplementation != null) {
+        if (sslEngineBuilder != null) {
+            throw new IllegalStateException("SslFactory was already configured.");
+        }
+        Map<String, Object> nextConfigs = new HashMap<>();
+        copyMapEntries(nextConfigs, configs, SslConfigs.NON_RECONFIGURABLE_CONFIGS);
+        copyMapEntries(nextConfigs, configs, SslConfigs.RECONFIGURABLE_CONFIGS);
+        if (clientAuthConfigOverride != null) {
+            nextConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, clientAuthConfigOverride);
+        }
+        SslEngineBuilder builder = new SslEngineBuilder(nextConfigs);
+        if (keystoreVerifiableUsingTruststore) {
             try {
-                this.secureRandomImplementation = SecureRandom.getInstance(secureRandomImplementation);
-            } catch (GeneralSecurityException e) {
-                throw new KafkaException(e);
+                SslEngineValidator.validate(builder, builder);
+            } catch (Exception e) {
+                throw new ConfigException("A client SSLEngine created with the provided settings " +
+                        "can't connect to a server SSLEngine created with those settings.", e);
             }
         }
-
-        String clientAuthConfig = clientAuthConfigOverride;
-        if (clientAuthConfig == null)
-            clientAuthConfig = (String) configs.get(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG);
-        if (clientAuthConfig != null) {
-            if (clientAuthConfig.equals("required"))
-                this.needClientAuth = true;
-            else if (clientAuthConfig.equals("requested"))
-                this.wantClientAuth = true;
-        }
-
-        this.kmfAlgorithm = (String) configs.get(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG);
-        this.tmfAlgorithm = (String) configs.get(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
-
-        this.keystore = createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
-                       (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
-                       (Password) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
-                       (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
-
-        this.truststore = createTruststore((String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
-                         (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
-                         (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
-        try {
-            this.sslContext = createSSLContext(keystore, truststore);
-            log.debug("Created SSL context with keystore {} truststore {}", keystore, truststore);
-        } catch (Exception e) {
-            throw new KafkaException(e);
-        }
+        this.sslEngineBuilder = builder;
     }
 
     @Override
@@ -151,344 +104,86 @@ public class SslFactory implements Reconfigurable {
     }
 
     @Override
-    public void validateReconfiguration(Map<String, ?> configs) {
-        try {
-            SecurityStore newKeystore = maybeCreateNewKeystore(configs);
-            SecurityStore newTruststore = maybeCreateNewTruststore(configs);
-            if (newKeystore != null || newTruststore != null) {
-                SecurityStore keystore = newKeystore != null ? newKeystore : this.keystore;
-                SecurityStore truststore = newTruststore != null ? newTruststore : this.truststore;
-                createSSLContext(keystore, truststore);
-            }
-        } catch (Exception e) {
-            log.debug("Validation of dynamic config update of SSL keystore/truststore failed", e);
-            throw new ConfigException("Validation of dynamic config update of SSL keystore/truststore failed: " + e);
-        }
+    public void validateReconfiguration(Map<String, ?> newConfigs) {
+        createNewSslEngineBuilder(newConfigs);
     }
 
     @Override
-    public void reconfigure(Map<String, ?> configs) throws KafkaException {
-        SecurityStore newKeystore = maybeCreateNewKeystore(configs);
-        SecurityStore newTruststore = maybeCreateNewTruststore(configs);
-        if (newKeystore != null || newTruststore != null) {
-            try {
-                SecurityStore keystore = newKeystore != null ? newKeystore : this.keystore;
-                SecurityStore truststore = newTruststore != null ? newTruststore : this.truststore;
-                this.sslContext = createSSLContext(keystore, truststore);
-                log.info("Created new {} SSL context with keystore {} truststore {}", mode, keystore, truststore);
-                this.keystore = keystore;
-                this.truststore = truststore;
-            } catch (Exception e) {
-                log.debug("Reconfiguration of SSL keystore/truststore failed", e);
-                throw new ConfigException("Reconfiguration of SSL keystore/truststore failed: " + e);
-            }
-        }
+    public void reconfigure(Map<String, ?> newConfigs) throws KafkaException {
+        this.sslEngineBuilder = createNewSslEngineBuilder(newConfigs);
     }
 
-    private SecurityStore maybeCreateNewKeystore(Map<String, ?> configs) {
-        boolean keystoreChanged  = false;
-        if (keystore != null) {
-            keystoreChanged = !Objects.equals(configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG), keystore.type) ||
-                    !Objects.equals(configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG), keystore.path) ||
-                    !Objects.equals(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), keystore.password) ||
-                    !Objects.equals(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG), keystore.keyPassword);
-            if (!keystoreChanged) {
-                keystoreChanged = keystore.modified();
-            }
+    private SslEngineBuilder createNewSslEngineBuilder(Map<String, ?> newConfigs) {
+        if (sslEngineBuilder == null) {
+            throw new IllegalStateException("SslFactory has not been configured.");
         }
-        if (keystoreChanged || keystore == null) {
-            return createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
-                    (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
-                    (Password) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
-                    (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
-        } else
-            return null;
-    }
-
-    private SecurityStore maybeCreateNewTruststore(Map<String, ?> configs) {
-        boolean truststoreChanged = false;
-        if (truststore != null) {
-            truststoreChanged = !Objects.equals(configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), truststore.type) ||
-                !Objects.equals(configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), truststore.path) ||
-                !Objects.equals(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), truststore.password);
-
-            if (!truststoreChanged) {
-                truststoreChanged = truststore.modified();
-            }
+        Map<String, Object> nextConfigs = new HashMap<>(sslEngineBuilder.configs());
+        copyMapEntries(nextConfigs, newConfigs, SslConfigs.RECONFIGURABLE_CONFIGS);
+        if (clientAuthConfigOverride != null) {
+            nextConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, clientAuthConfigOverride);
         }
-
-        if (truststoreChanged || truststore == null) {
-            return createTruststore((String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
-                    (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
-                    (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
-        } else
-            return null;
-    }
-
-    // package access for testing
-    SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore) throws GeneralSecurityException, IOException  {
-        SSLContext sslContext;
-        if (provider != null)
-            sslContext = SSLContext.getInstance(protocol, provider);
-        else
-            sslContext = SSLContext.getInstance(protocol);
-
-        KeyManager[] keyManagers = null;
-        if (keystore != null || kmfAlgorithm != null) {
-            String kmfAlgorithm = this.kmfAlgorithm != null ? this.kmfAlgorithm : KeyManagerFactory.getDefaultAlgorithm();
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(kmfAlgorithm);
-            if (keystore != null) {
-                KeyStore ks = keystore.load();
-                Password keyPassword = keystore.keyPassword != null ? keystore.keyPassword : keystore.password;
-                kmf.init(ks, keyPassword.value().toCharArray());
+        if (!sslEngineBuilder.shouldBeRebuilt(nextConfigs)) {
+            return sslEngineBuilder;
+        }
+        try {
+            SslEngineBuilder newSslEngineBuilder = new SslEngineBuilder(nextConfigs);
+            if (sslEngineBuilder.keystore() == null) {
+                if (newSslEngineBuilder.keystore() != null) {
+                    throw new ConfigException("Cannot add SSL keystore to an existing listener for " +
+                            "which no keystore was configured.");
+                }
             } else {
-                kmf.init(null,  null);
+                if (newSslEngineBuilder.keystore() == null) {
+                    throw new ConfigException("Cannot remove the SSL keystore from an existing listener for " +
+                            "which a keystore was configured.");
+                }
+                if (!CertificateEntries.create(sslEngineBuilder.keystore().load()).equals(
+                        CertificateEntries.create(newSslEngineBuilder.keystore().load()))) {
+                    throw new ConfigException("Keystore DistinguishedName or SubjectAltNames do not match");
+                }
             }
-            keyManagers = kmf.getKeyManagers();
-        }
-
-        String tmfAlgorithm = this.tmfAlgorithm != null ? this.tmfAlgorithm : TrustManagerFactory.getDefaultAlgorithm();
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
-        KeyStore ts = truststore == null ? null : truststore.load();
-        tmf.init(ts);
-
-        sslContext.init(keyManagers, tmf.getTrustManagers(), this.secureRandomImplementation);
-        boolean verifyKeystore = keystore != null && keystore != this.keystore;
-        boolean verifyTruststore = truststore != null && truststore != this.truststore;
-        if (verifyKeystore || verifyTruststore) {
-            if (this.keystore == null && keystore != null)
-                throw new ConfigException("Cannot add SSL keystore to an existing listener for which no keystore was configured.");
-            if (this.truststore == null && truststore != null)
-                throw new ConfigException("Cannot add SSL truststore to an existing listener for which no truststore was configured.");
-
+            if (sslEngineBuilder.truststore() == null && newSslEngineBuilder.truststore() != null) {
+                throw new ConfigException("Cannot add SSL truststore to an existing listener for which no " +
+                        "truststore was configured.");
+            }
             if (keystoreVerifiableUsingTruststore) {
-                SSLConfigValidatorEngine.validate(this, sslContext, this.sslContext);
-                SSLConfigValidatorEngine.validate(this, this.sslContext, sslContext);
+                if (sslEngineBuilder.truststore() != null || sslEngineBuilder.keystore() != null) {
+                    SslEngineValidator.validate(sslEngineBuilder, newSslEngineBuilder);
+                }
             }
-            if (verifyKeystore &&
-                    !CertificateEntries.create(this.keystore.load()).equals(CertificateEntries.create(keystore.load()))) {
-                throw new ConfigException("Keystore DistinguishedName or SubjectAltNames do not match");
-            }
+            return newSslEngineBuilder;
+        } catch (Exception e) {
+            log.debug("Validation of dynamic config update of SSLFactory failed.", e);
+            throw new ConfigException("Validation of dynamic config update of SSLFactory failed: " + e);
         }
-        return sslContext;
     }
 
     public SSLEngine createSslEngine(String peerHost, int peerPort) {
-        return createSslEngine(sslContext, peerHost, peerPort);
+        if (sslEngineBuilder == null) {
+            throw new IllegalStateException("SslFactory has not been configured.");
+        }
+        return sslEngineBuilder.createSslEngine(mode, peerHost, peerPort);
     }
 
-    private SSLEngine createSslEngine(SSLContext sslContext, String peerHost, int peerPort) {
-        SSLEngine sslEngine = sslContext.createSSLEngine(peerHost, peerPort);
-        if (cipherSuites != null) sslEngine.setEnabledCipherSuites(cipherSuites);
-        if (enabledProtocols != null) sslEngine.setEnabledProtocols(enabledProtocols);
-
-        // SSLParameters#setEndpointIdentificationAlgorithm enables endpoint validation
-        // only in client mode. Hence, validation is enabled only for clients.
-        if (mode == Mode.SERVER) {
-            sslEngine.setUseClientMode(false);
-            if (needClientAuth)
-                sslEngine.setNeedClientAuth(needClientAuth);
-            else
-                sslEngine.setWantClientAuth(wantClientAuth);
-        } else {
-            sslEngine.setUseClientMode(true);
-            SSLParameters sslParams = sslEngine.getSSLParameters();
-            sslParams.setEndpointIdentificationAlgorithm(endpointIdentification);
-            sslEngine.setSSLParameters(sslParams);
-        }
-        return sslEngine;
+    public SslEngineBuilder sslEngineBuilder() {
+        return sslEngineBuilder;
     }
 
     /**
-     * Returns a configured SSLContext.
-     * @return SSLContext.
+     * Copy entries from one map into another.
+     *
+     * @param destMap   The map to copy entries into.
+     * @param srcMap    The map to copy entries from.
+     * @param keySet    Only entries with these keys will be copied.
+     * @param <K>       The map key type.
+     * @param <V>       The map value type.
      */
-    public SSLContext sslContext() {
-        return sslContext;
-    }
-
-    private SecurityStore createKeystore(String type, String path, Password password, Password keyPassword) {
-        if (path == null && password != null) {
-            throw new KafkaException("SSL key store is not specified, but key store password is specified.");
-        } else if (path != null && password == null) {
-            throw new KafkaException("SSL key store is specified, but key store password is not specified.");
-        } else if (path != null && password != null) {
-            return new SecurityStore(type, path, password, keyPassword);
-        } else
-            return null; // path == null, clients may use this path with brokers that don't require client auth
-    }
-
-    private SecurityStore createTruststore(String type, String path, Password password) {
-        if (path == null && password != null) {
-            throw new KafkaException("SSL trust store is not specified, but trust store password is specified.");
-        } else if (path != null) {
-            return new SecurityStore(type, path, password, null);
-        } else
-            return null;
-    }
-
-    // package access for testing
-    static class SecurityStore {
-        private final String type;
-        private final String path;
-        private final Password password;
-        private final Password keyPassword;
-        private final Long fileLastModifiedMs;
-
-        SecurityStore(String type, String path, Password password, Password keyPassword) {
-            Objects.requireNonNull(type, "type must not be null");
-            this.type = type;
-            this.path = path;
-            this.password = password;
-            this.keyPassword = keyPassword;
-            fileLastModifiedMs = lastModifiedMs(path);
-        }
-
-        /**
-         * Loads this keystore
-         * @return the keystore
-         * @throws KafkaException if the file could not be read or if the keystore could not be loaded
-         *   using the specified configs (e.g. if the password or keystore type is invalid)
-         */
-        KeyStore load() {
-            try (InputStream in = Files.newInputStream(Paths.get(path))) {
-                KeyStore ks = KeyStore.getInstance(type);
-                // If a password is not set access to the truststore is still available, but integrity checking is disabled.
-                char[] passwordChars = password != null ? password.value().toCharArray() : null;
-                ks.load(in, passwordChars);
-                return ks;
-            } catch (GeneralSecurityException | IOException e) {
-                throw new KafkaException("Failed to load SSL keystore " + path + " of type " + type, e);
-            }
-        }
-
-        private Long lastModifiedMs(String path) {
-            try {
-                return Files.getLastModifiedTime(Paths.get(path)).toMillis();
-            } catch (IOException e) {
-                log.error("Modification time of key store could not be obtained: " + path, e);
-                return null;
-            }
-        }
-
-        boolean modified() {
-            Long modifiedMs = lastModifiedMs(path);
-            return modifiedMs != null && !Objects.equals(modifiedMs, this.fileLastModifiedMs);
-        }
-
-        @Override
-        public String toString() {
-            return "SecurityStore(" +
-                    "path=" + path +
-                    ", modificationTime=" + (fileLastModifiedMs == null ? null : new Date(fileLastModifiedMs)) + ")";
-        }
-    }
-
-    /**
-     * Validator used to verify dynamic update of keystore used in inter-broker communication.
-     * The validator checks that a successful handshake can be performed using the keystore and
-     * truststore configured on this SslFactory.
-     */
-    private static class SSLConfigValidatorEngine {
-        private static final ByteBuffer EMPTY_BUF = ByteBuffer.allocate(0);
-        private final SSLEngine sslEngine;
-        private SSLEngineResult handshakeResult;
-        private ByteBuffer appBuffer;
-        private ByteBuffer netBuffer;
-
-        static void validate(SslFactory sslFactory, SSLContext clientSslContext, SSLContext serverSslContext) throws SSLException {
-            SSLConfigValidatorEngine clientEngine = new SSLConfigValidatorEngine(sslFactory, clientSslContext, Mode.CLIENT);
-            SSLConfigValidatorEngine serverEngine = new SSLConfigValidatorEngine(sslFactory, serverSslContext, Mode.SERVER);
-            try {
-                clientEngine.beginHandshake();
-                serverEngine.beginHandshake();
-                while (!serverEngine.complete() || !clientEngine.complete()) {
-                    clientEngine.handshake(serverEngine);
-                    serverEngine.handshake(clientEngine);
-                }
-            } finally {
-                clientEngine.close();
-                serverEngine.close();
-            }
-        }
-
-        private SSLConfigValidatorEngine(SslFactory sslFactory, SSLContext sslContext, Mode mode) {
-            this.sslEngine = sslFactory.createSslEngine(sslContext, "localhost", 0); // these hints are not used for validation
-            sslEngine.setUseClientMode(mode == Mode.CLIENT);
-            appBuffer = ByteBuffer.allocate(sslEngine.getSession().getApplicationBufferSize());
-            netBuffer = ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize());
-        }
-
-        void beginHandshake() throws SSLException {
-            sslEngine.beginHandshake();
-        }
-
-        void handshake(SSLConfigValidatorEngine peerEngine) throws SSLException {
-            SSLEngineResult.HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
-            while (true) {
-                switch (handshakeStatus) {
-                    case NEED_WRAP:
-                        handshakeResult = sslEngine.wrap(EMPTY_BUF, netBuffer);
-                        switch (handshakeResult.getStatus()) {
-                            case OK: break;
-                            case BUFFER_OVERFLOW:
-                                netBuffer.compact();
-                                netBuffer = Utils.ensureCapacity(netBuffer, sslEngine.getSession().getPacketBufferSize());
-                                netBuffer.flip();
-                                break;
-                            case BUFFER_UNDERFLOW:
-                            case CLOSED:
-                            default:
-                                throw new SSLException("Unexpected handshake status: " + handshakeResult.getStatus());
-                        }
-                        return;
-                    case NEED_UNWRAP:
-                        if (peerEngine.netBuffer.position() == 0) // no data to unwrap, return to process peer
-                            return;
-                        peerEngine.netBuffer.flip(); // unwrap the data from peer
-                        handshakeResult = sslEngine.unwrap(peerEngine.netBuffer, appBuffer);
-                        peerEngine.netBuffer.compact();
-                        handshakeStatus = handshakeResult.getHandshakeStatus();
-                        switch (handshakeResult.getStatus()) {
-                            case OK: break;
-                            case BUFFER_OVERFLOW:
-                                appBuffer = Utils.ensureCapacity(appBuffer, sslEngine.getSession().getApplicationBufferSize());
-                                break;
-                            case BUFFER_UNDERFLOW:
-                                netBuffer = Utils.ensureCapacity(netBuffer, sslEngine.getSession().getPacketBufferSize());
-                                break;
-                            case CLOSED:
-                            default:
-                                throw new SSLException("Unexpected handshake status: " + handshakeResult.getStatus());
-                        }
-                        break;
-                    case NEED_TASK:
-                        sslEngine.getDelegatedTask().run();
-                        handshakeStatus = sslEngine.getHandshakeStatus();
-                        break;
-                    case FINISHED:
-                        return;
-                    case NOT_HANDSHAKING:
-                        if (handshakeResult.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.FINISHED)
-                            throw new SSLException("Did not finish handshake");
-                        return;
-                    default:
-                        throw new IllegalStateException("Unexpected handshake status " + handshakeStatus);
-                }
-            }
-        }
-
-        boolean complete() {
-            return sslEngine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED ||
-                    sslEngine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
-        }
-
-        void close() {
-            sslEngine.closeOutbound();
-            try {
-                sslEngine.closeInbound();
-            } catch (Exception e) {
-                // ignore
+    private static <K, V> void copyMapEntries(Map<K, V> destMap,
+                                              Map<K, ? extends V> srcMap,
+                                              Set<K> keySet) {
+        for (K k : keySet) {
+            if (srcMap.containsKey(k)) {
+                destMap.put(k, srcMap.get(k));
             }
         }
     }
@@ -534,6 +229,121 @@ public class SslFactory implements Reconfigurable {
         public String toString() {
             return "subjectPrincipal=" + subjectPrincipal +
                     ", subjectAltNames=" + subjectAltNames;
+        }
+    }
+
+    /**
+     * Validator used to verify dynamic update of keystore used in inter-broker communication.
+     * The validator checks that a successful handshake can be performed using the keystore and
+     * truststore configured on this SslFactory.
+     */
+    private static class SslEngineValidator {
+        private static final ByteBuffer EMPTY_BUF = ByteBuffer.allocate(0);
+        private final SSLEngine sslEngine;
+        private SSLEngineResult handshakeResult;
+        private ByteBuffer appBuffer;
+        private ByteBuffer netBuffer;
+
+        static void validate(SslEngineBuilder oldEngineBuilder,
+                             SslEngineBuilder newEngineBuilder) throws SSLException {
+            validate(oldEngineBuilder.createSslEngine(Mode.SERVER, "localhost", 0),
+                    newEngineBuilder.createSslEngine(Mode.CLIENT, "localhost", 0));
+            validate(newEngineBuilder.createSslEngine(Mode.SERVER, "localhost", 0),
+                    oldEngineBuilder.createSslEngine(Mode.CLIENT, "localhost", 0));
+        }
+
+        static void validate(SSLEngine clientEngine, SSLEngine serverEngine) throws SSLException {
+            SslEngineValidator clientValidator = new SslEngineValidator(clientEngine);
+            SslEngineValidator serverValidator = new SslEngineValidator(serverEngine);
+            try {
+                clientValidator.beginHandshake();
+                serverValidator.beginHandshake();
+                while (!serverValidator.complete() || !clientValidator.complete()) {
+                    clientValidator.handshake(serverValidator);
+                    serverValidator.handshake(clientValidator);
+                }
+            } finally {
+                clientValidator.close();
+                serverValidator.close();
+            }
+        }
+
+        private SslEngineValidator(SSLEngine engine) {
+            this.sslEngine = engine;
+            appBuffer = ByteBuffer.allocate(sslEngine.getSession().getApplicationBufferSize());
+            netBuffer = ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize());
+        }
+
+        void beginHandshake() throws SSLException {
+            sslEngine.beginHandshake();
+        }
+        void handshake(SslEngineValidator peerValidator) throws SSLException {
+            SSLEngineResult.HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            while (true) {
+                switch (handshakeStatus) {
+                    case NEED_WRAP:
+                        handshakeResult = sslEngine.wrap(EMPTY_BUF, netBuffer);
+                        switch (handshakeResult.getStatus()) {
+                            case OK: break;
+                            case BUFFER_OVERFLOW:
+                                netBuffer.compact();
+                                netBuffer = Utils.ensureCapacity(netBuffer, sslEngine.getSession().getPacketBufferSize());
+                                netBuffer.flip();
+                                break;
+                            case BUFFER_UNDERFLOW:
+                            case CLOSED:
+                            default:
+                                throw new SSLException("Unexpected handshake status: " + handshakeResult.getStatus());
+                        }
+                        return;
+                    case NEED_UNWRAP:
+                        if (peerValidator.netBuffer.position() == 0) // no data to unwrap, return to process peer
+                            return;
+                        peerValidator.netBuffer.flip(); // unwrap the data from peer
+                        handshakeResult = sslEngine.unwrap(peerValidator.netBuffer, appBuffer);
+                        peerValidator.netBuffer.compact();
+                        handshakeStatus = handshakeResult.getHandshakeStatus();
+                        switch (handshakeResult.getStatus()) {
+                            case OK: break;
+                            case BUFFER_OVERFLOW:
+                                appBuffer = Utils.ensureCapacity(appBuffer, sslEngine.getSession().getApplicationBufferSize());
+                                break;
+                            case BUFFER_UNDERFLOW:
+                                netBuffer = Utils.ensureCapacity(netBuffer, sslEngine.getSession().getPacketBufferSize());
+                                break;
+                            case CLOSED:
+                            default:
+                                throw new SSLException("Unexpected handshake status: " + handshakeResult.getStatus());
+                        }
+                        break;
+                    case NEED_TASK:
+                        sslEngine.getDelegatedTask().run();
+                        handshakeStatus = sslEngine.getHandshakeStatus();
+                        break;
+                    case FINISHED:
+                        return;
+                    case NOT_HANDSHAKING:
+                        if (handshakeResult.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.FINISHED)
+                            throw new SSLException("Did not finish handshake");
+                        return;
+                    default:
+                        throw new IllegalStateException("Unexpected handshake status " + handshakeStatus);
+                }
+            }
+        }
+
+        boolean complete() {
+            return sslEngine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED ||
+                    sslEngine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+        }
+
+        void close() {
+            sslEngine.closeOutbound();
+            try {
+                sslEngine.closeInbound();
+            } catch (Exception e) {
+                // ignore
+            }
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
@@ -50,7 +50,7 @@ class EchoServer extends Thread {
             case SSL:
                 this.sslFactory = new SslFactory(Mode.SERVER);
                 this.sslFactory.configure(configs);
-                SSLContext sslContext = this.sslFactory.sslContext();
+                SSLContext sslContext = this.sslFactory.sslEngineBuilder().sslContext();
                 this.serverSocket = sslContext.getServerSocketFactory().createServerSocket(0);
                 break;
             case PLAINTEXT:

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -20,11 +20,11 @@ import java.io.File;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.Provider;
+import java.util.Arrays;
 import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLHandshakeException;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
@@ -32,11 +32,11 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.ssl.mock.TestKeyManagerFactory;
 import org.apache.kafka.common.security.ssl.mock.TestProvider;
 import org.apache.kafka.common.security.ssl.mock.TestTrustManagerFactory;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.common.network.Mode;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -48,18 +48,17 @@ import static org.junit.Assert.fail;
 import java.security.Security;
 
 public class SslFactoryTest {
-
     @Test
     public void testSslFactoryConfiguration() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> serverSslConfig =
+                TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(serverSslConfig);
         //host and port are hints
         SSLEngine engine = sslFactory.createSslEngine("localhost", 0);
         assertNotNull(engine);
-        String[] expectedProtocols = {"TLSv1.2"};
-        assertArrayEquals(expectedProtocols, engine.getEnabledProtocols());
+        assertEquals(Utils.mkSet("TLSv1.2"), Utils.mkSet(engine.getEnabledProtocols()));
         assertEquals(false, engine.getUseClientMode());
     }
 
@@ -73,8 +72,7 @@ public class SslFactoryTest {
         );
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(serverSslConfig);
-        SSLContext sslContext = sslFactory.createSSLContext(null, null);
-        assertNotNull("SSL context not created", sslContext);
+        assertNotNull("SslEngineBuilder not created", sslFactory.sslEngineBuilder());
         Security.removeProvider(provider.getName());
     }
 
@@ -95,7 +93,8 @@ public class SslFactoryTest {
     @Test
     public void testClientMode() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = TestSslUtils.createSslConfig(false, true, Mode.CLIENT, trustStoreFile, "client");
+        Map<String, Object> clientSslConfig =
+                TestSslUtils.createSslConfig(false, true, Mode.CLIENT, trustStoreFile, "client");
         SslFactory sslFactory = new SslFactory(Mode.CLIENT);
         sslFactory.configure(clientSslConfig);
         //host and port are hints
@@ -106,79 +105,78 @@ public class SslFactoryTest {
     @Test
     public void testReconfiguration() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> sslConfig = TestSslUtils.
+                createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(sslConfig);
-        SSLContext sslContext = sslFactory.sslContext();
-        assertNotNull("SSL context not created", sslContext);
-        assertSame("SSL context recreated unnecessarily", sslContext, sslFactory.sslContext());
-        assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
+        SslEngineBuilder sslEngineBuilder = sslFactory.sslEngineBuilder();
+        assertNotNull("SslEngineBuilder not created", sslEngineBuilder);
 
-        // Verify that context is not recreated on reconfigure() if config and file are not changed
+        // Verify that SslEngineBuilder is not recreated on reconfigure() if config and
+        // file are not changed
         sslFactory.reconfigure(sslConfig);
-        assertSame("SSL context recreated unnecessarily", sslContext, sslFactory.sslContext());
+        assertSame("SslEngineBuilder recreated unnecessarily",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
 
-        // Verify that context is recreated on reconfigure() if config is changed
+        // Verify that the SslEngineBuilder is recreated on reconfigure() if config is changed
         trustStoreFile = File.createTempFile("truststore", ".jks");
         sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
-        sslContext = sslFactory.sslContext();
+        assertNotSame("SslEngineBuilder not recreated",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
+        sslEngineBuilder = sslFactory.sslEngineBuilder();
 
-        // Verify that context is recreated on reconfigure() if config is not changed, but truststore file was modified
+        // Verify that builder is recreated on reconfigure() if config is not changed, but truststore file was modified
         trustStoreFile.setLastModified(System.currentTimeMillis() + 10000);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
-        sslContext = sslFactory.sslContext();
+        assertNotSame("SslEngineBuilder not recreated",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
+        sslEngineBuilder = sslFactory.sslEngineBuilder();
 
-        // Verify that context is recreated on reconfigure() if config is not changed, but keystore file was modified
+        // Verify that builder is recreated on reconfigure() if config is not changed, but keystore file was modified
         File keyStoreFile = new File((String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
         keyStoreFile.setLastModified(System.currentTimeMillis() + 10000);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
-        sslContext = sslFactory.sslContext();
+        assertNotSame("SslEngineBuilder not recreated",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
+        sslEngineBuilder = sslFactory.sslEngineBuilder();
 
-        // Verify that context is recreated after validation on reconfigure() if config is not changed, but keystore file was modified
+        // Verify that builder is recreated after validation on reconfigure() if config is not changed, but keystore file was modified
         keyStoreFile.setLastModified(System.currentTimeMillis() + 15000);
         sslFactory.validateReconfiguration(sslConfig);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
-        sslContext = sslFactory.sslContext();
+        assertNotSame("SslEngineBuilder not recreated",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
+        sslEngineBuilder = sslFactory.sslEngineBuilder();
 
-        // Verify that the context is not recreated if modification time cannot be determined
+        // Verify that the builder is not recreated if modification time cannot be determined
         keyStoreFile.setLastModified(System.currentTimeMillis() + 20000);
         Files.delete(keyStoreFile.toPath());
         sslFactory.reconfigure(sslConfig);
-        assertSame("SSL context recreated unnecessarily", sslContext, sslFactory.sslContext());
+        assertSame("SslEngineBuilder recreated unnecessarily",
+                sslEngineBuilder, sslFactory.sslEngineBuilder());
     }
 
     @Test
     public void testReconfigurationWithoutTruststore() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = TestSslUtils
-            .createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> sslConfig = TestSslUtils.
+            createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
         sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
         sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(sslConfig);
-        SSLContext sslContext = sslFactory.sslContext();
+        SSLContext sslContext = sslFactory.sslEngineBuilder().sslContext();
         assertNotNull("SSL context not created", sslContext);
-        assertSame("SSL context recreated unnecessarily", sslContext, sslFactory.sslContext());
+        assertSame("SSL context recreated unnecessarily", sslContext,
+                sslFactory.sslEngineBuilder().sslContext());
         assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
 
-        trustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
-        sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-        sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-        sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
-        sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
-
-        trustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> sslConfig2 = TestSslUtils.
+            createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         try {
-            sslFactory.reconfigure(sslConfig);
+            sslFactory.validateReconfiguration(sslConfig2);
             fail("Truststore configured dynamically for listener without previous truststore");
         } catch (ConfigException e) {
             // Expected exception
@@ -188,30 +186,33 @@ public class SslFactoryTest {
     @Test
     public void testReconfigurationWithoutKeystore() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = TestSslUtils
-            .createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> sslConfig = TestSslUtils.
+                createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(sslConfig);
-        SSLContext sslContext = sslFactory.sslContext();
+        SSLContext sslContext = sslFactory.sslEngineBuilder().sslContext();
         assertNotNull("SSL context not created", sslContext);
-        assertSame("SSL context recreated unnecessarily", sslContext, sslFactory.sslContext());
+        assertSame("SSL context recreated unnecessarily", sslContext,
+                sslFactory.sslEngineBuilder().sslContext());
         assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
 
-        trustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        File newTrustStoreFile = File.createTempFile("truststore", ".jks");
+        sslConfig = TestSslUtils.
+                createSslConfig(false, true, Mode.SERVER, newTrustStoreFile, "server");
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame("SSL context not recreated", sslContext, sslFactory.sslContext());
+        assertNotSame("SSL context not recreated", sslContext,
+                sslFactory.sslEngineBuilder().sslContext());
 
-        trustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        sslConfig = TestSslUtils.
+                createSslConfig(false, true, Mode.SERVER, newTrustStoreFile, "server");
         try {
-            sslFactory.reconfigure(sslConfig);
+            sslFactory.validateReconfiguration(sslConfig);
             fail("Keystore configured dynamically for listener without previous keystore");
         } catch (ConfigException e) {
             // Expected exception
@@ -225,46 +226,51 @@ public class SslFactoryTest {
                 Mode.SERVER, trustStoreFile, "server");
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
         sslFactory.configure(serverSslConfig);
-        SSLContext sslContext = sslFactory.createSSLContext(sslKeyStore(serverSslConfig), null);
-        assertNotNull("SSL context not created", sslContext);
-
-        SSLContext sslContext2 = sslFactory.createSSLContext(null, sslTrustStore(serverSslConfig));
-        assertNotNull("SSL context not created", sslContext2);
-
-        SSLContext sslContext3 = sslFactory.createSSLContext(sslKeyStore(serverSslConfig), sslTrustStore(serverSslConfig));
-        assertNotNull("SSL context not created", sslContext3);
+        assertNotNull("SslEngineBuilder not created", sslFactory.sslEngineBuilder());
     }
 
     @Test
-    public void testUntrustedKeyStoreValidation() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = TestSslUtils.createSslConfig(false, true,
-                Mode.SERVER, trustStoreFile, "server");
-        Map<String, Object> untrustedConfig = TestSslUtils.createSslConfig(false, true,
-                Mode.SERVER, File.createTempFile("truststore", ".jks"), "server");
+    public void testUntrustedKeyStoreValidationFails() throws Exception {
+        File trustStoreFile1 = File.createTempFile("truststore1", ".jks");
+        File trustStoreFile2 = File.createTempFile("truststore2", ".jks");
+        Map<String, Object> sslConfig1 = TestSslUtils.createSslConfig(false, true,
+                Mode.SERVER, trustStoreFile1, "server");
+        Map<String, Object> sslConfig2 = TestSslUtils.createSslConfig(false, true,
+                Mode.SERVER, trustStoreFile2, "server");
         SslFactory sslFactory = new SslFactory(Mode.SERVER, null, true);
-        sslFactory.configure(serverSslConfig);
-        try {
-            sslFactory.createSSLContext(sslKeyStore(untrustedConfig), null);
-            fail("Validation did not fail with untrusted keystore");
-        } catch (SSLHandshakeException e) {
-            // Expected exception
+        for (String key : Arrays.asList(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+                SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
+                SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG)) {
+            sslConfig1.put(key, sslConfig2.get(key));
         }
         try {
-            sslFactory.createSSLContext(null, sslTrustStore(untrustedConfig));
+            sslFactory.configure(sslConfig1);
             fail("Validation did not fail with untrusted truststore");
-        } catch (SSLHandshakeException e) {
+        } catch (ConfigException e) {
             // Expected exception
         }
+    }
 
+    @Test
+    public void testKeystoreVerifiableUsingTruststore() throws Exception {
+        File trustStoreFile1 = File.createTempFile("truststore1", ".jks");
+        Map<String, Object> sslConfig1 = TestSslUtils.createSslConfig(false, true,
+                Mode.SERVER, trustStoreFile1, "server");
+        SslFactory sslFactory = new SslFactory(Mode.SERVER, null, true);
+        sslFactory.configure(sslConfig1);
+
+        File trustStoreFile2 = File.createTempFile("truststore2", ".jks");
+        Map<String, Object> sslConfig2 = TestSslUtils.createSslConfig(false, true,
+                Mode.SERVER, trustStoreFile2, "server");
         // Verify that `createSSLContext` fails even if certificate from new keystore is trusted by
         // the new truststore, if certificate is not trusted by the existing truststore on the `SslFactory`.
         // This is to prevent both keystores and truststores to be modified simultaneously on an inter-broker
         // listener to stores that may not work with other brokers where the update hasn't yet been performed.
         try {
-            sslFactory.createSSLContext(sslKeyStore(untrustedConfig), sslTrustStore(untrustedConfig));
-            fail("Validation did not fail with untrusted truststore");
-        } catch (SSLHandshakeException e) {
+            sslFactory.validateReconfiguration(sslConfig2);
+            fail("ValidateReconfiguration did not fail as expected");
+        } catch (ConfigException e) {
             // Expected exception
         }
     }
@@ -288,8 +294,8 @@ public class SslFactoryTest {
         assertNotEquals(SslFactory.CertificateEntries.create(ks1), SslFactory.CertificateEntries.create(ks3));
     }
 
-    private SslFactory.SecurityStore sslKeyStore(Map<String, Object> sslConfig) {
-        return new SslFactory.SecurityStore(
+    private SslEngineBuilder.SecurityStore sslKeyStore(Map<String, Object> sslConfig) {
+        return new SslEngineBuilder.SecurityStore(
                 (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
                 (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
                 (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
@@ -297,13 +303,12 @@ public class SslFactoryTest {
         );
     }
 
-    private SslFactory.SecurityStore sslTrustStore(Map<String, Object> sslConfig) {
-        return new SslFactory.SecurityStore(
+    private SslEngineBuilder.SecurityStore sslTrustStore(Map<String, Object> sslConfig) {
+        return new SslEngineBuilder.SecurityStore(
                 (String) sslConfig.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
                 (String) sslConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
                 (Password) sslConfig.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG),
                 null
         );
     }
-
 }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -88,6 +88,7 @@ object ConfigCommand extends Config {
         Exit.exit(1)
 
       case t: Throwable =>
+        logger.debug(s"Error while executing config command with args '${args.mkString(" ")}'", t)
         System.err.println(s"Error while executing config command with args '${args.mkString(" ")}'")
         t.printStackTrace(System.err)
         Exit.exit(1)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -18,7 +18,7 @@
 package kafka.server
 
 import java.util
-import java.util.{Collections, Properties}
+import java.util.{Collections, Locale, Properties}
 
 import kafka.api.{ApiVersion, ApiVersionValidator, KAFKA_0_10_0_IV1, KAFKA_2_1_IV0}
 import kafka.cluster.EndPoint
@@ -29,9 +29,9 @@ import kafka.utils.CoreUtils
 import kafka.utils.Implicits._
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common.Reconfigurable
-import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList}
+import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList, Validator}
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
-import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigException, SaslConfigs, SslConfigs, TopicConfig}
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigException, SaslConfigs, SslClientAuth, SslConfigs, TopicConfig}
 import org.apache.kafka.common.metrics.Sensor
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.{LegacyRecord, Records, TimestampType}
@@ -219,10 +219,8 @@ object Defaults {
   val SslKeyManagerAlgorithm = SslConfigs.DEFAULT_SSL_KEYMANGER_ALGORITHM
   val SslTrustManagerAlgorithm = SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM
   val SslEndpointIdentificationAlgorithm = SslConfigs.DEFAULT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
-  val SslClientAuthRequired = "required"
-  val SslClientAuthRequested = "requested"
-  val SslClientAuthNone = "none"
-  val SslClientAuth = SslClientAuthNone
+  val SslClientAuthentication = SslClientAuth.NONE.name().toLowerCase(Locale.ROOT)
+  val SslClientAuthenticationValidValues = SslClientAuth.VALUES.asScala.map(v => v.toString().toLowerCase(Locale.ROOT)).asJava.toArray(new Array[String](0))
   val SslPrincipalMappingRules = BrokerSecurityConfigs.DEFAULT_SSL_PRINCIPAL_MAPPING_RULES
 
     /** ********* General Security configuration ***********/
@@ -1048,7 +1046,7 @@ object KafkaConfig {
       .define(SslTrustManagerAlgorithmProp, STRING, Defaults.SslTrustManagerAlgorithm, MEDIUM, SslTrustManagerAlgorithmDoc)
       .define(SslEndpointIdentificationAlgorithmProp, STRING, Defaults.SslEndpointIdentificationAlgorithm, LOW, SslEndpointIdentificationAlgorithmDoc)
       .define(SslSecureRandomImplementationProp, STRING, null, LOW, SslSecureRandomImplementationDoc)
-      .define(SslClientAuthProp, STRING, Defaults.SslClientAuth, in(Defaults.SslClientAuthRequired, Defaults.SslClientAuthRequested, Defaults.SslClientAuthNone), MEDIUM, SslClientAuthDoc)
+      .define(SslClientAuthProp, STRING, Defaults.SslClientAuthentication, in(Defaults.SslClientAuthenticationValidValues:_*), MEDIUM, SslClientAuthDoc)
       .define(SslCipherSuitesProp, LIST, Collections.emptyList(), MEDIUM, SslCipherSuitesDoc)
       .define(SslPrincipalMappingRulesProp, LIST, Defaults.SslPrincipalMappingRules, LOW, SslPrincipalMappingRulesDoc)
 

--- a/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
+++ b/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
@@ -137,7 +137,7 @@ object StateChangeLogMerger extends Logging {
      */
     val pqueue = new mutable.PriorityQueue[LineIterator]()(dateBasedOrdering)
     val output: OutputStream = new BufferedOutputStream(System.out, 1024*1024)
-    val lineIterators = files.map(io.Source.fromFile(_).getLines)
+    val lineIterators = files.map(scala.io.Source.fromFile(_).getLines)
     var lines: List[LineIterator] = List()
 
     for (itr <- lineIterators) {


### PR DESCRIPTION
SslFactory: split the part of SslFactory that creates SSLEngine instances into SslEngineBuilder.  When (re)configuring, we simply create a new SslEngineBuilder.  This allows us to make all the builder fields immutable.  It also simplifies the logic for reconfiguring.  Because we   sometimes need to test old SslEngine instances against new ones, being able to use both the old and the new builder at once is useful.

Create an enum named SslClientAuth which encodes the possible values for ssl.client.auth.  This will simplify the handling of this configuration.

SslTransportLayer#maybeProcessHandshakeFailure should treat an SSLHandshakeException with a "Received fatal alert" message as a handshake error (and therefore an authentication error.)

SslFactoryTest: add some line breaks for very long lines.

ConfigCommand#main: when terminating the command due to an uncaught exception, log the exception using debug level in slf4j, in addition to printing it to stderr.  This makes it easier to debug failing junit tests, where stderr may not be kept, or may be reordered with respect to  other slf4j messages.  The use of debug level is consistent with how we handle other types of exceptions in ConfigCommand#main.

StateChangeLogMerger#main: spell out the full name of scala.io.Source rather than abbreviating it as io.Source.  This makes it clearer that it is part of the Scala standard library.  It also avoids compiler errors when other libraries whose groupId starts with "io" are used in the broker.