### PR TITLE
KAFKA-8456: Stabilize flaky StoreUpgradeIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreUpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreUpgradeIntegrationTest.java
@@ -329,56 +329,65 @@ public class StoreUpgradeIntegrationTest {
                 IntegerSerializer.class),
             CLUSTER.time);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyKeyValueStore<K, V> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.keyValueStore());
-                try (final KeyValueIterator<K, V> all = store.all()) {
-                    final List<KeyValue<K, V>> storeContent = new LinkedList<>();
-                    while (all.hasNext()) {
-                        storeContent.add(all.next());
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyKeyValueStore<K, V> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.keyValueStore());
+                    try (final KeyValueIterator<K, V> all = store.all()) {
+                        final List<KeyValue<K, V>> storeContent = new LinkedList<>();
+                        while (all.hasNext()) {
+                            storeContent.add(all.next());
+                        }
+                        return storeContent.equals(expectedStoreContent);
                     }
-                    return storeContent.equals(expectedStoreContent);
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
                 }
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K> void verifyCountWithTimestamp(final K key,
                                               final long value,
                                               final long timestamp) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
-                final ValueAndTimestamp<Long> count = store.get(key);
-                return count.value() == value && count.timestamp() == timestamp;
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                    final ValueAndTimestamp<Long> count = store.get(key);
+                    return count.value() == value && count.timestamp() == timestamp;
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
+                }
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K> void verifyCountWithSurrogateTimestamp(final K key,
                                                        final long value) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
-                final ValueAndTimestamp<Long> count = store.get(key);
-                return count.value() == value && count.timestamp() == -1L;
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                    final ValueAndTimestamp<Long> count = store.get(key);
+                    return count.value() == value && count.timestamp() == -1L;
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
+                }
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K, V> void processKeyValueAndVerifyCount(final K key,
@@ -394,23 +403,26 @@ public class StoreUpgradeIntegrationTest {
                 IntegerSerializer.class),
             timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
-                try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
-                    final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
-                    while (all.hasNext()) {
-                        storeContent.add(all.next());
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                    try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
+                        final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
+                        while (all.hasNext()) {
+                            storeContent.add(all.next());
+                        }
+                        return storeContent.equals(expectedStoreContent);
                     }
-                    return storeContent.equals(expectedStoreContent);
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
                 }
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K, V> void processKeyValueAndVerifyCountWithTimestamp(final K key,
@@ -426,23 +438,26 @@ public class StoreUpgradeIntegrationTest {
                 IntegerSerializer.class),
             timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
-                try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
-                    final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
-                    while (all.hasNext()) {
-                        storeContent.add(all.next());
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                    try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
+                        final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
+                        while (all.hasNext()) {
+                            storeContent.add(all.next());
+                        }
+                        return storeContent.equals(expectedStoreContent);
                     }
-                    return storeContent.equals(expectedStoreContent);
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
                 }
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     @Test
@@ -789,56 +804,65 @@ public class StoreUpgradeIntegrationTest {
                 IntegerSerializer.class),
             CLUSTER.time);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<K, V> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.windowStore());
-                try (final KeyValueIterator<Windowed<K>, V> all = store.all()) {
-                    final List<KeyValue<Windowed<K>, V>> storeContent = new LinkedList<>();
-                    while (all.hasNext()) {
-                        storeContent.add(all.next());
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyWindowStore<K, V> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.windowStore());
+                    try (final KeyValueIterator<Windowed<K>, V> all = store.all()) {
+                        final List<KeyValue<Windowed<K>, V>> storeContent = new LinkedList<>();
+                        while (all.hasNext()) {
+                            storeContent.add(all.next());
+                        }
+                        return storeContent.equals(expectedStoreContent);
                     }
-                    return storeContent.equals(expectedStoreContent);
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
                 }
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K> void verifyWindowedCountWithSurrogateTimestamp(final Windowed<K> key,
                                                                final long value) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
-                final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
-                return count.value() == value && count.timestamp() == -1L;
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                    final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
+                    return count.value() == value && count.timestamp() == -1L;
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
+                }
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K> void verifyWindowedCountWithTimestamp(final Windowed<K> key,
                                                       final long value,
                                                       final long timestamp) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
-                final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
-                return count.value() == value && count.timestamp() == timestamp;
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                    final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
+                    return count.value() == value && count.timestamp() == timestamp;
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
+                }
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private <K, V> void processKeyValueAndVerifyWindowedCountWithTimestamp(final K key,
@@ -854,23 +878,26 @@ public class StoreUpgradeIntegrationTest {
                 IntegerSerializer.class),
             timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<K, ValueAndTimestamp<V>> store =
-                    kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
-                try (final KeyValueIterator<Windowed<K>, ValueAndTimestamp<V>> all = store.all()) {
-                    final List<KeyValue<Windowed<K>, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
-                    while (all.hasNext()) {
-                        storeContent.add(all.next());
+        TestUtils.waitForCondition(
+            () -> {
+                try {
+                    final ReadOnlyWindowStore<K, ValueAndTimestamp<V>> store =
+                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                    try (final KeyValueIterator<Windowed<K>, ValueAndTimestamp<V>> all = store.all()) {
+                        final List<KeyValue<Windowed<K>, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
+                        while (all.hasNext()) {
+                            storeContent.add(all.next());
+                        }
+                        return storeContent.equals(expectedStoreContent);
                     }
-                    return storeContent.equals(expectedStoreContent);
+                } catch (final Exception swallow) {
+                    swallow.printStackTrace();
+                    System.err.println(swallow.getMessage());
+                    return false;
                 }
-            } catch (final Exception swallow) {
-                swallow.printStackTrace();
-                System.err.println(swallow.getMessage());
-                return false;
-            }
-        }, "Could not get expected result in time.");
+            },
+            60_000L,
+            "Could not get expected result in time.");
     }
 
     private static class KeyValueProcessor implements Processor<Integer, Integer> {


### PR DESCRIPTION
Running those tests locally, most run about 10 seconds. The default timeout is 15 seconds. I think it makes sense to provide more head room on Jenkins.

This PR increase the timeout to 60 seconds.