### PR TITLE
MINOR: Not all fields specified were printed in log event.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -256,7 +256,7 @@ class WorkerSinkTask extends WorkerTask {
         } else {
             long durationMillis = time.milliseconds() - commitStarted;
             if (error != null) {
-                log.error("{} Commit of offsets threw an unexpected exception for sequence number {}: {}",
+                log.error("{} Commit of offsets threw an unexpected exception for sequence number {}: {} with error {}",
                         this, seqno, committedOffsets, error);
                 commitFailures++;
                 recordCommitFailure(durationMillis, error);


### PR DESCRIPTION
The error was missed out preventing users to know the actual cause.

Before it didn't state the error cause:
`2019-04-26 21:31:26,355 ERROR org.apache.kafka.connect.runtime.WorkerSinkTask:261 - WorkerSinkTask{id=foobar-4} Commit of offsets threw an unexpected exception for sequence number 29: {foobar-topic-7=OffsetAndMetadata{offset=288227113, leaderEpoch=null, metadata=''}}`

With this change:
`2019-04-26 21:31:26,355 ERROR org.apache.kafka.connect.runtime.WorkerSinkTask:261 - WorkerSinkTask{id=foobar-4} Commit of offsets threw an unexpected exception for sequence number 29: {foobar-topic-7=OffsetAndMetadata{offset=288227113, leaderEpoch=null, metadata=''}} with error: <whatever is the cause>`