### PR TITLE
MINOR: move connectorConfig to AbstractHerder

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -234,6 +234,17 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected abstract Map<String, String> config(String connName);
 
     @Override
+    public void connectorConfig(String connName, Callback<Map<String, String>> callback) {
+        // Subset of connectorInfo, so piggy back on that implementation
+        connectorInfo(connName, (error, result) -> {
+            if (error != null)
+                callback.onCompletion(error, null);
+            else
+                callback.onCompletion(null, result.config());
+        });
+    }
+
+    @Override
     public Collection<String> connectors() {
         return configBackingStore.snapshot().connectors();
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -751,14 +751,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     @Override
     public void connectorConfig(String connName, final Callback<Map<String, String>> callback) {
-        // Subset of connectorInfo, so piggy back on that implementation
         log.trace("Submitting connector config read request {}", connName);
-        connectorInfo(connName, (error, result) -> {
-            if (error != null)
-                callback.onCompletion(error, null);
-            else
-                callback.onCompletion(null, result.config());
-        });
+        super.connectorConfig(connName, callback);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -154,18 +154,6 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
-    public void connectorConfig(String connName, final Callback<Map<String, String>> callback) {
-        // Subset of connectorInfo, so piggy back on that implementation
-        connectorInfo(connName, (error, result) -> {
-            if (error != null) {
-                callback.onCompletion(error, null);
-                return;
-            }
-            callback.onCompletion(null, result.config());
-        });
-    }
-
-    @Override
     public synchronized void deleteConnectorConfig(String connName, Callback<Created<ConnectorInfo>> callback) {
         try {
             if (!configState.contains(connName)) {


### PR DESCRIPTION
`StandaloneHerder` and `DistributedHerder` have identical implementations of
`connectorConfig` (apart from one line of logging). This commit moves the
common implementation of `connectorConfig` to `AbstractHerder`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
