### PR TITLE
MINOR: Enable console logs in Connect tests

### DIFF
--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-log4j.rootLogger=OFF, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] (%t) %p %m (%c:%L)%n
 
 log4j.logger.org.reflections=ERROR
-log4j.logger.org.apache.kafka=ERROR
+log4j.logger.kafka=WARN
+log4j.logger.org.apache.kafka.connect=DEBUG
+log4j.logger.org.apache.kafka.connect.runtime.distributed=DEBUG
+log4j.logger.org.apache.kafka.connect.integration=DEBUG


### PR DESCRIPTION
Enable console logs in Connect unit and integration tests. 

Ran the Connect tests and the verbosity of logs seems acceptable

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
