### PR TITLE
KAFKA-8442:Inconsistent ISR output in topic command

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -451,7 +451,7 @@ object TopicCommand extends Logging {
     print("\tPartition: " + tp.partition)
     print("\tLeader: " + (if(tp.leader.isDefined) tp.leader.get else "none"))
     print("\tReplicas: " + tp.assignedReplicas.mkString(","))
-    print("\tIsr: " + (if(tp.isr.isEmpty) "not available" else tp.isr.mkString(",")))
+    print("\tIsr: " + (if(tp.leader.isDefined) tp.isr.mkString(",") else "none"))
     print(markedForDeletionString)
     println()
   }

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -120,7 +120,10 @@ object TopicCommand extends Logging {
       opts.reportUnavailablePartitions && hasUnavailablePartitions(partitionDescription)
     }
     private def hasUnderMinIsrPartitions(partitionDescription: PartitionDescription) = {
-      partitionDescription.isr.size < partitionDescription.minIsrCount
+      if (partitionDescription.leader.isDefined)
+        partitionDescription.isr.size < partitionDescription.minIsrCount
+      else
+        partitionDescription.minIsrCount > 0
     }
     private def hasAtMinIsrPartitions(partitionDescription: PartitionDescription) = {
       partitionDescription.isr.size == partitionDescription.minIsrCount
@@ -451,7 +454,7 @@ object TopicCommand extends Logging {
     print("\tPartition: " + tp.partition)
     print("\tLeader: " + (if(tp.leader.isDefined) tp.leader.get else "none"))
     print("\tReplicas: " + tp.assignedReplicas.mkString(","))
-    print("\tIsr: " + (if(tp.leader.isDefined) tp.isr.mkString(",") else "none"))
+    print("\tIsr: " + tp.isr.mkString(","))
     print(markedForDeletionString)
     println()
   }

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -380,9 +380,10 @@ object TopicCommand extends Logging {
                 val partitionDesc = PartitionDescription(
                   topic,
                   partitionId,
-                  leader = if (leaderIsrEpoch.isEmpty) None else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
+                  leader = if (leaderIsrEpoch.isEmpty || !liveBrokers.contains(leaderIsrEpoch.get.leaderAndIsr.leader)) None
+                    else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
                   assignedReplicas,
-                  isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr,
+                  isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr.filter(liveBrokers.contains),
                   minIsrCount = 0,
                   markedForDeletion,
                   describeOptions.describeConfigs

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -380,10 +380,9 @@ object TopicCommand extends Logging {
                 val partitionDesc = PartitionDescription(
                   topic,
                   partitionId,
-                  leader = if (leaderIsrEpoch.isEmpty || !liveBrokers.contains(leaderIsrEpoch.get.leaderAndIsr.leader)) None
-                    else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
+                  leader = if (leaderIsrEpoch.isEmpty) None else Option(leaderIsrEpoch.get.leaderAndIsr.leader),
                   assignedReplicas,
-                  isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr.filter(liveBrokers.contains),
+                  isr = if (leaderIsrEpoch.isEmpty) Seq.empty[Int] else leaderIsrEpoch.get.leaderAndIsr.isr,
                   minIsrCount = 0,
                   markedForDeletion,
                   describeOptions.describeConfigs
@@ -452,7 +451,7 @@ object TopicCommand extends Logging {
     print("\tPartition: " + tp.partition)
     print("\tLeader: " + (if(tp.leader.isDefined) tp.leader.get else "none"))
     print("\tReplicas: " + tp.assignedReplicas.mkString(","))
-    print("\tIsr: " + tp.isr.mkString(","))
+    print("\tIsr: " + (if(tp.isr.isEmpty) "not available" else tp.isr.mkString(",")))
     print(markedForDeletionString)
     println()
   }

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -81,6 +81,8 @@ class MetadataCache(brokerId: Int) extends Logging {
         val replicaInfo = getEndpoints(snapshot, replicas, listenerName, errorUnavailableEndpoints)
         val offlineReplicaInfo = getEndpoints(snapshot, partitionState.offlineReplicas.asScala, listenerName, errorUnavailableEndpoints)
 
+        val isr = partitionState.basePartitionState.isr.asScala
+        val isrInfo = getEndpoints(snapshot, isr, listenerName, errorUnavailableEndpoints)
         maybeLeader match {
           case None =>
             val error = if (!snapshot.aliveBrokers.contains(brokerId)) { // we are already holding the read lock
@@ -91,13 +93,10 @@ class MetadataCache(brokerId: Int) extends Logging {
               if (errorUnavailableListeners) Errors.LISTENER_NOT_FOUND else Errors.LEADER_NOT_AVAILABLE
             }
             new MetadataResponse.PartitionMetadata(error, partitionId.toInt, Node.noNode(),
-              Optional.empty(), replicaInfo.asJava, java.util.Collections.emptyList(),
+              Optional.empty(), replicaInfo.asJava, isrInfo.asJava,
               offlineReplicaInfo.asJava)
 
           case Some(leader) =>
-            val isr = partitionState.basePartitionState.isr.asScala
-            val isrInfo = getEndpoints(snapshot, isr, listenerName, errorUnavailableEndpoints)
-
             if (replicaInfo.size < replicas.size) {
               debug(s"Error while fetching metadata for $topicPartition: replica information not available for " +
                 s"following brokers ${replicas.filterNot(replicaInfo.map(_.id).contains).mkString(",")}")

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -17,11 +17,9 @@
 package kafka.admin
 
 import kafka.admin.TopicCommand.{TopicCommandOptions, ZookeeperTopicService}
-import kafka.api.LeaderAndIsr
-import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.server.ConfigType
 import kafka.utils.{Logging, TestUtils}
-import kafka.zk.{BrokerIdZNode, ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode, ZkVersion, ZooKeeperTestHarness}
+import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode, ZooKeeperTestHarness}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplicationFactorException, TopicExistsException}
@@ -593,33 +591,5 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     }
     expectAlterInternalTopicPartitionCountFailed(Topic.GROUP_METADATA_TOPIC_NAME)
     expectAlterInternalTopicPartitionCountFailed(Topic.TRANSACTION_STATE_TOPIC_NAME)
-  }
-
-  @Test
-  def testDescribeTopicsWithNoLeaders(): Unit = {
-    TestUtils.createBrokersInZk(zkClient, List(0, 1, 2))
-    val topic = "test-topic"
-
-    // create the topics
-    val createOpts = new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "2", "--topic", topic))
-    topicService.createTopic(createOpts)
-    val leaderIsrAndControllerEpochs = Map(
-      new TopicPartition(topic, 0) -> LeaderIsrAndControllerEpoch(
-        LeaderAndIsr(leader = 0, leaderEpoch = 0, isr = List(0, 1), zkVersion = 0),
-        controllerEpoch = 0)
-    )
-    topicService.zkClient.createTopicPartitionStatesRaw(leaderIsrAndControllerEpochs, ZkVersion.MatchAnyVersion)
-
-    // Stop broker 0 and 1
-    topicService.zkClient.deletePath(BrokerIdZNode.path(0))
-    topicService.zkClient.deletePath(BrokerIdZNode.path(1))
-
-    val describeTopicCommandOpt = new TopicCommandOptions(Array("--topic", topic, "--describe"))
-    val output = TestUtils.grabConsoleOutput(topicService.describeTopic(describeTopicCommandOpt))
-    val rows = output.split("\n")
-    assertEquals(2, rows.size)
-    assertTrue(rows(1).contains("Leader: none"))
-    val isrField = rows(1).split("\\s+").last
-    assertEquals(isrField, "Isr:")
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -601,7 +601,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
           topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName, "--unavailable-partitions"))))
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
-      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: none"))
+      assertTrue(rows(0).contains("Leader: none\tReplicas: 0\tIsr:"))
     } finally {
       restartDeadBrokers()
     }
