### PR TITLE
MINOR: Reset numIterations to 1 on txn timeouts

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -812,7 +812,8 @@ public class StreamThread extends Thread {
                         "This implies that this thread missed a rebalance and dropped out of the consumer group. " +
                         "Will try to rejoin the consumer group. Below is the detailed description of the task:\n{}",
                     ignoreAndRejoinGroup.migratedTask().id(), ignoreAndRejoinGroup.migratedTask().toString(">"));
-
+                log.info("Resetting numIterations from {} to 1", numIterations);
+                numIterations = 1;
                 enforceRebalance();
             }
         }


### PR DESCRIPTION
With EOS enabled, in the `runOnce` loop the `numIterations` can get incremented to a size that causes the transaction to timeout if the record processing is slow.  When the producer is fenced due to its epoch being no longer valid, we should reset `numIterations` back to 1, otherwise, we see a repeated behavior of transaction time outs as `numIterations` stays at the value where the timeout occurred in the first place


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
