### PR TITLE
KAFKA-8448: Too many kafka.log.Log instances (Memory Leak)

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -333,7 +333,7 @@ class Log(@volatile var dir: File,
     },
     tags)
 
-  scheduler.schedule(name = "PeriodicProducerExpirationCheck", fun = () => {
+  val task = scheduler.schedule(name = "PeriodicProducerExpirationCheck", fun = () => {
     lock synchronized {
       producerStateManager.removeExpiredProducers(time.milliseconds)
     }
@@ -753,6 +753,7 @@ class Log(@volatile var dir: File,
     debug("Closing log")
     lock synchronized {
       checkIfMemoryMappedBufferClosed()
+      scheduler.removeTask(task)
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in dir ${dir.getParent}") {
         // We take a snapshot at the last written offset to hopefully avoid the need to scan the log
         // after restarting and to ensure that we cannot inadvertently hit the upgrade optimization

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -753,7 +753,7 @@ class Log(@volatile var dir: File,
     debug("Closing log")
     lock synchronized {
       checkIfMemoryMappedBufferClosed()
-        producerExpireCheck.cancel(true)
+      producerExpireCheck.cancel(true)
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in dir ${dir.getParent}") {
         // We take a snapshot at the last written offset to hopefully avoid the need to scan the log
         // after restarting and to ensure that we cannot inadvertently hit the upgrade optimization

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -333,7 +333,7 @@ class Log(@volatile var dir: File,
     },
     tags)
 
-  val task = scheduler.schedule(name = "PeriodicProducerExpirationCheck", fun = () => {
+  val producerExpireCheck = scheduler.schedule(name = "PeriodicProducerExpirationCheck", fun = () => {
     lock synchronized {
       producerStateManager.removeExpiredProducers(time.milliseconds)
     }
@@ -753,7 +753,7 @@ class Log(@volatile var dir: File,
     debug("Closing log")
     lock synchronized {
       checkIfMemoryMappedBufferClosed()
-      scheduler.removeTask(task)
+        producerExpireCheck.cancel(true)
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in dir ${dir.getParent}") {
         // We take a snapshot at the last written offset to hopefully avoid the need to scan the log
         // after restarting and to ensure that we cannot inadvertently hit the upgrade optimization

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -51,9 +51,9 @@ trait Scheduler {
    * @param delay The amount of time to wait before the first execution
    * @param period The period with which to execute the task. If < 0 the task will execute only once.
    * @param unit The unit for the preceding times
-   * @return the task scheduled, currently Future due to the MockScheduler, but could be more specific ScheduledFuture
+   * @return the task scheduled
    */
-  def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : Future[_]
+  def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : ScheduledFuture[_]
 }
 
 /**
@@ -127,7 +127,7 @@ class KafkaScheduler(val threads: Int,
     }
   }
 
-  def taskRunning(task: Future[_]) : Boolean = {
+  def taskRunning(task: ScheduledFuture[_]) : Boolean = {
     this synchronized {
       executor.getQueue().contains(task)
     }

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -23,51 +23,51 @@ import org.apache.kafka.common.utils.KafkaThread
 
 /**
  * A scheduler for running jobs
- *
+ * 
  * This interface controls a job scheduler that allows scheduling either repeating background jobs 
  * that execute periodically or delayed one-time actions that are scheduled in the future.
  */
 trait Scheduler {
-
+  
   /**
    * Initialize this scheduler so it is ready to accept scheduling of tasks
    */
   def startup()
-
+  
   /**
    * Shutdown this scheduler. When this method is complete no more executions of background tasks will occur. 
    * This includes tasks scheduled with a delayed execution.
    */
   def shutdown()
-
+  
   /**
    * Check if the scheduler has been started
    */
   def isStarted: Boolean
-
+  
   /**
    * Schedule a task
    * @param name The name of this task
    * @param delay The amount of time to wait before the first execution
    * @param period The period with which to execute the task. If < 0 the task will execute only once.
-   * @param unit The unit for the preceding times
-   * @return the task scheduled
+   * @param unit The unit for the preceding times.
+   * @return A Future object to manage the task scheduled.
    */
   def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : Future[_]
 }
 
 /**
  * A scheduler based on java.util.concurrent.ScheduledThreadPoolExecutor
- *
+ * 
  * It has a pool of kafka-scheduler- threads that do the actual work.
- *
+ * 
  * @param threads The number of threads in the thread pool
  * @param threadNamePrefix The name to use for scheduler threads. This prefix will have a number appended to it.
  * @param daemon If true the scheduler threads will be "daemon" threads and will not block jvm shutdown.
  */
 @threadsafe
-class KafkaScheduler(val threads: Int,
-                     val threadNamePrefix: String = "kafka-scheduler-",
+class KafkaScheduler(val threads: Int, 
+                     val threadNamePrefix: String = "kafka-scheduler-", 
                      daemon: Boolean = true) extends Scheduler with Logging {
   private var executor: ScheduledThreadPoolExecutor = null
   private val schedulerThreadId = new AtomicInteger(0)
@@ -82,12 +82,12 @@ class KafkaScheduler(val threads: Int,
       executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false)
       executor.setRemoveOnCancelPolicy(true)
       executor.setThreadFactory(new ThreadFactory() {
-        def newThread(runnable: Runnable): Thread =
-          new KafkaThread(threadNamePrefix + schedulerThreadId.getAndIncrement(), runnable, daemon)
-      })
+                                  def newThread(runnable: Runnable): Thread = 
+                                    new KafkaThread(threadNamePrefix + schedulerThreadId.getAndIncrement(), runnable, daemon)
+                                })
     }
   }
-
+  
   override def shutdown() {
     debug("Shutting down task scheduler.")
     // We use the local variable to avoid NullPointerException if another thread shuts down scheduler at same time.
@@ -107,7 +107,7 @@ class KafkaScheduler(val threads: Int,
 
   def schedule(name: String, fun: () => Unit, delay: Long, period: Long, unit: TimeUnit): ScheduledFuture[_] = {
     debug("Scheduling task %s with initial delay %d ms and period %d ms."
-      .format(name, TimeUnit.MILLISECONDS.convert(delay, unit), TimeUnit.MILLISECONDS.convert(period, unit)))
+        .format(name, TimeUnit.MILLISECONDS.convert(delay, unit), TimeUnit.MILLISECONDS.convert(period, unit)))
     this synchronized {
       ensureRunning()
       val runnable = CoreUtils.runnable {
@@ -137,16 +137,15 @@ class KafkaScheduler(val threads: Int,
   def resizeThreadPool(newSize: Int): Unit = {
     executor.setCorePoolSize(newSize)
   }
-
+  
   def isStarted: Boolean = {
     this synchronized {
       executor != null
     }
   }
-
+  
   private def ensureRunning(): Unit = {
     if (!isStarted)
       throw new IllegalStateException("Kafka scheduler is not running.")
   }
 }
-

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -53,7 +53,7 @@ trait Scheduler {
    * @param unit The unit for the preceding times.
    * @return A Future object to manage the task scheduled.
    */
-  def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : Future[_]
+  def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : ScheduledFuture[_]
 }
 
 /**
@@ -130,7 +130,7 @@ class KafkaScheduler(val threads: Int,
   /**
    * Package private for testing.
    */
-  private[utils] def taskRunning(task: Future[_]): Boolean = {
+  private[utils] def taskRunning(task: ScheduledFuture[_]): Boolean = {
     executor.getQueue().contains(task)
   }
 

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -51,7 +51,7 @@ trait Scheduler {
    * @param delay The amount of time to wait before the first execution
    * @param period The period with which to execute the task. If < 0 the task will execute only once.
    * @param unit The unit for the preceding times
-   * @return the task scheduled
+   * @return a Future object to manage the task scheduled
    */
   def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : ScheduledFuture[_]
 }

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -105,7 +105,7 @@ class KafkaScheduler(val threads: Int,
     schedule(name, fun, delay = 0L, period = -1L, unit = TimeUnit.MILLISECONDS)
   }
 
-  def schedule(name: String, fun: () => Unit, delay: Long, period: Long, unit: TimeUnit) : ScheduledFuture[_] = {
+  def schedule(name: String, fun: () => Unit, delay: Long, period: Long, unit: TimeUnit): ScheduledFuture[_] = {
     debug("Scheduling task %s with initial delay %d ms and period %d ms."
         .format(name, TimeUnit.MILLISECONDS.convert(delay, unit), TimeUnit.MILLISECONDS.convert(period, unit)))
     this synchronized {
@@ -127,10 +127,11 @@ class KafkaScheduler(val threads: Int,
     }
   }
 
-  def taskRunning(task: ScheduledFuture[_]) : Boolean = {
-    this synchronized {
+  /**
+   * Package private for testing.
+   */
+  private[utils] def taskRunning(task: ScheduledFuture[_]): Boolean = {
       executor.getQueue().contains(task)
-    }
   }
 
   def resizeThreadPool(newSize: Int): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -17,21 +17,21 @@
 package kafka.utils
 
 import scala.collection.mutable.PriorityQueue
-import java.util.concurrent.{Delayed, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{Delayed, CompletableFuture, TimeUnit}
 
 import org.apache.kafka.common.utils.Time
 
 /**
  * A mock scheduler that executes tasks synchronously using a mock time instance. Tasks are executed synchronously when
  * the time is advanced. This class is meant to be used in conjunction with MockTime.
- * 
+ *
  * Example usage
  * <code>
  *   val time = new MockTime
  *   time.scheduler.schedule("a task", println("hello world: " + time.milliseconds), delay = 1000)
  *   time.sleep(1001) // this should cause our scheduled task to fire
  * </code>
- *   
+ *
  * Incrementing the time to the exact next execution time of a task will result in that task executing (it as if execution itself takes no time).
  */
 class MockScheduler(val time: Time) extends Scheduler {
@@ -71,7 +71,7 @@ class MockScheduler(val time: Time) extends Scheduler {
     }
   }
 
-  def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): ScheduledFuture[Unit] = {
+  def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): CompletableFuture[Unit] = {
     var task : MockTask = null
     this synchronized {
       task = MockTask(name, fun, time.milliseconds + delay, period = period, time=time)
@@ -88,7 +88,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   }
 }
 
-case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends ScheduledFuture[Unit] {
+case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends CompletableFuture[Unit] {
   def periodic = period >= 0
   def compare(t: MockTask): Int = {
     if(t.nextExecution == nextExecution)
@@ -97,27 +97,6 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
       -1
     else
       1
-  }
-
-  /**
-   * Not used, so not not fully implemented
-   */
-  def cancel(mayInterruptIfRunning: Boolean) : Boolean = {
-    false
-  }
-
-  def get() {
-  }
-
-  def get(timeout: Long, unit: TimeUnit){
-  }
-
-  def isCancelled: Boolean = {
-    false
-  }
-
-  def isDone: Boolean = {
-    false
   }
 
   def getDelay(unit: TimeUnit): Long = {
@@ -137,3 +116,4 @@ object MockTask {
     }
   }
 }
+

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -24,32 +24,32 @@ import org.apache.kafka.common.utils.Time
 /**
  * A mock scheduler that executes tasks synchronously using a mock time instance. Tasks are executed synchronously when
  * the time is advanced. This class is meant to be used in conjunction with MockTime.
- *
+ * 
  * Example usage
  * <code>
  *   val time = new MockTime
  *   time.scheduler.schedule("a task", println("hello world: " + time.milliseconds), delay = 1000)
  *   time.sleep(1001) // this should cause our scheduled task to fire
  * </code>
- *
+ *   
  * Incrementing the time to the exact next execution time of a task will result in that task executing (it as if execution itself takes no time).
  */
 class MockScheduler(val time: Time) extends Scheduler {
-
+  
   /* a priority queue of tasks ordered by next execution time */
   private val tasks = new PriorityQueue[MockTask]()
-
+  
   def isStarted = true
 
   def startup() {}
-
+  
   def shutdown() {
     this synchronized {
       tasks.foreach(_.fun())
       tasks.clear()
     }
   }
-
+  
   /**
    * Check for any tasks that need to execute. Since this is a mock scheduler this check only occurs
    * when this method is called and the execution happens synchronously in the calling thread.
@@ -58,19 +58,19 @@ class MockScheduler(val time: Time) extends Scheduler {
   def tick() {
     this synchronized {
       val now = time.milliseconds
-      while (tasks.nonEmpty && tasks.head.nextExecution <= now) {
+      while(tasks.nonEmpty && tasks.head.nextExecution <= now) {
         /* pop and execute the task with the lowest next execution time */
         val curr = tasks.dequeue
         curr.fun()
         /* if the task is periodic, reschedule it and re-enqueue */
-        if (curr.periodic) {
+        if(curr.periodic) {
           curr.nextExecution += curr.period
           this.tasks += curr
         }
       }
     }
   }
-
+  
   def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): CompletableFuture[Unit] = {
     var task : MockTask = null
     this synchronized {
@@ -116,4 +116,3 @@ object MockTask {
     }
   }
 }
-

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -122,7 +122,7 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
 
   def getDelay(unit: TimeUnit): Long = {
     this synchronized {
-      time.milliseconds - nextExecution
+      time.milliseconds - nextExecutionbu
     }
   }
 
@@ -131,5 +131,9 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
   }
 }
 object MockTask {
-  implicit def MockTaskOrdering: Ordering[MockTask] = (x: MockTask, y: MockTask) => x.compare(y)
+  implicit def MockTaskOrdering : Ordering[MockTask] = new Ordering[MockTask] {
+    def compare(x: MockTask, y: MockTask): Int ={
+      x.compare(y)
+    }
+  }
 }

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -132,7 +132,7 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
 }
 object MockTask {
   implicit def MockTaskOrdering : Ordering[MockTask] = new Ordering[MockTask] {
-    def compare(x: MockTask, y: MockTask): Int ={
+    def compare(x: MockTask, y: MockTask): Int = {
       x.compare(y)
     }
   }

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -17,7 +17,7 @@
 package kafka.utils
 
 import scala.collection.mutable.PriorityQueue
-import java.util.concurrent.{Delayed, CompletableFuture, TimeUnit}
+import java.util.concurrent.{Delayed, ScheduledFuture, TimeUnit}
 
 import org.apache.kafka.common.utils.Time
 
@@ -71,7 +71,7 @@ class MockScheduler(val time: Time) extends Scheduler {
     }
   }
   
-  def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): CompletableFuture[Unit] = {
+  def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): ScheduledFuture[Unit] = {
     var task : MockTask = null
     this synchronized {
       task = MockTask(name, fun, time.milliseconds + delay, period = period, time=time)
@@ -86,9 +86,10 @@ class MockScheduler(val time: Time) extends Scheduler {
       tasks.clear()
     }
   }
+  
 }
 
-case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends CompletableFuture[Unit] {
+case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends ScheduledFuture[Unit] {
   def periodic = period >= 0
   def compare(t: MockTask): Int = {
     if(t.nextExecution == nextExecution)
@@ -97,6 +98,27 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
       -1
     else
       1
+  }
+
+  /**
+    * Not used, so not not fully implemented
+    */
+  def cancel(mayInterruptIfRunning: Boolean) : Boolean = {
+    false
+  }
+
+  def get() {
+  }
+
+  def get(timeout: Long, unit: TimeUnit){
+  }
+
+  def isCancelled: Boolean = {
+    false
+  }
+
+  def isDone: Boolean = {
+    false
   }
 
   def getDelay(unit: TimeUnit): Long = {

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -122,7 +122,7 @@ case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, peri
 
   def getDelay(unit: TimeUnit): Long = {
     this synchronized {
-      time.milliseconds - nextExecutionbu
+      time.milliseconds - nextExecution
     }
   }
 

--- a/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
@@ -126,9 +126,9 @@ class SchedulerTest {
     val log = new Log(logDir, logConfig, logStartOffset = 0, recoveryPoint = recoveryPoint, scheduler,
       brokerTopicStats, mockTime, maxProducerIdExpirationMs, LogManager.ProducerIdExpirationCheckIntervalMs,
       topicPartition, producerStateManager, new LogDirFailureChannel(10))
-    assertTrue(scheduler.taskRunning(log.task))
+    assertTrue(scheduler.taskRunning(log.producerExpireCheck))
     log.close()
-    assertTrue(!(scheduler.taskRunning(log.task)))
+    assertTrue(!(scheduler.taskRunning(log.producerExpireCheck)))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
@@ -16,9 +16,14 @@
  */
 package kafka.utils
 
+import java.util.Properties
+
 import org.junit.Assert._
 import java.util.concurrent.atomic._
-import org.junit.{Test, After, Before}
+
+import kafka.log.{Log, LogConfig, LogManager, ProducerStateManager}
+import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
+import org.junit.{After, Before, Test}
 import kafka.utils.TestUtils.retry
 
 class SchedulerTest {
@@ -107,4 +112,23 @@ class SchedulerTest {
     mockTime.sleep(1)
     assertEquals(2, counter1.get())
   }
+
+  @Test
+  def testUnscheduleProducerTask(): Unit = {
+    val tmpDir = TestUtils.tempDir()
+    val logDir = TestUtils.randomPartitionLogDir(tmpDir)
+    val logConfig = LogConfig(new Properties())
+    val brokerTopicStats = new BrokerTopicStats
+    val recoveryPoint = 0L
+    val maxProducerIdExpirationMs = 60 * 60 * 1000
+    val topicPartition = Log.parseTopicPartitionName(logDir)
+    val producerStateManager = new ProducerStateManager(topicPartition, logDir, maxProducerIdExpirationMs)
+    val log = new Log(logDir, logConfig, logStartOffset = 0, recoveryPoint = recoveryPoint, scheduler,
+      brokerTopicStats, mockTime, maxProducerIdExpirationMs, LogManager.ProducerIdExpirationCheckIntervalMs,
+      topicPartition, producerStateManager, new LogDirFailureChannel(10))
+    assertTrue(scheduler.taskRunning(log.task))
+    log.close()
+    assertTrue(!(scheduler.taskRunning(log.task)))
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
@@ -16,15 +16,13 @@
  */
 package kafka.utils
 
-import java.util.Properties
-
 import org.junit.Assert._
 import java.util.concurrent.atomic._
-
 import kafka.log.{Log, LogConfig, LogManager, ProducerStateManager}
 import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
 import org.junit.{After, Before, Test}
 import kafka.utils.TestUtils.retry
+import java.util.Properties
 
 class SchedulerTest {
 


### PR DESCRIPTION
Added a method to delete the PeriodicProducerExpirationCheck task that kept adding to the log.
Includes a test to show that the task exists and then is removed when the log is closed.
