### PR TITLE
Add compute() to InMemoryKeyValueStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -112,6 +112,9 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         return map.remove(key);
     }
     
+    /*
+    * Add compute() of the SkipListMap
+    */
     public byte[] compute(final Bytes key, final BiFunction<Bytes, byte[], byte[]> remappingFunction) {
         return map.compute(key, remappingFunction);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -112,9 +112,9 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         return map.remove(key);
     }
     
-    public byte[] compute(Bytes key, BiFunction<Bytes,byte[],byte[]> remappingFunction)
+    public byte[] compute(final Bytes key, final BiFunction<Bytes, byte[] , byte[]> remappingFunction)
     {
-        return map.compute(key,remappingFunction);
+        return map.compute(key, remappingFunction);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.function.BiFunction;
 
 public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private final String name;
@@ -109,6 +110,11 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     @Override
     public byte[] delete(final Bytes key) {
         return map.remove(key);
+    }
+    
+    public byte[] compute(Bytes key, BiFunction<Bytes,byte[],byte[]> remappingFunction)
+    {
+        return map.compute(key,remappingFunction);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -112,8 +112,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         return map.remove(key);
     }
     
-    public byte[] compute(final Bytes key, final BiFunction<Bytes, byte[] , byte[]> remappingFunction)
-    {
+    public byte[] compute(final Bytes key, final BiFunction<Bytes, byte[], byte[]> remappingFunction) {
         return map.compute(key, remappingFunction);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -112,9 +112,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         return map.remove(key);
     }
     
-    /*
-    * Add compute() of the SkipListMap
-    */
     public byte[] compute(final Bytes key, final BiFunction<Bytes, byte[], byte[]> remappingFunction) {
         return map.compute(key, remappingFunction);
     }


### PR DESCRIPTION
Should also be added to the KeyValueStore interface (at least as default method).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
