### PR TITLE
Add ConnectedStoreProvider to Processor API

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountTransformerDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountTransformerDemo.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.examples.wordcount;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.*;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.processor.*;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Demonstrates, using a {@link Transformer} which combines the low-level Processor APIs with the high-level KStream DSL,
+ * how to implement the WordCount program that computes a simple word occurrence histogram from an input text.
+ * <p>
+ * <strong>Note: This is simplified code that only works correctly for single partition input topics.
+ * Check out {@link WordCountDemo} for a generic example.</strong>
+ * <p>
+ * In this example, the input stream reads from a topic named "streams-plaintext-input", where the values of messages
+ * represent lines of text; and the histogram output is written to topic "streams-wordcount-processor-output" where each record
+ * is an updated count of a single word.
+ * <p>
+ * This example differs from {@link WordCountProcessorDemo} in that it uses a {@link Transformer} and {@link ConnectedStoreProvider}
+ * to define the application topology through a {@link StreamsBuilder}, which more closely resembles the high-level DSL.
+ * <p>
+ * Before running this example you must create the input topic and the output topic (e.g. via
+ * {@code bin/kafka-topics.sh --create ...}), and write some data to the input topic (e.g. via
+ * {@code bin/kafka-console-producer.sh}). Otherwise you won't see any data arriving in the output topic.
+ */
+public final class WordCountTransformerDemo {
+
+    static class MyTransformerSupplier implements TransformerSupplier<String, String, KeyValue<String, String>>, ConnectedStoreProvider {
+
+        @Override
+        public Transformer<String, String, KeyValue<String, String>> get() {
+            return new Transformer<String, String, KeyValue<String, String>>() {
+                private ProcessorContext context;
+                private KeyValueStore<String, Integer> kvStore;
+
+                @Override
+                @SuppressWarnings("unchecked")
+                public void init(final ProcessorContext context) {
+                    this.context = context;
+                    this.context.schedule(Duration.ofSeconds(1), PunctuationType.STREAM_TIME, timestamp -> {
+                        try (final KeyValueIterator<String, Integer> iter = kvStore.all()) {
+                            System.out.println("----------- " + timestamp + " ----------- ");
+
+                            while (iter.hasNext()) {
+                                final KeyValue<String, Integer> entry = iter.next();
+
+                                System.out.println("[" + entry.key + ", " + entry.value + "]");
+
+                                context.forward(entry.key, entry.value.toString());
+                            }
+                        }
+                    });
+                    this.kvStore = (KeyValueStore<String, Integer>) context.getStateStore("Counts");
+                }
+
+                @Override
+                public KeyValue<String, String> transform(final String dummy, final String line) {
+                    final String[] words = line.toLowerCase(Locale.getDefault()).split(" ");
+
+                    for (final String word : words) {
+                        final Integer oldValue = this.kvStore.get(word);
+
+                        if (oldValue == null) {
+                            this.kvStore.put(word, 1);
+                        } else {
+                            this.kvStore.put(word, oldValue + 1);
+                        }
+                    }
+
+                    context.commit();
+                    return null;
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(Stores.keyValueStoreBuilder(
+                    Stores.inMemoryKeyValueStore("Counts"),
+                    Serdes.String(),
+                    Serdes.Integer()));
+        }
+    }
+
+    public static void main(final String[] args) {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-wordcount-transformer");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+
+        // setting offset reset to earliest so that we can re-run the demo code with the same pre-loaded data
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.<String, String>stream("streams-plaintext-input")
+            .transform(new MyTransformerSupplier())
+            .to("streams-wordcount-processor-output");
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        // attach shutdown handler to catch control-c
+        Runtime.getRuntime().addShutdownHook(new Thread("streams-wordcount-shutdown-hook") {
+            @Override
+            public void run() {
+                streams.close();
+                latch.countDown();
+            }
+        });
+
+        try {
+            streams.start();
+            latch.await();
+        } catch (final Throwable e) {
+            System.exit(1);
+        }
+        System.exit(0);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ConnectedStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ConnectedStoreProvider.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor;
+
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+import java.util.Set;
+
+/**
+ * Provides a set of {@link StoreBuilder}s that will be automatically added to the topology and connected to the
+ * associated processor.
+ * The implementor of this interface must also implement one of {@link ProcessorSupplier},
+ * {@link TransformerSupplier}, {@link ValueTransformerSupplier}, or {@link ValueTransformerWithKeySupplier},
+ * <p>
+ * Different {@link ConnectedStoreProvider}s may provide the same instance of {@link StoreBuilder}, so that multiple
+ * processors may access the same store, as shown below.
+ * <pre>{@code
+ * class StateSharingProcessors {
+ *     StoreBuilder<KeyValueStore<String, String>> stringStoreBuilder =
+ *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("stringStore"), Serdes.String(), Serdes.String());
+ *     StoreBuilder<KeyValueStore<String, Integer>> integerStoreBuilder =
+ *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("integerStore"), Serdes.String(), Serdes.Integer());
+ *
+ *     class SupplierA implements ProcessorSupplier<String, Integer>, ConnectedStoreProvider {
+ *         Processor<String, Integer> get() {
+ *             return new Processor() {
+ *                 private StateStore stringStore;
+ *                 private StateStore integerStore;
+ *
+ *                 void init(ProcessorContext context) {
+ *                     this.stringStore = context.getStateStore("stringStore");
+ *                     this.integerStore = context.getStateStore("integerStore");
+ *                 }
+ *
+ *                 void process(String key, Integer value) {
+ *                     // can access this.stringStore and this.integerStore
+ *                 }
+ *
+ *                 void close() {
+ *                     // can access this.stringStore and this.integerStore
+ *                 }
+ *             }
+ *         }
+ *
+ *         Set<StoreBuilder> stores() {
+ *             Set<StoreBuilder> stores = new HashSet<>();
+ *             stores.add(stringStoreBuilder);
+ *             stores.add(integerStoreBuilder);
+ *             return stores;
+ *         }
+ *     }
+ *
+ *     class SupplierB implements ProcessorSupplier<String, String>, ConnectedStoreProvider {
+ *         Processor<String, String> get() {
+ *             return new Processor() {
+ *                 private StateStore stringStore;
+ *                 private StateStore integerStore;
+ *
+ *                 void init(ProcessorContext context) {
+ *                     this.stringStore = context.getStateStore("stringStore");
+ *                     this.integerStore = context.getStateStore("integerStore");
+ *                 }
+ *
+ *                 void process(String key, String value) {
+ *                     // can access this.stringStore and this.integerStore
+ *                 }
+ *
+ *                 void close() {
+ *                     // can access this.stringStore and this.integerStore
+ *                 }
+ *             }
+ *         }
+ *
+ *         Set<StoreBuilder> stores() {
+ *             Set<StoreBuilder> stores = new HashSet<>();
+ *             stores.add(stringStoreBuilder);
+ *             stores.add(integerStoreBuilder);
+ *             return stores;
+ *         }
+ *     }
+ * }
+ * }</pre>
+ * @see Topology#addProcessor(String, ProcessorSupplier, String...)
+ * @see KStream#process(ProcessorSupplier, String...)
+ * @see KStream#transform(TransformerSupplier, String...)
+ * @see KStream#transformValues(ValueTransformerSupplier, String...)
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see KStream#flatTransform(TransformerSupplier, String...)
+ * @see KStream#flatTransformValues(ValueTransformerSupplier, String...)
+ * @see KStream#flatTransformValues(ValueTransformerWithKeySupplier, String...)
+ */
+public interface ConnectedStoreProvider {
+
+    /**
+     * @return the state stores
+     */
+    Set<StoreBuilder> stores();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -516,8 +516,9 @@ public class InternalTopologyBuilder {
                                     final boolean allowOverride,
                                     final String... processorNames) {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
-        if (!allowOverride && stateFactories.containsKey(storeBuilder.name())) {
-            throw new TopologyException("StateStore " + storeBuilder.name() + " is already added.");
+        final StateStoreFactory stateFactory = stateFactories.get(storeBuilder.name());
+        if (!allowOverride && stateFactory != null && stateFactory.builder != storeBuilder) {
+            throw new TopologyException("A different StateStore has already been added with the name " + storeBuilder.name());
         }
 
         stateFactories.put(storeBuilder.name(), new StateStoreFactory(storeBuilder));

--- a/streams/src/main/java/org/apache/kafka/streams/state/StoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StoreBuilder.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import java.util.Map;
 
 /**
- * Build a {@link StateStore} wrapped with optional caching and logging.
+ * Build a {@link StateStore} wra`pped with optional caching and logging.
  * @param <T>  the type of store to build
  */
 public interface StoreBuilder<T extends StateStore> {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamTransformIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamTransformIntegrationTest.java
@@ -18,14 +18,10 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Transformer;
-import org.apache.kafka.streams.kstream.ValueTransformer;
-import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ConnectedStoreProvider;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -41,7 +37,9 @@ import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,18 +53,19 @@ public class KStreamTransformIntegrationTest {
     private final String topic = "stream";
     private final String stateStoreName = "myTransformState";
     private final List<KeyValue<Integer, Integer>> results = new ArrayList<>();
-    private final ForeachAction<Integer, Integer> action = (key, value) -> results.add(KeyValue.pair(key, value));
+    private final ForeachAction<Integer, Integer> accumulateExpected = (key, value) -> results.add(KeyValue.pair(key, value));
     private KStream<Integer, Integer> stream;
 
     @Before
     public void before() {
         builder = new StreamsBuilder();
-        final StoreBuilder<KeyValueStore<Integer, Integer>> keyValueStoreBuilder =
-                Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(stateStoreName),
-                                            Serdes.Integer(),
-                                            Serdes.Integer());
-        builder.addStateStore(keyValueStoreBuilder);
         stream = builder.stream(topic, Consumed.with(Serdes.Integer(), Serdes.Integer()));
+    }
+
+    private StoreBuilder<KeyValueStore<Integer, Integer>> storeBuilder() {
+        return Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(stateStoreName),
+                Serdes.Integer(),
+                Serdes.Integer());
     }
 
     private void verifyResult(final List<KeyValue<Integer, Integer>> expected) {
@@ -84,32 +83,37 @@ public class KStreamTransformIntegrationTest {
         assertThat(results, equalTo(expected));
     }
 
+    private class TestTransformer implements Transformer<Integer, Integer, KeyValue<Integer, Integer>> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public KeyValue<Integer, Integer> transform(final Integer key, final Integer value) {
+            state.putIfAbsent(key, 0);
+            Integer storedValue = state.get(key);
+            final KeyValue<Integer, Integer> result = new KeyValue<>(key + 1, value + storedValue++);
+            state.put(key, storedValue);
+            return result;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+
     @Test
     public void shouldTransform() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .transform(() -> new Transformer<Integer, Integer, KeyValue<Integer, Integer>>() {
-                private KeyValueStore<Integer, Integer> state;
-
-                @SuppressWarnings("unchecked")
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
-                }
-
-                @Override
-                public KeyValue<Integer, Integer> transform(final Integer key, final Integer value) {
-                    state.putIfAbsent(key, 0);
-                    Integer storedValue = state.get(key);
-                    final KeyValue<Integer, Integer> result = new KeyValue<>(key + 1, value + storedValue++);
-                    state.put(key, storedValue);
-                    return result;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+            .transform(TestTransformer::new, stateStoreName)
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(2, 1),
@@ -121,35 +125,67 @@ public class KStreamTransformIntegrationTest {
         verifyResult(expected);
     }
 
+    private class TestTransformerSupplier implements TransformerSupplier<Integer, Integer, KeyValue<Integer, Integer>>, ConnectedStoreProvider {
+        @Override
+        public Transformer<Integer, Integer, KeyValue<Integer, Integer>> get() {
+            return new TestTransformer();
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+    @Test
+    public void shouldTransformWithConnectedStoreProvider() {
+        stream
+            .transform(new TestTransformerSupplier())
+            .foreach(accumulateExpected);
+
+        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
+            KeyValue.pair(2, 1),
+            KeyValue.pair(3, 2),
+            KeyValue.pair(4, 3),
+            KeyValue.pair(3, 2),
+            KeyValue.pair(3, 5),
+            KeyValue.pair(2, 4));
+        verifyResult(expected);
+    }
+
+    private class TestFlatTransformer implements Transformer<Integer, Integer, Iterable<KeyValue<Integer, Integer>>> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public Iterable<KeyValue<Integer, Integer>> transform(final Integer key, final Integer value) {
+            final List<KeyValue<Integer, Integer>> result = new ArrayList<>();
+            state.putIfAbsent(key, 0);
+            Integer storedValue = state.get(key);
+            for (int i = 0; i < 3; i++) {
+                result.add(new KeyValue<>(key + i, value + storedValue++));
+            }
+            state.put(key, storedValue);
+            return result;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     @Test
     public void shouldFlatTransform() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .flatTransform(() -> new Transformer<Integer, Integer, Iterable<KeyValue<Integer, Integer>>>() {
-                private KeyValueStore<Integer, Integer> state;
-
-                @SuppressWarnings("unchecked")
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
-                }
-
-                @Override
-                public Iterable<KeyValue<Integer, Integer>> transform(final Integer key, final Integer value) {
-                    final List<KeyValue<Integer, Integer>> result = new ArrayList<>();
-                    state.putIfAbsent(key, 0);
-                    Integer storedValue = state.get(key);
-                    for (int i = 0; i < 3; i++) {
-                        result.add(new KeyValue<>(key + i, value + storedValue++));
-                    }
-                    state.put(key, storedValue);
-                    return result;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+            .flatTransform(TestFlatTransformer::new, stateStoreName)
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(1, 1),
@@ -173,31 +209,76 @@ public class KStreamTransformIntegrationTest {
         verifyResult(expected);
     }
 
+    private class TestFlatTransformerSupplier implements TransformerSupplier<Integer, Integer, Iterable<KeyValue<Integer, Integer>>>, ConnectedStoreProvider {
+        @Override
+        public Transformer<Integer, Integer, Iterable<KeyValue<Integer, Integer>>> get() {
+            return new TestFlatTransformer();
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+
+    @Test
+    public void shouldFlatTransformWithConnectedStoreProvider() {
+        stream
+            .flatTransform(new TestFlatTransformerSupplier())
+            .foreach(accumulateExpected);
+
+        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
+            KeyValue.pair(1, 1),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(3, 3),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(3, 3),
+            KeyValue.pair(4, 4),
+            KeyValue.pair(3, 3),
+            KeyValue.pair(4, 4),
+            KeyValue.pair(5, 5),
+            KeyValue.pair(2, 4),
+            KeyValue.pair(3, 5),
+            KeyValue.pair(4, 6),
+            KeyValue.pair(2, 9),
+            KeyValue.pair(3, 10),
+            KeyValue.pair(4, 11),
+            KeyValue.pair(1, 6),
+            KeyValue.pair(2, 7),
+            KeyValue.pair(3, 8));
+        verifyResult(expected);
+    }
+
+    private class TestValueTransformerWithKey implements ValueTransformerWithKey<Integer, Integer, Integer> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public Integer transform(final Integer key, final Integer value) {
+            state.putIfAbsent(key, 0);
+            Integer storedValue = state.get(key);
+            final Integer result = value + storedValue++;
+            state.put(key, storedValue);
+            return result;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     @Test
     public void shouldTransformValuesWithValueTransformerWithKey() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .transformValues(() -> new ValueTransformerWithKey<Integer, Integer, Integer>() {
-                private KeyValueStore<Integer, Integer> state;
-
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore("myTransformState");
-                }
-
-                @Override
-                public Integer transform(final Integer key, final Integer value) {
-                    state.putIfAbsent(key, 0);
-                    Integer storedValue = state.get(key);
-                    final Integer result = value + storedValue++;
-                    state.put(key, storedValue);
-                    return result;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+            .transformValues(TestValueTransformerWithKey::new, stateStoreName)
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(1, 1),
@@ -209,30 +290,54 @@ public class KStreamTransformIntegrationTest {
         verifyResult(expected);
     }
 
+    private class TestValueTransformerWithKeySupplier implements ValueTransformerWithKeySupplier<Integer, Integer, Integer>, ConnectedStoreProvider {
+        @Override
+        public ValueTransformerWithKey<Integer, Integer, Integer> get() {
+            return new TestValueTransformerWithKey();
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+
+    @Test
+    public void shouldTransformValuesWithValueTransformerWithKeyWithConnectedStoreProvider() {
+        stream
+            .transformValues(new TestValueTransformerWithKeySupplier())
+            .foreach(accumulateExpected);
+    }
+
+    private class TestValueTransformer implements ValueTransformer<Integer, Integer> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public Integer transform(final Integer value) {
+            state.putIfAbsent(value, 0);
+            Integer counter = state.get(value);
+            state.put(value, ++counter);
+            return counter;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     @Test
     public void shouldTransformValuesWithValueTransformerWithoutKey() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .transformValues(() -> new ValueTransformer<Integer, Integer>() {
-                private KeyValueStore<Integer, Integer> state;
-
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore("myTransformState");
-                }
-
-                @Override
-                public Integer transform(final Integer value) {
-                    state.putIfAbsent(value, 0);
-                    Integer counter = state.get(value);
-                    state.put(value, ++counter);
-                    return counter;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+            .transformValues(TestValueTransformer::new, stateStoreName)
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(1, 1),
@@ -244,34 +349,67 @@ public class KStreamTransformIntegrationTest {
         verifyResult(expected);
     }
 
+    private class TestValueTransformerSupplier implements ValueTransformerSupplier<Integer, Integer>, ConnectedStoreProvider {
+        @Override
+        public ValueTransformer<Integer, Integer> get() {
+            return new TestValueTransformer();
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+
+    @Test
+    public void shouldTransformValuesWithValueTransformerWithoutKeyWithConnectedStoreProvider() {
+        stream
+            .transformValues(new TestValueTransformerSupplier())
+            .foreach(accumulateExpected);
+
+        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
+            KeyValue.pair(1, 1),
+            KeyValue.pair(2, 1),
+            KeyValue.pair(3, 1),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(1, 3));
+        verifyResult(expected);
+    }
+
+    private class TestValueTransformerWithoutKey implements ValueTransformerWithKey<Integer, Integer, Iterable<Integer>> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public Iterable<Integer> transform(final Integer key, final Integer value) {
+            final List<Integer> result = new ArrayList<>();
+            state.putIfAbsent(key, 0);
+            Integer storedValue = state.get(key);
+            for (int i = 0; i < 3; i++) {
+                result.add(value + storedValue++);
+            }
+            state.put(key, storedValue);
+            return result;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     @Test
     public void shouldFlatTransformValuesWithKey() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .flatTransformValues(() -> new ValueTransformerWithKey<Integer, Integer, Iterable<Integer>>() {
-                private KeyValueStore<Integer, Integer> state;
-
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore("myTransformState");
-                }
-
-                @Override
-                public Iterable<Integer> transform(final Integer key, final Integer value) {
-                    final List<Integer> result = new ArrayList<>();
-                    state.putIfAbsent(key, 0);
-                    Integer storedValue = state.get(key);
-                    for (int i = 0; i < 3; i++) {
-                        result.add(value + storedValue++);
-                    }
-                    state.put(key, storedValue);
-                    return result;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+            .flatTransformValues(TestValueTransformerWithoutKey::new, stateStoreName)
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(1, 1),
@@ -295,34 +433,120 @@ public class KStreamTransformIntegrationTest {
         verifyResult(expected);
     }
 
+    private class TestValueTransformerWithoutKeySupplier implements ValueTransformerWithKeySupplier<Integer, Integer, Iterable<Integer>>, ConnectedStoreProvider {
+        @Override
+        public ValueTransformerWithKey<Integer, Integer, Iterable<Integer>> get() {
+            return new TestValueTransformerWithoutKey();
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+    @Test
+    public void shouldFlatTransformValuesWithKeyWithConnectedStoreProvider() {
+        stream
+            .flatTransformValues(new TestValueTransformerWithoutKeySupplier())
+            .foreach(accumulateExpected);
+
+        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
+            KeyValue.pair(1, 1),
+            KeyValue.pair(1, 2),
+            KeyValue.pair(1, 3),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(2, 3),
+            KeyValue.pair(2, 4),
+            KeyValue.pair(3, 3),
+            KeyValue.pair(3, 4),
+            KeyValue.pair(3, 5),
+            KeyValue.pair(2, 4),
+            KeyValue.pair(2, 5),
+            KeyValue.pair(2, 6),
+            KeyValue.pair(2, 9),
+            KeyValue.pair(2, 10),
+            KeyValue.pair(2, 11),
+            KeyValue.pair(1, 6),
+            KeyValue.pair(1, 7),
+            KeyValue.pair(1, 8));
+        verifyResult(expected);
+    }
+
+    private class TestFlatValueTransformer implements ValueTransformer<Integer, Iterable<Integer>> {
+        private KeyValueStore<Integer, Integer> state;
+
+        @Override
+        public void init(final ProcessorContext context) {
+            state = (KeyValueStore<Integer, Integer>) context.getStateStore(stateStoreName);
+        }
+
+        @Override
+        public Iterable<Integer> transform(final Integer value) {
+            final List<Integer> result = new ArrayList<>();
+            state.putIfAbsent(value, 0);
+            Integer counter = state.get(value);
+            for (int i = 0; i < 3; i++) {
+                result.add(++counter);
+            }
+            state.put(value, counter);
+            return result;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+
     @Test
     public void shouldFlatTransformValuesWithValueTransformerWithoutKey() {
+        builder.addStateStore(storeBuilder());
+
         stream
-            .flatTransformValues(() -> new ValueTransformer<Integer, Iterable<Integer>>() {
-                private KeyValueStore<Integer, Integer> state;
+            .flatTransformValues(TestFlatValueTransformer::new, stateStoreName)
+            .foreach(accumulateExpected);
 
-                @Override
-                public void init(final ProcessorContext context) {
-                    state = (KeyValueStore<Integer, Integer>) context.getStateStore("myTransformState");
-                }
+        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
+            KeyValue.pair(1, 1),
+            KeyValue.pair(1, 2),
+            KeyValue.pair(1, 3),
+            KeyValue.pair(2, 1),
+            KeyValue.pair(2, 2),
+            KeyValue.pair(2, 3),
+            KeyValue.pair(3, 1),
+            KeyValue.pair(3, 2),
+            KeyValue.pair(3, 3),
+            KeyValue.pair(2, 4),
+            KeyValue.pair(2, 5),
+            KeyValue.pair(2, 6),
+            KeyValue.pair(2, 4),
+            KeyValue.pair(2, 5),
+            KeyValue.pair(2, 6),
+            KeyValue.pair(1, 7),
+            KeyValue.pair(1, 8),
+            KeyValue.pair(1, 9));
+        verifyResult(expected);
+    }
 
-                @Override
-                public Iterable<Integer> transform(final Integer value) {
-                    final List<Integer> result = new ArrayList<>();
-                    state.putIfAbsent(value, 0);
-                    Integer counter = state.get(value);
-                    for (int i = 0; i < 3; i++) {
-                        result.add(++counter);
-                    }
-                    state.put(value, counter);
-                    return result;
-                }
+    private class TestFlatValueTransformerSupplier implements ValueTransformerSupplier<Integer, Iterable<Integer>>, ConnectedStoreProvider {
+        @Override
+        public ValueTransformer<Integer, Iterable<Integer>> get() {
+            return new TestFlatValueTransformer();
+        }
 
-                @Override
-                public void close() {
-                }
-            }, "myTransformState")
-            .foreach(action);
+        @Override
+        public Set<StoreBuilder> stores() {
+            return Collections.singleton(storeBuilder());
+        }
+    }
+
+
+    @Test
+    public void shouldFlatTransformValuesWithValueTransformerWithoutKeyWithConnectedStoreProvider() {
+        stream
+            .flatTransformValues(new TestFlatValueTransformerSupplier())
+            .foreach(accumulateExpected);
 
         final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
             KeyValue.pair(1, 1),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.ConnectedStoreProvider;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
@@ -50,7 +51,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -207,6 +210,22 @@ public class ProcessorTopologyTest {
         assertNoOutputRecord(OUTPUT_TOPIC_1);
 
         final KeyValueStore<String, String> store = driver.getKeyValueStore(storeName);
+        assertEquals("value4", store.get("key1"));
+        assertEquals("value2", store.get("key2"));
+        assertEquals("value3", store.get("key3"));
+        assertNull(store.get("key4"));
+    }
+
+    @Test
+    public void testDrivingConnectedStateStoreTopology() {
+        driver = new TopologyTestDriver(createConnectedStateStoreTopology("connectedStore"), props);
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC_1, "key1", "value1"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC_1, "key2", "value2"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC_1, "key3", "value3"));
+        driver.pipeInput(recordFactory.create(INPUT_TOPIC_1, "key1", "value4"));
+        assertNoOutputRecord(OUTPUT_TOPIC_1);
+
+        final KeyValueStore<String, String> store = driver.getKeyValueStore("connectedStore");
         assertEquals("value4", store.get("key1"));
         assertEquals("value2", store.get("key2"));
         assertEquals("value3", store.get("key3"));
@@ -549,6 +568,14 @@ public class ProcessorTopologyTest {
             .addSink("counts", OUTPUT_TOPIC_1, "processor");
     }
 
+    private Topology createConnectedStateStoreTopology(final String storeName) {
+        StoreBuilder<KeyValueStore<String, String>> storeBuilder = Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore(storeName), Serdes.String(), Serdes.String());
+        return topology
+            .addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
+            .addProcessor("processor", defineWithStores(new StatefulProcessor(storeName), Collections.singleton(storeBuilder)), "source")
+            .addSink("counts", OUTPUT_TOPIC_1, "processor");
+    }
+
     private Topology createInternalRepartitioningTopology() {
         topology.addSource("source", INPUT_TOPIC_1)
             .addSink("sink0", THROUGH_TOPIC_1, "source")
@@ -721,6 +748,31 @@ public class ProcessorTopologyTest {
 
     private <K, V> ProcessorSupplier<K, V> define(final Processor<K, V> processor) {
         return () -> processor;
+    }
+
+    private class ProcessorSupplierAndConnectedStoreProvider<K, V> implements ProcessorSupplier<K, V>, ConnectedStoreProvider {
+        private final Processor<K, V> processor;
+        private final Set<StoreBuilder> stores;
+
+        ProcessorSupplierAndConnectedStoreProvider(Processor<K, V> processor, Set<StoreBuilder> stores) {
+            this.processor = processor;
+            this.stores = stores;
+        }
+
+        @Override
+        public Set<StoreBuilder> stores() {
+            return stores;
+        }
+
+        @Override
+        public Processor<K, V> get() {
+            return processor;
+        }
+    }
+
+    private <K, V> ProcessorSupplierAndConnectedStoreProvider<K, V> defineWithStores(final Processor<K, V> processor,
+                                                                                     final Set<StoreBuilder> stores) {
+        return new ProcessorSupplierAndConnectedStoreProvider<>(processor, stores);
     }
 
     /**


### PR DESCRIPTION
 - ConnectedStoreProvider allows a Processor/TransformerSupplier to
 specify a store it uses, which will be automatically added and
 connected to the topology

I _do not_ recommend merging, this was a proof-of-concept implementation for KIP-401, and I don't think it should be the final version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
