### PR TITLE
KAFKA-8361. Fix ConsumerPerformanceTest#testNonDetailedHeaderMatchBody to test a real ConsumerPerformance's method

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -60,28 +60,14 @@ object ConsumerPerformance extends LazyLogging {
       metrics = consumer.metrics.asScala
     }
     consumer.close()
-    val elapsedSecs = (endMs - startMs) / 1000.0
-    val fetchTimeInMs = (endMs - startMs) - joinGroupTimeInMs.get
+
     if (!config.showDetailedStats) {
-      val totalMBRead = (totalBytesRead.get * 1.0) / (1024 * 1024)
-      println("%s, %s, %.4f, %.4f, %d, %.4f, %d, %d, %.4f, %.4f".format(
-        config.dateFormat.format(startMs),
-        config.dateFormat.format(endMs),
-        totalMBRead,
-        totalMBRead / elapsedSecs,
-        totalMessagesRead.get,
-        totalMessagesRead.get / elapsedSecs,
-        joinGroupTimeInMs.get,
-        fetchTimeInMs,
-        totalMBRead / (fetchTimeInMs / 1000.0),
-        totalMessagesRead.get / (fetchTimeInMs / 1000.0)
-      ))
+      printBody(totalBytesRead, totalMessagesRead, joinGroupTimeInMs, startMs, endMs, config.dateFormat)
     }
 
     if (metrics != null) {
       ToolsUtils.printMetrics(metrics)
     }
-
   }
 
   private[tools] def printHeader(showDetailedStats: Boolean): Unit = {
@@ -90,6 +76,29 @@ object ConsumerPerformance extends LazyLogging {
       println("start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec" + newFieldsInHeader)
     else
       println("time, threadId, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec" + newFieldsInHeader)
+  }
+
+  private[tools] def printBody(totalBytesRead: AtomicLong,
+                               totalMessagesRead: AtomicLong,
+                               joinGroupTimeInMs: AtomicLong,
+                               startMs: Long,
+                               endMs: Long,
+                               dateFormat: SimpleDateFormat): Unit = {
+    val elapsedSecs = (endMs - startMs) / 1000.0
+    val fetchTimeInMs = (endMs - startMs) - joinGroupTimeInMs.get
+    val totalMBRead = (totalBytesRead.get * 1.0) / (1024 * 1024)
+    println("%s, %s, %.4f, %.4f, %d, %.4f, %d, %d, %.4f, %.4f".format(
+      dateFormat.format(startMs),
+      dateFormat.format(endMs),
+      totalMBRead,
+      totalMBRead / elapsedSecs,
+      totalMessagesRead.get,
+      totalMessagesRead.get / elapsedSecs,
+      joinGroupTimeInMs.get,
+      fetchTimeInMs,
+      totalMBRead / (fetchTimeInMs / 1000.0),
+      totalMessagesRead.get / (fetchTimeInMs / 1000.0)
+    ))
   }
 
   def consume(consumer: KafkaConsumer[Array[Byte], Array[Byte]],
@@ -154,14 +163,14 @@ object ConsumerPerformance extends LazyLogging {
   }
 
   def printConsumerProgress(id: Int,
-                               bytesRead: Long,
-                               lastBytesRead: Long,
-                               messagesRead: Long,
-                               lastMessagesRead: Long,
-                               startMs: Long,
-                               endMs: Long,
-                               dateFormat: SimpleDateFormat,
-                               periodicJoinTimeInMs: Long): Unit = {
+                            bytesRead: Long,
+                            lastBytesRead: Long,
+                            messagesRead: Long,
+                            lastMessagesRead: Long,
+                            startMs: Long,
+                            endMs: Long,
+                            dateFormat: SimpleDateFormat,
+                            periodicJoinTimeInMs: Long): Unit = {
     printBasicProgress(id, bytesRead, lastBytesRead, messagesRead, lastMessagesRead, startMs, endMs, dateFormat)
     printExtendedProgress(bytesRead, lastBytesRead, messagesRead, lastMessagesRead, startMs, endMs, periodicJoinTimeInMs)
     println()

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -19,6 +19,7 @@ package kafka.tools
 
 import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
+import java.util.concurrent.atomic.AtomicLong
 
 import joptsimple.OptionException
 import org.junit.Assert.assertEquals
@@ -37,8 +38,8 @@ class ConsumerPerformanceTest {
 
   @Test
   def testNonDetailedHeaderMatchBody(): Unit = {
-    testHeaderMatchContent(detailed = false, 2, () => println(s"${dateFormat.format(System.currentTimeMillis)}, " +
-      s"${dateFormat.format(System.currentTimeMillis)}, 1.0, 1.0, 1, 1.0, 1, 1, 1.1, 1.1"))
+    testHeaderMatchContent(detailed = false, 2,
+      () => ConsumerPerformance.printBody(new AtomicLong(1024 * 1024), new AtomicLong(1), new AtomicLong(1), 0, 1, dateFormat))
   }
 
   @Test


### PR DESCRIPTION
kafka.tools.ConsumerPerformanceTest#testNonDetailedHeaderMatchBody
doesn't work as a regression test, since it checks the number of the
fields which are output by an inline `println`, not by a real method of
ConsumerPerformance. This PR makes ConsumerPerformance's output logic
an independent method and testNonDetailedHeaderMatchBody test it.
It also includes some formatting fixes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
