### PR TITLE
KAFKA-8425: Fix for correctly handling immutable maps (KIP-421 bug)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -459,6 +459,9 @@ public class AbstractConfig {
     private  Map<String, ?> resolveConfigVariables(Map<String, ?> configProviderProps, Map<String, Object> originals) {
         Map<String, String> providerConfigString;
         Map<String, ?> configProperties;
+        Map<String, Object> originalsMutable = new HashMap<>();
+
+        originalsMutable.putAll(originals);
 
         // As variable configs are strings, parse the originals and obtain the potential variable configs.
         Map<String, String> indirectVariables = extractPotentialVariables(originals);
@@ -475,10 +478,10 @@ public class AbstractConfig {
         if (!providers.isEmpty()) {
             ConfigTransformer configTransformer = new ConfigTransformer(providers);
             ConfigTransformerResult result = configTransformer.transform(indirectVariables);
-            originals.putAll(result.data());
+            originalsMutable.putAll(result.data());
         }
 
-        return originals;
+        return originalsMutable;
     }
 
     private Map<String, Object> configProviderProperties(String configProviderPrefix, Map<String, ?> providerConfigProperties) {

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -589,27 +589,28 @@ public class AbstractConfig {
     }
 
     /**
-     * ResolvingMap keeps a track of the original map instance and the resolved configs. It marks keys retrieved via `get`.
-     * `originals map` passed to the AbstractConfig can be an instance of RecordingMap. ResolvingMap ensures all the access to the keys are
-     * recorded by calling a get on the originals Map.
-     *
+     * ResolvingMap keeps a track of the original map instance and the resolved configs.
+     * The originals are tracked in a separate nested map and may be a `RecordingMap`; thus
+     * any access to a value for a key needs to be recorded on the originals map.
+     * The resolved configs are kept in the inherited map and are therefore mutable, though any
+     * mutations are not applied to the originals.
      */
-    private class ResolvingMap<V> extends HashMap<String, V> {
+    private static class ResolvingMap<V> extends HashMap<String, V> {
 
         private final Map<String, ?> originals;
 
-        ResolvingMap(Map<String, ? extends V> m, Map<String, ?> originals) {
-            super(m);
+        ResolvingMap(Map<String, ? extends V> resolved, Map<String, ?> originals) {
+            super(resolved);
             this.originals = Collections.unmodifiableMap(originals);
         }
 
         @Override
         public V get(Object key) {
             if (key instanceof String && originals.containsKey(key)) {
-                // Mark the key in the originals as retrieved.
+                // Intentionally ignore the result; call just to mark the original entry as used
                 originals.get(key);
             }
-
+            // But always use the resolved entry
             return super.get(key);
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -364,6 +364,19 @@ public class AbstractConfigTest {
     }
 
     @Test
+    public void testImmutableOriginalsWithConfigProvidersProps() {
+      // Test Case: Valid Test Case for ConfigProviders as a separate variable
+      Properties providers = new Properties();
+      providers.put("config.providers", "file");
+      providers.put("config.providers.file.class", "org.apache.kafka.common.config.provider.MockFileConfigProvider");
+      Properties props = new Properties();
+      props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
+      final Map<String, ?> immutableMap = convertPropertiesToMap(providers);
+      TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, immutableMap);
+      assertEquals(config.originals().get("sasl.kerberos.key"), "testKey");
+    }
+
+    @Test
     public void testAutoConfigResolutionWithMultipleConfigProviders() {
         // Test Case: Valid Test Case With Multiple ConfigProviders as a separate variable
         Properties providers = new Properties();

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -365,15 +365,16 @@ public class AbstractConfigTest {
 
     @Test
     public void testImmutableOriginalsWithConfigProvidersProps() {
-      // Test Case: Valid Test Case for ConfigProviders as a separate variable
-      Properties providers = new Properties();
-      providers.put("config.providers", "file");
-      providers.put("config.providers.file.class", "org.apache.kafka.common.config.provider.MockFileConfigProvider");
-      Properties props = new Properties();
-      props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
-      final Map<String, ?> immutableMap = convertPropertiesToMap(providers);
-      TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, immutableMap);
-      assertEquals(config.originals().get("sasl.kerberos.key"), "testKey");
+        // Test Case: Valid Test Case for ConfigProviders as a separate variable
+        Properties providers = new Properties();
+        providers.put("config.providers", "file");
+        providers.put("config.providers.file.class", "org.apache.kafka.common.config.provider.MockFileConfigProvider");
+        Properties props = new Properties();
+        props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
+        Map<?, ?> immutableMap = Collections.unmodifiableMap(props);
+        Map<String, ?> provMap = convertPropertiesToMap(providers);
+        TestIndirectConfigResolution config = new TestIndirectConfigResolution(immutableMap, provMap);
+        assertEquals(config.originals().get("sasl.kerberos.key"), "testKey");
     }
 
     @Test

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -332,4 +332,11 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <!-- END Suppress warnings for unused members that are undetectably used by Jackson -->
 
+    <Match>
+        <!-- Suppress a warning about ignoring return value because this is intentional. -->
+        <Class name="org.apache.kafka.common.config.AbstractConfig$ResolvingMap"/>
+        <Method name="get"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
The originals map passed to the AbstractConfig class can be immutable. The resolveConfigVariable function was modifying the originals map. If this map is immutable it will result in an exception.

This fix resolves this issue

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
