### PR TITLE
KAFKA-8469: Fix topology compatibility for suppress

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -400,6 +400,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         }
 
         final SuppressedInternal<K> suppressedInternal = buildSuppress(suppressed, name);
+
         // We need to burn an index for the store name even if provided
         final String generatedSuppressedStoreName = builder.newStoreName(SUPPRESS_NAME);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -390,17 +390,21 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
     @Override
     public KTable<K, V> suppress(final Suppressed<? super K> suppressed) {
         final String name;
+        // We need to burn an index even if name provided
+        final String generatedSuppressedName = builder.newProcessorName(SUPPRESS_NAME);
         if (suppressed instanceof NamedSuppressed) {
             final String givenName = ((NamedSuppressed<?>) suppressed).name();
-            name = givenName != null ? givenName : builder.newProcessorName(SUPPRESS_NAME);
+            name = givenName != null ? givenName : generatedSuppressedName;
         } else {
             throw new IllegalArgumentException("Custom subclasses of Suppressed are not supported.");
         }
 
         final SuppressedInternal<K> suppressedInternal = buildSuppress(suppressed, name);
+        // We need to burn an index for the store name even if provided
+        final String generatedSuppressedStoreName = builder.newStoreName(SUPPRESS_NAME);
 
         final String storeName =
-            suppressedInternal.name() != null ? suppressedInternal.name() + "-store" : builder.newStoreName(SUPPRESS_NAME);
+            suppressedInternal.name() != null ? suppressedInternal.name() + "-store" : generatedSuppressedStoreName;
 
         final ProcessorSupplier<K, Change<V>> suppressionSupplier = new KTableSuppressProcessorSupplier<>(
             suppressedInternal,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
@@ -62,16 +62,16 @@ public class SuppressTopologyTest {
         "      --> myname\n" +
         "      <-- KSTREAM-SOURCE-0000000005\n" +
         "    Processor: myname (stores: [myname-store])\n" +
-        "      --> KTABLE-TOSTREAM-0000000006\n" +
+        "      --> KTABLE-TOSTREAM-0000000008\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
-        "    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])\n" +
-        "      --> KSTREAM-MAP-0000000007\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])\n" +
+        "      --> KSTREAM-MAP-0000000009\n" +
         "      <-- myname\n" +
-        "    Processor: KSTREAM-MAP-0000000007 (stores: [])\n" +
-        "      --> KSTREAM-SINK-0000000008\n" +
-        "      <-- KTABLE-TOSTREAM-0000000006\n" +
-        "    Sink: KSTREAM-SINK-0000000008 (topic: output-suppressed)\n" +
-        "      <-- KSTREAM-MAP-0000000007\n" +
+        "    Processor: KSTREAM-MAP-0000000009 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000010\n" +
+        "      <-- KTABLE-TOSTREAM-0000000008\n" +
+        "    Sink: KSTREAM-SINK-0000000010 (topic: output-suppressed)\n" +
+        "      <-- KSTREAM-MAP-0000000009\n" +
         "\n";
 
     private static final String ANONYMOUS_FINAL_TOPOLOGY = "Topologies:\n" +
@@ -114,13 +114,13 @@ public class SuppressTopologyTest {
         "      --> asdf\n" +
         "      <-- KSTREAM-SOURCE-0000000000\n" +
         "    Processor: asdf (stores: [asdf-store])\n" +
-        "      --> KTABLE-TOSTREAM-0000000003\n" +
+        "      --> KTABLE-TOSTREAM-0000000005\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
-        "    Processor: KTABLE-TOSTREAM-0000000003 (stores: [])\n" +
-        "      --> KSTREAM-SINK-0000000004\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000005 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000006\n" +
         "      <-- asdf\n" +
-        "    Sink: KSTREAM-SINK-0000000004 (topic: output)\n" +
-        "      <-- KTABLE-TOSTREAM-0000000003\n" +
+        "    Sink: KSTREAM-SINK-0000000006 (topic: output)\n" +
+        "      <-- KTABLE-TOSTREAM-0000000005\n" +
         "\n";
 
     private static final String ANONYMOUS_INTERMEDIATE_TOPOLOGY = "Topologies:\n" +


### PR DESCRIPTION
The KTable#suppress operator can take a user-supplied name for the operator. If the user does supply a name, the code should still increment the name counter index to ensure any downstream operators that use the generated name don't change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
