### PR TITLE
MINOR: Remove unused variables from vagrant-up.sh

### DIFF
--- a/vagrant/vagrant-up.sh
+++ b/vagrant/vagrant-up.sh
@@ -18,9 +18,6 @@ set -o nounset
 set -o errexit  # exit script if any command exits with nonzero value
 
 readonly PROG_NAME=$(basename $0)
-readonly PROG_DIR=$(dirname $(realpath $0))
-readonly INVOKE_DIR=$(pwd)
-readonly ARGS="$@"
 
 # overrideable defaults
 AWS=false


### PR DESCRIPTION
Running vagrant/vagrant-up.sh shows the following error message
on the environment which doesn't have the realpath command, e.g. macOS:

```
vagrant/vagrant-up.sh: line 21: realpath: command not found
usage: dirname path
```

In the first place, these variables are not used and can be removed.

```
readonly PROG_DIR=$(dirname $(realpath $0))
readonly INVOKE_DIR=$(pwd)
readonly ARGS="$@"
```

I ran vagrant-up.sh without these variables and confirmed it worked.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
