### PR TITLE
MINOR: Reinstate info-level log for dynamic update of SSL keystores

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -114,7 +114,12 @@ public class SslFactory implements Reconfigurable {
 
     @Override
     public void reconfigure(Map<String, ?> newConfigs) throws KafkaException {
-        this.sslEngineBuilder = createNewSslEngineBuilder(newConfigs);
+        SslEngineBuilder newSslEngineBuilder = createNewSslEngineBuilder(newConfigs);
+        if (newSslEngineBuilder != this.sslEngineBuilder) {
+            this.sslEngineBuilder = newSslEngineBuilder;
+            log.info("Created new {} SSL engine builder with keystore {} truststore {}", mode,
+                    newSslEngineBuilder.keystore(), newSslEngineBuilder.truststore());
+        }
     }
 
     private SslEngineBuilder createNewSslEngineBuilder(Map<String, ?> newConfigs) {


### PR DESCRIPTION
We log all dynamic updates at info-level in DynamicBrokerConfig. In addition to this, we also used to have an info-level log entry in SslFactory for SSL keystore and truststore update including the modification time of the file, since we update these without an actual config change. We seem to have lost that entry when making updates to the factory recently.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
