### PR TITLE
KAFKA-8501: Removing key and value from exception message

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -58,7 +58,7 @@ public class RecordCollectorImpl implements RecordCollector {
     private final static String LOG_MESSAGE = "Error sending record to topic {} due to {}; " +
         "No more records will be sent and no more offsets will be recorded for this task. " +
         "Enable TRACE logging to view failed record key and value.";
-    private final static String EXCEPTION_MESSAGE = "%sAbort sending since %s with a previous record (key %s value %s timestamp %d) to topic %s due to %s";
+    private final static String EXCEPTION_MESSAGE = "%sAbort sending since %s with a previous record (timestamp %d) to topic %s due to %s";
     private final static String PARAMETER_HINT = "\nYou can increase producer parameter `retries` and `retry.backoff.ms` to avoid this error.";
     private volatile KafkaException sendException;
 
@@ -139,8 +139,6 @@ public class RecordCollectorImpl implements RecordCollector {
                 errorMessage,
                 logPrefix,
                 "an error caught",
-                key,
-                value,
                 timestamp,
                 topic,
                 exception.toString()
@@ -187,8 +185,6 @@ public class RecordCollectorImpl implements RecordCollector {
                                         EXCEPTION_MESSAGE,
                                         logPrefix,
                                         "producer got fenced",
-                                        key,
-                                        value,
                                         timestamp,
                                         topic,
                                         exception.toString()
@@ -245,8 +241,6 @@ public class RecordCollectorImpl implements RecordCollector {
                         EXCEPTION_MESSAGE,
                         logPrefix,
                         "an error caught",
-                        key,
-                        value,
                         timestamp,
                         topic,
                         uncaughtException.toString()


### PR DESCRIPTION
Messages containing key and value were moved to the TRACE logging level, however the exception is still adding the key and value.
This commits remove the key and value from StreamsException.

*Summary of testing strategy (including rationale)
The content of the exception message is not tested anywhere, and I think it would be really difficult to provide a reliable test to check for content inside a string.

### Committer Checklist (excluded from commit message)
- [ X ] Verify design and implementation 
- [ X ] Verify test coverage and CI build status
- [ X ] Verify documentation (including upgrade notes)
