### PR TITLE
KAFKA-8338: consumer offset expiration should consider subscription.

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember
 import org.apache.kafka.common.utils.Time
+import scala.collection.JavaConverters._
 
 import scala.collection.{Seq, immutable, mutable}
 
@@ -605,8 +606,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private def isSubscribedTopicPartition(topicPartition: TopicPartition): Boolean = {
     val topic = topicPartition.topic
     members.values.foreach { member =>
-      val found = ConsumerProtocol.deserializeAssignment(ByteBuffer.wrap(member.assignment)).partitions.stream
-        .anyMatch(_.topic == topic)
+      val found = ConsumerProtocol.deserializeAssignment(ByteBuffer.wrap(member.assignment)).partitions.asScala.exists(_.topic == topic)
       if (found)
         return true
     }

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -553,7 +553,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
                           onlyCheckOffsetsFromNonSubscribedPartition: Boolean = false): Map[TopicPartition, OffsetAndMetadata] = {
       offsets.filter {
         case (topicPartition, commitRecordMetadataAndOffset) =>
-          def isNonPendingAndExpired = !pendingOffsetCommits.contains(topicPartition) && {
+          val isNonPendingAndExpired = !pendingOffsetCommits.contains(topicPartition) && {
             commitRecordMetadataAndOffset.offsetAndMetadata.expireTimestamp match {
               case None =>
                 // current version with no per partition retention
@@ -564,7 +564,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
             }
           }
 
-          isNonPendingAndExpired && (!onlyCheckOffsetsFromNonSubscribedPartition || !isSubscribedTopicPartition(topicPartition))
+          isNonPendingAndExpired && !(onlyCheckOffsetsFromNonSubscribedPartition && isSubscribedTopicPartition(topicPartition))
       }.map {
         case (topicPartition, commitRecordOffsetAndMetadata) =>
           (topicPartition, commitRecordOffsetAndMetadata.offsetAndMetadata)
@@ -581,7 +581,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
         getExpiredOffsets(commitRecordMetadataAndOffset =>
           currentStateTimestamp.getOrElse(commitRecordMetadataAndOffset.offsetAndMetadata.commitTimestamp))
       case Some(_) if is(Stable) =>
-        // even when the group is in Stable state, we still check whether there exist expired offsets from any non-subscribed partitions
+        // even when the group is in Stable state, we still check whether there exists expired offsets from any non-subscribed partitions
         getExpiredOffsets(commitRecordMetadataAndOffset =>
           currentStateTimestamp.getOrElse(commitRecordMetadataAndOffset.offsetAndMetadata.commitTimestamp), true)
       case None =>

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -323,11 +323,7 @@ class GroupMetadataTest {
     var offsetAndMetadata = OffsetAndMetadata(37, "", firstCommitTimestamp)
     val commitRecordOffset = Some(3L)
 
-    // Set group state to Stable to see whether any expired offsets could be retrieved via `removeExpiredOffsets`
-    group.transitionTo(PreparingRebalance)
-    group.transitionTo(CompletingRebalance)
-    group.transitionTo(Stable)
-
+    val group = new GroupMetadata("groupId", Stable, timer.time)
     val member = new MemberMetadata("memberId", groupId, groupInstanceId, clientId, clientHost,
       rebalanceTimeoutMs, sessionTimeoutMs,
       protocolType, List(("range", Array.empty[Byte]), ("range", Array.empty[Byte])))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8338

Currently only empty groups will be checked to seek any expired offsets. However, if a group is in Stable state but no longer subscribes any partitions, the offsets for these partitions will never be removed.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
