### PR TITLE
KAFKA-8349. Add Windows batch files corresponding to kafka-delete-records.sh and kafka-log-dirs.sh

### DIFF
--- a/bin/windows/kafka-delete-records.bat
+++ b/bin/windows/kafka-delete-records.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" kafka.admin.DeleteRecordsCommand %*

--- a/bin/windows/kafka-log-dirs.bat
+++ b/bin/windows/kafka-log-dirs.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" kafka.admin.LogDirsCommand %*


### PR DESCRIPTION
Some shell scripts don't have corresponding batch files in bin\windows.
For improving Windows platform support, This PR adds the following batch files:

- bin\windows\kafka-delete-records.bat
- bin\windows\kafka-log-dirs.bat

I confirmed that they worked on Windows 10 Pro as follows:

```
PS C:\kafka-2.2.0> .\bin\windows\kafka-log-dirs.bat --bootstrap-server localhost:9092 --describe

(snip)

Querying brokers for log directories information
Received log directory information from brokers 0
{"version":1,"brokers":[{"broker":0,"logDirs":[{"logDir":"C:\\tmp\\kafka-logs","error":null,"partitions":[{"partition":"sandbox-0","size":213,"offsetLag":0,"isFuture":false}]}]}]}
```

```
PS C:\kafka-2.2.0> .\bin\windows\kafka-delete-records.bat --bootstrap-server localhost:9092 --offset-json-file offset-json-file.txt

(snip)

Executing records delete operation
Records delete operation completed:
partition: sandbox-0    low_watermark: 2
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
