### PR TITLE
MINOR: Remove spammy log message during topic deletion

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -609,7 +609,8 @@ class KafkaController(val config: KafkaConfig,
               // first register ISR change listener
               reassignedPartitionContext.registerReassignIsrChangeHandler(zkClient)
               // mark topic ineligible for deletion for the partitions being reassigned
-              topicDeletionManager.markTopicIneligibleForDeletion(Set(topic))
+              topicDeletionManager.markTopicIneligibleForDeletion(Set(topic),
+                reason = "topic reassignment in progress")
               onPartitionReassignment(tp, reassignedPartitionContext)
             } catch {
               case e: ControllerMovedException =>
@@ -1385,7 +1386,8 @@ class KafkaController(val config: KafkaConfig,
           val partitionReassignmentInProgress =
             controllerContext.partitionsBeingReassigned.keySet.map(_.topic).contains(topic)
           if (partitionReassignmentInProgress)
-            topicDeletionManager.markTopicIneligibleForDeletion(Set(topic))
+            topicDeletionManager.markTopicIneligibleForDeletion(Set(topic),
+              reason = "topic reassignment in progress")
         }
         // add topic to deletion list
         topicDeletionManager.enqueueTopicsForDeletion(topicsToBeDeleted)


### PR DESCRIPTION
Deletion of a large number of topics can cause a ton of log spam. In a test case on 2.2, deletion of 50 topics with 100 partitions each caused about 158 Mb of data in the controller log. With the improvements to batch StopReplica and the patch here, we reduce that to about 1.5 Mb.

Kudos to @gwenshap for spotting these spammy messages.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
