### PR TITLE
KAFKA-7315 DOCS update TOC internal links serdes all versions

### DIFF
--- a/docs/streams/developer-guide/datatypes.html
+++ b/docs/streams/developer-guide/datatypes.html
@@ -48,7 +48,7 @@
           <ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
-              <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
+              <li><a class="reference internal" href="#implementing-custom-serdes" id="id5">Implementing custom serdes</a></li>
           </ul>
           <li><a class="reference internal" href="#scala-dsl-serdes" id="id8">Kafka Streams DSL for Scala Implicit SerDes</a></li>
       </ul>


### PR DESCRIPTION
- **apache/kafka** docs update per https://issues.apache.org/jira/browse/KAFKA-7315
- follow up to PR https://github.com/apache/kafka-site/pull/177 to update same links in other version folders
- associated PR for kafka-site repo is https://github.com/apache/kafka-site/pull/212

Reviewers: @mjsax , @JimGalasyn , @joel-hamill

Signed-off-by: Victoria Bialas <vicky@confluent.io>


