### PR TITLE
MINOR: Remove integration package prefix from ConsumerTopicCreationTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package integration.kafka.api
+package kafka.api
 
 import java.lang.{Boolean => JBoolean}
 import java.time.Duration


### PR DESCRIPTION
This PR removes the `integration` package prefix from the `ConsumerTopicCreationTest`, bringing it back in line with the rest of the integration tests. 