### PR TITLE
KAFKA-8430: unit test to make sure null `group.id` and valid `group.instance.id` are valid combo

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -211,6 +211,18 @@ public class KafkaConsumerTest {
     }
 
     @Test
+    public void testInitSuccessWithDefaultNullGroupIdAndValidGroupInstanceId() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(ConsumerConfig.SEND_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
+        config.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "instance_id");
+        KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(
+                config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        consumer.close();
+    }
+
+    @Test
     public void testSubscription() {
         KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId);
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -211,11 +211,9 @@ public class KafkaConsumerTest {
     }
 
     @Test
-    public void testInitSuccessWithDefaultNullGroupIdAndValidGroupInstanceId() {
+    public void shouldIgnoreGroupInstanceIdForEmptyGroupId() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        config.put(ConsumerConfig.SEND_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
-        config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
         config.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "instance_id");
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(
                 config, new ByteArrayDeserializer(), new ByteArrayDeserializer());


### PR DESCRIPTION
as title suggests, this unit test is just a double check. No need to push in 2.3

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
