### PR TITLE
MINOR: Align KTableAgg and KTableReduce

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -59,7 +59,6 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-
             store = (KeyValueStore<K, V>) context.getStateStore(storeName);
             tupleForwarder = new TupleForwarder<>(store, context, new ForwardingCacheFlushListener<K, V>(context), sendOldValues);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
@@ -80,7 +80,7 @@ public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, V> {
                 intermediateAgg = oldAgg;
             }
 
-            // than try to add the new value
+            // then try to add the new value
             final V newAgg;
             if (value.newValue != null) {
                 if (intermediateAgg == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
@@ -71,20 +71,25 @@ public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, V> {
             }
 
             final V oldAgg = store.get(key);
-            V newAgg = oldAgg;
+            final V intermediateAgg;
 
-            // first try to add the new value
-            if (value.newValue != null) {
-                if (newAgg == null) {
-                    newAgg = value.newValue;
-                } else {
-                    newAgg = addReducer.apply(newAgg, value.newValue);
-                }
+            // first try to remove the old value
+            if (value.oldValue != null && oldAgg != null) {
+                intermediateAgg = removeReducer.apply(oldAgg, value.oldValue);
+            } else {
+                intermediateAgg = oldAgg;
             }
 
-            // then try to remove the old value
-            if (value.oldValue != null) {
-                newAgg = removeReducer.apply(newAgg, value.oldValue);
+            // than try to add the new value
+            final V newAgg;
+            if (value.newValue != null) {
+                if (intermediateAgg == null) {
+                    newAgg = value.newValue;
+                } else {
+                    newAgg = addReducer.apply(intermediateAgg, value.newValue);
+                }
+            } else {
+                newAgg = intermediateAgg;
             }
 
             // update the store with the new value


### PR DESCRIPTION
This PR aligns the logic of `KTableAgg` and `KTableReduce` and makes the code more readable. It also fixes some bugs in both implementations:

 - 'remove' should be done before 'add'
 - 'remove' should only be done if an old value exists in the store
 - init() should not be called for 'remove' case if old value does not exist in store
