### PR TITLE
KAFKA-8446: Kafka Streams restoration crashes with NPE when the record value is null

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -27,6 +27,15 @@ public final class RecordConverters {
     private static final RecordConverter RAW_TO_TIMESTAMED_INSTANCE = record -> {
         final byte[] rawValue = record.value();
         final long timestamp = record.timestamp();
+//        final byte[] recordValue = rawValue == null ? null :
+//                ByteBuffer.allocate(8 + rawValue.length)
+//                        .putLong(timestamp)
+//                        .put(rawValue)
+//                        .array();
+        final byte[] recordValue = ByteBuffer.allocate(8 + rawValue.length)
+                        .putLong(timestamp)
+                        .put(rawValue)
+                        .array();
         return new ConsumerRecord<>(
             record.topic(),
             record.partition(),
@@ -37,11 +46,7 @@ public final class RecordConverters {
             record.serializedKeySize(),
             record.serializedValueSize(),
             record.key(),
-            ByteBuffer
-                .allocate(8 + rawValue.length)
-                .putLong(timestamp)
-                .put(rawValue)
-                .array(),
+            recordValue,
             record.headers(),
             record.leaderEpoch()
         );

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -27,16 +27,11 @@ public final class RecordConverters {
     private static final RecordConverter RAW_TO_TIMESTAMED_INSTANCE = record -> {
         final byte[] rawValue = record.value();
         final long timestamp = record.timestamp();
-//        final byte[] recordValue = rawValue == null ? null :
-//            ByteBuffer.allocate(8 + rawValue.length)
-//                .putLong(timestamp)
-//                .put(rawValue)
-//                .array();
-        final byte[] recordValue =
-                ByteBuffer.allocate(8 + rawValue.length)
-                        .putLong(timestamp)
-                        .put(rawValue)
-                        .array();
+        final byte[] recordValue = rawValue == null ? null :
+            ByteBuffer.allocate(8 + rawValue.length)
+                .putLong(timestamp)
+                .put(rawValue)
+                .array();
         return new ConsumerRecord<>(
             record.topic(),
             record.partition(),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -27,15 +27,11 @@ public final class RecordConverters {
     private static final RecordConverter RAW_TO_TIMESTAMED_INSTANCE = record -> {
         final byte[] rawValue = record.value();
         final long timestamp = record.timestamp();
-//        final byte[] recordValue = rawValue == null ? null :
-//                ByteBuffer.allocate(8 + rawValue.length)
-//                        .putLong(timestamp)
-//                        .put(rawValue)
-//                        .array();
-        final byte[] recordValue = ByteBuffer.allocate(8 + rawValue.length)
-                        .putLong(timestamp)
-                        .put(rawValue)
-                        .array();
+        final byte[] recordValue = rawValue == null ? null :
+            ByteBuffer.allocate(8 + rawValue.length)
+                .putLong(timestamp)
+                .put(rawValue)
+                .array();
         return new ConsumerRecord<>(
             record.topic(),
             record.partition(),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -27,11 +27,16 @@ public final class RecordConverters {
     private static final RecordConverter RAW_TO_TIMESTAMED_INSTANCE = record -> {
         final byte[] rawValue = record.value();
         final long timestamp = record.timestamp();
-        final byte[] recordValue = rawValue == null ? null :
-            ByteBuffer.allocate(8 + rawValue.length)
-                .putLong(timestamp)
-                .put(rawValue)
-                .array();
+//        final byte[] recordValue = rawValue == null ? null :
+//            ByteBuffer.allocate(8 + rawValue.length)
+//                .putLong(timestamp)
+//                .put(rawValue)
+//                .array();
+        final byte[] recordValue =
+                ByteBuffer.allocate(8 + rawValue.length)
+                        .putLong(timestamp)
+                        .put(rawValue)
+                        .array();
         return new ConsumerRecord<>(
             record.topic(),
             record.partition(),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
@@ -18,11 +18,16 @@ package org.apache.kafka.streams.integration;
 
 import kafka.utils.MockTime;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.*;
-import org.apache.kafka.streams.*;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
-import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -36,26 +41,24 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 @Category({IntegrationTest.class})
 public class KStreamRestorationIntegrationTest {
-
-    private Logger LOG = LoggerFactory.getLogger(KStreamRestorationIntegrationTest.class);
-
     private StreamsBuilder builder = new StreamsBuilder();
 
     private static final String APPLICATION_ID = "restoration-test-app";
     private static final String STATE_STORE_NAME = "stateStore";
     private static final String INPUT_TOPIC = "input";
     private static final String OUTPUT_TOPIC = "output";
-
-    private static final String STATE_STORE_CHANGELOG = APPLICATION_ID + "-" + STATE_STORE_NAME + "-changelog";
 
     private Properties streamsConfiguration;
 
@@ -66,8 +69,6 @@ public class KStreamRestorationIntegrationTest {
     @Before
     public void setUp() throws Exception {
         final Properties props = new Properties();
-        props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 1024 * 10);
-        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 5000);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         streamsConfiguration = StreamsTestUtils.getStreamsConfig(
@@ -78,8 +79,7 @@ public class KStreamRestorationIntegrationTest {
                 props);
 
         CLUSTER.createTopics(INPUT_TOPIC);
-        CLUSTER.createTopics("output");
-        CLUSTER.createTopics(STATE_STORE_CHANGELOG);
+        CLUSTER.createTopics(OUTPUT_TOPIC);
 
         final StoreBuilder<KeyValueStore<Integer, byte[]>> keyValueStoreBuilder =
                 Stores.keyValueStoreBuilder(Stores.persistentTimestampedKeyValueStore(STATE_STORE_NAME),
@@ -89,50 +89,52 @@ public class KStreamRestorationIntegrationTest {
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
     }
 
-
     @Test
     public void shouldRestoreNullRecord() throws InterruptedException, ExecutionException {
         final KStream<Integer, byte[]> sourceStream = builder.stream(INPUT_TOPIC);
-        KStream<Integer, byte[]> transformedStream = sourceStream.transform(() -> new Transformer<Integer, byte[], KeyValue<Integer, byte[]>>() {
-            private KeyValueStore<Integer, byte[]> state;
+        final KStream<Integer, byte[]> transformedStream =
+                sourceStream.transform(() -> new Transformer<Integer, byte[], KeyValue<Integer, byte[]>>() {
+                    private KeyValueStore<Integer, byte[]> state;
 
-            @SuppressWarnings("unchecked")
-            @Override
-            public void init(final ProcessorContext context) {
-                state = (KeyValueStore<Integer, byte[]>) context.getStateStore(STATE_STORE_NAME);
-            }
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public void init(final ProcessorContext context) {
+                        state = (KeyValueStore<Integer, byte[]>) context.getStateStore(STATE_STORE_NAME);
+                    }
 
-            @Override
-            public KeyValue<Integer, byte[]> transform(final Integer key, final byte[] value) {
-                state.put(key, value);
-                LOG.info("processed record {}", value);
-                return new KeyValue<>(key, value);
-            }
+                    @Override
+                    public KeyValue<Integer, byte[]> transform(final Integer key, final byte[] value) {
+                        state.put(key, value);
+                        return new KeyValue<>(key, value);
+                    }
 
-            @Override
-            public void close() {
-            }
-        }, STATE_STORE_NAME);
+                    @Override
+                    public void close() {
+                    }
+                }, STATE_STORE_NAME);
         transformedStream.to(OUTPUT_TOPIC);
 
-        final List<KeyValue<Integer, byte[]>> expectedCountKeyValues = Arrays.asList(KeyValue.pair(1, new byte[1]), KeyValue.pair(3, null));
-        Properties producerConfig = TestUtils.producerConfig(CLUSTER.bootstrapServers(), IntegerSerializer.class, ByteArraySerializer.class);
+        final Properties producerConfig = TestUtils.producerConfig(CLUSTER.bootstrapServers(), IntegerSerializer.class, ByteArraySerializer.class);
 
-        IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_TOPIC, expectedCountKeyValues, producerConfig, mockTime);
+        final List<KeyValue<Integer, byte[]>> initialKeyValues = Arrays.asList(KeyValue.pair(3, null), KeyValue.pair(1, new byte[]{5}));
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_TOPIC, initialKeyValues, producerConfig, mockTime);
 
         KafkaStreams streams = new KafkaStreams(builder.build(streamsConfiguration), streamsConfiguration);
         streams.start();
 
         final Properties consumerConfig = TestUtils.consumerConfig(CLUSTER.bootstrapServers(), IntegerDeserializer.class, ByteArrayDeserializer.class);
-        IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived(consumerConfig, OUTPUT_TOPIC, expectedCountKeyValues);
-
+        // We couldn't use a #waitUntilFinalKeyValueRecordsReceived here because the byte array comparison is not triggered correctly.
+        final List<KeyValue<Integer, byte[]>> outputs = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_TOPIC, initialKeyValues.size());
+        for (int i = 0; i < outputs.size(); i++) {
+            assertEquals(outputs.get(i).key, initialKeyValues.get(i).key);
+            assertArrayEquals(outputs.get(i).value, initialKeyValues.get(i).value);
+        }
 
         streams.close();
         streams.cleanUp();
 
-//        IntegrationTestUtils.produceKeyValuesSynchronously(STATE_STORE_CHANGELOG, Arrays.asList(KeyValue.pair(3, null)), producerConfig, mockTime);
-
-        // Restart the stream instance
+        // Restart the stream instance. There should not be exception handling the null value within changelog topic.
         final List<KeyValue<Integer, byte[]>> expectedNewKeyValues = Collections.singletonList(KeyValue.pair(1, null));
         IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_TOPIC, expectedNewKeyValues, producerConfig, mockTime);
         streams = new KafkaStreams(builder.build(streamsConfiguration), streamsConfiguration);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
@@ -69,7 +69,6 @@ public class KStreamRestorationIntegrationTest {
     @Before
     public void setUp() throws Exception {
         final Properties props = new Properties();
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         streamsConfiguration = StreamsTestUtils.getStreamsConfig(
                 APPLICATION_ID,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRestorationIntegrationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import kafka.utils.MockTime;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.*;
+import org.apache.kafka.streams.*;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+
+@Category({IntegrationTest.class})
+public class KStreamRestorationIntegrationTest {
+
+    private Logger LOG = LoggerFactory.getLogger(KStreamRestorationIntegrationTest.class);
+
+    private StreamsBuilder builder = new StreamsBuilder();
+
+    private KStream<Integer, Integer> transformedStream;
+
+    private static final String APPLICATION_ID = "restoration-test-app";
+    private static final String STATE_STORE_NAME = "stateStore";
+    private static final String INPUT_TOPIC = "input";
+    private static final String OUTPUT_TOPIC = "output";
+
+    private static final String STATE_STORE_CHANGELOG = APPLICATION_ID + "-" + STATE_STORE_NAME + "-changelog";
+
+    private Properties streamsConfiguration;
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+    private final MockTime mockTime = CLUSTER.time;
+
+    @Before
+    public void setUp() throws Exception {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 1024 * 10);
+        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 5000);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        streamsConfiguration = StreamsTestUtils.getStreamsConfig(
+                APPLICATION_ID,
+                CLUSTER.bootstrapServers(),
+                Serdes.Integer().getClass().getName(),
+                Serdes.Integer().getClass().getName(),
+                props);
+
+        CLUSTER.createTopics(INPUT_TOPIC);
+        CLUSTER.createTopics("output");
+        CLUSTER.createTopics(STATE_STORE_CHANGELOG);
+
+        final StoreBuilder<KeyValueStore<Integer, Integer>> keyValueStoreBuilder =
+                Stores.keyValueStoreBuilder(Stores.persistentTimestampedKeyValueStore(STATE_STORE_NAME),
+                        Serdes.Integer(),
+                        Serdes.Integer());
+        builder.addStateStore(keyValueStoreBuilder);
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+    }
+
+
+    @Test
+    public void shouldRestoreNullRecord() throws InterruptedException, ExecutionException {
+        final KStream<Integer, Integer> sourceStream = builder.stream(INPUT_TOPIC);
+        transformedStream = sourceStream.transform(() -> new Transformer<Integer, Integer, KeyValue<Integer, Integer>>() {
+            private KeyValueStore<Integer, Integer> state;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void init(final ProcessorContext context) {
+                state = (KeyValueStore<Integer, Integer>) context.getStateStore(STATE_STORE_NAME);
+            }
+
+            @Override
+            public KeyValue<Integer, Integer> transform(final Integer key, final Integer value) {
+                state.putIfAbsent(key, 0);
+                Integer storedValue = state.get(key);
+                final KeyValue<Integer, Integer> result = new KeyValue<>(key, value);
+                state.put(key, storedValue);
+                LOG.info("processed record {}", value);
+                return result;
+            }
+
+            @Override
+            public void close() {
+            }
+        }, STATE_STORE_NAME);
+        transformedStream.to(OUTPUT_TOPIC);
+
+        final List<KeyValue<Integer, Integer>> expectedCountKeyValues = Arrays.asList(KeyValue.pair(1, 1), KeyValue.pair(2, 2), KeyValue.pair(3, null));
+        Properties producerConfig = TestUtils.producerConfig(CLUSTER.bootstrapServers(), IntegerSerializer.class, IntegerSerializer.class);
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_TOPIC, expectedCountKeyValues, producerConfig, mockTime);
+
+        KafkaStreams kafkaStreams = new KafkaStreams(builder.build(streamsConfiguration), streamsConfiguration);
+        kafkaStreams.start();
+
+        final Properties consumerConfig = TestUtils.consumerConfig(CLUSTER.bootstrapServers(), IntegerDeserializer.class, IntegerDeserializer.class);
+        IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived(consumerConfig, OUTPUT_TOPIC, expectedCountKeyValues);
+
+
+        kafkaStreams.close();
+        kafkaStreams.cleanUp();
+
+//        IntegrationTestUtils.produceKeyValuesSynchronously(STATE_STORE_CHANGELOG, Arrays.asList(KeyValue.pair(3, null)), producerConfig, mockTime);
+
+        // Restart the stream instance
+        final List<KeyValue<Integer, Integer>> expectedNewKeyValues = Arrays.asList(KeyValue.pair(1, 1));
+        IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_TOPIC, expectedNewKeyValues, producerConfig, mockTime);
+        kafkaStreams = new KafkaStreams(builder.build(streamsConfiguration), streamsConfiguration);
+        kafkaStreams.start();
+        IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived(consumerConfig, OUTPUT_TOPIC, expectedNewKeyValues);
+        kafkaStreams.close();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.apache.kafka.streams.state.internals.RecordConverters.rawValueToTimestampedValue;
+
+public class RecordConvertersTest {
+
+    @Test
+    public void testNullRawValueShouldReturnNullRecordValue() {
+        ConsumerRecord<byte[], byte[]> nullValueRecord = new ConsumerRecord<>("", 0, 0L, new byte[0], null);
+        Assert.assertNull(rawValueToTimestampedValue().convert(nullValueRecord).value());
+    }
+
+    @Test
+    public void testEncodeRecordValue() {
+        long timestamp = 10L;
+        byte[] value = new byte[1];
+        ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
+                "topic", 1, 0, timestamp, TimestampType.CREATE_TIME, 0L, 0, 0, new byte[0], value);
+        byte[] expectedValue = ByteBuffer.allocate(9).putLong(timestamp).put(value).array();
+        byte[] actualValue = rawValueToTimestampedValue().convert(inputRecord).value();
+        Assert.assertArrayEquals(expectedValue, actualValue);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
@@ -29,18 +29,18 @@ public class RecordConvertersTest {
 
     @Test
     public void testNullRawValueShouldReturnNullRecordValue() {
-        ConsumerRecord<byte[], byte[]> nullValueRecord = new ConsumerRecord<>("", 0, 0L, new byte[0], null);
+        final ConsumerRecord<byte[], byte[]> nullValueRecord = new ConsumerRecord<>("", 0, 0L, new byte[0], null);
         Assert.assertNull(rawValueToTimestampedValue().convert(nullValueRecord).value());
     }
 
     @Test
     public void testEncodeRecordValue() {
-        long timestamp = 10L;
-        byte[] value = new byte[1];
-        ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
+        final long timestamp = 10L;
+        final byte[] value = new byte[1];
+        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
                 "topic", 1, 0, timestamp, TimestampType.CREATE_TIME, 0L, 0, 0, new byte[0], value);
-        byte[] expectedValue = ByteBuffer.allocate(9).putLong(timestamp).put(value).array();
-        byte[] actualValue = rawValueToTimestampedValue().convert(inputRecord).value();
+        final byte[] expectedValue = ByteBuffer.allocate(9).putLong(timestamp).put(value).array();
+        final byte[] actualValue = rawValueToTimestampedValue().convert(inputRecord).value();
         Assert.assertArrayEquals(expectedValue, actualValue);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
@@ -18,29 +18,32 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
 import static org.apache.kafka.streams.state.internals.RecordConverters.rawValueToTimestampedValue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
 
 public class RecordConvertersTest {
 
+    private final RecordConverter timestampedValueConverter = rawValueToTimestampedValue();
+
     @Test
-    public void testNullRawValueShouldReturnNullRecordValue() {
+    public void shouldPreserveNullValueOnConversion() {
         final ConsumerRecord<byte[], byte[]> nullValueRecord = new ConsumerRecord<>("", 0, 0L, new byte[0], null);
-        Assert.assertNull(rawValueToTimestampedValue().convert(nullValueRecord).value());
+        assertNull(timestampedValueConverter.convert(nullValueRecord).value());
     }
 
     @Test
-    public void testEncodeRecordValue() {
+    public void shouldAddTimestampToValueOnConversionWhenValueIsNotNull() {
         final long timestamp = 10L;
         final byte[] value = new byte[1];
         final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
                 "topic", 1, 0, timestamp, TimestampType.CREATE_TIME, 0L, 0, 0, new byte[0], value);
         final byte[] expectedValue = ByteBuffer.allocate(9).putLong(timestamp).put(value).array();
-        final byte[] actualValue = rawValueToTimestampedValue().convert(inputRecord).value();
-        Assert.assertArrayEquals(expectedValue, actualValue);
+        final byte[] actualValue = timestampedValueConverter.convert(inputRecord).value();
+        assertArrayEquals(expectedValue, actualValue);
     }
 }


### PR DESCRIPTION
When the restored record value is null, we are in danger of NPE during restoration phase.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
