### PR TITLE
MINOR: Refined code for electPreferredLeaders

### DIFF
--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -177,13 +177,12 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
               zkClient.getAllPartitions().map(_.topic)
           }
 
-        val partitionsFromZk = zkClient.getPartitionsForTopics(topics).flatMap{ case (topic, partitions) =>
-          partitions.map(new TopicPartition(topic, _))
-        }.toSet
-
         val (validPartitions, invalidPartitions) =
           partitionsFromUser match {
             case Some(partitions) =>
+              val partitionsFromZk = zkClient.getPartitionsForTopics(topics).flatMap{ case (topic, partitions) =>
+                partitions.map(new TopicPartition(topic, _))
+              }.toSet
               partitions.partition(partitionsFromZk.contains)
             case None =>
               (zkClient.getAllPartitions(), Set.empty)


### PR DESCRIPTION
In ZkCommand.electPreferredLeaders, `partitionFromZk` is always evaluated no matter if it will used or not later. Should move this calculation near where it's used.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
