### PR TITLE
MINOR: Fix red herring when ConnectDistributedTest.test_bounce fails.

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -339,7 +339,7 @@ class ConnectDistributedTest(Test):
             node.account.ssh("echo -e -n " + repr(self.SECOND_INPUTS) + " >> " + self.INPUT_FILE)
         wait_until(lambda: self._validate_file_output(self.FIRST_INPUT_LIST + self.SECOND_INPUT_LIST), timeout_sec=70, err_msg="Sink output file never converged to the same state as the input file")
 
-    @cluster(num_nodes=5)
+    @cluster(num_nodes=6)
     @matrix(clean=[True, False])
     def test_bounce(self, clean):
         """


### PR DESCRIPTION
Test `ConnectDistributedTest.test_bounce` requires 5 nodes(3 Workers, 1 Broker, 1 ZK) when it succeeds and it also needs one more node for `ConsoleConsumer` when it fails and tries to collect data from a topic for debugging purposes.

With this change, the test gives a real failure reason:
```
Triggering test 2 of 17...
21:08:45 [INFO:2019-05-29 21:08:45,918]: RunnerClient: Loading test {'directory': '/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/tests/kafkatest/tests/connect', 'file_name': 'connect_distributed_test.py', 'method_name': 'test_bounce', 'cls_name': 'ConnectDistributedTest', 'injected_args': {'clean': True}}
21:08:45 [INFO:2019-05-29 21:08:45,937]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_bounce.clean=True: Setting up...
21:08:45 [INFO:2019-05-29 21:08:45,938]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_bounce.clean=True: Running...
21:12:46 [ERROR - 2019-05-29 21:12:46,469 - connect_distributed_test - test_bounce - lineno:409]: Duplicate source sequence numbers for task 0
21:12:46 [ERROR - 2019-05-29 21:12:46,523 - connect_distributed_test - test_bounce - lineno:429]: Duplicate sink sequence numbers for task 0
21:12:46 [ERROR - 2019-05-29 21:12:46,569 - connect_distributed_test - test_bounce - lineno:409]: Duplicate source sequence numbers for task 1
21:12:46 [ERROR - 2019-05-29 21:12:46,629 - connect_distributed_test - test_bounce - lineno:429]: Duplicate sink sequence numbers for task 1
21:12:46 [ERROR - 2019-05-29 21:12:46,684 - connect_distributed_test - test_bounce - lineno:409]: Duplicate source sequence numbers for task 2
21:12:46 [ERROR - 2019-05-29 21:12:46,734 - connect_distributed_test - test_bounce - lineno:429]: Duplicate sink sequence numbers for task 2
21:12:54 [INFO:2019-05-29 21:12:54,416]: RunnerClient: kafkatest.tests.connect.connect_distributed_test.ConnectDistributedTest.test_bounce.clean=True: FAIL: Found validation errors:
21:12:54 Found duplicate source sequence numbers for task 0: ...
21:13:10   Found duplicate sink sequence numbers for task 1: ...
21:13:10   Found duplicate source sequence numbers for task 2: ... 
21:13:10   Found duplicate sink sequence numbers for task 2: ...
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
