### PR TITLE
KAFKA-8395: Add the ability to back up segment files on truncation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -47,6 +47,10 @@ public class TopicConfig {
         "maps offsets to file positions. We preallocate this index file and shrink it only after log " +
         "rolls. You generally should not need to change this setting.";
 
+    public static final String SEGMENT_BACKUP_ON_TRUNCATE_TO_ZERO_CONFIG = "segment.backup.on.truncate.to.zero";
+    public static final String SEGMENT_BACKUP_ON_TRUNCATE_TO_ZERO_DOC = "This configuration controls whether or not a segment file should be backed up " +
+        "instead of truncated when a truncate to 0 offset is requested.";
+
     public static final String FLUSH_MESSAGES_INTERVAL_CONFIG = "flush.messages";
     public static final String FLUSH_MESSAGES_INTERVAL_DOC = "This setting allows specifying an interval at " +
         "which we will force an fsync of data written to the log. For example if this was set to 1 " +

--- a/clients/src/main/java/org/apache/kafka/common/record/FileChannelOptions.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileChannelOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+class FileChannelOptions {
+    private final boolean mutable;
+    private final boolean fileAlreadyExists;
+    private final int initFileSize;
+    private final boolean preallocate;
+
+    FileChannelOptions(boolean mutable,
+                       boolean fileAlreadyExists,
+                       int initFileSize,
+                       boolean preallocate) {
+        this.mutable = mutable;
+        this.fileAlreadyExists = fileAlreadyExists;
+        this.initFileSize = initFileSize;
+        this.preallocate = preallocate;
+    }
+
+    boolean isMutable() {
+        return mutable;
+    }
+
+    boolean isFileAlreadyExists() {
+        return fileAlreadyExists;
+    }
+
+    int getInitFileSize() {
+        return initFileSize;
+    }
+
+    boolean isPreallocate() {
+        return preallocate;
+    }
+
+    FileChannelOptions withFileAlreadyExists(boolean fileAlreadyExists) {
+        return new FileChannelOptions(mutable,
+            fileAlreadyExists,
+            initFileSize,
+            preallocate
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordsBackupNameStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordsBackupNameStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.record;
+
+import java.io.File;
+
+public interface RecordsBackupNameStrategy {
+    File getBackupFile(File recordsFile);
+}

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -468,6 +468,7 @@ class Log(@volatile var dir: File,
           baseOffset = baseOffset,
           config,
           time = time,
+          backupOnTruncateToZero = config.backupOnTruncateToZero,
           fileAlreadyExists = true)
 
         try segment.sanityCheck(timeIndexFileNewlyCreated)
@@ -522,6 +523,7 @@ class Log(@volatile var dir: File,
         baseOffset = baseOffset,
         config,
         time = time,
+        backupOnTruncateToZero = config.backupOnTruncateToZero,
         fileSuffix = SwapFileSuffix)
       info(s"Found log file ${swapFile.getPath} from interrupted swap operation, repairing.")
       recoverSegment(swapSegment)
@@ -634,6 +636,7 @@ class Log(@volatile var dir: File,
         baseOffset = logStartOffset,
         config,
         time = time,
+        backupOnTruncateToZero = config.backupOnTruncateToZero,
         fileAlreadyExists = false,
         initFileSize = this.initFileSize,
         preallocate = config.preallocate))
@@ -1701,6 +1704,7 @@ class Log(@volatile var dir: File,
           config,
           time = time,
           fileAlreadyExists = false,
+          backupOnTruncateToZero = config.backupOnTruncateToZero,
           initFileSize = initFileSize,
           preallocate = config.preallocate)
         addSegment(segment)
@@ -1878,6 +1882,7 @@ class Log(@volatile var dir: File,
           config = config,
           time = time,
           fileAlreadyExists = false,
+          backupOnTruncateToZero = config.backupOnTruncateToZero,
           initFileSize = initFileSize,
           preallocate = config.preallocate))
         updateLogEndOffset(newOffset)

--- a/core/src/main/scala/kafka/log/LogBackupNameStrategy.scala
+++ b/core/src/main/scala/kafka/log/LogBackupNameStrategy.scala
@@ -1,0 +1,36 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package kafka.log
+
+import java.io.File
+
+import org.apache.kafka.common.record.RecordsBackupNameStrategy
+import org.apache.kafka.common.utils.Time
+
+import scala.util.Random
+
+class LogBackupNameStrategy private[log] (val time: Time) extends RecordsBackupNameStrategy {
+  override def getBackupFile(recordsFile: File): File = {
+    val logFileName = recordsFile.getAbsolutePath
+    val baseName = logFileName.split("\\.log")(0)
+    new File(
+      s"${logFileName.split(".log")(0)}." +
+        s"${(Random.alphanumeric take 5).mkString("")}." +
+        s"${time.milliseconds}.log.backup"
+    )
+  }
+}

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -432,7 +432,8 @@ object LogCleaner {
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
     LogSegment.deleteIfExists(log.dir, baseOffset, fileSuffix = Log.CleanedFileSuffix)
     LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      fileSuffix = Log.CleanedFileSuffix, initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+      backupOnTruncateToZero = log.config.backupOnTruncateToZero, fileSuffix = Log.CleanedFileSuffix,
+      initFileSize = log.initFileSize, preallocate = log.config.preallocate)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -40,6 +40,7 @@ object Defaults {
   val FlushMs = kafka.server.Defaults.LogFlushSchedulerIntervalMs
   val RetentionSize = kafka.server.Defaults.LogRetentionBytes
   val RetentionMs = kafka.server.Defaults.LogRetentionHours * 60 * 60 * 1000L
+  val BackupOnTruncateToZero = kafka.server.Defaults.LogBackupOnTruncateToZero
   val MaxMessageSize = kafka.server.Defaults.MessageMaxBytes
   val MaxIndexSize = kafka.server.Defaults.LogIndexSizeMaxBytes
   val IndexInterval = kafka.server.Defaults.LogIndexIntervalBytes
@@ -97,8 +98,10 @@ case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] 
   val messageFormatVersion = ApiVersion(getString(LogConfig.MessageFormatVersionProp))
   val messageTimestampType = TimestampType.forName(getString(LogConfig.MessageTimestampTypeProp))
   val messageTimestampDifferenceMaxMs = getLong(LogConfig.MessageTimestampDifferenceMaxMsProp).longValue
+  val backupOnTruncateToZero = getBoolean(LogConfig.BackupOnTruncateToZeroProp)
   val LeaderReplicationThrottledReplicas = getList(LogConfig.LeaderReplicationThrottledReplicasProp)
   val FollowerReplicationThrottledReplicas = getList(LogConfig.FollowerReplicationThrottledReplicasProp)
+
   val messageDownConversionEnable = getBoolean(LogConfig.MessageDownConversionEnableProp)
 
   def randomSegmentJitter: Long =
@@ -120,6 +123,7 @@ object LogConfig {
   val SegmentMsProp = TopicConfig.SEGMENT_MS_CONFIG
   val SegmentJitterMsProp = TopicConfig.SEGMENT_JITTER_MS_CONFIG
   val SegmentIndexBytesProp = TopicConfig.SEGMENT_INDEX_BYTES_CONFIG
+  val BackupOnTruncateToZeroProp = TopicConfig.SEGMENT_BACKUP_ON_TRUNCATE_TO_ZERO_CONFIG
   val FlushMessagesProp = TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG
   val FlushMsProp = TopicConfig.FLUSH_MS_CONFIG
   val RetentionBytesProp = TopicConfig.RETENTION_BYTES_CONFIG
@@ -143,6 +147,7 @@ object LogConfig {
   val MessageTimestampDifferenceMaxMsProp = TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG
   val MessageDownConversionEnableProp = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_CONFIG
 
+
   // Leave these out of TopicConfig for now as they are replication quota configs
   val LeaderReplicationThrottledReplicasProp = "leader.replication.throttled.replicas"
   val FollowerReplicationThrottledReplicasProp = "follower.replication.throttled.replicas"
@@ -151,6 +156,7 @@ object LogConfig {
   val SegmentMsDoc = TopicConfig.SEGMENT_MS_DOC
   val SegmentJitterMsDoc = TopicConfig.SEGMENT_JITTER_MS_DOC
   val MaxIndexSizeDoc = TopicConfig.SEGMENT_INDEX_BYTES_DOC
+  val BackupOnTruncateToZeroDoc = TopicConfig.SEGMENT_BACKUP_ON_TRUNCATE_TO_ZERO_DOC
   val FlushIntervalDoc = TopicConfig.FLUSH_MESSAGES_INTERVAL_DOC
   val FlushMsDoc = TopicConfig.FLUSH_MS_DOC
   val RetentionSizeDoc = TopicConfig.RETENTION_BYTES_DOC
@@ -233,6 +239,8 @@ object LogConfig {
         KafkaConfig.LogRollTimeJitterMillisProp)
       .define(SegmentIndexBytesProp, INT, Defaults.MaxIndexSize, atLeast(0), MEDIUM, MaxIndexSizeDoc,
         KafkaConfig.LogIndexSizeMaxBytesProp)
+      .define(BackupOnTruncateToZeroProp, BOOLEAN, Defaults.BackupOnTruncateToZero, MEDIUM, BackupOnTruncateToZeroDoc,
+        KafkaConfig.BackupOnTruncateToZeroProp)
       .define(FlushMessagesProp, LONG, Defaults.FlushInterval, atLeast(0), MEDIUM, FlushIntervalDoc,
         KafkaConfig.LogFlushIntervalMessagesProp)
       .define(FlushMsProp, LONG, Defaults.FlushMs, atLeast(0), MEDIUM, FlushMsDoc,

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -102,6 +102,7 @@ object Defaults {
   val LogCleanerMinCleanRatio = 0.5d
   val LogCleanerEnable = true
   val LogCleanerDeleteRetentionMs = 24 * 60 * 60 * 1000L
+  val LogBackupOnTruncateToZero = false
   val LogCleanerMinCompactionLagMs = 0L
   val LogCleanerMaxCompactionLagMs = Long.MaxValue
   val LogIndexSizeMaxBytes = 10 * 1024 * 1024
@@ -341,6 +342,7 @@ object KafkaConfig {
   val LogMessageTimestampTypeProp = LogConfigPrefix + "message.timestamp.type"
   val LogMessageTimestampDifferenceMaxMsProp = LogConfigPrefix + "message.timestamp.difference.max.ms"
   val LogMaxIdMapSnapshotsProp = LogConfigPrefix + "max.id.map.snapshots"
+  val BackupOnTruncateToZeroProp = "segment.backup.on.truncate.to.zero"
   val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
   val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -492,7 +492,7 @@ class LogCleanerManagerTest extends Logging {
       new LogCleanerManager(Array(logDir), pool, null)
   }
 
-  private def createLog(segmentSize: Int, cleanupPolicy: String, segmentsCount: Int = 0): Log = {
+  private def createLog(segmentSize: Int, cleanupPolicy: String, segmentsCount: Int = 0, backupOnTruncateToZero: Boolean = false): Log = {
     val logProps = new Properties()
     logProps.put(LogConfig.SegmentBytesProp, segmentSize: Integer)
     logProps.put(LogConfig.RetentionMsProp, 1: Integer)
@@ -514,7 +514,7 @@ class LogCleanerManagerTest extends Logging {
     for (i <- 0 until segmentsCount) {
       val startOffset = i * 10
       val endOffset = startOffset + 10
-      val segment = LogUtils.createSegment(startOffset, logDir)
+      val segment = LogUtils.createSegment(startOffset, logDir, backupOnTruncateToZero = backupOnTruncateToZero)
       var lastTimestamp = 0L
       val records = (startOffset until endOffset).map { offset =>
         val currentTimestamp = time.milliseconds()

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -367,7 +367,7 @@ class LogTest {
 
         override def addSegment(segment: LogSegment): LogSegment = {
           val wrapper = new LogSegment(segment.log, segment.lazyOffsetIndex, segment.lazyTimeIndex, segment.txnIndex, segment.baseOffset,
-            segment.indexIntervalBytes, segment.rollJitterMs, mockTime) {
+            segment.indexIntervalBytes, segment.rollJitterMs, mockTime, segment.backupOnTruncateToZero) {
 
             override def read(startOffset: Long, maxOffset: Option[Long], maxSize: Int, maxPosition: Long,
                               minOneMessage: Boolean): FetchDataInfo = {

--- a/core/src/test/scala/unit/kafka/log/LogUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogUtils.scala
@@ -19,7 +19,7 @@ package kafka.log
 
 import java.io.File
 
-import org.apache.kafka.common.record.FileRecords
+import org.apache.kafka.common.record.{FileRecords, RecordsBackupNameStrategy}
 import org.apache.kafka.common.utils.Time
 
 object LogUtils {
@@ -29,12 +29,15 @@ object LogUtils {
   def createSegment(offset: Long,
                     logDir: File,
                     indexIntervalBytes: Int = 10,
-                    time: Time = Time.SYSTEM): LogSegment = {
+                    time: Time = Time.SYSTEM,
+                    backupOnTruncateToZero: Boolean = false,
+                    recordsBackupNameStrategy: Option[RecordsBackupNameStrategy] = None): LogSegment = {
     val ms = FileRecords.open(Log.logFile(logDir, offset))
     val idx = new LazyOffsetIndex(Log.offsetIndexFile(logDir, offset), offset, maxIndexSize = 1000)
     val timeIdx = new LazyTimeIndex(Log.timeIndexFile(logDir, offset), offset, maxIndexSize = 1500)
     val txnIndex = new TransactionIndex(offset, Log.transactionIndexFile(logDir, offset))
 
-    new LogSegment(ms, idx, timeIdx, txnIndex, offset, indexIntervalBytes, 0, time)
+    new LogSegment(ms, idx, timeIdx, txnIndex, offset, indexIntervalBytes, 0,
+      time, backupOnTruncateToZero, recordsBackupNameStrategy)
   }
 }

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -866,6 +866,11 @@
         <td></td>
       </tr>
       <tr>
+        <td>Rate of backup files created</td>
+        <td>kafka.log:type=LogBackupStats,name=SegmentFileBackupPerMin</td>
+        <td>0</td>
+      </tr>
+      <tr>
         <td># of under replicated partitions (|ISR| &lt |all replicas|)</td>
         <td>kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions</td>
         <td>0</td>


### PR DESCRIPTION
This adds the ability to rename/back up segment files on truncation
to zero. This is useful in the rare case that offset conflict resolution
results in an offset reset, which can result in data loss.

To enable, turn set `segment.backup.on.truncate.to.zero` to true
in the configuration.

We have unit tests included here and are starting
to stress test a working cluster to see if we can
reproduce the issue in a live environment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
