### PR TITLE
KAFKA-8337: Fix tests/setup.cfg to work with pytest 4.x

### DIFF
--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -20,7 +20,7 @@
 #
 # To ease possible confusion, 'check' instead of 'test' as a prefix for unit tests, since
 # many system test files, classes, and methods have 'test' somewhere in the name
-[pytest]
+[tool:pytest]
 testpaths=unit
 python_files=check_*.py
 python_classes=Check


### PR DESCRIPTION
This PR replaces [pytest] section in tests/setup.cfg with [tool:pytest] so that the unit tests for the system tests work with pytest 4.x.
I ran `python setup.py test` and confirmed it succeeded.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
