### PR TITLE
KAFKA-5998: Create state dir and checkpoint file if it doesn't exist when checkpointing

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -656,17 +656,24 @@ public class ProcessorStateManagerTest {
         LogCaptureAppender.unregister(appender);
 
         boolean foundExpectedLogMessage = false;
+        boolean createdFileLogMessage = false;
         for (final LogCaptureAppender.Event event : appender.getEvents()) {
             if ("WARN".equals(event.getLevel())
-                && event.getMessage().startsWith("process-state-manager-test Failed to write offset checkpoint file to [")
-                && event.getMessage().endsWith(".checkpoint]")
+                && event.getMessage().startsWith("Checkpoint file doesn't exist will attempt to create [")
+                && event.getMessage().contains(".checkpoint]")
                 && event.getThrowableInfo().get().startsWith("java.io.FileNotFoundException: ")) {
 
                 foundExpectedLogMessage = true;
-                break;
+            }
+
+            if ("INFO".equals(event.getLevel())
+                && event.getMessage().startsWith("Successfully created checkpoint file")) {
+
+                createdFileLogMessage = true;
             }
         }
         assertTrue(foundExpectedLogMessage);
+        assertTrue(createdFileLogMessage);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/OffsetCheckpointTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/OffsetCheckpointTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.test.TestUtils;
@@ -51,6 +52,28 @@ public class OffsetCheckpointTest {
             assertFalse(f.exists());
 
             offsets.put(new TopicPartition(topic, 3), 3L);
+            checkpoint.write(offsets);
+            assertEquals(offsets, checkpoint.read());
+        } finally {
+            checkpoint.delete();
+        }
+    }
+
+    @Test
+    public void shouldCreateCheckpointFileWhenItDoesNotExist() throws IOException {
+        final String tmpdir = System.getProperty("java.io.tmpdir");
+        final int random = new Random().nextInt();
+        final File checkPointThatDoesNotExistYet = new File(tmpdir + "/kafka-streams/my-streams-app/0_" + random + "/.checkpoint.tmp");
+        checkPointThatDoesNotExistYet.deleteOnExit();
+
+        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkPointThatDoesNotExistYet);
+
+        try {
+            final Map<TopicPartition, Long> offsets = new HashMap<>();
+            offsets.put(new TopicPartition(topic, 0), 0L);
+            offsets.put(new TopicPartition(topic, 1), 1L);
+            offsets.put(new TopicPartition(topic, 2), 2L);
+
             checkpoint.write(offsets);
             assertEquals(offsets, checkpoint.read());
         } finally {


### PR DESCRIPTION
There can exist a condition where the state directory for a task gets deleted by the cleanup thread as the directory has not been modified within the clean-up delay.  But the directory is still needed for the given task.  

This PR will catch the `FileNotFoundException` and create the required task directory when checkpointing.

Tests have been updated to validate the task directory and checkpoint file are created when a `FileNotFoundException` is thrown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
