### PR TITLE
KAFKA-7869: Refactor RocksDBConfigSetter API to separate DBOptions and CFOptions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -16,12 +16,14 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
 import org.rocksdb.Options;
-
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * An interface to that allows developers to customize the RocksDB settings for a given Store.
@@ -44,6 +46,17 @@ public interface RocksDBConfigSetter {
     void setConfig(final String storeName, final Options options, final Map<String, Object> configs);
 
     /**
+     * Set the rocks db options for the provided storeName.
+     *
+     * @param storeName             the name of the store being configured
+     * @param dbOptions             the RocksDB DBOptions
+     * @param columnFamilyOptions   the RocksDB ColumnFamilyOptions
+     * @param configs               the configuration supplied to {@link org.apache.kafka.streams.StreamsConfig}
+     */
+    default void setConfig(final String storeName, final DBOptions dbOptions, final ColumnFamilyOptions columnFamilyOptions, final Map<String, Object> configs) {
+    }
+
+    /**
      * Close any user-constructed objects that inherit from {@code org.rocksdb.RocksObject}.
      * <p>
      * Any object created with {@code new} in {@link RocksDBConfigSetter#setConfig setConfig()} and that inherits
@@ -58,5 +71,23 @@ public interface RocksDBConfigSetter {
      */
     default void close(final String storeName, final Options options) {
         LOG.warn("The default close will be removed in 3.0.0 -- you should overwrite it if you have implemented RocksDBConfigSetter");
+    }
+
+
+    /**
+     * Close any user-constructed objects that inherit from {@code org.rocksdb.RocksObject}.
+     * <p>
+     * Any object created with {@code new} in {@link RocksDBConfigSetter#setConfig setConfig()} and that inherits
+     * from {@code org.rocksdb.RocksObject} should have {@code org.rocksdb.RocksObject#close()}
+     * called on it here to avoid leaking off-heap memory. Objects to be closed can be saved by the user or retrieved
+     * back from {@code options} using its getter methods.
+     * <p>
+     * Example objects needing to be closed include {@code org.rocksdb.Filter} and {@code org.rocksdb.Cache}.
+     *
+     * @param storeName             the name of the store being configured
+     * @param dbOptions             the RocksDB options
+     * @param columnFamilyOptions   the RocksDB options
+     */
+    default void close(final String storeName, final DBOptions dbOptions, final ColumnFamilyOptions columnFamilyOptions) {
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.rocksdb.Options;
+import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.WriteBatch;
 
 import java.io.File;
@@ -138,7 +138,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
     abstract AbstractSegments<S> newSegments();
 
-    abstract Options getOptions(S segment);
+    abstract ColumnFamilyOptions getOptions(S segment);
 
     @Test
     public void shouldPutAndFetch() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.rocksdb.Options;
+import org.rocksdb.ColumnFamilyOptions;
 
 public class RocksDBSegmentedBytesStoreTest extends AbstractRocksDBSegmentedBytesStoreTest<KeyValueSegment> {
 
@@ -37,7 +37,7 @@ public class RocksDBSegmentedBytesStoreTest extends AbstractRocksDBSegmentedByte
     }
 
     @Override
-    Options getOptions(final KeyValueSegment segment) {
-        return segment.getOptions();
+    ColumnFamilyOptions getOptions(final KeyValueSegment segment) {
+        return segment.getCFOptions();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -100,15 +100,15 @@ public class RocksDBStoreTest {
 
         restoreListener.onRestoreStart(null, rocksDBStore.name(), 0L, 0L);
 
-        assertThat(rocksDBStore.getOptions().level0FileNumCompactionTrigger(), equalTo(1 << 30));
-        assertThat(rocksDBStore.getOptions().level0SlowdownWritesTrigger(), equalTo(1 << 30));
-        assertThat(rocksDBStore.getOptions().level0StopWritesTrigger(), equalTo(1 << 30));
+        assertThat(rocksDBStore.getCFOptions().level0FileNumCompactionTrigger(), equalTo(1 << 30));
+        assertThat(rocksDBStore.getCFOptions().level0SlowdownWritesTrigger(), equalTo(1 << 30));
+        assertThat(rocksDBStore.getCFOptions().level0StopWritesTrigger(), equalTo(1 << 30));
 
         restoreListener.onRestoreEnd(null, rocksDBStore.name(), 0L);
 
-        assertThat(rocksDBStore.getOptions().level0FileNumCompactionTrigger(), equalTo(10));
-        assertThat(rocksDBStore.getOptions().level0SlowdownWritesTrigger(), equalTo(20));
-        assertThat(rocksDBStore.getOptions().level0StopWritesTrigger(), equalTo(36));
+        assertThat(rocksDBStore.getCFOptions().level0FileNumCompactionTrigger(), equalTo(10));
+        assertThat(rocksDBStore.getCFOptions().level0SlowdownWritesTrigger(), equalTo(20));
+        assertThat(rocksDBStore.getCFOptions().level0StopWritesTrigger(), equalTo(36));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.rocksdb.Options;
+import org.rocksdb.ColumnFamilyOptions;
 
 public class RocksDBTimestampedSegmentedBytesStoreTest
     extends AbstractRocksDBSegmentedBytesStoreTest<TimestampedSegment> {
@@ -37,7 +37,7 @@ public class RocksDBTimestampedSegmentedBytesStoreTest
     }
 
     @Override
-    Options getOptions(final TimestampedSegment segment) {
-        return segment.getOptions();
+    ColumnFamilyOptions getOptions(final TimestampedSegment segment) {
+        return segment.getCFOptions();
     }
 }


### PR DESCRIPTION
This is a draft implementation of [KAFKA-7869](https://issues.apache.org/jira/browse/KAFKA-7869). @guozhangwang Is this what you intended?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
