### PR TITLE
Kafka 7358: Adds "always" Round-Robin partition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitioner.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.producer.internals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Utils;
+
+/**
+ * The "Round-Robin" partitioner
+ * 
+ * This partitioning strategy can be used when user wants 
+ * to distribute the writes to all partitions equally. This
+ * is the default behaviour regardless of record key hash.
+ *
+ */
+public class RoundRobinPartitioner implements Partitioner {
+
+    private final ConcurrentMap<String, AtomicInteger> topicCounterMap = new ConcurrentHashMap<>();
+
+    public void configure(Map<String, ?> configs) {}
+
+    /**
+     * Compute the partition for the given record.
+     *
+     * @param topic The topic name
+     * @param key The key to partition on (or null if no key)
+     * @param keyBytes serialized key to partition on (or null if no key)
+     * @param value The value to partition on or null
+     * @param valueBytes serialized value to partition on or null
+     * @param cluster The current cluster metadata
+     */
+	public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+		List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
+		int numPartitions = partitions.size();
+		int nextValue = nextValue(topic);
+		List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
+		if (availablePartitions.size() > 0) {
+			int part = Utils.toPositive(nextValue) % availablePartitions.size();
+			return availablePartitions.get(part).partition();
+		} else {
+			// no partitions are available, give a non-available partition
+			return Utils.toPositive(nextValue) % numPartitions;
+		}
+	}
+
+    private int nextValue(String topic) {
+        AtomicInteger counter = topicCounterMap.get(topic);
+        if (null == counter) {
+            counter = new AtomicInteger(ThreadLocalRandom.current().nextInt());
+            AtomicInteger currentCounter = topicCounterMap.putIfAbsent(topic, counter);
+            if (currentCounter != null) {
+                counter = currentCounter;
+            }
+        }
+        return counter.getAndIncrement();
+    }
+
+    public void close() {}
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitioner.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.utils.Utils;
  * 
  * This partitioning strategy can be used when user wants 
  * to distribute the writes to all partitions equally. This
