### PR TITLE
Improve high watermark checkpointing performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1374,9 +1374,13 @@ project(':jmh-benchmarks') {
   dependencies {
     compile project(':clients')
     compile project(':streams')
+    compile project(':core')
+    compile project(':clients').sourceSets.test.output
+    compile project(':core').sourceSets.test.output
     compile libs.jmhCore
     annotationProcessor libs.jmhGeneratorAnnProcess
     compile libs.jmhCoreBenchmarks
+    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.26'
   }
 
   jar {

--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -52,5 +52,10 @@
   <subpackage name="examples">
     <allow pkg="org.apache.kafka.clients" />
   </subpackage>
+  <subpackage name="server">
+    <subpackage name="checkpoints">
+      <allow class="kafka.server.LogDirFailureChannel"/>
+    </subpackage>
+  </subpackage>
 
 </import-control>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -284,6 +284,11 @@
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.streams" />
     <allow pkg="org.github.jamm" />
+    <allow pkg="kafka.cluster"/>
+    <allow pkg="kafka.log"/>
+    <allow pkg="kafka.server"/>
+    <allow pkg="kafka.utils"/>
+    <allow pkg="scala"/>
   </subpackage>
 
   <subpackage name="log4jappender">

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -222,6 +222,9 @@ class Log(@volatile var dir: File,
   /* last time it was flushed */
   private val lastFlushedTime = new AtomicLong(time.milliseconds)
 
+  // Cache value of parent directory
+  def parentDir: String = dir.getParent
+
   def initFileSize: Int = {
     if (config.preallocate)
       config.segmentSize

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -66,7 +66,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
 
   /* the offset checkpoints holding the last cleaned point for each log */
   @volatile private var checkpoints = logDirs.map(dir =>
-    (dir, new OffsetCheckpointFile(new File(dir, offsetCheckpointFile), logDirFailureChannel))).toMap
+    (dir, OffsetCheckpointFile(new File(dir, offsetCheckpointFile), logDirFailureChannel))).toMap
 
   /* the set of logs currently being cleaned */
   private val inProgress = mutable.HashMap[TopicPartition, LogCleaningState]()

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -96,9 +96,9 @@ class LogManager(logDirs: Seq[File],
 
   private val dirLocks = lockLogDirs(liveLogDirs)
   @volatile private var recoveryPointCheckpoints = liveLogDirs.map(dir =>
-    (dir, new OffsetCheckpointFile(new File(dir, RecoveryPointCheckpointFile), logDirFailureChannel))).toMap
+    (dir, OffsetCheckpointFile(new File(dir, RecoveryPointCheckpointFile), logDirFailureChannel))).toMap
   @volatile private var logStartOffsetCheckpoints = liveLogDirs.map(dir =>
-    (dir, new OffsetCheckpointFile(new File(dir, LogStartOffsetCheckpointFile), logDirFailureChannel))).toMap
+    (dir, OffsetCheckpointFile(new File(dir, LogStartOffsetCheckpointFile), logDirFailureChannel))).toMap
 
   private val preferredLogDirs = new ConcurrentHashMap[TopicPartition, String]()
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -30,7 +30,7 @@ import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
-import kafka.server.checkpoints.OffsetCheckpointFile
+import kafka.server.checkpoints.{OffsetCheckpointFile, OffsetCheckpointFileEntry}
 import kafka.utils._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.errors._
@@ -189,7 +189,7 @@ class ReplicaManager(val config: KafkaConfig,
   val replicaAlterLogDirsManager = createReplicaAlterLogDirsManager(quotaManagers.alterLogDirs, brokerTopicStats)
   private val highWatermarkCheckPointThreadStarted = new AtomicBoolean(false)
   @volatile var highWatermarkCheckpoints = logManager.liveLogDirs.map(dir =>
-    (dir.getAbsolutePath, new OffsetCheckpointFile(new File(dir, ReplicaManager.HighWatermarkFilename), logDirFailureChannel))).toMap
+    (dir.getAbsolutePath, OffsetCheckpointFile(new File(dir, ReplicaManager.HighWatermarkFilename), logDirFailureChannel))).toMap
 
   private var hwThreadInitialized = false
   this.logIdent = s"[ReplicaManager broker=$localBrokerId] "
@@ -1414,24 +1414,21 @@ class ReplicaManager(val config: KafkaConfig,
   def getLogEndOffset(topicPartition: TopicPartition): Option[Long] =
     nonOfflinePartition(topicPartition).flatMap(_.leaderReplicaIfLocal.map(_.logEndOffset))
 
-  private def populateHWMMap(mapping: java.util.HashMap[String, util.HashMap[TopicPartition, Long]], optReplica: Option[Replica]): Unit = {
+  private def populateHWMMap(mapping: util.HashMap[String, util.List[OffsetCheckpointFileEntry]], optReplica: Option[Replica]): Unit = {
     optReplica.foreach(replica => {
       if (replica.log.isDefined) {
         val dir = replica.log.get.parentDir
         val tp = replica.topicPartition
-        val slot = mapping.computeIfAbsent(dir, new function.Function[String, util.HashMap[TopicPartition, Long]] {
-          override def apply(t: String): util.HashMap[TopicPartition, Long] = {
-            return new util.HashMap[TopicPartition, Long]()
-          }
-        })
-        slot.put(tp, replica.highWatermark.messageOffset)
+        val entry = new OffsetCheckpointFileEntry(tp, replica.highWatermark.messageOffset)
+        val slot = mapping.computeIfAbsent(dir, (_: String) => new util.ArrayList[OffsetCheckpointFileEntry]())
+        slot.add(entry)
       }
     })
   }
 
   // Flushes the highwatermark value for all partitions to the highwatermark file
   def checkpointHighWatermarks(): Unit = {
-    val hwmMap = new util.HashMap[String, util.HashMap[TopicPartition, Long]](allPartitions.size)
+    val hwmMap = new util.HashMap[String, util.List[OffsetCheckpointFileEntry]](allPartitions.size)
     nonOfflinePartitionsIterator.foreach(partition => {
       populateHWMMap(hwmMap, partition.localReplica)
       populateHWMMap(hwmMap, partition.futureLocalReplica)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1420,7 +1420,11 @@ class ReplicaManager(val config: KafkaConfig,
         val dir = replica.log.get.parentDir
         val tp = replica.topicPartition
         val entry = new OffsetCheckpointFileEntry(tp, replica.highWatermark.messageOffset)
-        val slot = mapping.computeIfAbsent(dir, (_: String) => new util.ArrayList[OffsetCheckpointFileEntry]())
+        val slot = mapping.computeIfAbsent(dir, new function.Function[String, util.List[OffsetCheckpointFileEntry]] {
+          override def apply(t: String): util.List[OffsetCheckpointFileEntry] = {
+            new util.ArrayList[OffsetCheckpointFileEntry]()
+          }
+        })
         slot.add(entry)
       }
     })

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFileEntry.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFileEntry.scala
@@ -1,0 +1,37 @@
+package kafka.server.checkpoints
+
+import org.apache.kafka.common.TopicPartition
+import java.util
+import java.io.IOException
+
+trait CheckpointFileEntry {
+  /**
+    * Encodes this CheckpointFileEntry as a line of text for the given StringBuilder.
+    */
+  def writeLine(stringBuilder: StringBuilder): Unit
+}
+
+final case class OffsetCheckpointFileEntry(topicPartition: TopicPartition, offset: Long) extends CheckpointFileEntry() {
+  /**
+    * Encodes this CheckpointFileEntry as a line of text for the given StringBuilder.
+    */
+  override def writeLine(stringBuilder: StringBuilder): Unit = {
+    stringBuilder
+      .append(topicPartition.topic)
+      .append(' ')
+      .append(topicPartition.partition)
+      .append(' ')
+      .append(offset)
+  }
+}
+
+object OffsetCheckpointFileEntry {
+  private val SEPARATOR: util.regex.Pattern = util.regex.Pattern.compile("\\s")
+  def apply(line: String): OffsetCheckpointFileEntry = {
+    SEPARATOR.split(line) match {
+      case Array(topic, partition, offset) => OffsetCheckpointFileEntry(new TopicPartition(topic, partition.toInt), offset.toLong)
+      case _ =>
+        throw new IOException(s"Expected 3 elements for OffsetCheckpointFileEntry")
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFileEntry.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFileEntry.scala
@@ -1,3 +1,19 @@
+/*
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package kafka.server.checkpoints
 
 import org.apache.kafka.common.TopicPartition

--- a/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
@@ -15,49 +15,38 @@
   * limitations under the License.
   */
 package kafka.server.checkpoints
-
-import java.io._
-import java.util.regex.Pattern
+import java.io.File
 
 import kafka.server.LogDirFailureChannel
-import kafka.server.epoch.EpochEntry
 import org.apache.kafka.common.TopicPartition
-
 import scala.collection._
-
-object OffsetCheckpointFile {
-  private val WhiteSpacesPattern = Pattern.compile("\\s+")
-  private[checkpoints] val CurrentVersion = 0
-
-  object Formatter extends CheckpointFileFormatter[(TopicPartition, Long)] {
-    override def toLine(entry: (TopicPartition, Long)): String = {
-      s"${entry._1.topic} ${entry._1.partition} ${entry._2}"
-    }
-
-    override def fromLine(line: String): Option[(TopicPartition, Long)] = {
-      WhiteSpacesPattern.split(line) match {
-        case Array(topic, partition, offset) =>
-          Some(new TopicPartition(topic, partition.toInt), offset.toLong)
-        case _ => None
-      }
-    }
-  }
-}
-
-trait OffsetCheckpoint {
-  def write(epochs: Seq[EpochEntry])
-  def read(): Seq[EpochEntry]
-}
 
 /**
   * This class persists a map of (Partition => Offsets) to a file (for a certain replica)
   */
-class OffsetCheckpointFile(val file: File, logDirFailureChannel: LogDirFailureChannel = null) {
-  val checkpoint = new CheckpointFile[(TopicPartition, Long)](file, OffsetCheckpointFile.CurrentVersion,
-    OffsetCheckpointFile.Formatter, logDirFailureChannel, file.getParent)
+class OffsetCheckpointFile(val checkpointFile: CheckpointFile[OffsetCheckpointFileEntry]) extends AnyVal {
+  def file: File = checkpointFile.file
 
-  def write(offsets: Map[TopicPartition, Long]): Unit = checkpoint.write(offsets.toSeq)
+  @deprecated("prefer using write(Seq[OffsetCheckpointFileEntry]) to avoid intermediate allocation")
+  def write(entries: Map[TopicPartition, Long]): Unit = {
+    val converted: Seq[OffsetCheckpointFileEntry] = entries.map({case (tp: TopicPartition, offset: Long) => new OffsetCheckpointFileEntry(tp, offset)})(collection.breakOut)
+    write(converted)
+  }
 
-  def read(): Map[TopicPartition, Long] = checkpoint.read().toMap
+  def write(entries: Seq[OffsetCheckpointFileEntry]): Unit = {
+    checkpointFile.write(entries)
+  }
 
+  def read(): Map[TopicPartition, Long] = {
+    val entries = checkpointFile.read()
+    entries.map(e => e.topicPartition -> e.offset)(collection.breakOut)
+  }
+}
+
+object OffsetCheckpointFile {
+  val CurrentVersion = 0
+  def apply(file: File, logDirFailureChannel: LogDirFailureChannel = null): OffsetCheckpointFile = {
+    val checkpointFile = new CheckpointFile[OffsetCheckpointFileEntry](file, CurrentVersion, logDirFailureChannel, file.getParent, (line: String) => OffsetCheckpointFileEntry(line))
+    new OffsetCheckpointFile(checkpointFile)
+  }
 }

--- a/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/OffsetCheckpointFile.scala
@@ -27,7 +27,7 @@ import scala.collection._
 class OffsetCheckpointFile(val checkpointFile: CheckpointFile[OffsetCheckpointFileEntry]) extends AnyVal {
   def file: File = checkpointFile.file
 
-  @deprecated("prefer using write(Seq[OffsetCheckpointFileEntry]) to avoid intermediate allocation")
+  @deprecated("prefer using write(Seq[OffsetCheckpointFileEntry]) to avoid intermediate allocation", "2.2.0")
   def write(entries: Map[TopicPartition, Long]): Unit = {
     val converted: Seq[OffsetCheckpointFileEntry] = entries.map({case (tp: TopicPartition, offset: Long) => new OffsetCheckpointFileEntry(tp, offset)})(collection.breakOut)
     write(converted)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -83,7 +83,7 @@ class LogCleanerParameterizedIntegrationTest(compressionCodec: String) extends A
     // and make sure its gone from checkpoint file
     cleaner.logs.remove(topicPartitions(0))
     cleaner.updateCheckpoints(logDir)
-    val checkpoints = new OffsetCheckpointFile(new File(logDir, cleaner.cleanerManager.offsetCheckpointFile)).read()
+    val checkpoints = OffsetCheckpointFile(new File(logDir, cleaner.cleanerManager.offsetCheckpointFile)).read()
     // we expect partition 0 to be gone
     assertFalse(checkpoints.contains(topicPartitions(0)))
   }

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -329,7 +329,7 @@ class LogManagerTest {
     }
 
     logManager.checkpointLogRecoveryOffsets()
-    val checkpoints = new OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
+    val checkpoints = OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
 
     topicPartitions.zip(logs).foreach { case (tp, log) =>
       assertEquals("Recovery point should equal checkpoint", checkpoints(tp), log.recoveryPoint)
@@ -398,7 +398,7 @@ class LogManagerTest {
 
     logManager.checkpointRecoveryOffsetsAndCleanSnapshot(this.logDir, allLogs.filter(_.dir.getName.contains("test-a")))
 
-    val checkpoints = new OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
+    val checkpoints = OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
 
     tps.zip(allLogs).foreach { case (tp, log) =>
       assertEquals("Recovery point should equal checkpoint", checkpoints(tp), log.recoveryPoint)

--- a/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
@@ -56,8 +56,8 @@ class LogRecoveryTest extends ZooKeeperTestHarness {
   val message = "hello"
 
   var producer: KafkaProducer[Integer, String] = null
-  def hwFile1 = new OffsetCheckpointFile(new File(configProps1.logDirs.head, ReplicaManager.HighWatermarkFilename))
-  def hwFile2 = new OffsetCheckpointFile(new File(configProps2.logDirs.head, ReplicaManager.HighWatermarkFilename))
+  def hwFile1 = OffsetCheckpointFile(new File(configProps1.logDirs.head, ReplicaManager.HighWatermarkFilename))
+  def hwFile2 = OffsetCheckpointFile(new File(configProps2.logDirs.head, ReplicaManager.HighWatermarkFilename))
   var servers = Seq.empty[KafkaServer]
 
   // Some tests restart the brokers then produce more data. But since test brokers use random ports, we need

--- a/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointFileTest.scala
@@ -20,8 +20,7 @@ class CheckpointFileTest {
     val entries = Seq(
       new OffsetCheckpointFileEntry(new TopicPartition("foo", 0), 0L),
       new OffsetCheckpointFileEntry(new TopicPartition("foo", 1), 1L),
-      new OffsetCheckpointFileEntry(new TopicPartition("foo", 2), 2L),
-    )
+      new OffsetCheckpointFileEntry(new TopicPartition("foo", 2), 2L))
     checkpointFile.write(entries)
     val readEntries = checkpointFile.read()
     for (entry <- readEntries) {

--- a/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointFileTest.scala
@@ -1,0 +1,49 @@
+package unit.kafka.server.checkpoints
+
+import java.io.File
+import java.util.UUID
+
+import kafka.server.LogDirFailureChannel
+import kafka.server.checkpoints.{CheckpointFile, OffsetCheckpointFileEntry}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.KafkaStorageException
+import org.junit.function.ThrowingRunnable
+import org.junit.{Assert, Test}
+
+class CheckpointFileTest {
+  @Test
+  def testRoundTripCheckpoints(): Unit = {
+    val file = File.createTempFile("temp-checkpoint-file", UUID.randomUUID().toString)
+    file.deleteOnExit()
+    val failureChannel = new LogDirFailureChannel(1)
+    val checkpointFile = CheckpointFile(file, 0, failureChannel, file.getParent, OffsetCheckpointFileEntry.apply)
+    val entries = Seq(
+      new OffsetCheckpointFileEntry(new TopicPartition("foo", 0), 0L),
+      new OffsetCheckpointFileEntry(new TopicPartition("foo", 1), 1L),
+      new OffsetCheckpointFileEntry(new TopicPartition("foo", 2), 2L),
+    )
+    checkpointFile.write(entries)
+    val readEntries = checkpointFile.read()
+    for (entry <- readEntries) {
+      Assert.assertEquals(entry.topicPartition.topic(), "foo")
+      Assert.assertEquals(entry.topicPartition.partition(), entry.offset)
+    }
+  }
+
+  @Test
+  def testReadDeletedFile(): Unit = {
+    val file = File.createTempFile("temp-checkpoint-file", UUID.randomUUID().toString)
+    file.deleteOnExit()
+    val failureChannel = new LogDirFailureChannel(1)
+    val checkpointFile = CheckpointFile(file, 0, failureChannel, file.getParent, OffsetCheckpointFileEntry.apply)
+    file.delete()
+    Assert.assertThrows(
+      "Expected read of deleted file to throw KafkaStorageException",
+      classOf[KafkaStorageException], new ThrowingRunnable {
+        override def run(): Unit = {
+          checkpointFile.read()
+        }
+      })
+    Assert.assertEquals("Expected checkpoint logdir to be failed", failureChannel.takeNextOfflineLogDir(), file.getParent)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
@@ -30,7 +30,7 @@ class LeaderEpochCheckpointFileTest extends Logging {
     val file = File.createTempFile("temp-checkpoint-file", System.nanoTime().toString)
     file.deleteOnExit()
 
-    val checkpoint = new LeaderEpochCheckpointFile(file)
+    val checkpoint = LeaderEpochCheckpointFile(file)
 
     //Given
     val epochs = Seq(EpochEntry(0, 1L), EpochEntry(1, 2L), EpochEntry(2, 3L))
@@ -57,12 +57,12 @@ class LeaderEpochCheckpointFileTest extends Logging {
     file.deleteOnExit()
 
     //Given a file with data in
-    val checkpoint = new LeaderEpochCheckpointFile(file)
+    val checkpoint = LeaderEpochCheckpointFile(file)
     val epochs = Seq(EpochEntry(0, 1L), EpochEntry(1, 2L), EpochEntry(2, 3L))
     checkpoint.write(epochs)
 
     //When we recreate
-    val checkpoint2 = new LeaderEpochCheckpointFile(file)
+    val checkpoint2 = LeaderEpochCheckpointFile(file)
 
     //The data should still be there
     assertEquals(epochs, checkpoint2.read())

--- a/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
@@ -30,7 +30,7 @@ class OffsetCheckpointFileTest extends Logging {
   @Test
   def shouldPersistAndOverwriteAndReloadFile(): Unit = {
 
-    val checkpoint = new OffsetCheckpointFile(TestUtils.tempFile())
+    val checkpoint = OffsetCheckpointFile(TestUtils.tempFile())
 
     //Given
     val offsets = Map(new TopicPartition("foo", 1) -> 5L, new TopicPartition("bar", 2) -> 10L)
@@ -54,7 +54,7 @@ class OffsetCheckpointFileTest extends Logging {
   @Test
   def shouldHandleMultipleLines(): Unit = {
 
-    val checkpoint = new OffsetCheckpointFile(TestUtils.tempFile())
+    val checkpoint = OffsetCheckpointFile(TestUtils.tempFile())
 
     //Given
     val offsets = Map(
@@ -76,13 +76,13 @@ class OffsetCheckpointFileTest extends Logging {
   def shouldReturnEmptyMapForEmptyFile(): Unit = {
 
     //When
-    val checkpoint = new OffsetCheckpointFile(TestUtils.tempFile())
+    val checkpoint = OffsetCheckpointFile(TestUtils.tempFile())
 
     //Then
     assertEquals(Map(), checkpoint.read())
 
     //When
-    checkpoint.write(Map())
+    checkpoint.write(Seq())
 
     //Then
     assertEquals(Map(), checkpoint.read())
@@ -92,10 +92,10 @@ class OffsetCheckpointFileTest extends Logging {
   def shouldThrowIfVersionIsNotRecognised(): Unit = {
     val file = TestUtils.tempFile()
     val logDirFailureChannel = new LogDirFailureChannel(10)
-    val checkpointFile = new CheckpointFile(file, OffsetCheckpointFile.CurrentVersion + 1,
-      OffsetCheckpointFile.Formatter, logDirFailureChannel, file.getParent)
-    checkpointFile.write(Seq(new TopicPartition("foo", 5) -> 10L))
-    new OffsetCheckpointFile(checkpointFile.file, logDirFailureChannel).read()
+    val checkpointFile = CheckpointFile(file, OffsetCheckpointFile.CurrentVersion + 1, logDirFailureChannel, file.getParent, OffsetCheckpointFileEntry.apply)
+    val entry = OffsetCheckpointFileEntry(new TopicPartition("foo", 5), 10L)
+    checkpointFile.write(Seq(entry))
+    OffsetCheckpointFile(checkpointFile.file, logDirFailureChannel).read()
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
@@ -227,14 +227,14 @@ class LeaderEpochFileCacheTest {
   @Test
   def shouldPersistEpochsBetweenInstances(){
     val checkpointPath = TestUtils.tempFile().getAbsolutePath
-    val checkpoint = new LeaderEpochCheckpointFile(new File(checkpointPath))
+    val checkpoint = LeaderEpochCheckpointFile(new File(checkpointPath))
 
     //Given
     val cache = new LeaderEpochFileCache(tp, logEndOffset _, checkpoint)
     cache.assign(epoch = 2, startOffset = 6)
 
     //When
-    val checkpoint2 = new LeaderEpochCheckpointFile(new File(checkpointPath))
+    val checkpoint2 = LeaderEpochCheckpointFile(new File(checkpointPath))
     val cache2 = new LeaderEpochFileCache(tp, logEndOffset _, checkpoint2)
 
     //Then

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1064,7 +1064,7 @@ object TestUtils extends Logging {
     // ensure that topic is removed from all cleaner offsets
     TestUtils.waitUntilTrue(() => servers.forall(server => topicPartitions.forall { tp =>
       val checkpoints = server.getLogManager.liveLogDirs.map { logDir =>
-        new OffsetCheckpointFile(new File(logDir, "cleaner-offset-checkpoint")).read()
+        OffsetCheckpointFile(new File(logDir, "cleaner-offset-checkpoint")).read()
       }
       checkpoints.forall(checkpointsPerLogDir => !checkpointsPerLogDir.contains(tp))
     }), "Cleaner offset for deleted partition should have been removed")

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -150,6 +150,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Package name="org.apache.kafka.jmh.common.generated"/>
             <Package name="org.apache.kafka.jmh.record.generated"/>
             <Package name="org.apache.kafka.jmh.producer.generated"/>
+            <Package name="org.apache.kafka.jmh.server.generated"/>
         </Or>
     </Match>
 

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -329,6 +329,14 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Package name="org.apache.kafka.streams.examples.pageview"/>
         <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
     </Match>
+    <!-- Suppress warnings for EQ_UNUSUAL for subclasses of AnyVal -->
+    <Match>
+        <Or>
+            <Class name="kafka.server.checkpoints.LeaderEpochCheckpointFile"/>
+            <Class name="kafka.server.checkpoints.OffsetCheckpointFile"/>
+        </Or>
+        <Bug pattern="EQ_UNUSUAL"></Bug>
+    </Match>
 
     <!-- END Suppress warnings for unused members that are undetectably used by Jackson -->
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
@@ -1,0 +1,151 @@
+package org.apache.kafka.jmh.server;
+
+import kafka.cluster.Partition;
+import kafka.cluster.Replica;
+import kafka.log.CleanerConfig;
+import kafka.log.Log;
+import kafka.log.LogConfig;
+import kafka.log.LogManager;
+import kafka.server.BrokerTopicStats;
+import kafka.server.KafkaConfig;
+import kafka.server.LogDirFailureChannel;
+import kafka.server.MetadataCache;
+import kafka.server.QuotaFactory;
+import kafka.server.ReplicaManager;
+import kafka.utils.KafkaScheduler;
+import kafka.utils.MockTime;
+import kafka.utils.Scheduler;
+import kafka.utils.TestUtils;
+import kafka.zk.KafkaZkClient;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Utils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import scala.Option;
+import scala.collection.JavaConverters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class HighwatermarkCheckpointBench {
+    @Param({"100", "1000", "2000"})
+    public int numTopics;
+    @Param({"3"})
+    public int numPartitions;
+
+    private final String topicName = "foo";
+
+    private Scheduler scheduler;
+
+    private Metrics metrics;
+
+    private MockTime time;
+
+    private KafkaConfig brokerProperties;
+
+    private ReplicaManager replicaManager;
+    private QuotaFactory.QuotaManagers quotaManagers;
+    private LogDirFailureChannel failureChannel;
+    private LogManager logManager;
+
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        this.scheduler = new KafkaScheduler(1, "scheduler-thread", true);
+        this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
+                0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
+                Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true));
+        this.metrics = new Metrics();
+        this.time = new MockTime();
+        this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());
+        final List<File> files =
+                JavaConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
+        this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
+                LogConfig.apply(),
+                CleanerConfig.apply(
+                        1, 4*1024*1024L, 0.9d,
+                        1024*1024, 32*1024*1024,
+                        Double.MAX_VALUE, 15 * 1000, true, "MD5"),
+                time);
+        scheduler.startup();
+        final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
+        final MetadataCache metadataCache =
+                new MetadataCache(this.brokerProperties.brokerId());
+        this.quotaManagers =
+                QuotaFactory.instantiate(this.brokerProperties,
+                        this.metrics,
+                        this.time, "");
+        this.replicaManager = new ReplicaManager(
+                this.brokerProperties,
+                this.metrics,
+                this.time,
+                null,//this.zkClient,
+                this.scheduler,
+                this.logManager,
+                new AtomicBoolean(false),
+                this.quotaManagers,
+                brokerTopicStats,
+                metadataCache,
+                this.failureChannel,
+                Option.empty());
+        this.replicaManager.startup();
+
+        List<TopicPartition> topicPartitions = new ArrayList<>();
+        for (int topicNum = 0; topicNum < numTopics; topicNum++) {
+            final String topicName = this.topicName + "-" + topicNum;
+            for (int partitionNum = 0; partitionNum < numPartitions; partitionNum++) {
+                topicPartitions.add(new TopicPartition(topicName, partitionNum));
+            }
+        }
+        this.replicaManager.checkpointHighWatermarks();
+        for (TopicPartition topicPartition : topicPartitions) {
+            final Partition partition =
+                    this.replicaManager.getOrCreatePartition(topicPartition);
+            final Log log = this.logManager.getOrCreateLog(topicPartition,
+                    LogConfig.apply(), true, false);
+            final Replica replica = new Replica(this.brokerProperties.brokerId(),
+                    topicPartition, this.time, 0, Option.apply(log));
+            partition.addReplicaIfNotExists(replica);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        this.replicaManager.shutdown(false);
+        this.metrics.close();
+        this.scheduler.shutdown();
+        this.quotaManagers.shutdown();
+        for (File dir : JavaConverters.asJavaCollection(logManager.liveLogDirs())) {
+            Utils.delete(dir);
+        }
+    }
+
+
+    @Benchmark
+    @Threads(1)
+    public void measureCheckpointHighWatermarks() {
+        this.replicaManager.checkpointHighWatermarks();
+    }
+}
+

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.jmh.server;
 
 import kafka.cluster.Partition;
@@ -81,12 +97,9 @@ public class HighwatermarkCheckpointBench {
         final List<File> files =
                 JavaConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
         this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
-                LogConfig.apply(),
-                CleanerConfig.apply(
-                        1, 4*1024*1024L, 0.9d,
-                        1024*1024, 32*1024*1024,
-                        Double.MAX_VALUE, 15 * 1000, true, "MD5"),
-                time);
+                LogConfig.apply(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
+                        1024 * 1024, 32 * 1024 * 1024,
+                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
         scheduler.startup();
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
         final MetadataCache metadataCache =
@@ -99,7 +112,7 @@ public class HighwatermarkCheckpointBench {
                 this.brokerProperties,
                 this.metrics,
                 this.time,
-                null,//this.zkClient,
+                null,
                 this.scheduler,
                 this.logManager,
                 new AtomicBoolean(false),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
@@ -16,7 +16,6 @@ import kafka.utils.KafkaScheduler;
 import kafka.utils.MockTime;
 import kafka.utils.Scheduler;
 import kafka.utils.TestUtils;
-import kafka.zk.KafkaZkClient;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Utils;
@@ -71,7 +70,7 @@ public class HighwatermarkCheckpointBench {
 
 
     @Setup(Level.Trial)
-    public void setup() throws Exception {
+    public void setup() {
         this.scheduler = new KafkaScheduler(1, "scheduler-thread", true);
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
                 0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),


### PR DESCRIPTION
This PR works to improve high watermark checkpointing performance. 

`ReplicaManager.checkpointHighWatermarks()` was found to be a major contributor to GC pressure, especially on Kafka clusters with high partition counts.

#### Commit gardnervickers@4307a73 
Adds a JMH benchmark for `checkpointHighWatermarks` which establishes a baseline for the commits which come after it. 

The parameterized benchmark was run with 100, 1000 and 2000 topics. 

#### Commit gardnervickers@ceb8272 
Modifies `ReplicaManager.checkpointHighWatermarks()` to avoid extra copies, and caches the Log parent directory to avoid frequent allocations when calculating the `File.getParent()`. It appears `Log.dir` is accessed from `ReplicaManager.checkpointHighWatermarks` without taking the `Log.lock` currently, this PR does the same for the cached `Log.parentDir`. I considered making these values change atomically but I had some trouble thinking of a case where not taking the lock would be safe with the current implementation, but unsafe with these proposed changes.  

The following improvements were measured off baseline
- 100 topics
  - +29% ops/ms
  - -63% MB/sec alloc
- 1000 topics
  - +86% ops/ms
  - -35% MB/sec alloc
- 2000 topics
  - +72% ops/ms
  - -55% MB/sec alloc

#### Commit gardnervickers@c1830fe
This is a pretty invasive/significant refactor of the `CheckpointFile` code and accompanying classes. The goal was to avoid unnecessary buffering and allocation when constructing and writing out the checkpoint file. Also, I attempted to encourage inlining as much as possible. The change set is pretty drastic but the improvements are attractive. 

The following improvements were measured off baseline
- 100 topics
  - +45% ops/ms
  - -679% MB/sec alloc
- 1000 topics
  - +222% ops/ms
  - -256% MB/sec alloc
- 2000 topics
  - +186% ops/ms
  - -339% MB/sec alloc


I think it would be reasonable if the project only wanted to take gardnervickers@ceb8272 (or a variant of it) for now, if the changes in gardnervickers@c1830fe seem too extreme. 

#### JMH output
[logs-0.8.0-beta1-5620-gc1830fec95.txt](https://github.com/apache/kafka/files/3146181/logs-0.8.0-beta1-5620-gc1830fec95.txt)
[logs-0.8.0-beta1-5619-gceb8272a61.txt](https://github.com/apache/kafka/files/3146182/logs-0.8.0-beta1-5619-gceb8272a61.txt)
[logs-0.8.0-beta1-5618-g4307a734ef.txt](https://github.com/apache/kafka/files/3146183/logs-0.8.0-beta1-5618-g4307a734ef.txt)
