### PR TITLE
KAFKA-8433 : Use serializers and deserializers with IntegrationTestUtils

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -404,6 +404,8 @@ public class IntegrationTestUtils {
      * @param records             Data records to write to Kafka
      * @param producerConfig      Kafka producer configuration
      * @param timestamp           Timestamp of the record
+     * @param keySerializer       Producer key serializer
+     * @param valueSerializer     Producer value serializer
      * @param <K>                 Key type of the data records
      * @param <V>                 Value type of the data records
      */

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -338,7 +338,17 @@ public class IntegrationTestUtils {
                                                    final String topic,
                                                    final Optional<Integer> partition,
                                                    final List<KeyValueTimestamp<K, V>> toProduce) {
-        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig)) {
+        produceSynchronously(producerConfig, eos, topic, partition, toProduce, null, null);
+    }
+
+    public static <V, K> void produceSynchronously(final Properties producerConfig,
+                                                   final boolean eos,
+                                                   final String topic,
+                                                   final Optional<Integer> partition,
+                                                   final List<KeyValueTimestamp<K, V>> toProduce,
+                                                   final Serializer<K> keySerializer,
+                                                   final Serializer<V> valueSerializer) {
+        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig, keySerializer, valueSerializer)) {
             if (eos) {
                 producer.initTransactions();
                 producer.beginTransaction();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.requests.UpdateMetadataRequest;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
@@ -247,7 +248,7 @@ public class IntegrationTestUtils {
                                                                          final Long timestamp,
                                                                          final boolean enableTransactions)
         throws ExecutionException, InterruptedException {
-        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions);
+        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions, null, null);
     }
 
     /**
@@ -267,7 +268,31 @@ public class IntegrationTestUtils {
                                                                          final Long timestamp,
                                                                          final boolean enableTransactions)
         throws ExecutionException, InterruptedException {
-        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig)) {
+        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, headers, timestamp, enableTransactions, null, null);
+    }
+
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param timestamp           Timestamp of the record
+     * @param enableTransactions  Send messages in a transaction
+     * @param keySerializer       Producer key serializer
+     * @param valueSerializer     Producer value serializer
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                         final Collection<KeyValue<K, V>> records,
+                                                                         final Properties producerConfig,
+                                                                         final Headers headers,
+                                                                         final Long timestamp,
+                                                                         final boolean enableTransactions,
+                                                                         final Serializer<K> keySerializer,
+                                                                         final Serializer<V> valueSerializer)
+            throws ExecutionException, InterruptedException {
+        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig, keySerializer, valueSerializer)) {
             if (enableTransactions) {
                 producer.initTransactions();
                 producer.beginTransaction();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -272,7 +272,7 @@ public class IntegrationTestUtils {
                                                                          final Long timestamp,
                                                                          final boolean enableTransactions)
         throws ExecutionException, InterruptedException {
-        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions, null, null);
+        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions);
     }
 
     /**
@@ -393,7 +393,28 @@ public class IntegrationTestUtils {
                                                                                 final Properties producerConfig,
                                                                                 final Long timestamp)
         throws ExecutionException, InterruptedException {
-        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig)) {
+        produceAbortedKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, timestamp, null, null);
+    }
+
+    /**
+     * Produce data records and send them synchronously in an aborted transaction; that is, a transaction is started for
+     * each data record but not committed.
+     *
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param timestamp           Timestamp of the record
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
+    public static <K, V> void produceAbortedKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                                final Collection<KeyValue<K, V>> records,
+                                                                                final Properties producerConfig,
+                                                                                final Long timestamp,
+                                                                                final Serializer<K> keySerializer,
+                                                                                final Serializer<V> valueSerializer)
+            throws ExecutionException, InterruptedException {
+        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig, keySerializer, valueSerializer)) {
             producer.initTransactions();
             for (final KeyValue<K, V> record : records) {
                 producer.beginTransaction();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -205,6 +205,28 @@ public class IntegrationTestUtils {
                                                             final Headers headers,
                                                             final Time time,
                                                             final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+        produceKeyValuesSynchronously(topic, records, producerConfig, null, time, enableTransactions, null, null);
+    }
+
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param time                Timestamp provider
+     * @param enableTransactions  Send messages in a transaction
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronously(final String topic,
+                                                            final Collection<KeyValue<K, V>> records,
+                                                            final Properties producerConfig,
+                                                            final Headers headers,
+                                                            final Time time,
+                                                            final boolean enableTransactions,
+                                                            final Serializer<K> keySerializer,
+                                                            final Serializer<V> valueSerializer)
         throws ExecutionException, InterruptedException {
         for (final KeyValue<K, V> record : records) {
             produceKeyValuesSynchronouslyWithTimestamp(topic,
@@ -212,7 +234,9 @@ public class IntegrationTestUtils {
                 producerConfig,
                 headers,
                 time.milliseconds(),
-                enableTransactions);
+                enableTransactions,
+                keySerializer,
+                valueSerializer);
             time.sleep(1L);
         }
     }


### PR DESCRIPTION
Add serializers and deserializers to methods

Only IntegrationTestUtils is modified.
No regression detected in stream tests.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
