### PR TITLE
KAFKA-8418: Wait until REST resources are loaded when starting a Connect Worker.

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -104,10 +104,11 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         """
         self.external_config_template_func = external_config_template_func
 
-    def rest_loaded(self, node):
+    def listening(self, node):
         try:
             self.list_connectors(node)
-            self.logger.debug("Checking whether REST resources are loaded...")
+            self.logger.debug("Connect worker started serving REST at: '%s:%s')", node.account.hostname,
+                              self.CONNECT_REST_PORT)
             return True
         except requests.exceptions.ConnectionError:
             self.logger.debug("REST resources are not loaded yet")
@@ -131,7 +132,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
 
     def start_and_wait_to_load_rest(self, node, worker_type, remote_connector_configs):
         self.start_and_return_immediately(node, worker_type, remote_connector_configs)
-        wait_until(lambda: self.rest_loaded(node), timeout_sec=self.startup_timeout_sec,
+        wait_until(lambda: self.listening(node), timeout_sec=self.startup_timeout_sec,
                    err_msg="Kafka Connect failed to start on node: %s in condition mode: %s" %
                    (str(node.account), self.startup_mode))
 

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -130,7 +130,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
                                err_msg="Never saw message indicating Kafka Connect finished startup on node: " +
                                        "%s in condition mode: %s" % (str(node.account), self.startup_mode))
 
-    def start_and_wait_to_load_rest(self, node, worker_type, remote_connector_configs):
+    def start_and_wait_to_start_listening(self, node, worker_type, remote_connector_configs):
         self.start_and_return_immediately(node, worker_type, remote_connector_configs)
         wait_until(lambda: self.listening(node), timeout_sec=self.startup_timeout_sec,
                    err_msg="Kafka Connect failed to start on node: %s in condition mode: %s" %
@@ -309,7 +309,7 @@ class ConnectStandaloneService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'standalone', remote_connector_configs)
         else:
             # The default mode is to wait until the complete startup of the worker
-            self.start_and_wait_to_load_rest(node, 'standalone', remote_connector_configs)
+            self.start_and_wait_to_start_listening(node, 'standalone', remote_connector_configs)
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")
@@ -356,7 +356,7 @@ class ConnectDistributedService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'distributed', '')
         else:
             # The default mode is to wait until the complete startup of the worker
-            self.start_and_wait_to_load_rest(node, 'distributed', '')
+            self.start_and_wait_to_start_listening(node, 'distributed', '')
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -20,7 +20,6 @@ import signal
 import time
 
 import requests
-from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.errors import DucktapeError
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -105,14 +104,13 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         """
         self.external_config_template_func = external_config_template_func
 
-    def listening(self, node):
+    def rest_loaded(self, node):
         try:
-            cmd = "nc -z %s %s" % (node.account.hostname, self.CONNECT_REST_PORT)
-            node.account.ssh_output(cmd, allow_fail=False)
-            self.logger.debug("Connect worker started accepting connections at: '%s:%s')", node.account.hostname,
-                              self.CONNECT_REST_PORT)
+            self.list_connectors(node)
+            self.logger.debug("Checking whether REST resources are loaded...")
             return True
-        except (RemoteCommandError, ValueError) as e:
+        except requests.exceptions.ConnectionError:
+            self.logger.debug("REST resources are not loaded yet")
             return False
 
     def start(self, mode=STARTUP_MODE_LISTEN):
@@ -131,9 +129,9 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
                                err_msg="Never saw message indicating Kafka Connect finished startup on node: " +
                                        "%s in condition mode: %s" % (str(node.account), self.startup_mode))
 
-    def start_and_wait_to_start_listening(self, node, worker_type, remote_connector_configs):
+    def start_and_wait_to_load_rest(self, node, worker_type, remote_connector_configs):
         self.start_and_return_immediately(node, worker_type, remote_connector_configs)