- * is the default behaviour regardless of record key hash.
+ * is the behaviour regardless of record key hash. 
  *
  */
 public class RoundRobinPartitioner implements Partitioner {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RoundRobinPartitionerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.producer.internals;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RoundRobinPartitionerTest {
+	private byte[] keyBytes = "key".getBytes();
+	private Partitioner partitioner = new RoundRobinPartitioner();
+	private Node node0 = new Node(0, "localhost", 99);
+	private Node node1 = new Node(1, "localhost", 100);
+	private Node node2 = new Node(2, "localhost", 101);
+	private Node[] nodes = new Node[] { node0, node1, node2 };
+	private String topic = "test";
+	// Intentionally make the partition list not in partition order to test the edge
+	// cases.
+	private List<PartitionInfo> partitions = asList(new PartitionInfo(topic, 1, null, nodes, nodes),
+			new PartitionInfo(topic, 2, node1, nodes, nodes), new PartitionInfo(topic, 0, node0, nodes, nodes));
+	private Cluster cluster = new Cluster("clusterId", asList(node0, node1, node2), partitions,
+			Collections.<String>emptySet(), Collections.<String>emptySet());
+
+	@Test
+	public void testRoundRobinWithUnavailablePartitions() {
+		// When there are some unavailable partitions, we want to make sure that (1) we
+		// always pick an available partition,
+		// and (2) the available partitions are selected in a round robin way.
+		int countForPart0 = 0;
+		int countForPart2 = 0;
+		for (int i = 1; i <= 100; i++) {
+			int part = partitioner.partition(topic, null, null, null, null, cluster);
+			assertTrue("We should never choose a leader-less node in round robin", part == 0 || part == 2);
+			if (part == 0)
+				countForPart0++;
+			else
+				countForPart2++;
+		}
+		assertEquals("The distribution between two available partitions should be even", countForPart0, countForPart2);
+	}
+
+	@Test
+	public void testRoundRobinWithKeyBytes() throws InterruptedException {
+		final String topicA = "topicA";
+		final String topicB = "topicB";
+
+		List<PartitionInfo> allPartitions = asList(new PartitionInfo(topicA, 0, node0, nodes, nodes),
+				new PartitionInfo(topicA, 1, node1, nodes, nodes), new PartitionInfo(topicA, 2, node2, nodes, nodes),
+				new PartitionInfo(topicB, 0, node0, nodes, nodes));
+		Cluster testCluster = new Cluster("clusterId", asList(node0, node1, node2), allPartitions,
+				Collections.<String>emptySet(), Collections.<String>emptySet());
+
+		final Map<Integer, Integer> partitionCount = new HashMap<>();
+
+		for (int i = 0; i < 30; ++i) {
+			int partition = partitioner.partition(topicA, null, keyBytes, null, null, testCluster);
+			Integer count = partitionCount.get(partition);
+			if (null == count)
+				count = 0;
+			partitionCount.put(partition, count + 1);
+
+			if (i % 5 == 0) {
+				partitioner.partition(topicB, null, keyBytes, null, null, testCluster);
+			}
+		}
+
+		assertEquals(10, (int) partitionCount.get(0));
+		assertEquals(10, (int) partitionCount.get(1));
+		assertEquals(10, (int) partitionCount.get(2));
+	}
+	
+	@Test
+	public void testRoundRobinWithNullKeyBytes() throws InterruptedException {
+		final String topicA = "topicA";
+		final String topicB = "topicB";
+
+		List<PartitionInfo> allPartitions = asList(new PartitionInfo(topicA, 0, node0, nodes, nodes),
+				new PartitionInfo(topicA, 1, node1, nodes, nodes), new PartitionInfo(topicA, 2, node2, nodes, nodes),
+				new PartitionInfo(topicB, 0, node0, nodes, nodes));
+		Cluster testCluster = new Cluster("clusterId", asList(node0, node1, node2), allPartitions,
+				Collections.<String>emptySet(), Collections.<String>emptySet());
+
+		final Map<Integer, Integer> partitionCount = new HashMap<>();
+
+		for (int i = 0; i < 30; ++i) {
+			int partition = partitioner.partition(topicA, null, null, null, null, testCluster);
+			Integer count = partitionCount.get(partition);
+			if (null == count)
+				count = 0;
+			partitionCount.put(partition, count + 1);
+
+			if (i % 5 == 0) {
+				partitioner.partition(topicB, null, null, null, null, testCluster);
+			}
+		}
+
+		assertEquals(10, (int) partitionCount.get(0));
+		assertEquals(10, (int) partitionCount.get(1));
+		assertEquals(10, (int) partitionCount.get(2));
+	}	
+}

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -28,7 +28,7 @@ import kafka.utils._
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.record.FileRecords.LogOffsetPosition
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{Time, OperatingSystem}
 
 import scala.collection.JavaConverters._
 import scala.math._
@@ -410,6 +410,12 @@ class LogSegment private[log] (val log: FileRecords,
    * IOException from this method should be handled by the caller
    */
   def changeFileSuffixes(oldSuffix: String, newSuffix: String) {
+        if (OperatingSystem.IS_WINDOWS) {
+      log.close()
+       offsetIndex.forceUnmap() 
+       timeIndex.forceUnmap()
+       txnIndex.close()
+    }
     log.renameTo(new File(CoreUtils.replaceSuffix(log.file.getPath, oldSuffix, newSuffix)))
     offsetIndex.renameTo(new File(CoreUtils.replaceSuffix(offsetIndex.file.getPath, oldSuffix, newSuffix)))
     timeIndex.renameTo(new File(CoreUtils.replaceSuffix(timeIndex.file.getPath, oldSuffix, newSuffix)))

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -28,6 +28,7 @@ import kafka.utils._
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.record.FileRecords.LogOffsetPosition
 import org.apache.kafka.common.record._
+import org.apache.kafka.common.utils.Time
 
 import scala.collection.JavaConverters._
 import scala.math._

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -28,7 +28,6 @@ import kafka.utils._
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.record.FileRecords.LogOffsetPosition
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.{Time, OperatingSystem}
 
 import scala.collection.JavaConverters._
 import scala.math._
@@ -410,12 +409,6 @@ class LogSegment private[log] (val log: FileRecords,
    * IOException from this method should be handled by the caller
    */
   def changeFileSuffixes(oldSuffix: String, newSuffix: String) {
-        if (OperatingSystem.IS_WINDOWS) {
-      log.close()
-       offsetIndex.forceUnmap() 
-       timeIndex.forceUnmap()
-       txnIndex.close()
-    }
     log.renameTo(new File(CoreUtils.replaceSuffix(log.file.getPath, oldSuffix, newSuffix)))
     offsetIndex.renameTo(new File(CoreUtils.replaceSuffix(offsetIndex.file.getPath, oldSuffix, newSuffix)))
     timeIndex.renameTo(new File(CoreUtils.replaceSuffix(timeIndex.file.getPath, oldSuffix, newSuffix)))


### PR DESCRIPTION
Adds "Round-Robin" partitioner which always uses round-robin regardless of record key bytes. This is **NOT** the default behaviour and does not require a doc change. No change in `partitioner.class` value. User has to change it based on their scenarios.

The only unit tests necessary for this is the partitioning without/without key bytes. No other change should be necessary.
