### PR TITLE
KAFKA-8475: Temporarily restore SslFactory.sslContext() helper

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -169,7 +169,7 @@ public class SslFactory implements Reconfigurable {
         return sslEngineBuilder.createSslEngine(mode, peerHost, peerPort, endpointIdentification);
     }
 
-    // Keep this for backward compatibility
+    // Retain this while non-AK users migrate away from reusing this non-public API class
     public SSLContext sslContext() {
         return sslEngineBuilder.sslContext();
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
@@ -166,6 +167,11 @@ public class SslFactory implements Reconfigurable {
             throw new IllegalStateException("SslFactory has not been configured.");
         }
         return sslEngineBuilder.createSslEngine(mode, peerHost, peerPort, endpointIdentification);
+    }
+
+    // Keep this for backward compatibility
+    public SSLContext sslContext() {
+        return sslEngineBuilder.sslContext();
     }
 
     public SslEngineBuilder sslEngineBuilder() {

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -169,7 +169,7 @@ public class SslFactory implements Reconfigurable {
         return sslEngineBuilder.createSslEngine(mode, peerHost, peerPort, endpointIdentification);
     }
 
-    // Retain this while non-AK users migrate away from reusing this non-public API class
+    @Deprecated
     public SSLContext sslContext() {
         return sslEngineBuilder.sslContext();
     }


### PR DESCRIPTION
The `sslContext()` method was recently removed in #6674 as part of a refactoring. Even though this is not a public API, removing the method would break any non-AK components that use this class to easily set up SSL clients. Since the cost of keeping this is low, this PR restores the method temporarily to give developers time to move away from reusing this utility class that is not part of the AK public API.

This should be backported to the `2.3` branch, which is where #6674 was originally applied.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