-        wait_until(lambda: self.listening(node), timeout_sec=self.startup_timeout_sec,
+        wait_until(lambda: self.rest_loaded(node), timeout_sec=self.startup_timeout_sec,
                    err_msg="Kafka Connect failed to start on node: %s in condition mode: %s" %
                    (str(node.account), self.startup_mode))
 
@@ -310,7 +308,7 @@ class ConnectStandaloneService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'standalone', remote_connector_configs)
         else:
             # The default mode is to wait until the complete startup of the worker
-            self.start_and_wait_to_start_listening(node, 'standalone', remote_connector_configs)
+            self.start_and_wait_to_load_rest(node, 'standalone', remote_connector_configs)
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")
@@ -357,7 +355,7 @@ class ConnectDistributedService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'distributed', '')
         else:
             # The default mode is to wait until the complete startup of the worker
-            self.start_and_wait_to_start_listening(node, 'distributed', '')
+            self.start_and_wait_to_load_rest(node, 'distributed', '')
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")


### PR DESCRIPTION
Currently, we are waiting on Worker's port to start listening, but it might take some time until all REST resources are actually loaded - so this PR changes the behavior and waits until REST resources are ready.

The following test was run in order to test the change - `tests/kafkatest/tests/connect/connect_rest_test.py`.
The PR fixes following intermittent error in `ConnectRestApiTest.test_rest_api`:
```
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 404 Not Found</title>
</head>
<body><h2>HTTP ERROR 404</h2>
<p>Problem accessing /connector-plugins/. Reason:
<pre>    Not Found</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.4.18.v20190429</a><hr/>

</body>
</html>

Traceback (most recent call last):
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/venv/local/lib/python2.7/site-packages/ducktape-0.7.5-py2.7.egg/ducktape/tests/runner_client.py", line 132, in run
    data = self.run_test()
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/venv/local/lib/python2.7/site-packages/ducktape-0.7.5-py2.7.egg/ducktape/tests/runner_client.py", line 189, in run_test
    return self.test_context.function(self.test)
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/tests/kafkatest/tests/connect/connect_rest_test.py", line 89, in test_rest_api
    assert set([connector_plugin['class'] for connector_plugin in self.cc.list_connector_plugins()]) == {self.FILE_SOURCE_CONNECTOR, self.FILE_SINK_CONNECTOR}
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/tests/kafkatest/services/connect.py", line 218, in list_connector_plugins
    return self._rest('/connector-plugins/', node=node)
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/tests/kafkatest/services/connect.py", line 234, in _rest
    raise ConnectRestError(resp.status_code, resp.text, resp.url)
ConnectRestError
```

With this PR merged, the folllowing error is expected, and tracked in https://issues.apache.org/jira/browse/KAFKA-8449:
```
Data added to input file was not seen in the output file in a reasonable amount of time.
Traceback (most recent call last):
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/venv/local/lib/python2.7/site-packages/ducktape-0.7.5-py2.7.egg/ducktape/tests/runner_client.py", line 132, in run
    data = self.run_test()
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/venv/local/lib/python2.7/site-packages/ducktape-0.7.5-py2.7.egg/ducktape/tests/runner_client.py", line 189, in run_test
    return self.test_context.function(self.test)
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/tests/kafkatest/tests/connect/connect_rest_test.py", line 178, in test_rest_api
    wait_until(lambda: self.validate_output(self.LONGER_INPUT_LIST), timeout_sec=120, err_msg="Data added to input file was not seen in the output file in a reasonable amount of time.")
  File "/home/jenkins/workspace/system-test-kafka_5.3.x/kafka/venv/local/lib/python2.7/site-packages/ducktape-0.7.5-py2.7.egg/ducktape/utils/util.py", line 41, in wait_until
    raise TimeoutError(err_msg() if callable(err_msg) else err_msg)
TimeoutError: Data added to input file was not seen in the output file in a reasonable amount of time.
```

This PR has to be backported up to `1.0`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