@@ -743,21 +743,5 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     output = TestUtils.grabConsoleOutput(topicService.listTopics(new TopicCommandOptions(Array("--list", "--exclude-internal"))))
     assertTrue(output.contains(testTopicName))
     assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
-  }
-
-  @Test
-  def testDescribeTopicsWithEmptyISR(): Unit = {
-    createAndWaitTopic(
-      new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "2", "--topic", testTopicName)))
-
-    try {
-      val testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName)).all.get.asScala(testTopicName)
-      testTopicDescription.partitions.asScala.head.isr.asScala.map(_.id).foreach(killBroker)
-      val output = TestUtils.grabConsoleOutput(topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
-      val rows = output.split("\n")
-      assertTrue(rows(1).endsWith("Isr: none"))
-    } finally {
-      restartDeadBrokers()
-    }
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -601,7 +601,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
           topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName, "--unavailable-partitions"))))
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
-      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: "))
+      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: not available"))
     } finally {
       restartDeadBrokers()
     }
@@ -743,5 +743,21 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     output = TestUtils.grabConsoleOutput(topicService.listTopics(new TopicCommandOptions(Array("--list", "--exclude-internal"))))
     assertTrue(output.contains(testTopicName))
     assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
+  }
+
+  @Test
+  def testDescribeTopicsWithEmptyISR(): Unit = {
+    createAndWaitTopic(
+      new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "2", "--topic", testTopicName)))
+
+    try {
+      val testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName)).all.get.asScala(testTopicName)
+      testTopicDescription.partitions.asScala.head.isr.asScala.map(_.id).foreach(killBroker)
+      val output = TestUtils.grabConsoleOutput(topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
+      val rows = output.split("\n")
+      assertTrue(rows(1).endsWith("Isr: not available"))
+    } finally {
+      restartDeadBrokers()
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -601,7 +601,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
           topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName, "--unavailable-partitions"))))
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
-      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: not available"))
+      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: none"))
     } finally {
       restartDeadBrokers()
     }
@@ -755,7 +755,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       testTopicDescription.partitions.asScala.head.isr.asScala.map(_.id).foreach(killBroker)
       val output = TestUtils.grabConsoleOutput(topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
       val rows = output.split("\n")
-      assertTrue(rows(1).endsWith("Isr: not available"))
+      assertTrue(rows(1).endsWith("Isr: none"))
     } finally {
       restartDeadBrokers()
     }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -182,7 +182,7 @@ class MetadataCacheTest {
     val partitionMetadata = partitionMetadatas.get(0)
     assertEquals(0, partitionMetadata.partition)
     assertEquals(expectedError, partitionMetadata.error)
-    assertTrue(partitionMetadata.isr.isEmpty)
+    assertFalse(partitionMetadata.isr.isEmpty)
     assertEquals(1, partitionMetadata.replicas.size)
     assertEquals(0, partitionMetadata.replicas.get(0).id)
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8442

Modify leader and ISR output for --zookeeper path in TopicCommand, to be consistent with --bootstrap-server path.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
