### PR TITLE
KAFKA-8206: Allow consumer and producer to rebootstrap

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -997,6 +997,11 @@ public class NetworkClient implements KafkaClient {
             // Beware that the behavior of this method and the computation of timeouts for poll() are
             // highly dependent on the behavior of leastLoadedNode.
             Node node = leastLoadedNode(now);
+            if (node == null && !hasFetchInProgress()) {
+                metadata.rebootstrap(now);
+                node = leastLoadedNode(now);
+            }
+
             if (node == null) {
                 log.debug("Give up sending metadata request since no node is available");
                 return reconnectBackoffMs;

--- a/core/src/test/scala/integration/kafka/api/RebootstrapTest.scala
+++ b/core/src/test/scala/integration/kafka/api/RebootstrapTest.scala
@@ -1,0 +1,111 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
+
+package integration.kafka.api
+
+import java.util.concurrent.TimeUnit
+import java.util.{Collections, Properties}
+
+import kafka.api.{AbstractConsumerTest, FixedPortTestUtils}
+import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.utils.Logging
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.junit.Test
+
+/**
+  * This test checks if a consumer and a producer are able to continue working
+  * if no broker they cached during the bootstrap is available,
+  * but some brokers from the initial bootstrap list are available.
+  * <p>
+  * This situation is possible when a consumer or producer was bootstrapped
+  * when the cluster was partially available and later the nodes that were
+  * initially available went down and some other nodes from the bootstrap list
+  * came online.
+  */
+class RebootstrapTest extends AbstractConsumerTest with Logging {
+
+  override val brokerCount: Int = 2
+
+  def server0: KafkaServer = serverForId(0).get
+  def server1: KafkaServer = serverForId(1).get
+
+  override def generateConfigs: Seq[KafkaConfig] = {
+    val overridingProps = new Properties()
+    overridingProps.put(KafkaConfig.OffsetsTopicReplicationFactorProp, brokerCount.toString)
+    overridingProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
+
+    // In this test, fixed ports are necessary, because brokers must have the
+    // same port after the restart.
+    FixedPortTestUtils.createBrokerConfigs(brokerCount, zkConnect, enableControlledShutdown = false)
+      .map(KafkaConfig.fromProps(_, overridingProps))
+  }
+
+  @Test
+  def testConsumer(): Unit = {
+    sendRecords(10, 0)
+
+    server1.shutdown()
+    server1.awaitShutdown()
+
+    // Only server 0 is available for the consumer during the bootstrap.
+    val consumer = createConsumer()
+    consumer.assign(Collections.singleton(tp))
+
+    consumeAndVerifyRecords(consumer, 10, 0)
+
+    server0.shutdown()
+    server0.awaitShutdown()
+
+    server1.startup()
+
+    sendRecords(10, 10)
+
+    // Server 0, originally cached during the bootstrap, is offline.
+    // However, server 1 from the bootstrap list is online.
+    // Should be able to consume records.
+    consumeAndVerifyRecords(consumer, 10, 10, startingKeyAndValueIndex = 10, startingTimestamp = 10)
+  }
+
+  private def sendRecords(numRecords: Int, from: Int): Unit = {
+    val producer: KafkaProducer[Array[Byte], Array[Byte]] = createProducer()
+    (from until (numRecords + from)).foreach { i =>
+      val record = new ProducerRecord(tp.topic(), tp.partition(), i.toLong, s"key $i".getBytes, s"value $i".getBytes)
+      producer.send(record)
+      record
+    }
+    producer.flush()
+    producer.close()
+  }
+
+  @Test
+  def testProducer(): Unit = {
+    server1.shutdown()
+    server1.awaitShutdown()
+
+    // Only server 0 is available for the producer during the bootstrap.
+    val producer = createProducer()
+    producer.send(new ProducerRecord(topic, part, "key 0".getBytes, "value 0".getBytes))
+      .get(1, TimeUnit.MINUTES)
+
+    server0.shutdown()
+    server0.awaitShutdown()
+
+    server1.startup()
+
+    // Server 0, originally cached during the bootstrap, is offline.
+    // However, server 1 from the bootstrap list is online.
+    // Should be able to produce records.
+    producer.send(new ProducerRecord(topic, part, "key 1".getBytes, "value 1".getBytes))
+      .get(1, TimeUnit.MINUTES)
+  }
+}


### PR DESCRIPTION
This commit allows a consumer and a producer to repopulate their cluster
metadata cache in case no nodes of currently cached are available.

This is useful in the following situation.
1. A cluster was partially available (including some bootstrap nodes
were offline) when a client (a producer or consumer) was created.
2. The client used the bootstrap list to get the list of available
cluster nodes and cached this list in its metadata cache.
3. All the nodes cached by the client (i.e., the nodes that were
available during the bootstrap) went offline.
4. Nodes that were offline during the bootstrap became available.

Before this commit, the client was not able to discover nodes that had
become available and could not continue working, despite the cluster was
alive. This commit makes this possible by rerunning the bootstrapping
process by the client.

This commit also tests this scenario by reproducing the situation with
a partially available cluster for a consumer and a producer and ensuring
they can operate normally (i.e., can consume and produce messages).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
