### PR TITLE
MINOR: Fix system test logic to handle duplicates between kafka.properties and server_prop_overides

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -215,20 +215,38 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.advertised_listeners = ','.join(advertised_listeners)
 
     def prop_file(self, node):
-        cfg = KafkaConfig(**node.config)
-        cfg[config_property.ADVERTISED_HOSTNAME] = node.account.hostname
-        cfg[config_property.ZOOKEEPER_CONNECT] = self.zk_connect_setting()
-
-        for prop in self.server_prop_overides:
-            cfg[prop[0]] = prop[1]
-
         self.set_protocol_and_port(node)
 
-        # TODO - clean up duplicate configuration logic
-        prop_file = cfg.render()
-        prop_file += self.render('kafka.properties', node=node, broker_id=self.idx(node),
+        #load template configs as dictionary
+        config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
                                  security_config=self.security_config, num_nodes=self.num_nodes)
+
+        configs = dict( l.rstrip().split('=') for l in config_template.split('\n')
+                        if not l.startswith("#") and "=" in l )
+
+        #load specific test override configs
+        override_configs = KafkaConfig(**node.config)
+        override_configs[config_property.ADVERTISED_HOSTNAME] = node.account.hostname
+        override_configs[config_property.ZOOKEEPER_CONNECT] = self.zk_connect_setting()
+
+        for prop in self.server_prop_overides:
+            override_configs[prop[0]] = prop[1]
+
+        #update template configs with test override configs
+        configs.update(override_configs)
+
+        prop_file = self.render_configs(configs)
         return prop_file
+
+    def render_configs(self, configs):
+        """Render self as a series of lines key=val\n, and do so in a consistent order. """
+        keys = [k for k in configs.keys()]
+        keys.sort()
+
+        s = ""
+        for k in keys:
+            s += "%s=%s\n" % (k, str(configs[k]))
+        return s
 
     def start_cmd(self, node):
         cmd = "export JMX_PORT=%d; " % self.jmx_port


### PR DESCRIPTION
The changes are cherry-picked from commit 914ffa9dbef3c8ad6851b380276a1cb7c5aa4a0d which is present in 2.1+ versions

The reason for this patch is that the 2.0 `log_dir_failure_test.py` system test very frequently fails due to expecting one partition of the `__consumer_offsets` topic. The override config for the partitions count is passed but gets overridden by the value in kafka.properties.