### PR TITLE
KAFKA-8106:Reducing the allocation and copying of ByteBuffer when logValidator do validation(target trunk). 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecordBatch.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.record;
 
 abstract class AbstractRecordBatch implements RecordBatch {
-
+    public boolean isSimplified = false;
     @Override
     public boolean hasProducerId() {
         return RecordBatch.NO_PRODUCER_ID < producerId();
@@ -33,4 +33,13 @@ abstract class AbstractRecordBatch implements RecordBatch {
         return compressionType() != CompressionType.NONE;
     }
 
+    @Override
+    public void setSimplified(boolean isSimplified) {
+        this.isSimplified = isSimplified;
+    }
+
+    @Override
+    public  boolean isSimplified() {
+        return isSimplified;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -35,29 +35,29 @@ import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
 
 /**
  * This class implements the inner record format for magic 2 and above. The schema is as follows:
- * <p>
- * <p>
+ *
+ *
  * Record =>
- * Length => Varint
- * Attributes => Int8
- * TimestampDelta => Varlong
- * OffsetDelta => Varint
- * Key => Bytes
- * Value => Bytes
- * Headers => [HeaderKey HeaderValue]
- * HeaderKey => String
- * HeaderValue => Bytes
- * <p>
+ *   Length => Varint
+ *   Attributes => Int8
+ *   TimestampDelta => Varlong
+ *   OffsetDelta => Varint
+ *   Key => Bytes
+ *   Value => Bytes
+ *   Headers => [HeaderKey HeaderValue]
+ *     HeaderKey => String
+ *     HeaderValue => Bytes
+ *
  * Note that in this schema, the Bytes and String types use a variable length integer to represent
  * the length of the field. The array type used for the headers also uses a Varint for the number of
  * headers.
- * <p>
+ *
  * The current record attributes are depicted below:
- * <p>
- * ----------------
- * | Unused (0-7) |
- * ----------------
- * <p>
+ *
+ *  ----------------
+ *  | Unused (0-7) |
+ *  ----------------
+ *
  * The offset and timestamp deltas compute the difference relative to the base offset and
  * base timestamp of the batch that this record is contained in.
  */
@@ -132,8 +132,7 @@ public class DefaultRecord implements Record {
     }
 
     @Override
-    public void ensureValid() {
-    }
+    public void ensureValid() {}
 
     @Override
     public int keySize() {

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordBatch.java
@@ -199,6 +199,14 @@ public interface RecordBatch extends Iterable<Record> {
     boolean isCompressed();
 
     /**
+     *
+     * @param isSimplified
+     */
+    void setSimplified(boolean isSimplified);
+
+    boolean isSimplified();
+
+    /**
      * Write this record batch into a buffer.
      * @param buffer The buffer to write the batch to
      */

--- a/clients/src/main/java/org/apache/kafka/common/record/SimplifiedDefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/SimplifiedDefaultRecord.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.header.Header;
+
+import java.nio.ByteBuffer;
+
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
+
+/**
+ *
+ * @Flower.min
+ */
+public class SimplifiedDefaultRecord implements Record {
+
+    private final int sizeInBytes;
+    private final byte attributes;
+    private final long offset;
+    private final long timestamp;
+    private final int sequence;
+    private final boolean isHasKey;
+
+    public SimplifiedDefaultRecord(int sizeInBytes,
+                                   byte attributes,
+                                   long offset,
+                                   long timestamp,
+                                   int sequence,
+                                   boolean isHasKey) {
+        this.sizeInBytes = sizeInBytes;
+        this.attributes = attributes;
+        this.offset = offset;
+        this.timestamp = timestamp;
+        this.sequence = sequence;
+        this.isHasKey = isHasKey;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public int sequence() {
+        return sequence;
+    }
+
+    public int sizeInBytes() {
+        return sizeInBytes;
+    }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public Long checksumOrNull() {
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+    @Override
+    public void ensureValid() {
+
+    }
+
+    @Override
+    public int keySize() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasKey() {
+        return isHasKey;
+    }
+
+    @Override
+    public ByteBuffer key() {
+        return null;
+    }
+
+    @Override
+    public int valueSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasValue() {
+        return false;
+    }
+
+    @Override
+    public ByteBuffer value() {
+        return null;
+    }
+
+    @Override
+    public boolean hasMagic(byte magic) {
+        return magic >= MAGIC_VALUE_V2;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return false;
+    }
+
+    @Override
+    public boolean hasTimestampType(TimestampType timestampType) {
+        return false;
+    }
+
+    @Override
+    public Header[] headers() {
+        return new Header[0];
+    }
+
+    public byte attributes() {
+        return attributes;
+    }
+
+    public boolean isHasKey() {
+        return isHasKey;
+    }
+
+}

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -266,6 +266,7 @@ private[kafka] object LogValidator extends Logging {
         if (sourceCodec == NoCompressionCodec && batch.isControlBatch)
           inPlaceAssignment = true
 
+        batch.setSimplified(true)
         for (record <- batch.asScala) {
           if (sourceCodec != NoCompressionCodec && record.isCompressed)
             throw new InvalidRecordException("Compressed outer record should not have an inner record with a " +
@@ -290,6 +291,7 @@ private[kafka] object LogValidator extends Logging {
 
           validatedRecords += record
         }
+        batch.setSimplified(false)
       }
 
       if (!inPlaceAssignment) {


### PR DESCRIPTION
We suggest that reducing the allocation and copying of ByteBuffer when logValidator do validation when magic value to use is above 1 and no format conversion or value overwriting is required for compressed messages.And improved code is as follows.
1. Adding a class **SimplifiedDefaultRecord** implement class Record which define  various attributes of a message. 
2. Adding Function **simplifiedreadFrom**() at class **DefaultRecord** .This function will not read data from DataInput to  ByteBuffer which need newly creating .**This will reduce the allocation and copying of ByteBuffer** when logValidator do validation .This will reduces GC frequency. We offer a simple read function to read data from **DataInput** whithout create ByteBuffer.Of course this opertion can not avoid deconmpression to data.
3. Adding Function **simplifiedIterator**() and **simplifiedCompressedIterator**() at class **DefaultRecordBatch**.This two functions will return iterator of instance belongs to class **SimplifiedDefaultRecord**.
4. Modify code of function **validateMessagesAndAssignOffsetsCompressed**() at class  LogValidator.

    **After modifing code wich  reducing the allocation and copying of ByteBuffer**, the test performance is greatly improved, and the CPU's stable usage is below 60%. The following is a comparison of different code test performance under the same conditions.
**Result of performance testing**
Main config of Kafka: Single Message:1024B;TopicPartitions:200;linger.ms:1000ms,
**1.Before modified code(Source code):**
Network inflow rate:600M/s;CPU(%)(97%);production:25,000,000 messages/s
**2.After modified code(remove allocation of ByteBuffer):**
Network inflow rate:1G/s;CPU(%)(<60%);production:41,000,000 messages/s
 **1.Before modified code(Source code) GC:**
![](https://i.loli.net/2019/05/07/5cd16df163ad3.png)
**2.After modified code(remove allocation of ByteBuffer) GC:**
![](https://i.loli.net/2019/05/07/5cd16dae1dbc2.png)
