### PR TITLE
MINOR: Create a new topic for each test for flaky RegexSourceIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -90,7 +90,6 @@ public class RegexSourceIntegrationTest {
     private static final String PARTITIONED_TOPIC_1 = "partitioned-1";
     private static final String PARTITIONED_TOPIC_2 = "partitioned-2";
 
-    private static final String DEFAULT_OUTPUT_TOPIC_NAME = "outputTopic";
     private static final String STRING_SERDE_CLASSNAME = Serdes.String().getClass().getName();
     private Properties streamsConfiguration;
     private static final String STREAM_TASKS_NOT_UPDATED = "Stream tasks not updated";
@@ -175,8 +174,8 @@ public class RegexSourceIntegrationTest {
 
     }
 
-    private String createTopic(final String s) throws InterruptedException {
-        final String outputTopic = DEFAULT_OUTPUT_TOPIC_NAME + s;
+    private String createTopic(final String suffix) throws InterruptedException {
+        final String outputTopic = "outputTopic" + suffix;
         CLUSTER.createTopic(outputTopic);
         return outputTopic;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -96,6 +96,7 @@ public class RegexSourceIntegrationTest {
     private static final String STREAM_TASKS_NOT_UPDATED = "Stream tasks not updated";
     private KafkaStreams streams;
     private static volatile AtomicInteger topicSuffixGenerator = new AtomicInteger(0);
+    private String outputTopic;
 
 
     @BeforeClass
@@ -114,7 +115,8 @@ public class RegexSourceIntegrationTest {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws InterruptedException {
+        outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
         final Properties properties = new Properties();
         properties.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
@@ -139,7 +141,6 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testRegexMatchesTopicsAWhenCreated() throws Exception {
-        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final Serde<String> stringSerde = Serdes.String();
         final List<String> expectedFirstAssignment = Collections.singletonList("TEST-TOPIC-1");
@@ -183,7 +184,6 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testRegexMatchesTopicsAWhenDeleted() throws Exception {
-        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final Serde<String> stringSerde = Serdes.String();
         final List<String> expectedFirstAssignment = Arrays.asList("TEST-TOPIC-A", "TEST-TOPIC-B");
@@ -252,7 +252,6 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testShouldReadFromRegexAndNamedTopics() throws Exception {
-        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final String topic1TestMessage = "topic-1 test";
         final String topic2TestMessage = "topic-2 test";
@@ -303,7 +302,6 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testMultipleConsumersCanReadFromPartitionedTopic() throws Exception {
-        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         KafkaStreams partitionedStreamsLeader = null;
         KafkaStreams partitionedStreamsFollower = null;
@@ -364,7 +362,6 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testNoMessagesSentExceptionFromOverlappingPatterns() throws Exception {
-        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final String fMessage = "fMessage";
         final String fooMessage = "fooMessage";

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -94,6 +95,7 @@ public class RegexSourceIntegrationTest {
     private Properties streamsConfiguration;
     private static final String STREAM_TASKS_NOT_UPDATED = "Stream tasks not updated";
     private KafkaStreams streams;
+    private static volatile AtomicInteger topicSuffixGenerator = new AtomicInteger(0);
 
 
     @BeforeClass
@@ -113,7 +115,6 @@ public class RegexSourceIntegrationTest {
 
     @Before
     public void setUp() {
-
         final Properties properties = new Properties();
         properties.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
@@ -138,7 +139,7 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testRegexMatchesTopicsAWhenCreated() throws Exception {
-        final String outputTopic = createTopic("_1");
+        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final Serde<String> stringSerde = Serdes.String();
         final List<String> expectedFirstAssignment = Collections.singletonList("TEST-TOPIC-1");
@@ -174,15 +175,15 @@ public class RegexSourceIntegrationTest {
 
     }
 
-    private String createTopic(final String suffix) throws InterruptedException {
-        final String outputTopic = "outputTopic" + suffix;
+    private String createTopic(final int suffix) throws InterruptedException {
+        final String outputTopic = "outputTopic_" + suffix;
         CLUSTER.createTopic(outputTopic);
         return outputTopic;
     }
 
     @Test
     public void testRegexMatchesTopicsAWhenDeleted() throws Exception {
-        final String outputTopic = createTopic("_2");
+        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final Serde<String> stringSerde = Serdes.String();
         final List<String> expectedFirstAssignment = Arrays.asList("TEST-TOPIC-A", "TEST-TOPIC-B");
@@ -251,7 +252,7 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testShouldReadFromRegexAndNamedTopics() throws Exception {
-        final String outputTopic = createTopic("_3");
+        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final String topic1TestMessage = "topic-1 test";
         final String topic2TestMessage = "topic-2 test";
@@ -302,7 +303,7 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testMultipleConsumersCanReadFromPartitionedTopic() throws Exception {
-        final String outputTopic = createTopic("_4");
+        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         KafkaStreams partitionedStreamsLeader = null;
         KafkaStreams partitionedStreamsFollower = null;
@@ -363,7 +364,7 @@ public class RegexSourceIntegrationTest {
 
     @Test
     public void testNoMessagesSentExceptionFromOverlappingPatterns() throws Exception {
-        final String outputTopic = createTopic("_5");
+        final String outputTopic = createTopic(topicSuffixGenerator.incrementAndGet());
 
         final String fMessage = "fMessage";
         final String fooMessage = "fooMessage";


### PR DESCRIPTION
The `RegexSourceIntegrationTest` has some flakiness as it deletes and re-creates the same output topic before each test.  This PR reduces the chance for errors by creating a unique output topic for each test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
