### PR TITLE
Hot Fix: Close unused ColumnFamilyHandle

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -75,6 +75,7 @@ public class RocksDBTimestampedStore extends RocksDBStore {
             } else {
                 log.info("Opening store {} in regular mode", name);
                 dbAccessor = new SingleColumnFamilyAccessor(columnFamilies.get(1));
+                noTimestampColumnFamily.close();
             }
             noTimestampsIter.close();
         } catch (final RocksDBException e) {


### PR DESCRIPTION
In RocksDBTimestampedStore#openRocksDB we try to open a db with two column families. If this succeeds but the first column family is empty (db.newIterator.seekToFirst.isValid() == false) we never actually close its ColumnFamilyHandle