### PR TITLE
KAFKA-8331: stream static membership system test

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -802,6 +802,11 @@ public abstract class AbstractCoordinator implements Closeable {
         return generation;
     }
 
+    protected synchronized String memberId() {
+        return generation == null ? JoinGroupRequest.UNKNOWN_MEMBER_ID :
+                generation.memberId;
+    }
+
     /**
      * Check whether given generation id is matching the record within current generation.
      * Only using in unit tests.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -587,7 +587,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     void invokeCompletedOffsetCommitCallbacks() {
         if (asyncCommitFenced.get()) {
             throw new FencedInstanceIdException("Get fenced exception for group.instance.id: " +
-                    groupInstanceId.orElse("unset_instance_id") + ", current member.id is " + generation().memberId);
+                    groupInstanceId.orElse("unset_instance_id") + ", current member.id is " + memberId());
         }
         while (true) {
             OffsetCommitCompletion completion = completedOffsetCommits.poll();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -586,7 +586,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     // visible for testing
     void invokeCompletedOffsetCommitCallbacks() {
         if (asyncCommitFenced.get()) {
-            throw new FencedInstanceIdException("Get fenced exception for group.instance.id " + groupInstanceId.orElse("unset_instance_id"));
+            throw new FencedInstanceIdException("Get fenced exception for group.instance.id: " +
+                    groupInstanceId.orElse("unset_instance_id") + ", current member.id is " + generation().memberId);
         }
         while (true) {
             OffsetCommitCompletion completion = completedOffsetCommits.poll();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -227,6 +227,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         return super.rejoinNeededOrPending() || (assignmentSnapshot == null || assignmentSnapshot.failed()) || rejoinRequested;
     }
 
+    @Override
     public String memberId() {
         Generation generation = generation();
         if (generation != null)

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
@@ -26,9 +26,9 @@ import org.apache.kafka.streams.kstream.KStream;
 import java.util.Objects;
 import java.util.Properties;
 
-public class StreamsStaticMembershipTest {
+public class StaticMemberTestClient {
 
-    private static String testName = "StreamsStaticMembershipTest";
+    private static String testName = "StaticMemberTestClient";
 
     @SuppressWarnings("unchecked")
     public static void main(final String[] args) throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
@@ -117,7 +117,5 @@ public class StreamsNamedRepartitionTest {
             System.out.println("NAMED_REPARTITION_TEST Streams Stopped");
             System.out.flush();
         }));
-
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.tests;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+
+import java.util.Objects;
+import java.util.Properties;
+
+public class StreamsStaticMembershipTest {
+
+    private static String testName = "StreamsStaticMembershipTest";
+
+    @SuppressWarnings("unchecked")
+    public static void main(final String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println(testName + " requires one argument (properties-file) but none provided: ");
+        }
+
+        System.out.println("StreamsTest instance started");
+
+        final String propFileName = args[0];
+
+        final Properties streamsProperties = Utils.loadProps(propFileName);
+
+        assert(streamsProperties.contains(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
+        String groupInstanceId = streamsProperties.getProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
+
+        System.out.println(testName + " instance started with group.instance.id " + groupInstanceId);
+        System.out.println("props=" + streamsProperties);
+        System.out.flush();
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final String inputTopic = (String) (Objects.requireNonNull(streamsProperties.remove("input.topic")));
+
+        final KStream dataStream = builder.stream(inputTopic);
+        dataStream.peek((k, v) ->  System.out.println(String.format("PROCESSED key=%s value=%s", k, v)));
+
+        final Properties config = new Properties();
+        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, testName);
+        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
+
+        config.putAll(streamsProperties);
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), config);
+        streams.setStateListener((newState, oldState) -> {
+            if (oldState == KafkaStreams.State.REBALANCING && newState == KafkaStreams.State.RUNNING) {
+                System.out.println("REBALANCING -> RUNNING");
+                System.out.flush();
+            }
+        });
+
+        streams.start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("closing Kafka Streams instance");
+                System.out.flush();
+                streams.close();
+                System.out.println("Static membership test closed");
+                System.out.flush();
+            }
+        });
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.kstream.KStream;
 import java.util.Objects;
 import java.util.Properties;
 
+import static org.junit.Assert.assertTrue;
+
 public class StreamsStaticMembershipTest {
 
     private static String testName = "StreamsStaticMembershipTest";
@@ -42,8 +44,8 @@ public class StreamsStaticMembershipTest {
 
         final Properties streamsProperties = Utils.loadProps(propFileName);
 
-        assert(streamsProperties.contains(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
-        String groupInstanceId = streamsProperties.getProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
+        assertTrue(streamsProperties.contains(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
+        final String groupInstanceId = streamsProperties.getProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
 
         System.out.println(testName + " instance started with group.instance.id " + groupInstanceId);
         System.out.println("props=" + streamsProperties);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStaticMembershipTest.java
@@ -26,8 +26,6 @@ import org.apache.kafka.streams.kstream.KStream;
 import java.util.Objects;
 import java.util.Properties;
 
-import static org.junit.Assert.assertTrue;
-
 public class StreamsStaticMembershipTest {
 
     private static String testName = "StreamsStaticMembershipTest";
@@ -44,8 +42,7 @@ public class StreamsStaticMembershipTest {
 
         final Properties streamsProperties = Utils.loadProps(propFileName);
 
-        assertTrue(streamsProperties.contains(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
-        final String groupInstanceId = streamsProperties.getProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
+        final String groupInstanceId = Objects.requireNonNull(streamsProperties.getProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
 
         System.out.println(testName + " instance started with group.instance.id " + groupInstanceId);
         System.out.println("props=" + streamsProperties);

--- a/tests/kafkatest/services/consumer_property.py
+++ b/tests/kafkatest/services/consumer_property.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 """
-Define Streams configuration property names here.
+Define Consumer configuration property names here.
 """
 
-STATE_DIR = "state.dir"
-KAFKA_SERVERS = "bootstrap.servers"
-NUM_THREADS = "num.stream.threads"
+GROUP_INSTANCE_ID = "group.instance.id"
+SESSION_TIMEOUT_MS = "session.timeout.ms"

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -536,16 +536,18 @@ class StreamsNamedRepartitionTopicService(StreamsTestBaseService):
         return cfg.render()
 
 class StreamsStaticMembershipService(StreamsTestBaseService):
-    def __init__(self, test_context, kafka, group_instance_id):
+    def __init__(self, test_context, kafka, group_instance_id, num_threads):
         super(StreamsStaticMembershipService, self).__init__(test_context,
                                                              kafka,
                                                              "org.apache.kafka.streams.tests.StreamsStaticMembershipTest",
                                                              "")
         self.INPUT_TOPIC = None
         self.GROUP_INSTANCE_ID = group_instance_id
+        self.NUM_THREADS = num_threads
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
                       streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      streams_property.NUM_THREADS: self.NUM_THREADS,
                       consumer_property.GROUP_INSTANCE_ID: self.GROUP_INSTANCE_ID,
                       consumer_property.SESSION_TIMEOUT_MS: 60000}
 

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -535,12 +535,12 @@ class StreamsNamedRepartitionTopicService(StreamsTestBaseService):
         cfg = KafkaConfig(**properties)
         return cfg.render()
 
-class StreamsStaticMembershipService(StreamsTestBaseService):
+class StaticMemberTestService(StreamsTestBaseService):
     def __init__(self, test_context, kafka, group_instance_id, num_threads):
-        super(StreamsStaticMembershipService, self).__init__(test_context,
-                                                             kafka,
-                                                             "org.apache.kafka.streams.tests.StreamsStaticMembershipTest",
-                                                             "")
+        super(StaticMemberTestService, self).__init__(test_context,
+                                                      kafka,
+                                                      "org.apache.kafka.streams.tests.StaticMemberTestClient",
+                                                      "")
         self.INPUT_TOPIC = None
         self.GROUP_INSTANCE_ID = group_instance_id
         self.NUM_THREADS = num_threads

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -16,6 +16,7 @@
 import os.path
 import signal
 import streams_property
+import consumer_property
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
@@ -530,6 +531,25 @@ class StreamsNamedRepartitionTopicService(StreamsTestBaseService):
         properties['input.topic'] = self.INPUT_TOPIC
         properties['aggregation.topic'] = self.AGGREGATION_TOPIC
         properties['add.operations'] = self.ADD_ADDITIONAL_OPS
+
+        cfg = KafkaConfig(**properties)
+        return cfg.render()
+
+class StreamsStaticMembershipService(StreamsTestBaseService):
+    def __init__(self, test_context, kafka, group_instance_id):
+        super(StreamsStaticMembershipService, self).__init__(test_context,
+                                                             kafka,
+                                                             "org.apache.kafka.streams.tests.StreamsStaticMembershipTest",
+                                                             "")
+        self.INPUT_TOPIC = None
+        self.GROUP_INSTANCE_ID = group_instance_id
+    def prop_file(self):
+        properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
+                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      consumer_property.GROUP_INSTANCE_ID: self.GROUP_INSTANCE_ID,
+                      consumer_property.SESSION_TIMEOUT_MS: 60000}
+
+        properties['input.topic'] = self.INPUT_TOPIC
 
         cfg = KafkaConfig(**properties)
         return cfg.render()

--- a/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
+++ b/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
@@ -18,7 +18,7 @@ from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsNamedRepartitionTopicService
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.tests.streams.utils import stop_processors, verify_running
+from kafkatest.tests.streams.utils import verify_stopped, stop_processors, verify_running
 
 class StreamsNamedRepartitionTopicTest(Test):
     """
@@ -71,7 +71,7 @@ class StreamsNamedRepartitionTopicTest(Test):
 
         # do rolling upgrade
         for processor in processors:
-            self.verify_stopped(processor, self.stopped_message)
+            verify_stopped(processor, self.stopped_message)
             #  will tell app to add operations before repartition topic
             processor.ADD_ADDITIONAL_OPS = 'true'
             verify_running(processor, 'UPDATED Topology')

--- a/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
+++ b/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from ducktape.tests.test import Test
-from ducktape.utils.util import wait_until
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsNamedRepartitionTopicService
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
-
+from kafkatest.tests.streams.utils import stop_processors, verify_running
 
 class StreamsNamedRepartitionTopicTest(Test):
     """
@@ -32,6 +30,7 @@ class StreamsNamedRepartitionTopicTest(Test):
     input_topic = 'inputTopic'
     aggregation_topic = 'aggregationTopic'
     pattern = 'AGGREGATED'
+    stopped_message = 'NAMED_REPARTITION_TEST Streams Stopped'
 
     def __init__(self, test_context):
         super(StreamsNamedRepartitionTopicTest, self).__init__(test_context)
@@ -66,42 +65,24 @@ class StreamsNamedRepartitionTopicTest(Test):
         for processor in processors:
             processor.CLEAN_NODE_ENABLED = False
             self.set_topics(processor)
-            self.verify_running(processor, 'REBALANCING -> RUNNING')
+            verify_running(processor, 'REBALANCING -> RUNNING')
 
         self.verify_processing(processors)
 
         # do rolling upgrade
         for processor in processors:
-            self.verify_stopped(processor)
+            self.verify_stopped(processor, self.stopped_message)
             #  will tell app to add operations before repartition topic
             processor.ADD_ADDITIONAL_OPS = 'true'
-            self.verify_running(processor, 'UPDATED Topology')
+            verify_running(processor, 'UPDATED Topology')
 
         self.verify_processing(processors)
 
-        self.stop_processors(processors)
+        stop_processors(processors, self.stopped_message)
 
         self.producer.stop()
         self.kafka.stop()
         self.zookeeper.stop()
-
-    @staticmethod
-    def verify_running(processor, message):
-        node = processor.node
-        with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
-            processor.start()
-            monitor.wait_until(message,
-                               timeout_sec=60,
-                               err_msg="Never saw '%s' message " % message + str(processor.node.account))
-
-    @staticmethod
-    def verify_stopped(processor):
-        node = processor.node
-        with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
-            processor.stop()
-            monitor.wait_until('NAMED_REPARTITION_TEST Streams Stopped',
-                               timeout_sec=60,
-                               err_msg="'NAMED_REPARTITION_TEST Streams Stopped' message" + str(processor.node.account))
 
     def verify_processing(self, processors):
         for processor in processors:
@@ -109,10 +90,6 @@ class StreamsNamedRepartitionTopicTest(Test):
                 monitor.wait_until(self.pattern,
                                    timeout_sec=60,
                                    err_msg="Never saw processing of %s " % self.pattern + str(processor.node.account))
-
-    def stop_processors(self, processors):
-        for processor in processors:
-            self.verify_stopped(processor)
 
     def set_topics(self, processor):
         processor.INPUT_TOPIC = self.input_topic

--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -31,7 +31,7 @@ class StreamsStaticMembershipTest(Test):
     def __init__(self, test_context):
         super(StreamsStaticMembershipTest, self).__init__(test_context)
         self.topics = {
-            self.input_topic: {'partitions': 6},
+            self.input_topic: {'partitions': 18},
         }
 
         self.zookeeper = ZookeeperService(self.test_context, num_nodes=1)
@@ -50,9 +50,10 @@ class StreamsStaticMembershipTest(Test):
         self.zookeeper.start()
         self.kafka.start()
 
-        processor1 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-A")
-        processor2 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-B")
-        processor3 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-C")
+        numThreads = 3
+        processor1 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-A", numThreads)
+        processor2 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-B", numThreads)
+        processor3 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-C", numThreads)
 
         processors = [processor1, processor2, processor3]
 
@@ -75,7 +76,7 @@ class StreamsStaticMembershipTest(Test):
         stableGeneration = 3
         for processor in processors:
             generations = self.extract_generation_from_logs(processor)
-            for generation in generations[-numBounces:]:
+            for generation in generations[-(numBounces * numThreads):]:
                 assert stableGeneration == int(generation), \
                     "Stream rolling bounce have caused unexpected generation bump %d" % int(generation)
 

--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.tests.test import Test
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.streams import StreamsStaticMembershipService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.zookeeper import ZookeeperService
+
+class StreamsStaticMembershipTest(Test):
+    """
+    Tests using static membership when broker points to minimum supported
+    version (2.3) or higher.
+    """
+
+    input_topic = 'inputTopic'
+    pattern = 'PROCESSED'
+
+    def __init__(self, test_context):
+        super(StreamsStaticMembershipTest, self).__init__(test_context)
+        self.topics = {
+            self.input_topic: {'partitions': 6},
+        }
+
+        self.zookeeper = ZookeeperService(self.test_context, num_nodes=1)
+        self.kafka = KafkaService(self.test_context, num_nodes=3,
+                                  zk=self.zookeeper, topics=self.topics)
+
+        self.producer = VerifiableProducer(self.test_context,
+                                           1,
+                                           self.kafka,
+                                           self.input_topic,
+                                           throughput=1000,
+                                           acks=1)
+
+    def test_rolling_bounces_will_not_trigger_rebalance_under_static_membership(self):
+        self.logger.info("code rolling bounce test started")
+        self.zookeeper.start()
+        self.kafka.start()
+
+        processor1 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-A")
+        processor2 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-B")
+        processor3 = StreamsStaticMembershipService(self.test_context, self.kafka, "consumer-C")
+
+        processors = [processor1, processor2, processor3]
+
+        self.producer.start()
+
+        for processor in processors:
+            processor.CLEAN_NODE_ENABLED = False
+            self.set_topics(processor)
+            self.verify_running(processor, 'REBALANCING -> RUNNING')
+
+        self.verify_processing(processors)
+
+        # do several rolling bounces
+        numBounces = 3
+        for i in range(0, numBounces):
+            for processor in processors:
+                self.verify_stopped(processor)
+                self.verify_running(processor, 'REBALANCING -> RUNNING')
+
+        stableGeneration = 3
+        for processor in processors:
+            generations = self.extract_generation_from_logs(processor)
+            for generation in generations[-numBounces:]:
+                assert stableGeneration == int(generation), \
+                    "Stream rolling bounce have caused unexpected generation bump %d" % int(generation)
+
+        self.verify_processing(processors)
+
+        self.stop_processors(processors)
+
+        self.producer.stop()
+        self.kafka.stop()
+        self.zookeeper.stop()
+
+    @staticmethod
+    def extract_generation_from_logs(processor):
+        return list(processor.node.account.ssh_capture("grep \"Successfully joined group with generation\" %s| awk \'{for(i=1;i<=NF;i++) {if ($i == \"generation\") beginning=i+1; if($i== \"(org.apache.kafka.clients.consumer.internals.AbstractCoordinator)\") ending=i }; for (j=beginning;j<ending;j++) printf $j; printf \"\\n\"}\'" % processor.LOG_FILE, allow_fail=True))
+
+    @staticmethod
+    def verify_running(processor, message):
+        node = processor.node
+        with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+            processor.start()
+            monitor.wait_until(message,
+                               timeout_sec=60,
+                               err_msg="Never saw '%s' message " % message + str(processor.node.account))
+
+    @staticmethod
+    def verify_stopped(processor):
+        node = processor.node
+        with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+            processor.stop()
+            monitor.wait_until('Static membership test closed',
+                               timeout_sec=60,
+                               err_msg="'Static membership test closed' message" + str(processor.node.account))
+
+    def verify_processing(self, processors):
+        for processor in processors:
+            with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+                monitor.wait_until(self.pattern,
+                                   timeout_sec=60,
+                                   err_msg="Never saw processing of %s " % self.pattern + str(processor.node.account))
+
+    def stop_processors(self, processors):
+        for processor in processors:
+            self.verify_stopped(processor)
+
+    def set_topics(self, processor):
+        processor.INPUT_TOPIC = self.input_topic

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -60,7 +60,7 @@ which are outlined here:
    
 4. Then update all relevant versions in the tests/docker/Dockerfile
 
-5. Add a new "upgrade-system-tests-XXXX module under streams.  You can probably just copy the 
+5. Add a new upgrade-system-tests-XXXX module under streams.  You can probably just copy the 
    latest system test module from the last release.  Just make sure to update the systout print
    statement in StreamsUpgradeTest to the version for the release.  After you add the new module
    you'll need to update settings.gradle file to include the name of the module you just created

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -23,8 +23,10 @@ from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService, \
     StreamsUpgradeTestJobRunnerService
 from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.tests.streams.utils import extract_generation_from_logs
 from kafkatest.version import LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, \
     LATEST_2_0, LATEST_2_1, DEV_BRANCH, DEV_VERSION, KafkaVersion
+
 
 # broker 0.10.0 is not compatible with newer Kafka Streams versions
 broker_upgrade_versions = [str(LATEST_0_10_1), str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0), str(LATEST_1_1), str(LATEST_2_0), str(LATEST_2_1), str(DEV_BRANCH)]
@@ -592,9 +594,9 @@ class StreamsUpgradeTest(Test):
                     retries = 0
 
                     while retries < 10:
-                        processor_found = self.extract_generation_from_logs(processor)
-                        first_other_processor_found = self.extract_generation_from_logs(first_other_processor)
-                        second_other_processor_found = self.extract_generation_from_logs(second_other_processor)
+                        processor_found = extract_generation_from_logs(processor)
+                        first_other_processor_found = extract_generation_from_logs(first_other_processor)
+                        second_other_processor_found = extract_generation_from_logs(second_other_processor)
 
                         if len(processor_found) > 0 and len(first_other_processor_found) > 0 and len(second_other_processor_found) > 0:
                             self.logger.info("processor: " + str(processor_found))
@@ -625,9 +627,6 @@ class StreamsUpgradeTest(Test):
                         self.verify_metadata_no_upgraded_yet()
 
         return current_generation
-
-    def extract_generation_from_logs(self, processor):
-        return list(processor.node.account.ssh_capture("grep \"Successfully joined group with generation\" %s| awk \'{for(i=1;i<=NF;i++) {if ($i == \"generation\") beginning=i+1; if($i== \"(org.apache.kafka.clients.consumer.internals.AbstractCoordinator)\") ending=i }; for (j=beginning;j<ending;j++) printf $j; printf \"\\n\"}\'" % processor.LOG_FILE, allow_fail=True))
 
     def extract_highest_generation(self, found_generations):
         return int(found_generations[-1])

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -43,7 +43,7 @@ anyone can verify that by calling
 curl https://s3-us-west-2.amazonaws.com/kafka-packages/kafka_$scala_version-$version.tgz to download the jar
 and if it is not uploaded yet, ping the dev@kafka mailing list to request it being uploaded.
 
-This test needs to get updated, but this requires several steps
+This test needs to get updated, but this requires several steps,
 which are outlined here:
 
 1. Update all relevant versions in tests/kafkatest/version.py this will include adding a new version for the new
@@ -55,17 +55,17 @@ which are outlined here:
    during the system test run.
    
 3. Update the vagrant/bash.sh file to include all new versions, including the newly released version
-   and all point releases for existing releases.  You only need to list the latest version in 
+   and all point releases for existing releases. You only need to list the latest version in 
    this file.
    
 4. Then update all relevant versions in the tests/docker/Dockerfile
 
-5. Add a new upgrade-system-tests-XXXX module under streams.  You can probably just copy the 
-   latest system test module from the last release.  Just make sure to update the systout print
-   statement in StreamsUpgradeTest to the version for the release.  After you add the new module
+5. Add a new upgrade-system-tests-XXXX module under streams. You can probably just copy the 
+   latest system test module from the last release. Just make sure to update the systout print
+   statement in StreamsUpgradeTest to the version for the release. After you add the new module
    you'll need to update settings.gradle file to include the name of the module you just created
-   for gradle to recognize the newly added module
-   
+   for gradle to recognize the newly added module.
+
 6. Then you'll need to update any version changes in gradle/dependencies.gradle
 
 """

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -27,7 +27,6 @@ from kafkatest.tests.streams.utils import extract_generation_from_logs
 from kafkatest.version import LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, \
     LATEST_2_0, LATEST_2_1, DEV_BRANCH, DEV_VERSION, KafkaVersion
 
-
 # broker 0.10.0 is not compatible with newer Kafka Streams versions
 broker_upgrade_versions = [str(LATEST_0_10_1), str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0), str(LATEST_1_1), str(LATEST_2_0), str(LATEST_2_1), str(DEV_BRANCH)]
 

--- a/tests/kafkatest/tests/streams/utils/__init__.py
+++ b/tests/kafkatest/tests/streams/utils/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from util import verify_running, verify_stopped

--- a/tests/kafkatest/tests/streams/utils/__init__.py
+++ b/tests/kafkatest/tests/streams/utils/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import verify_running, verify_stopped
+from util import verify_running, verify_stopped, stop_processors, extract_generation_from_logs

--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -1,0 +1,29 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def verify_running(processor, message):
+    node = processor.node
+    with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+        processor.start()
+        monitor.wait_until(message,
+                           timeout_sec=60,
+                           err_msg="Never saw '%s' message " % message + str(processor.node.account))
+
+def verify_stopped(processor, message):
+    node = processor.node
+    with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+        processor.stop()
+        monitor.wait_until('Static membership test closed',
+                           timeout_sec=60,
+                           err_msg="'%s' message " % message + str(processor.node.account))

--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -24,7 +24,7 @@ def verify_stopped(processor, message):
     node = processor.node
     with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
         processor.stop()
-        monitor.wait_until('Static membership test closed',
+        monitor.wait_until(message,
                            timeout_sec=60,
                            err_msg="'%s' message " % message + str(processor.node.account))
 

--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -27,3 +27,10 @@ def verify_stopped(processor, message):
         monitor.wait_until('Static membership test closed',
                            timeout_sec=60,
                            err_msg="'%s' message " % message + str(processor.node.account))
+
+def stop_processors(processors, stopped_message):
+    for processor in processors:
+        verify_stopped(processor, stopped_message)
+
+def extract_generation_from_logs(processor):
+    return list(processor.node.account.ssh_capture("grep \"Successfully joined group with generation\" %s| awk \'{for(i=1;i<=NF;i++) {if ($i == \"generation\") beginning=i+1; if($i== \"(org.apache.kafka.clients.consumer.internals.AbstractCoordinator)\") ending=i }; for (j=beginning;j<ending;j++) printf $j; printf \"\\n\"}\'" % processor.LOG_FILE, allow_fail=True))

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -119,5 +119,6 @@ V_2_1_0 = KafkaVersion("2.1.0")
 V_2_1_1 = KafkaVersion("2.1.1")
 LATEST_2_1 = V_2_1_1
 
+# 2.2.x versions
 V_2_2_0 = KafkaVersion("2.2.0")
 LATEST_2_2 = V_2_2_0


### PR DESCRIPTION
As title suggested, we boost 3 stream instances stream job with one minute session timeout, and once the group is stable, doing couple of rolling bounces for the entire cluster. Every rejoin based on restart should have no generation bump on the client side.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
