### PR TITLE
KAFKA-8341. Retry Consumer group operation for NOT_COORDINATOR error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -166,6 +166,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.requests.MetadataRequest.convertToMetadataRequestTopic;
@@ -2510,21 +2511,93 @@ public class KafkaAdminClient extends AdminClient {
         return new DescribeDelegationTokenResult(tokensFuture);
     }
 
+    /**
+     * Context class to encapsulate parameters of a call to find and use a consumer group coordinator.
+     * Some of the parameters are provided at construction and are immutable whereas others are provided
+     * as "Call" are completed and values are available, like node id of the coordinator.
+     *
+     * @param <T> The type of return value of the KafkaFuture
+     * @param <O> The type of configuration option. Different for different consumer group commands.
+     */
+    private final static class ConsumerGroupOperationContext<T, O extends AbstractOptions<O>> {
+        final private String groupId;
+        final private O options;
+        final private long deadline;
+        final private KafkaFutureImpl<T> future;
+        private Optional<Node> node;
+
+        public ConsumerGroupOperationContext(String groupId,
+                                             O options,
+                                             long deadline,
+                                             KafkaFutureImpl<T> future) {
+            this.groupId = groupId;
+            this.options = options;
+            this.deadline = deadline;
+            this.future = future;
+            this.node = Optional.empty();
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public O getOptions() {
+            return options;
+        }
+
+        public long getDeadline() {
+            return deadline;
+        }
+
+        public KafkaFutureImpl<T> getFuture() {
+            return future;
+        }
+
+        public Optional<Node> getNode() {
+            return node;
+        }
+
+        public void setNode(Node node) {
+            this.node = Optional.ofNullable(node);
+        }
+
+        public boolean hasCoordinatorMoved(AbstractResponse response) {
+            return response.errorCounts().keySet()
+                    .stream()
+                    .anyMatch(error -> error == Errors.NOT_COORDINATOR);
+        }
+    }
+
+    private void rescheduleTask(ConsumerGroupOperationContext<?, ?> context, Supplier<Call> nextCall) {
+        log.info("Node {} is no longer the Coordinator. Retrying with new coordinator.",
+                context.getNode().orElse(null));
+        // Requeue the task so that we can try with new coordinator
+        context.setNode(null);
+        Call findCoordinatorCall = getFindCoordinatorCall(context, nextCall);
+        runnable.call(findCoordinatorCall, time.milliseconds());
+    }
+
+    private static <T> Map<String, KafkaFutureImpl<T>> createFutures(Collection<String> groupIds) {
+        return new HashSet<>(groupIds).stream().collect(
+            Collectors.toMap(groupId -> groupId,
+                groupId -> {
+                    if (groupIdIsUnrepresentable(groupId)) {
+                        KafkaFutureImpl<T> future = new KafkaFutureImpl<>();
+                        future.completeExceptionally(new InvalidGroupIdException("The given group id '" +
+                                groupId + "' cannot be represented in a request."));
+                        return future;
+                    } else {
+                        return new KafkaFutureImpl<>();
+                    }
+                }
+            ));
+    }
+
     @Override
     public DescribeConsumerGroupsResult describeConsumerGroups(final Collection<String> groupIds,
                                                                final DescribeConsumerGroupsOptions options) {
 
-        final Map<String, KafkaFutureImpl<ConsumerGroupDescription>> futures = new HashMap<>(groupIds.size());
-        for (String groupId: groupIds) {
-            if (groupIdIsUnrepresentable(groupId)) {
-                KafkaFutureImpl<ConsumerGroupDescription> future = new KafkaFutureImpl<>();
-                future.completeExceptionally(new InvalidGroupIdException("The given group id '" +
-                        groupId + "' cannot be represented in a request."));
-                futures.put(groupId, future);
-            } else if (!futures.containsKey(groupId)) {
-                futures.put(groupId, new KafkaFutureImpl<>());
-            }
-        }
+        final Map<String, KafkaFutureImpl<ConsumerGroupDescription>> futures = createFutures(groupIds);
 
         // TODO: KAFKA-6788, we should consider grouping the request per coordinator and send one request with a list of
         // all consumer groups this coordinator host
@@ -2537,97 +2610,120 @@ public class KafkaAdminClient extends AdminClient {
 
             final long startFindCoordinatorMs = time.milliseconds();
             final long deadline = calcDeadlineMs(startFindCoordinatorMs, options.timeoutMs());
-
-            runnable.call(new Call("findCoordinator", deadline, new LeastLoadedNodeProvider()) {
-                @Override
-                FindCoordinatorRequest.Builder createRequest(int timeoutMs) {
-                    return new FindCoordinatorRequest.Builder(
-                            new FindCoordinatorRequestData()
-                                .setKeyType(CoordinatorType.GROUP.id())
-                                .setKey(groupId));
-                }
-
-                @Override
-                void handleResponse(AbstractResponse abstractResponse) {
-                    final FindCoordinatorResponse fcResponse = (FindCoordinatorResponse) abstractResponse;
-
-                    if (handleGroupRequestError(fcResponse.error(), futures.get(groupId)))
-                        return;
-
-                    final long nowDescribeConsumerGroups = time.milliseconds();
-                    final int nodeId = fcResponse.node().id();
-                    runnable.call(new Call("describeConsumerGroups", deadline, new ConstantNodeIdProvider(nodeId)) {
-                        @Override
-                        AbstractRequest.Builder createRequest(int timeoutMs) {
-                            return new DescribeGroupsRequest.Builder(
-                                new DescribeGroupsRequestData()
-                                    .setGroups(Collections.singletonList(groupId))
-                                    .setIncludeAuthorizedOperations(options.includeAuthorizedOperations()));
-                        }
-
-                        @Override
-                        void handleResponse(AbstractResponse abstractResponse) {
-                            final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
-
-                            KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
-                            final DescribedGroup describedGroup = response.data()
-                                .groups()
-                                .stream()
-                                .filter(group -> groupId.equals(group.groupId()))
-                                .findFirst().get();
-
-                            final Errors groupError = Errors.forCode(describedGroup.errorCode());
-
-                            if (handleGroupRequestError(groupError, future))
-                                return;
-
-                            final String protocolType = describedGroup.protocolType();
-                            if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
-                                final List<DescribedGroupMember> members = describedGroup.members();
-                                final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
-                                final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
-                                for (DescribedGroupMember groupMember : members) {
-                                    Set<TopicPartition> partitions = Collections.emptySet();
-                                    if (groupMember.memberAssignment().length > 0) {
-                                        final PartitionAssignor.Assignment assignment = ConsumerProtocol.
-                                            deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
-                                        partitions = new HashSet<>(assignment.partitions());
-                                    }
-                                    final MemberDescription memberDescription =
-                                        new MemberDescription(groupMember.memberId(),
-                                            groupMember.clientId(),
-                                            groupMember.clientHost(),
-                                            new MemberAssignment(partitions));
-                                    memberDescriptions.add(memberDescription);
-                                }
-                                final ConsumerGroupDescription consumerGroupDescription =
-                                    new ConsumerGroupDescription(groupId, protocolType.isEmpty(),
-                                        memberDescriptions,
-                                        describedGroup.protocolData(),
-                                        ConsumerGroupState.parse(describedGroup.groupState()),
-                                        fcResponse.node(),
-                                        authorizedOperations);
-                                future.complete(consumerGroupDescription);
-                            }
-                        }
-
-                        @Override
-                        void handleFailure(Throwable throwable) {
-                            KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
-                            future.completeExceptionally(throwable);
-                        }
-                    }, nowDescribeConsumerGroups);
-                }
-
-                @Override
-                void handleFailure(Throwable throwable) {
-                    KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
-                    future.completeExceptionally(throwable);
-                }
-            }, startFindCoordinatorMs);
+            ConsumerGroupOperationContext<ConsumerGroupDescription, DescribeConsumerGroupsOptions> context =
+                    new ConsumerGroupOperationContext<>(groupId, options, deadline, futures.get(groupId));
+            Call findCoordinatorCall = getFindCoordinatorCall(context,
+                () -> KafkaAdminClient.this.getDescribeConsumerGroupsCall(context));
+            runnable.call(findCoordinatorCall, startFindCoordinatorMs);
         }
 
         return new DescribeConsumerGroupsResult(new HashMap<>(futures));
+    }
+
+    /**
+     * Returns a {@code Call} object to fetch the coordinator for a consumer group id. Takes another Call
+     * parameter to schedule action that need to be taken using the coordinator. The param is a Supplier
+     * so that it can be lazily created, so that it can use the results of find coordinator call in its
+     * construction.
+     */
+    private <T, O extends AbstractOptions<O>> Call getFindCoordinatorCall(ConsumerGroupOperationContext<T, O> context,
+                                               Supplier<Call> nextCall) {
+        return new Call("findCoordinator", context.getDeadline(), new LeastLoadedNodeProvider()) {
+            @Override
+            FindCoordinatorRequest.Builder createRequest(int timeoutMs) {
+                return new FindCoordinatorRequest.Builder(
+                        new FindCoordinatorRequestData()
+                                .setKeyType(CoordinatorType.GROUP.id())
+                                .setKey(context.getGroupId()));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+
+                if (handleGroupRequestError(response.error(), context.getFuture()))
+                    return;
+
+                context.setNode(response.node());
+
+                runnable.call(nextCall.get(), time.milliseconds());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                context.getFuture().completeExceptionally(throwable);
+            }
+        };
+    }
+
+    private Call getDescribeConsumerGroupsCall(
+            ConsumerGroupOperationContext<ConsumerGroupDescription, DescribeConsumerGroupsOptions> context) {
+        return new Call("describeConsumerGroups",
+                context.getDeadline(),
+                new ConstantNodeIdProvider(context.getNode().get().id())) {
+            @Override
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new DescribeGroupsRequest.Builder(
+                    new DescribeGroupsRequestData()
+                        .setGroups(Collections.singletonList(context.getGroupId()))
+                        .setIncludeAuthorizedOperations(context.getOptions().includeAuthorizedOperations()));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
+
+                final DescribedGroup describedGroup = response.data()
+                    .groups()
+                    .stream()
+                    .filter(group -> context.getGroupId().equals(group.groupId()))
+                    .findFirst().get();
+
+                // If coordinator changed since we fetched it, retry
+                if (context.hasCoordinatorMoved(response)) {
+                    rescheduleTask(context, () -> getDescribeConsumerGroupsCall(context));
+                    return;
+                }
+
+                final Errors groupError = Errors.forCode(describedGroup.errorCode());
+                if (handleGroupRequestError(groupError, context.getFuture()))
+                    return;
+
+                final String protocolType = describedGroup.protocolType();
+                if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
+                    final List<DescribedGroupMember> members = describedGroup.members();
+                    final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+                    final Set<AclOperation> authorizedOperations = validAclOperations(describedGroup.authorizedOperations());
+                    for (DescribedGroupMember groupMember : members) {
+                        Set<TopicPartition> partitions = Collections.emptySet();
+                        if (groupMember.memberAssignment().length > 0) {
+                            final PartitionAssignor.Assignment assignment = ConsumerProtocol.
+                                deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
+                            partitions = new HashSet<>(assignment.partitions());
+                        }
+                        final MemberDescription memberDescription =
+                            new MemberDescription(groupMember.memberId(),
+                                groupMember.clientId(),
+                                groupMember.clientHost(),
+                                new MemberAssignment(partitions));
+                        memberDescriptions.add(memberDescription);
+                    }
+                    final ConsumerGroupDescription consumerGroupDescription =
+                        new ConsumerGroupDescription(context.getGroupId(), protocolType.isEmpty(),
+                            memberDescriptions,
+                            describedGroup.protocolData(),
+                            ConsumerGroupState.parse(describedGroup.groupState()),
+                            context.getNode().get(),
+                            authorizedOperations);
+                    context.getFuture().complete(consumerGroupDescription);
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                context.getFuture().completeExceptionally(throwable);
+            }
+        };
     }
 
     private Set<AclOperation> validAclOperations(final int authorizedOperations) {
@@ -2776,162 +2872,125 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final String groupId, final ListConsumerGroupOffsetsOptions options) {
+    public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final String groupId,
+                                                                   final ListConsumerGroupOffsetsOptions options) {
         final KafkaFutureImpl<Map<TopicPartition, OffsetAndMetadata>> groupOffsetListingFuture = new KafkaFutureImpl<>();
-
         final long startFindCoordinatorMs = time.milliseconds();
         final long deadline = calcDeadlineMs(startFindCoordinatorMs, options.timeoutMs());
 
-        runnable.call(new Call("findCoordinator", deadline, new LeastLoadedNodeProvider()) {
+        ConsumerGroupOperationContext<Map<TopicPartition, OffsetAndMetadata>, ListConsumerGroupOffsetsOptions> context =
+                new ConsumerGroupOperationContext<>(groupId, options, deadline, groupOffsetListingFuture);
+
+        Call findCoordinatorCall = getFindCoordinatorCall(context,
+            () -> KafkaAdminClient.this.getListConsumerGroupOffsetsCall(context));
+        runnable.call(findCoordinatorCall, startFindCoordinatorMs);
+
+        return new ListConsumerGroupOffsetsResult(groupOffsetListingFuture);
+    }
+
+    private Call getListConsumerGroupOffsetsCall(ConsumerGroupOperationContext<Map<TopicPartition, OffsetAndMetadata>,
+            ListConsumerGroupOffsetsOptions> context) {
+        return new Call("listConsumerGroupOffsets", context.getDeadline(),
+                new ConstantNodeIdProvider(context.getNode().get().id())) {
             @Override
-            FindCoordinatorRequest.Builder createRequest(int timeoutMs) {
-                return new FindCoordinatorRequest.Builder(
-                        new FindCoordinatorRequestData()
-                            .setKeyType(CoordinatorType.GROUP.id())
-                            .setKey(groupId));
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new OffsetFetchRequest.Builder(context.getGroupId(), context.getOptions().topicPartitions());
             }
 
             @Override
             void handleResponse(AbstractResponse abstractResponse) {
-                final FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+                final OffsetFetchResponse response = (OffsetFetchResponse) abstractResponse;
+                final Map<TopicPartition, OffsetAndMetadata> groupOffsetsListing = new HashMap<>();
 
-                if (handleGroupRequestError(response.error(), groupOffsetListingFuture))
+                // If coordinator changed since we fetched it, retry
+                if (context.hasCoordinatorMoved(response)) {
+                    rescheduleTask(context, () -> getListConsumerGroupOffsetsCall(context));
+                    return;
+                }
+
+                if (handleGroupRequestError(response.error(), context.getFuture()))
                     return;
 
-                final long nowListConsumerGroupOffsets = time.milliseconds();
+                for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry :
+                    response.responseData().entrySet()) {
+                    final TopicPartition topicPartition = entry.getKey();
+                    OffsetFetchResponse.PartitionData partitionData = entry.getValue();
+                    final Errors error = partitionData.error;
 
-                final int nodeId = response.node().id();
-
-                runnable.call(new Call("listConsumerGroupOffsets", deadline, new ConstantNodeIdProvider(nodeId)) {
-                    @Override
-                    AbstractRequest.Builder createRequest(int timeoutMs) {
-                        return new OffsetFetchRequest.Builder(groupId, options.topicPartitions());
+                    if (error == Errors.NONE) {
+                        final Long offset = partitionData.offset;
+                        final String metadata = partitionData.metadata;
+                        final Optional<Integer> leaderEpoch = partitionData.leaderEpoch;
+                        groupOffsetsListing.put(topicPartition, new OffsetAndMetadata(offset, leaderEpoch, metadata));
+                    } else {
+                        log.warn("Skipping return offset for {} due to error {}.", topicPartition, error);
                     }
-
-                    @Override
-                    void handleResponse(AbstractResponse abstractResponse) {
-                        final OffsetFetchResponse response = (OffsetFetchResponse) abstractResponse;
-                        final Map<TopicPartition, OffsetAndMetadata> groupOffsetsListing = new HashMap<>();
-
-                        if (handleGroupRequestError(response.error(), groupOffsetListingFuture))
-                            return;
-
-                        for (Map.Entry<TopicPartition, OffsetFetchResponse.PartitionData> entry :
-                            response.responseData().entrySet()) {
-                            final TopicPartition topicPartition = entry.getKey();
-                            OffsetFetchResponse.PartitionData partitionData = entry.getValue();
-                            final Errors error = partitionData.error;
-
-                            if (error == Errors.NONE) {
-                                final Long offset = partitionData.offset;
-                                final String metadata = partitionData.metadata;
-                                final Optional<Integer> leaderEpoch = partitionData.leaderEpoch;
-                                groupOffsetsListing.put(topicPartition, new OffsetAndMetadata(offset, leaderEpoch, metadata));
-                            } else {
-                                log.warn("Skipping return offset for {} due to error {}.", topicPartition, error);
-                            }
-                        }
-                        groupOffsetListingFuture.complete(groupOffsetsListing);
-                    }
-
-                    @Override
-                    void handleFailure(Throwable throwable) {
-                        groupOffsetListingFuture.completeExceptionally(throwable);
-                    }
-                }, nowListConsumerGroupOffsets);
+                }
+                context.getFuture().complete(groupOffsetsListing);
             }
 
             @Override
             void handleFailure(Throwable throwable) {
-                groupOffsetListingFuture.completeExceptionally(throwable);
+                context.getFuture().completeExceptionally(throwable);
             }
-        }, startFindCoordinatorMs);
-
-        return new ListConsumerGroupOffsetsResult(groupOffsetListingFuture);
+        };
     }
 
     @Override
     public DeleteConsumerGroupsResult deleteConsumerGroups(Collection<String> groupIds, DeleteConsumerGroupsOptions options) {
 
-        final Map<String, KafkaFutureImpl<Void>> futures = new HashMap<>(groupIds.size());
-        for (String groupId: groupIds) {
-            if (groupIdIsUnrepresentable(groupId)) {
-                KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
-                future.completeExceptionally(new ApiException("The given group id '" +
-                        groupId + "' cannot be represented in a request."));
-                futures.put(groupId, future);
-            } else if (!futures.containsKey(groupId)) {
-                futures.put(groupId, new KafkaFutureImpl<>());
-            }
-        }
+        final Map<String, KafkaFutureImpl<Void>> futures = createFutures(groupIds);
 
         // TODO: KAFKA-6788, we should consider grouping the request per coordinator and send one request with a list of
         // all consumer groups this coordinator host
         for (final String groupId : groupIds) {
             // skip sending request for those futures that already failed.
-            if (futures.get(groupId).isCompletedExceptionally())
+            final KafkaFutureImpl<Void> future = futures.get(groupId);
+            if (future.isCompletedExceptionally())
                 continue;
 
             final long startFindCoordinatorMs = time.milliseconds();
             final long deadline = calcDeadlineMs(startFindCoordinatorMs, options.timeoutMs());
-
-            runnable.call(new Call("findCoordinator", deadline, new LeastLoadedNodeProvider()) {
-                @Override
-                FindCoordinatorRequest.Builder createRequest(int timeoutMs) {
-                    return new FindCoordinatorRequest.Builder(
-                            new FindCoordinatorRequestData()
-                                .setKeyType(CoordinatorType.GROUP.id())
-                                .setKey(groupId));
-                }
-
-                @Override
-                void handleResponse(AbstractResponse abstractResponse) {
-                    final FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
-
-                    if (handleGroupRequestError(response.error(), futures.get(groupId)))
-                        return;
-
-                    final long nowDeleteConsumerGroups = time.milliseconds();
-
-                    final int nodeId = response.node().id();
-
-                    runnable.call(new Call("deleteConsumerGroups", deadline, new ConstantNodeIdProvider(nodeId)) {
-
-                        @Override
-                        AbstractRequest.Builder createRequest(int timeoutMs) {
-                            return new DeleteGroupsRequest.Builder(Collections.singleton(groupId));
-                        }
-
-                        @Override
-                        void handleResponse(AbstractResponse abstractResponse) {
-                            final DeleteGroupsResponse response = (DeleteGroupsResponse) abstractResponse;
-
-                            KafkaFutureImpl<Void> future = futures.get(groupId);
-                            final Errors groupError = response.get(groupId);
-
-                            if (handleGroupRequestError(groupError, future))
-                                return;
-
-                            future.complete(null);
-                        }
-
-                        @Override
-                        void handleFailure(Throwable throwable) {
-                            KafkaFutureImpl<Void> future = futures.get(groupId);
-                            future.completeExceptionally(throwable);
-                        }
-                    }, nowDeleteConsumerGroups);
-                }
-
-                @Override
-                void handleFailure(Throwable throwable) {
-                    KafkaFutureImpl<Void> future = futures.get(groupId);
-                    future.completeExceptionally(throwable);
-                }
-            }, startFindCoordinatorMs);
+            ConsumerGroupOperationContext<Void, DeleteConsumerGroupsOptions> context =
+                    new ConsumerGroupOperationContext<>(groupId, options, deadline, future);
+            Call findCoordinatorCall = getFindCoordinatorCall(context,
+                () -> KafkaAdminClient.this.getDeleteConsumerGroupsCall(context));
+            runnable.call(findCoordinatorCall, startFindCoordinatorMs);
         }
 
         return new DeleteConsumerGroupsResult(new HashMap<>(futures));
+    }
+
+    private Call getDeleteConsumerGroupsCall(ConsumerGroupOperationContext<Void, DeleteConsumerGroupsOptions> context) {
+        return new Call("deleteConsumerGroups", context.getDeadline(), new ConstantNodeIdProvider(context.getNode().get().id())) {
+
+            @Override
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new DeleteGroupsRequest.Builder(Collections.singleton(context.getGroupId()));
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                final DeleteGroupsResponse response = (DeleteGroupsResponse) abstractResponse;
+
+                // If coordinator changed since we fetched it, retry
+                if (context.hasCoordinatorMoved(response)) {
+                    rescheduleTask(context, () -> getDeleteConsumerGroupsCall(context));
+                    return;
+                }
+
+                final Errors groupError = response.get(context.getGroupId());
+                if (handleGroupRequestError(groupError, context.getFuture()))
+                    return;
+
+                context.getFuture().complete(null);
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                context.getFuture().completeExceptionally(throwable);
+            }
+        };
     }
 
     @Override
@@ -2968,5 +3027,4 @@ public class KafkaAdminClient extends AdminClient {
         }, now);
         return new ElectPreferredLeadersResult(electionFuture, partitionSet);
     }
-
 }


### PR DESCRIPTION
An api call for consumer groups is made up of two calls:
1. Find the consumer group coordinator
2. Send the request to the node found in step 1

But the coordinator can get moved between step 1 and 2. In that case we
currently fail. This change fixes that by detecting this error and then
retrying.

Following APIs are impacted by this behavior:
1. listConsumerGroupOffsets
2. deleteConsumerGroups
3. describeConsumerGroups

Each of these call result in AdminClient making multiple calls to the backend.
As AdminClient code invokes each backend api in a separate event loop, the code
that detects the error (step 2) need to restart whole operation including
step 1. This needed a change to capture the "Call" object for step 1 in
step 2.

This change thus refactors the code to make it easy to perform a retry of
whole operation. It creates a Context object to capture the api arguments
that can then be referred by each "Call" objects. This is just for convenience
and makes method signature simpler as we only need to pass one object instead
of multiple api arguments.

The creation of each "Call" object is done in a new method, so we can
easily resubmit step 1 in step 2.

This change also modifies corresponding unit test to test this scenario.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
