### PR TITLE
MINOR: improve error message for Serde type miss match

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -172,7 +172,7 @@ public final class StateSerdes<K, V> {
         } catch (final ClassCastException e) {
             final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             throw new StreamsException(
-                    String.format("A serializer (key: %s) is not compatible to the actual key type " +
+                    String.format("A serializer (%s) is not compatible to the actual key type " +
                                     "(key type: %s). Change the default Serdes in StreamConfig or " +
                                     "provide correct Serdes via method parameters.",
                             keySerializer().getClass().getName(),
@@ -201,7 +201,7 @@ public final class StateSerdes<K, V> {
                 valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             }
             throw new StreamsException(
-                    String.format("A serializer (value: %s) is not compatible to the actual value type " +
+                    String.format("A serializer (%s) is not compatible to the actual value type " +
                                     "(value type: %s). Change the default Serdes in StreamConfig or " +
                                     "provide correct Serdes via method parameters.",
                             serializerClass.getName(),

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer;
 
 import java.util.Objects;
 
@@ -190,12 +191,20 @@ public final class StateSerdes<K, V> {
         try {
             return valueSerde.serializer().serialize(topic, value);
         } catch (final ClassCastException e) {
-            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            final String valueClass;
+            final Class<? extends Serializer> serializerClass;
+            if (valueSerializer() instanceof ValueAndTimestampSerializer) {
+                serializerClass = ((ValueAndTimestampSerializer) valueSerializer()).valueSerializer.getClass();
+                valueClass = value == null ? "unknown because value is null" : ((ValueAndTimestamp) value).value().getClass().getName();
+            } else {
+                serializerClass = valueSerializer().getClass();
+                valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            }
             throw new StreamsException(
                     String.format("A serializer (value: %s) is not compatible to the actual value type " +
                                     "(value type: %s). Change the default Serdes in StreamConfig or " +
                                     "provide correct Serdes via method parameters.",
-                            valueSerializer().getClass().getName(),
+                            serializerClass.getName(),
                             valueClass),
                     e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
@@ -28,7 +28,7 @@ public class ValueAndTimestampSerde<V> implements Serde<ValueAndTimestamp<V>> {
     private final ValueAndTimestampSerializer<V> valueAndTimestampSerializer;
     private final ValueAndTimestampDeserializer<V> valueAndTimestampDeserializer;
 
-    ValueAndTimestampSerde(final Serde<V> valueSerde) {
+    public ValueAndTimestampSerde(final Serde<V> valueSerde) {
         Objects.requireNonNull(valueSerde);
         valueAndTimestampSerializer = new ValueAndTimestampSerializer<>(valueSerde.serializer());
         valueAndTimestampDeserializer = new ValueAndTimestampDeserializer<>(valueSerde.deserializer());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
-class ValueAndTimestampSerializer<V> implements Serializer<ValueAndTimestamp<V>> {
+public class ValueAndTimestampSerializer<V> implements Serializer<ValueAndTimestamp<V>> {
     public final Serializer<V> valueSerializer;
     private final Serializer<Long> timestampSerializer;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -19,10 +19,15 @@ package org.apache.kafka.streams.state;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.state.internals.ValueAndTimestampSerde;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("unchecked")
 public class StateSerdesTest {
@@ -88,20 +93,47 @@ public class StateSerdesTest {
         new StateSerdes<>("anyName", Serdes.ByteArray(), null);
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowIfIncompatibleSerdeForValue() throws ClassNotFoundException {
         final Class myClass = Class.forName("java.lang.String");
         final StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
         final Integer myInt = 123;
-        stateSerdes.rawValue(myInt);
+        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(myInt));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "A serializer (value: org.apache.kafka.common.serialization.StringSerializer) " +
+                "is not compatible to the actual value type (value type: java.lang.Integer). " +
+                "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
+    public void shouldSkipValueAndTimestampeInformationForErrorOnTimestampAndValueSerialization() throws ClassNotFoundException {
+        final Class myClass = Class.forName("java.lang.String");
+        final StateSerdes<Object, Object> stateSerdes =
+            new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), new ValueAndTimestampSerde(Serdes.serdeFrom(myClass)));
+        final Integer myInt = 123;
+        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(ValueAndTimestamp.make(myInt, 0L)));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "A serializer (value: org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual value type (value type: java.lang.Integer). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+    }
+
+    @Test
     public void shouldThrowIfIncompatibleSerdeForKey() throws ClassNotFoundException {
         final Class myClass = Class.forName("java.lang.String");
         final StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
         final Integer myInt = 123;
-        stateSerdes.rawKey(myInt);
+        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawKey(myInt));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "A serializer (key: org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual key type (key type: java.lang.Integer). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -102,7 +102,7 @@ public class StateSerdesTest {
         assertThat(
             e.getMessage(),
             equalTo(
-                "A serializer (value: org.apache.kafka.common.serialization.StringSerializer) " +
+                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                 "is not compatible to the actual value type (value type: java.lang.Integer). " +
                 "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }
@@ -117,7 +117,7 @@ public class StateSerdesTest {
         assertThat(
             e.getMessage(),
             equalTo(
-                "A serializer (value: org.apache.kafka.common.serialization.StringSerializer) " +
+                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                     "is not compatible to the actual value type (value type: java.lang.Integer). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }
@@ -131,7 +131,7 @@ public class StateSerdesTest {
         assertThat(
             e.getMessage(),
             equalTo(
-                "A serializer (key: org.apache.kafka.common.serialization.StringSerializer) " +
+                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                     "is not compatible to the actual key type (key type: java.lang.Integer). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }


### PR DESCRIPTION
Atm, if the type does not match, the error is miss leading and not helpful:
```
A serializer (value: org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer) is not compatible to the actual value type (value type: org.apache.kafka.streams.state.ValueAndTimestamp). Change the default Serdes in StreamConfig or provide correct Serdes via method parameters.
```

This PR makes sure that the actual value type information is in the message to make the `ValueAndTimestamp` wrapping transparent to the user and to make the error message useful.

This should be cherry-picked to `2.3` branch.