### PR TITLE
KAFKA-8513: Add kafka-streams-application-reset.bat for Windows platform

### DIFF
--- a/bin/windows/kafka-streams-application-reset.bat
+++ b/bin/windows/kafka-streams-application-reset.bat
@@ -1,0 +1,21 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
+        set KAFKA_HEAP_OPTS=-Xmx512M
+)
+
+"%~dp0kafka-run-class.bat" kafka.tools.StreamsResetter %*

--- a/bin/windows/kafka-streams-application-reset.bat
+++ b/bin/windows/kafka-streams-application-reset.bat
@@ -14,8 +14,10 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
+SetLocal
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
         set KAFKA_HEAP_OPTS=-Xmx512M
 )
 
 "%~dp0kafka-run-class.bat" kafka.tools.StreamsResetter %*
+EndLocal


### PR DESCRIPTION
For improving Windows support, this PR adds a batch file correponding to bin/kafka-streams-application-reset.sh.

I Ran the added batch file and confirmed it worked on Windows 10 as follows:

```
PS C:\kafka-trunk> .\bin\windows\kafka-streams-application-reset.bat --application-id streams-pipe --input-topics streams-plaintext-input --to-earliest

(snip)

Reset-offsets for input topics [streams-plaintext-input]
Following input topics offsets will be reset to (for consumer group streams-pipe)
Topic: streams-plaintext-input Partition: 0 Offset: 0
Done.
Deleting all internal/auto-created topics for application streams-pipe
Done.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
