### PR TITLE
MINOR: Throw ProducerFencedException directly but with a new instance

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -86,6 +86,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class TransactionManagerTest {
@@ -1388,35 +1389,11 @@ public class TransactionManagerTest {
             assertTrue(e.getCause() instanceof ProducerFencedException);
         }
 
-        // make sure the produce was expired.
-        try {
-            transactionManager.beginTransaction();
-            fail("Expected to get a ExecutionException from the beginTransaction call");
-        } catch (RuntimeException e) {
-            assertTrue(e instanceof ProducerFencedException);
-        }
-
         // make sure the exception was thrown directly from the follow-up calls.
-        try {
-            transactionManager.beginCommit();
-            fail("Expected to get a ProducerFencedException from the beginCommit call");
-        } catch (RuntimeException e) {
-            assertTrue(e instanceof ProducerFencedException);
-        }
-
-        try {
-            transactionManager.beginAbort();
-            fail("Expected to get a ProducerFencedException from the beginAbort call");
-        } catch (RuntimeException e) {
-            assertTrue(e instanceof ProducerFencedException);
-        }
-
-        try {
-            transactionManager.sendOffsetsToTransaction(Collections.emptyMap(), "dummyId");
-            fail("Expected to get a ProducerFencedException from the sendOffsetsToTransaction call");
-        } catch (RuntimeException e) {
-            assertTrue(e instanceof ProducerFencedException);
-        }
+        assertThrows(ProducerFencedException.class, () -> transactionManager.beginTransaction());
+        assertThrows(ProducerFencedException.class, () -> transactionManager.beginCommit());
+        assertThrows(ProducerFencedException.class, () -> transactionManager.beginAbort());
+        assertThrows(ProducerFencedException.class, () -> transactionManager.sendOffsetsToTransaction(Collections.emptyMap(), "dummyId"));
     }
 
     @Test


### PR DESCRIPTION
Currently in maybeFailWithError, we always wrap the lastError as a KafkaException. For ProducerFencedException however, we should just throw the exception itself; however we throw a new instance since the previous book-kept one's call trace is not from this call, and hence could be confusing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
