### PR TITLE
KAFKA-8417: Remove redundant network definition --net=host when starting testing docker containers

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -240,7 +240,7 @@ docker_run() {
     # and mount FUSE filesystems inside the container.  We also need it to
     # run iptables inside the container.
     must_do -v docker run --privileged \
-        -d -t --net=host -h "${node}" --network ducknet \
+        -d -t -h "${node}" --network ducknet \
         --memory=${docker_run_memory_limit} --memory-swappiness=1 \
         -v "${kafka_dir}:/opt/kafka-dev" --name "${node}" -- "${image_name}"
 }


### PR DESCRIPTION
* Remove non-user-defined network --net=host which is redundant when starting system test docker containers

* Tested by running a round of system tests locally and on jenkins

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
