### PR TITLE
MINOR: Remove unnecessary OptionParser#accepts method call from PreferredReplicaLeaderElectionCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -148,7 +148,6 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
       .describedAs("config file")
       .ofType(classOf[String])
 
-    parser.accepts("")
     options = parser.parse(args: _*)
   }
 


### PR DESCRIPTION
I found a strange hyphen between the header and the body
in kafka-preferred-replica-election.sh's help message.
This PR removes it.

```
$ bin/kafka-preferred-replica-election.sh --help

(snip)

Option                                  Description
------                                  -----------
-
--admin.config <String: config file>    Admin client config properties file to
```

I confirmed that its unit test succeeded and the command worked without that line.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
