### PR TITLE
MINOR: Update lz4-java to 1.6.0 for 12-18% decompression improvement

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -79,7 +79,7 @@ versions += [
   kafka_11: "1.1.1",
   kafka_20: "2.0.1",
   kafka_21: "2.1.0",
-  lz4: "1.5.1",
+  lz4: "1.6.0",
   mavenArtifact: "3.6.1",
   metrics: "2.2.0",
   mockito: "2.27.0",


### PR DESCRIPTION
lz4-java 1.6.0 relies on lz4 1.9.1, which includes significant
decompression performance improvements first released as part
of 1.9.0:

Version | v1.8.3 | v1.9.0 | Improvement
-- | -- | -- | --
enwik8 | 4090 MB/s | 4560 MB/s | +12%
calgary.tar | 4320 MB/s | 4860 MB/s | +13%
silesia.tar | 4210 MB/s | 4970 MB/s | +18%

See https://github.com/lz4/lz4/releases/tag/v1.9.0 for more
details.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
