### PR TITLE
MINOR: Fix a wrong description in PipeDemo's javadoc

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pipe/PipeDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pipe/PipeDemo.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CountDownLatch;
  * Demonstrates, using the high-level KStream DSL, how to read data from a source (input) topic and how to
  * write data to a sink (output) topic.
  *
- * In this example, we implement a simple "pipe" program that reads from a source topic "streams-file-input"
+ * In this example, we implement a simple "pipe" program that reads from a source topic "streams-plaintext-input"
  * and writes the data as-is (i.e. unmodified) into a sink topic "streams-pipe-output".
  *
  * Before running this example you must create the input topic and the output topic (e.g. via


### PR DESCRIPTION
This PR fixes a wrong input stream name in PipeDemo's javadoc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
