### PR TITLE
KAFKA-8363: Fix parsing bug for config providers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
@@ -53,7 +53,7 @@ import java.util.regex.Pattern;
  * {@link ConfigProvider#unsubscribe(String, Set, ConfigChangeCallback)} methods.
  */
 public class ConfigTransformer {
-    public static final Pattern DEFAULT_PATTERN = Pattern.compile("\\$\\{(.*?):((.*?):)?(.*?)\\}");
+    public static final Pattern DEFAULT_PATTERN = Pattern.compile("\\$\\{([^}]*?):(([^}]*?):)?([^}]*?)\\}");
     private static final String EMPTY_PATH = "";
 
     private final Map<String, ConfigProvider> configProviders;

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
@@ -96,6 +96,13 @@ public class ConfigTransformerTest {
     }
 
     @Test
+    public void testReplaceMultipleVariablesWithoutPathInValue() throws Exception {
+        ConfigTransformerResult result = configTransformer.transform(Collections.singletonMap(MY_KEY, "first ${test:testKey}; second ${test:testKey}"));
+        Map<String, String> data = result.data();
+        assertEquals("first testResultNoPath; second testResultNoPath", data.get(MY_KEY));
+    }
+
+    @Test
     public void testNullConfigValue() throws Exception {
         ConfigTransformerResult result = configTransformer.transform(Collections.singletonMap(MY_KEY, null));
         Map<String, String> data = result.data();


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-8363)

The regex used to parse config provider syntax can fail to accurately parse provided configurations when multiple path-less configs are requested (e.g., `${provider:pathOne} ${provider:pathTwo}`). This change fixes that parsing and adds a unit test to prevent regression.

This bug is present since the addition of config providers and so should be backported through to 2.0, when they were first added.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
