### PR TITLE
MINOR: fix integration tests

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddres
 COPY ./ssh-config /root/.ssh/config
 # NOTE: The paramiko library supports the PEM-format private key, but does not support the RFC4716 format.
 RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && cp -f /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+# Recent changes in openjdk:8 base image installs Java at non-standard location, and ENV directive
+# doesn't work for Paramiko SSH client, so we have to set environment variables using ForceCommand.
 RUN echo "ForceCommand JAVA_HOME='$JAVA_HOME' PATH='$PATH' bash -c "'"$SSH_ORIGINAL_COMMAND"' >> /etc/ssh/sshd_config
 
 # Install binary test dependencies.

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddres
 COPY ./ssh-config /root/.ssh/config
 # NOTE: The paramiko library supports the PEM-format private key, but does not support the RFC4716 format.
 RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && cp -f /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN echo "ForceCommand JAVA_HOME='$JAVA_HOME' PATH='$PATH' bash -c "'"$SSH_ORIGINAL_COMMAND"' >> /etc/ssh/sshd_config
 
 # Install binary test dependencies.
 # we use the same versions as in vagrant/base.sh


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*
Starting a few days ago, Kafka integration tests started to fail, with the error "Zookeeper node failed to start". The reason is kafka-run-class.sh can't find java in the PATH. Further investigation shows it is caused by a breaking change in openjdk:8 docker image: https://github.com/docker-library/openjdk/commit/3eb0351b208d739fac35345c85e3c6237c2114ec

The image no longer installs a symlink of java in standard path /usr/bin, but uses ENV directive to specify custom PATH. On the other hand, ducktape use Paramiko to SSH to other docker instances to start ZK, which doesn't source any bashrc, thus not able to find the java.

This PR fixes it by using ForceCommand directive in sshd_config so that the environment variable is set even for Paramiko sessions.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

Running integration tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
