### PR TITLE
MINOR: Add missing option for running vagrant-up.sh with AWS to vagrant/README.md

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -127,7 +127,7 @@ Next, configure parameters in `Vagrantfile.local`. A few are *required*:
 
 Now start things up, but specify the aws provider:
 
-    $ vagrant/vagrant-up.sh
+    $ vagrant/vagrant-up.sh --aws
 
 Your instances should get tagged with a name including your hostname to make
 them identifiable and make it easier to track instances in the AWS management


### PR DESCRIPTION
Contrary to the previous explanation, a command example in
vagrant/README.md lacks the option to specify the aws provider.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
