### PR TITLE
MINOR: Remove stale streams producer retry default docs.

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -658,11 +658,7 @@
               <td>Consumer</td>
               <td>1000</td>
             </tr>
-            <tr class="row-odd"><td>retries</td>
-              <td>Producer</td>
-              <td>10</td>
-            </tr>
-            <tr class="row-even"><td>rocksdb.config.setter</td>
+            <tr class="row-odd"><td>rocksdb.config.setter</td>
               <td>Consumer</td>
               <td>&nbsp;</td>
             </tr>


### PR DESCRIPTION
As part of https://github.com/apache/kafka/pull/5425 the streams default override for producer retries was removed. The documentation was not updated to reflect that change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
