### PR TITLE
MINOR: Work around OpenJDK 11 javadocs issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1437,10 +1437,9 @@ project(':connect:api') {
 
   javadoc {
     include "**/org/apache/kafka/connect/**" // needed for the `javadocAll` task
-    // Work around javadoc external linking issue in some OpenJDK 11 versions
-    // See https://bugs.openjdk.java.net/browse/JDK-8212233
-    if (JavaVersion.current().isJava11())
-      options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+    // The URL structure was changed to include the locale after Java 8
+    if (JavaVersion.current().isJava11Compatible())
+      options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
     else
       options.links "https://docs.oracle.com/javase/8/docs/api/"
   }
@@ -1721,10 +1720,9 @@ task aggregatedJavadoc(type: Javadoc) {
   classpath = files(projectsWithJavadoc.collect { it.sourceSets.main.compileClasspath })
   includes = projectsWithJavadoc.collectMany { it.javadoc.getIncludes() }
   excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
-  // Work around javadoc external linking issue in some OpenJDK 11 versions
-  // See https://bugs.openjdk.java.net/browse/JDK-8212233
-  if (JavaVersion.current().isJava11())
-    options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+  // The URL structure was changed to include the locale after Java 8
+  if (JavaVersion.current().isJava11Compatible())
+    options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
   else
     options.links "https://docs.oracle.com/javase/8/docs/api/"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1437,7 +1437,12 @@ project(':connect:api') {
 
   javadoc {
     include "**/org/apache/kafka/connect/**" // needed for the `javadocAll` task
-    options.links "https://docs.oracle.com/javase/8/docs/api/"
+    // Work around javadoc external linking issue in some OpenJDK 11 versions
+    // See https://bugs.openjdk.java.net/browse/JDK-8212233
+    if (JavaVersion.current().isJava11())
+      options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+    else
+      options.links "https://docs.oracle.com/javase/8/docs/api/"
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
@@ -1716,5 +1721,10 @@ task aggregatedJavadoc(type: Javadoc) {
   classpath = files(projectsWithJavadoc.collect { it.sourceSets.main.compileClasspath })
   includes = projectsWithJavadoc.collectMany { it.javadoc.getIncludes() }
   excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
-  options.links "https://docs.oracle.com/javase/8/docs/api/"
+  // Work around javadoc external linking issue in some OpenJDK 11 versions
+  // See https://bugs.openjdk.java.net/browse/JDK-8212233
+  if (JavaVersion.current().isJava11())
+    options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+  else
+    options.links "https://docs.oracle.com/javase/8/docs/api/"
 }


### PR DESCRIPTION
Some versions of OpenJDK 11 do not properly handle external javadocs links referencing previous Java versions. See: https://bugs.openjdk.java.net/browse/JDK-8212233.

Failure symptom:
`> Task :connect:api:javadoc
javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
1 error`

This PR conditionally sets the Java api docs link for the affected Gradle tasks. I verified that the links render correctly in the generated documentation when building with `1.8.0_181` and `11.0.3`. For example, in `build/docs/javadoc/org/apache/kafka/connect/source/SourceTask.html` the hyperlink to `java.nio.channels.Selector` points to a valid page on Oracle's site in both cases.

Note that while the workaround is also applied to the `aggregatedJavadoc` task, this task was already failing for another, unrelated reason. There is some discussion in https://github.com/apache/kafka/pull/6439. I validated the workaround locally by disabling the `:streams:test-utils:javadoc` task.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
