### PR TITLE
MINOR: Improve Javadoc style

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 
-/*
+/**
  * This class implements the common APIs that are shared by Options classes for various AdminClient commands
  */
 public abstract class AbstractOptions<T extends AbstractOptions> {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -991,7 +991,7 @@ public class KafkaAdminClient extends AdminClient {
          *
          * @param now                   The current time in milliseconds.
          * @param responses             The latest responses from KafkaClient.
-         **/
+         */
         private void handleResponses(long now, List<ClientResponse> responses) {
             for (ClientResponse response : responses) {
                 int correlationId = response.requestHeader().correlationId();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -62,13 +62,13 @@ public interface Consumer<K, V> extends Closeable {
     void assign(Collection<TopicPartition> partitions);
 
     /**
-    * @see KafkaConsumer#subscribe(Pattern, ConsumerRebalanceListener)
-    */
+     * @see KafkaConsumer#subscribe(Pattern, ConsumerRebalanceListener)
+     */
     void subscribe(Pattern pattern, ConsumerRebalanceListener callback);
 
     /**
-    * @see KafkaConsumer#subscribe(Pattern)
-    */
+     * @see KafkaConsumer#subscribe(Pattern)
+     */
     void subscribe(Pattern pattern);
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1402,38 +1402,38 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
-    * Commit the specified offsets for the specified list of topics and partitions.
-    * <p>
-    * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
-    * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
-    * should not be used. The committed offset should be the next message your application will consume,
-    * i.e. lastProcessedMessageOffset + 1.
-    * <p>
-    * This is a synchronous commits and will block until either the commit succeeds, an unrecoverable error is
-    * encountered (in which case it is thrown to the caller), or the timeout expires.
-    * <p>
-    * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
-    * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
-    *
-    * @param offsets A map of offsets by partition with associated metadata
-    * @param timeout The maximum amount of time to await completion of the offset commit
-    * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
-    *             This can only occur if you are using automatic group management with {@link #subscribe(Collection)},
-    *             or if there is an active group with the same groupId which is using group management.
-    * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
-    *             function is called
-    * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
-    *             this function is called
-    * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
-    * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
-    *             configured groupId. See the exception for more details
-    * @throws java.lang.IllegalArgumentException if the committed offset is negative
-    * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. if offset metadata
-    *             is too large or if the topic does not exist).
-    * @throws org.apache.kafka.common.errors.TimeoutException if the timeout expires before successful completion
-    *            of the offset commit
-    * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
-    */
+     * Commit the specified offsets for the specified list of topics and partitions.
+     * <p>
+     * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
+     * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
+     * should not be used. The committed offset should be the next message your application will consume,
+     * i.e. lastProcessedMessageOffset + 1.
+     * <p>
+     * This is a synchronous commits and will block until either the commit succeeds, an unrecoverable error is
+     * encountered (in which case it is thrown to the caller), or the timeout expires.
+     * <p>
+     * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
+     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
+     *
+     * @param offsets A map of offsets by partition with associated metadata
+     * @param timeout The maximum amount of time to await completion of the offset commit
+     * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
+     *             This can only occur if you are using automatic group management with {@link #subscribe(Collection)},
+     *             or if there is an active group with the same groupId which is using group management.
+     * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
+     *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
+     * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
+     * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
+     *             configured groupId. See the exception for more details
+     * @throws java.lang.IllegalArgumentException if the committed offset is negative
+     * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. if offset metadata
+     *             is too large or if the topic does not exist).
+     * @throws org.apache.kafka.common.errors.TimeoutException if the timeout expires before successful completion
+     *            of the offset commit
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this consumer instance gets fenced by broker.
+     */
     @Override
     public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout) {
         acquireAndEnsureOpen();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-/*
+/**
  * A thread-safe helper class to hold batches that haven't been acknowledged yet (including those
  * which have and have not been sent).
  */

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -116,10 +116,10 @@ public abstract class KafkaFuture<T> implements Future<T> {
     public abstract <R> KafkaFuture<R> thenApply(BaseFunction<T, R> function);
 
     /**
-     * @see KafkaFuture#thenApply(BaseFunction)
-     *
      * Prefer {@link KafkaFuture#thenApply(BaseFunction)} as this function is here for backwards compatibility reasons
      * and might be deprecated/removed in a future release.
+     *
+     * @see KafkaFuture#thenApply(BaseFunction)
      */
     public abstract <R> KafkaFuture<R> thenApply(Function<T, R> function);
 

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclPermissionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclPermissionType.java
@@ -59,12 +59,12 @@ public enum AclPermissionType {
     }
 
     /**
-    * Parse the given string as an ACL permission.
-    *
-    * @param str    The string to parse.
-    *
-    * @return       The AclPermissionType, or UNKNOWN if the string could not be matched.
-    */
+     * Parse the given string as an ACL permission.
+     *
+     * @param str    The string to parse.
+     *
+     * @return       The AclPermissionType, or UNKNOWN if the string could not be matched.
+     */
     public static AclPermissionType fromString(String str) {
         try {
             return AclPermissionType.valueOf(str.toUpperCase(Locale.ROOT));

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
@@ -51,7 +51,7 @@ public interface ConfigProvider extends Configurable, Closeable {
      * @param path the path where the data resides
      * @param keys the keys whose values will be retrieved
      * @param callback the callback to invoke upon change
-     * @throws {@link UnsupportedOperationException} if the subscribe operation is not supported
+     * @throws UnsupportedOperationException if the subscribe operation is not supported
      */
     default void subscribe(String path, Set<String> keys, ConfigChangeCallback callback) {
         throw new UnsupportedOperationException();
@@ -63,7 +63,7 @@ public interface ConfigProvider extends Configurable, Closeable {
      * @param path the path where the data resides
      * @param keys the keys whose values will be retrieved
      * @param callback the callback to be unsubscribed from changes
-     * @throws {@link UnsupportedOperationException} if the unsubscribe operation is not supported
+     * @throws UnsupportedOperationException if the unsubscribe operation is not supported
      */
     default void unsubscribe(String path, Set<String> keys, ConfigChangeCallback callback) {
         throw new UnsupportedOperationException();
@@ -72,7 +72,7 @@ public interface ConfigProvider extends Configurable, Closeable {
     /**
      * Clears all subscribers (optional operation).
      *
-     * @throws {@link UnsupportedOperationException} if the unsubscribeAll operation is not supported
+     * @throws UnsupportedOperationException if the unsubscribeAll operation is not supported
      */
     default void unsubscribeAll() {
         throw new UnsupportedOperationException();

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -102,7 +102,7 @@ public class Metrics implements Closeable {
     }
 
 
-  /**
+    /**
      * Create a metrics repository with no reporters and the given default config. This config will be used for any
      * metric that doesn't override its own config. Expiration of Sensors is disabled.
      * @param defaultConfig The default config to use for all metrics that don't override their config

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.network;
 
-/*
+/**
  * Transport layer for PLAINTEXT communication
  */
 

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -16,10 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-/**
- * Transport layer for PLAINTEXT communication
- */
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -30,6 +26,9 @@ import java.security.Principal;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
+/**
+ * Transport layer for PLAINTEXT communication
+ */
 public class PlaintextTransportLayer implements TransportLayer {
     private final SelectionKey key;
     private final SocketChannel socketChannel;

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -92,12 +92,12 @@ public class PlaintextTransportLayer implements TransportLayer {
     public void handshake() {}
 
     /**
-    * Reads a sequence of bytes from this channel into the given buffer.
-    *
-    * @param dst The buffer into which bytes are to be transferred
-    * @return The number of bytes read, possible zero or -1 if the channel has reached end-of-stream
-    * @throws IOException if some other I/O error occurs
-    */
+     * Reads a sequence of bytes from this channel into the given buffer.
+     *
+     * @param dst The buffer into which bytes are to be transferred
+     * @return The number of bytes read, possible zero or -1 if the channel has reached end-of-stream
+     * @throws IOException if some other I/O error occurs
+     */
     @Override
     public int read(ByteBuffer dst) throws IOException {
         return socketChannel.read(dst);
@@ -129,38 +129,38 @@ public class PlaintextTransportLayer implements TransportLayer {
     }
 
     /**
-    * Writes a sequence of bytes to this channel from the given buffer.
-    *
-    * @param src The buffer from which bytes are to be retrieved
-    * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the given buffer.
+     *
+     * @param src The buffer from which bytes are to be retrieved
+     * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public int write(ByteBuffer src) throws IOException {
         return socketChannel.write(src);
     }
 
     /**
-    * Writes a sequence of bytes to this channel from the given buffer.
-    *
-    * @param srcs The buffer from which bytes are to be retrieved
-    * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the given buffer.
+     *
+     * @param srcs The buffer from which bytes are to be retrieved
+     * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public long write(ByteBuffer[] srcs) throws IOException {
         return socketChannel.write(srcs);
     }
 
     /**
-    * Writes a sequence of bytes to this channel from the subsequence of the given buffers.
-    *
-    * @param srcs The buffers from which bytes are to be retrieved
-    * @param offset The offset within the buffer array of the first buffer from which bytes are to be retrieved; must be non-negative and no larger than srcs.length.
-    * @param length - The maximum number of buffers to be accessed; must be non-negative and no larger than srcs.length - offset.
-    * @return returns no.of bytes written , possibly zero.
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the subsequence of the given buffers.
+     *
+     * @param srcs The buffers from which bytes are to be retrieved
+     * @param offset The offset within the buffer array of the first buffer from which bytes are to be retrieved; must be non-negative and no larger than srcs.length.
+     * @param length - The maximum number of buffers to be accessed; must be non-negative and no larger than srcs.length - offset.
+     * @return returns no.of bytes written , possibly zero.
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
         return socketChannel.write(srcs, offset, length);

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -42,7 +42,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
-/*
+/**
  * Transport layer for SSL communication
  */
 public class SslTransportLayer implements TransportLayer {

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -152,8 +152,8 @@ public class SslTransportLayer implements TransportLayer {
 
 
     /**
-    * Sends a SSL close message and closes socketChannel.
-    */
+     * Sends a SSL close message and closes socketChannel.
+     */
     @Override
     public void close() throws IOException {
         State prevState = state;
@@ -206,12 +206,12 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     /**
-    * Flushes the buffer to the network, non blocking.
-    * Visible for testing.
-    * @param buf ByteBuffer
-    * @return boolean true if the buffer has been emptied out, false otherwise
-    * @throws IOException
-    */
+     * Flushes the buffer to the network, non blocking.
+     * Visible for testing.
+     * @param buf ByteBuffer
+     * @return boolean true if the buffer has been emptied out, false otherwise
+     * @throws IOException
+     */
     protected boolean flush(ByteBuffer buf) throws IOException {
         int remaining = buf.remaining();
         if (remaining > 0) {
@@ -222,28 +222,28 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     /**
-    * Performs SSL handshake, non blocking.
-    * Before application data (kafka protocols) can be sent client & kafka broker must
-    * perform ssl handshake.
-    * During the handshake SSLEngine generates encrypted data that will be transported over socketChannel.
-    * Each SSLEngine operation generates SSLEngineResult , of which SSLEngineResult.handshakeStatus field is used to
-    * determine what operation needs to occur to move handshake along.
-    * A typical handshake might look like this.
-    * +-------------+----------------------------------+-------------+
-    * |  client     |  SSL/TLS message                 | HSStatus    |
-    * +-------------+----------------------------------+-------------+
-    * | wrap()      | ClientHello                      | NEED_UNWRAP |
-    * | unwrap()    | ServerHello/Cert/ServerHelloDone | NEED_WRAP   |
-    * | wrap()      | ClientKeyExchange                | NEED_WRAP   |
-    * | wrap()      | ChangeCipherSpec                 | NEED_WRAP   |
-    * | wrap()      | Finished                         | NEED_UNWRAP |
-    * | unwrap()    | ChangeCipherSpec                 | NEED_UNWRAP |
-    * | unwrap()    | Finished                         | FINISHED    |
-    * +-------------+----------------------------------+-------------+
-    *
-    * @throws IOException if read/write fails
-    * @throws SslAuthenticationException if handshake fails with an {@link SSLException}
-    */
+     * Performs SSL handshake, non blocking.
+     * Before application data (kafka protocols) can be sent client & kafka broker must
+     * perform ssl handshake.
+     * During the handshake SSLEngine generates encrypted data that will be transported over socketChannel.
+     * Each SSLEngine operation generates SSLEngineResult , of which SSLEngineResult.handshakeStatus field is used to
+     * determine what operation needs to occur to move handshake along.
+     * A typical handshake might look like this.
+     * +-------------+----------------------------------+-------------+
+     * |  client     |  SSL/TLS message                 | HSStatus    |
+     * +-------------+----------------------------------+-------------+
+     * | wrap()      | ClientHello                      | NEED_UNWRAP |
+     * | unwrap()    | ServerHello/Cert/ServerHelloDone | NEED_WRAP   |
+     * | wrap()      | ClientKeyExchange                | NEED_WRAP   |
+     * | wrap()      | ChangeCipherSpec                 | NEED_WRAP   |
+     * | wrap()      | Finished                         | NEED_UNWRAP |
+     * | unwrap()    | ChangeCipherSpec                 | NEED_UNWRAP |
+     * | unwrap()    | Finished                         | FINISHED    |
+     * +-------------+----------------------------------+-------------+
+     *
+     * @throws IOException if read/write fails
+     * @throws SslAuthenticationException if handshake fails with an {@link SSLException}
+     */
     @Override
     public void handshake() throws IOException {
         if (state == State.NOT_INITALIZED)
@@ -433,11 +433,11 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     /**
-    * Performs the WRAP function
-    * @param doWrite boolean
-    * @return SSLEngineResult
-    * @throws IOException
-    */
+     * Performs the WRAP function
+     * @param doWrite boolean
+     * @return SSLEngineResult
+     * @throws IOException
+     */
     private SSLEngineResult handshakeWrap(boolean doWrite) throws IOException {
         log.trace("SSLHandshake handshakeWrap {}", channelId);
         if (netWriteBuffer.hasRemaining())
@@ -499,14 +499,14 @@ public class SslTransportLayer implements TransportLayer {
 
 
     /**
-    * Reads a sequence of bytes from this channel into the given buffer. Reads as much as possible
-    * until either the dst buffer is full or there is no more data in the socket.
-    *
-    * @param dst The buffer into which bytes are to be transferred
-    * @return The number of bytes read, possible zero or -1 if the channel has reached end-of-stream
-    *         and no more data is available
-    * @throws IOException if some other I/O error occurs
-    */
+     * Reads a sequence of bytes from this channel into the given buffer. Reads as much as possible
+     * until either the dst buffer is full or there is no more data in the socket.
+     *
+     * @param dst The buffer into which bytes are to be transferred
+     * @return The number of bytes read, possible zero or -1 if the channel has reached end-of-stream
+     *         and no more data is available
+     * @throws IOException if some other I/O error occurs
+     */
     @Override
     public int read(ByteBuffer dst) throws IOException {
         if (state == State.CLOSING) return -1;
@@ -634,12 +634,12 @@ public class SslTransportLayer implements TransportLayer {
 
 
     /**
-    * Writes a sequence of bytes to this channel from the given buffer.
-    *
-    * @param src The buffer from which bytes are to be retrieved
-    * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the given buffer.
+     *
+     * @param src The buffer from which bytes are to be retrieved
+     * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public int write(ByteBuffer src) throws IOException {
         int written = 0;
@@ -678,14 +678,14 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     /**
-    * Writes a sequence of bytes to this channel from the subsequence of the given buffers.
-    *
-    * @param srcs The buffers from which bytes are to be retrieved
-    * @param offset The offset within the buffer array of the first buffer from which bytes are to be retrieved; must be non-negative and no larger than srcs.length.
-    * @param length - The maximum number of buffers to be accessed; must be non-negative and no larger than srcs.length - offset.
-    * @return returns no.of bytes written , possibly zero.
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the subsequence of the given buffers.
+     *
+     * @param srcs The buffers from which bytes are to be retrieved
+     * @param offset The offset within the buffer array of the first buffer from which bytes are to be retrieved; must be non-negative and no larger than srcs.length.
+     * @param length - The maximum number of buffers to be accessed; must be non-negative and no larger than srcs.length - offset.
+     * @return returns no.of bytes written , possibly zero.
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
         if ((offset < 0) || (length < 0) || (offset > srcs.length - length))
@@ -711,12 +711,12 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     /**
-    * Writes a sequence of bytes to this channel from the given buffers.
-    *
-    * @param srcs The buffers from which bytes are to be retrieved
-    * @return returns no.of bytes consumed by SSLEngine.wrap , possibly zero.
-    * @throws IOException If some other I/O error occurs
-    */
+     * Writes a sequence of bytes to this channel from the given buffers.
+     *
+     * @param srcs The buffers from which bytes are to be retrieved
+     * @return returns no.of bytes consumed by SSLEngine.wrap , possibly zero.
+     * @throws IOException If some other I/O error occurs
+     */
     @Override
     public long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
@@ -72,7 +72,7 @@ public interface TransportLayer extends ScatteringByteChannel, GatheringByteChan
      * {@link org.apache.kafka.common.config.SslConfigs#SSL_CLIENT_AUTH_CONFIG}.
      * @throws AuthenticationException if handshake fails due to an {@link javax.net.ssl.SSLException}.
      * @throws IOException if read or write fails with an I/O error.
-    */
+     */
     void handshake() throws AuthenticationException, IOException;
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
@@ -16,13 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-/**
- * Transport layer for underlying communication.
- * At very basic level it is wrapper around SocketChannel and can be used as substitute for SocketChannel
- * and other network Channel implementations.
- * As NetworkClient replaces BlockingChannel and other implementations we will be using KafkaChannel as
- * a network I/O channel.
- */
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SelectionKey;
@@ -34,6 +27,13 @@ import java.security.Principal;
 
 import org.apache.kafka.common.errors.AuthenticationException;
 
+/**
+ * Transport layer for underlying communication.
+ * At very basic level it is wrapper around SocketChannel and can be used as substitute for SocketChannel
+ * and other network Channel implementations.
+ * As NetworkClient replaces BlockingChannel and other implementations we will be using KafkaChannel as
+ * a network I/O channel.
+ */
 public interface TransportLayer extends ScatteringByteChannel, GatheringByteChannel {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.network;
 
-/*
+/**
  * Transport layer for underlying communication.
  * At very basic level it is wrapper around SocketChannel and can be used as substitute for SocketChannel
  * and other network Channel implementations.

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
@@ -39,7 +39,7 @@ public interface Message {
      *
      * @param version       The version to use.
      *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
+     * @throws org.apache.kafka.common.errors.UnsupportedVersionException
      *                      If the specified version is too new to be supported
      *                      by this software.
      */
@@ -51,7 +51,7 @@ public interface Message {
      * @param writable      The destination writable.
      * @param version       The version to use.
      *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
+     * @throws org.apache.kafka.common.errors.UnsupportedVersionException
      *                      If the specified version is too new to be supported
      *                      by this software.
      */
@@ -64,7 +64,7 @@ public interface Message {
      * @param readable      The source readable.
      * @param version       The version to use.
      *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
+     * @throws org.apache.kafka.common.errors.UnsupportedVersionException
      *                      If the specified version is too new to be supported
      *                      by this software.
      */
@@ -84,7 +84,7 @@ public interface Message {
      *
      * @param version       The version to use.
      *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
+     * @throws org.apache.kafka.common.errors.UnsupportedVersionException
      *                      If the specified version is too new to be supported
      *                      by this software.
      */

--- a/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockInputStream.java
@@ -35,10 +35,10 @@ import static org.apache.kafka.common.record.KafkaLZ4BlockOutputStream.MAGIC;
 
 /**
  * A partial implementation of the v1.5.1 LZ4 Frame format.
+ * <p>
+ * This class is not thread-safe.
  *
  * @see <a href="https://github.com/lz4/lz4/wiki/lz4_Frame_format.md">LZ4 Frame Format</a>
- *
- * This class is not thread-safe.
  */
 public final class KafkaLZ4BlockInputStream extends InputStream {
 

--- a/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
@@ -28,10 +28,10 @@ import net.jpountz.xxhash.XXHashFactory;
 
 /**
  * A partial implementation of the v1.5.1 LZ4 Frame format.
+ * <p>
+ * This class is not thread-safe.
  *
  * @see <a href="https://github.com/lz4/lz4/wiki/lz4_Frame_format.md">LZ4 Frame Format</a>
- *
- * This class is not thread-safe.
  */
 public final class KafkaLZ4BlockOutputStream extends OutputStream {
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
@@ -43,10 +43,10 @@ public class SaslHandshakeResponse extends AbstractResponse {
     }
 
     /*
-    * Possible error codes:
-    *   UNSUPPORTED_SASL_MECHANISM(33): Client mechanism not enabled in server
-    *   ILLEGAL_SASL_STATE(34) : Invalid request during SASL handshake
-    */
+     * Possible error codes:
+     *   UNSUPPORTED_SASL_MECHANISM(33): Client mechanism not enabled in server
+     *   ILLEGAL_SASL_STATE(34) : Invalid request during SASL handshake
+     */
     public Errors error() {
         return Errors.forCode(data.errorCode());
     }

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourcePattern.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourcePattern.java
@@ -38,7 +38,7 @@ public class ResourcePattern {
     private final String name;
     private final PatternType patternType;
 
-   /**
+    /**
      * Create a pattern using the supplied parameters.
      *
      * @param resourceType non-null, specific, resource type

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/AuthenticateCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/AuthenticateCallbackHandler.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.AppConfigurationEntry;
 
-/*
+/**
  * Callback handler for SASL-based authentication
  */
 public interface AuthenticateCallbackHandler extends CallbackHandler {

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/DefaultPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/DefaultPrincipalBuilder.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.KafkaException;
 /**
  * DefaultPrincipalBuilder which return transportLayer's peer Principal
  * @deprecated As of Kafka 1.0.0. This will be removed in a future major release.
- **/
+ */
 @Deprecated
 public class DefaultPrincipalBuilder implements PrincipalBuilder {
 

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainAuthenticateCallback.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.security.plain;
 
 import javax.security.auth.callback.Callback;
 
-/*
+/**
  * Authentication callback for SASL/PLAIN authentication. Callback handler must
  * set authenticated flag to true if the client provided password in the callback
  * matches the expected password.

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -781,9 +781,9 @@ public final class Utils {
         return other == null ? Collections.emptyList() : other;
     }
 
-   /**
-    * Get the ClassLoader which loaded Kafka.
-    */
+    /**
+     * Get the ClassLoader which loaded Kafka.
+     */
     public static ClassLoader getKafkaClassLoader() {
         return Utils.class.getClassLoader();
     }

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterDetails.java
@@ -27,6 +27,6 @@ public interface ConnectClusterDetails {
      * Get the cluster ID of the Kafka cluster backing this Connect cluster.
      * 
      * @return the cluster ID of the Kafka cluster backing this Connect cluster
-     **/
+     */
     String kafkaClusterId();
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/health/ConnectClusterState.java
@@ -65,7 +65,7 @@ public interface ConnectClusterState {
      * Get details about the setup of the Connect cluster.
      * @return a {@link ConnectClusterDetails} object containing information about the cluster
      * @throws java.lang.UnsupportedOperationException if the default implementation has not been overridden
-     **/
+     */
     default ConnectClusterDetails clusterDetails() {
         throw new UnsupportedOperationException();
     }

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -48,7 +48,7 @@ import java.util.Map;
  *     the new assignment will be opened using {@link #open(Collection)}.</li>
  *     <li><b>Shutdown:</b> When the task needs to be shutdown, Connect will close active partitions (if there
  *     are any) and stop the task using {@link #stop()}</li>
-  * </ol>
+ * </ol>
  *
  */
 public abstract class SinkTask implements Task {

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -37,10 +37,10 @@ public interface Transformation<R extends ConnectRecord<R>> extends Configurable
      */
     R apply(R record);
 
-    /** Configuration specification for this transformation. **/
+    /** Configuration specification for this transformation. */
     ConfigDef config();
 
-    /** Signal that this transformation instance will no longer will be used. **/
+    /** Signal that this transformation instance will no longer will be used. */
     @Override
     void close();
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -354,7 +354,7 @@ class WorkerSinkTask extends WorkerTask {
     /**
      * Starts an offset commit by flushing outstanding messages from the task and then starting
      * the write commit.
-     **/
+     */
     private void doCommit(Map<TopicPartition, OffsetAndMetadata> offsets, boolean closing, int seqno) {
         if (closing) {
             doCommitSync(offsets, seqno);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -48,10 +48,12 @@ import static org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.Lea
 
 /**
  * An assignor that computes a distribution of connectors and tasks according to the incremental
- * cooperative strategy for rebalancing. {@see
- * https://cwiki.apache.org/confluence/display/KAFKA/KIP-415%3A+Incremental+Cooperative
- * +Rebalancing+in+Kafka+Connect} for a description of the assignment policy.
- *
+ * cooperative strategy for rebalancing.
+ * <p>
+ * See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-415%3A+Incremental+Cooperative+Rebalancing+in+Kafka+Connect">
+ * KIP-415: Incremental Cooperative Rebalancing in Kafka Connect</a>
+ * for a description of the assignment policy.
+ * <p>
  * Note that this class is NOT thread-safe.
  */
 public class IncrementalCooperativeAssignor implements ConnectAssignor {
@@ -131,8 +133,10 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
     /**
      * Performs task assignment based on the incremental cooperative connect protocol.
+     * <p>
      * Read more on the design and implementation in:
-     * {@see https://cwiki.apache.org/confluence/display/KAFKA/KIP-415%3A+Incremental+Cooperative+Rebalancing+in+Kafka+Connect}
+     * <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-415%3A+Incremental+Cooperative+Rebalancing+in+Kafka+Connect">
+     *   KIP-415: Incremental Cooperative Rebalancing in Kafka Connect</a>
      *
      * @param leaderId the ID of the group leader
      * @param maxOffset the latest known offset of the configuration topic

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -175,7 +175,7 @@ public class TopicAdmin implements AutoCloseable {
         this.adminConfig = adminConfig != null ? adminConfig : Collections.<String, Object>emptyMap();
     }
 
-   /**
+    /**
      * Attempt to create the topic described by the given definition, returning true if the topic was created or false
      * if the topic already existed.
      *

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -167,7 +167,7 @@ public class ConnectorHandle {
         }
     }
 
-     /**
+    /**
      * Wait for this connector to meet the expected number of commits as defined by {@code
      * expectedCommits}.
      *

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -696,7 +696,7 @@ class Partition(val topicPartition: TopicPartition,
     followerEndOffset >= highWatermark && leaderEpochStartOffsetOpt.exists(followerEndOffset >= _)
   }
 
-  /*
+  /**
    * Returns a tuple where the first element is a boolean indicating whether enough replicas reached `requiredOffset`
    * and the second element is an error (which would be `Errors.NONE` for no error).
    *

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -870,7 +870,7 @@ class Partition(val topicPartition: TopicPartition,
      * the last time when the replica was fully caught up. If either of the above conditions
      * is violated, that replica is considered to be out of sync
      *
-     **/
+     */
     val candidateReplicas = inSyncReplicas - localBrokerId
     val currentTimeMs = time.milliseconds()
     val leaderEndOffset = localLogOrException.logEndOffset

--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -50,7 +50,7 @@ class Replica(val brokerId: Int, val topicPartition: TopicPartition) extends Log
 
   def lastCaughtUpTimeMs: Long = _lastCaughtUpTimeMs
 
-  /*
+  /**
    * If the FetchRequest reads up to the log end offset of the leader when the current fetch request is received,
    * set `lastCaughtUpTimeMs` to the time when the current fetch request was received.
    *

--- a/core/src/main/scala/kafka/common/BaseEnum.scala
+++ b/core/src/main/scala/kafka/common/BaseEnum.scala
@@ -16,7 +16,7 @@
  */
 package kafka.common
 
-/*
+/**
  * We inherit from `Product` and `Serializable` because `case` objects and classes inherit from them and if we don't
  * do it here, the compiler will infer types that unexpectedly include `Product` and `Serializable`, see
  * http://underscore.io/blog/posts/2015/06/04/more-on-sealed.html for more information.

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -337,7 +337,7 @@ class KafkaController(val config: KafkaConfig,
     info("Resigned")
   }
 
-  /*
+  /**
    * This callback is invoked by the controller's LogDirEventNotificationListener with the list of broker ids who
    * have experienced new log directory failures. In response the controller should send LeaderAndIsrRequest
    * to all these brokers to query the state of their replicas. Replicas with an offline log directory respond with
@@ -416,7 +416,7 @@ class KafkaController(val config: KafkaConfig,
     }
   }
 
-  /*
+  /**
    * This callback is invoked by the replica state machine's broker change listener with the list of failed brokers
    * as input. It will call onReplicaBecomeOffline(...) with the list of replicas on those failed brokers as input.
    */

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -855,7 +855,7 @@ class GroupMetadataManager(brokerId: Int,
     }
   }
 
-  /*
+  /**
    * Check if the offset metadata length is valid
    */
   private def validateOffsetMetadataLength(metadata: String) : Boolean = {

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -160,7 +160,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     }
   }
 
-   /**
+  /**
     * Choose the log to clean next and add it to the in-progress set. We recompute this
     * each time from the full set of logs to allow logs to be dynamically added to the pool of logs
     * the log manager maintains.

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -313,7 +313,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     Option(quotaCallback.quotaLimit(clientQuotaType, metricTags)).map(_.toDouble)getOrElse(Long.MaxValue)
   }
 
-  /*
+  /**
    * This calculates the amount of time needed to bring the metric within quota
    * assuming that no new metrics are recorded.
    *
@@ -339,7 +339,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     }
   }
 
-  /*
+  /**
    * This function either returns the sensors for a given client id or creates them if they don't exist
    * First sensor of the tuple is the quota enforcement sensor. Second one is the throttle time sensor
    */

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -52,7 +52,7 @@ abstract class DelayedOperation(override val delayMs: Long,
   // Visible for testing
   private[server] val lock: Lock = lockOpt.getOrElse(new ReentrantLock)
 
-  /*
+  /**
    * Force completing the delayed operation, if not already completed.
    * This function can be triggered when
    *
@@ -137,7 +137,7 @@ abstract class DelayedOperation(override val delayMs: Long,
     done
   }
 
-  /*
+  /**
    * run() method defines a task that is executed on timeout
    */
   override def run(): Unit = {
@@ -177,7 +177,7 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
 
     val watchersLock = new ReentrantLock()
 
-    /*
+    /**
      * Return all the current watcher lists,
      * note that the returned watchers may be removed from the list by other threads
      */
@@ -325,7 +325,7 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
     }
   }
 
-  /*
+  /**
    * Return the watch list of the given key, note that we need to
    * grab the removeWatchersLock to avoid the operation being added to a removed watcher list
    */
@@ -337,7 +337,7 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
     }
   }
 
-  /*
+  /**
    * Remove the key from watcher lists if its list is empty
    */
   private def removeKeyIfEmpty(key: Any, watchers: Watchers) {

--- a/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
+++ b/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap}
 
 import kafka.utils.Logging
 
-/*
+/**
  * LogDirFailureChannel allows an external thread to block waiting for new offline log dirs.
  *
  * There should be a single instance of LogDirFailureChannel accessible by any class that does disk-IO operation.
@@ -39,7 +39,7 @@ class LogDirFailureChannel(logDirNum: Int) extends Logging {
   private val offlineLogDirs = new ConcurrentHashMap[String, String]
   private val offlineLogDirQueue = new ArrayBlockingQueue[String](logDirNum)
 
-  /*
+  /**
    * If the given logDir is not already offline, add it to the
    * set of offline log dirs and enqueue it to the logDirFailureEvent queue
    */
@@ -49,7 +49,7 @@ class LogDirFailureChannel(logDirNum: Int) extends Logging {
       offlineLogDirQueue.add(logDir)
   }
 
-  /*
+  /**
    * Get the next offline log dir from logDirFailureEvent queue.
    * The method will wait if necessary until a new offline log directory becomes available
    */

--- a/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
+++ b/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
@@ -32,7 +32,7 @@ object LogOffsetMetadata {
 
 }
 
-/*
+/**
  * A log offset structure, including:
  *  1. the message offset
  *  2. the base message offset of the located segment

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -51,7 +51,7 @@ import org.apache.kafka.common.utils.Time
 import scala.collection.JavaConverters._
 import scala.collection._
 
-/*
+/**
  * Result metadata of a log append operation on the log
  */
 case class LogAppendResult(info: LogAppendInfo, exception: Option[Throwable] = None) {
@@ -68,7 +68,7 @@ case class LogDeleteRecordsResult(requestedOffset: Long, lowWatermark: Long, exc
   }
 }
 
-/*
+/**
  * Result metadata of a log read operation on the log
  * @param info @FetchDataInfo returned by the @Log read
  * @param hw high watermark of the local replica
@@ -629,7 +629,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  /*
+  /**
    * Get the LogDirInfo for the specified list of partitions.
    *
    * Each LogDirInfo specifies the following information for a given log directory:
@@ -1164,7 +1164,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  /*
+  /**
    * Make the current broker to become leader for a given set of partitions by:
    *
    * 1. Stop fetchers for these partitions
@@ -1240,7 +1240,7 @@ class ReplicaManager(val config: KafkaConfig,
     partitionsToMakeLeaders
   }
 
-  /*
+  /**
    * Make the current broker to become follower for a given set of partitions by:
    *
    * 1. Remove these partitions from the leader partitions set.

--- a/core/src/main/scala/kafka/utils/timer/Timer.scala
+++ b/core/src/main/scala/kafka/utils/timer/Timer.scala
@@ -97,7 +97,7 @@ class SystemTimer(executorName: String,
 
   private[this] val reinsert = (timerTaskEntry: TimerTaskEntry) => addTimerTaskEntry(timerTaskEntry)
 
-  /*
+  /**
    * Advances the clock if there is an expired bucket. If there isn't any expired bucket when called,
    * waits up to timeoutMs before giving up.
    */

--- a/core/src/main/scala/kafka/utils/timer/TimingWheel.scala
+++ b/core/src/main/scala/kafka/utils/timer/TimingWheel.scala
@@ -21,7 +21,7 @@ import kafka.utils.nonthreadsafe
 import java.util.concurrent.DelayQueue
 import java.util.concurrent.atomic.AtomicInteger
 
-/*
+/**
  * Hierarchical Timing Wheels
  *
  * A simple timing wheel is a circular list of buckets of timer tasks. Let u be the time unit.

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -538,7 +538,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     }
   }
 
-  /*
+  /**
    * even if the topic doesn't exist, request APIs should not leak the topic name
    */
   @Test

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -79,7 +79,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
   @Ignore // To be re-enabled once we can make it less flaky (KAFKA-4801)
   def testConsumptionWithBrokerFailures() = consumeWithBrokerFailures(10)
 
-  /*
+  /**
    * 1. Produce a bunch of messages
    * 2. Then consume the messages while killing and restarting brokers at random
    */

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -329,7 +329,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     confirmReauthenticationMetrics
   }
 
-   /**
+  /**
     * Tests that a consumer fails to consume messages without the appropriate
     * ACL set.
     */

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.authenticator.LoginManager
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 
-/*
+/**
  * Implements an enumeration for the modes enabled here:
  * zk only, kafka only, both, custom KafkaServer.
  */
@@ -41,7 +41,7 @@ case object ZkSasl extends SaslSetupMode
 case object KafkaSasl extends SaslSetupMode
 case object Both extends SaslSetupMode
 
-/*
+/**
  * Trait used in SaslTestHarness and EndToEndAuthorizationTest to setup keytab and jaas files.
  */
 trait SaslSetup {

--- a/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
@@ -64,7 +64,7 @@ class MetricsDuringTopicCreationDeletionTest extends KafkaServerTestHarness with
     super.setUp
   }
 
-  /*
+  /**
    * checking all metrics we care in a single test is faster though it would be more elegant to have 3 @Test methods
    */
   @Test

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -755,7 +755,7 @@ class SocketServerTest {
     }
   }
 
-  /*
+  /**
    * Test that we update request metrics if the channel has been removed from the selector when the broker calls
    * `selector.send` (selector closes old connections, for example).
    */

--- a/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
@@ -67,7 +67,7 @@ class IsrExpirationTest {
     metrics.close()
   }
 
-  /*
+  /**
    * Test the case where a follower is caught up but stops making requests to the leader. Once beyond the configured time limit, it should fall out of ISR
    */
   @Test
@@ -97,7 +97,7 @@ class IsrExpirationTest {
     EasyMock.verify(log)
   }
 
-  /*
+  /**
    * Test the case where a follower never makes a fetch request. It should fall out of ISR because it will be declared stuck
    */
   @Test
@@ -116,7 +116,7 @@ class IsrExpirationTest {
     EasyMock.verify(log)
   }
 
-  /*
+  /**
    * Test the case where a follower continually makes fetch requests but is unable to catch up. It should fall out of the ISR
    * However, any time it makes a request to the LogEndOffset it should be back in the ISR
    */
@@ -172,7 +172,7 @@ class IsrExpirationTest {
     EasyMock.verify(log)
   }
 
-  /*
+  /**
    * Test the case where a follower has already caught up with same log end offset with the leader. This follower should not be considered as out-of-sync
    */
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -438,7 +438,7 @@ class KafkaApisTest {
     assertEquals(Set(0, 1), response.brokers.asScala.map(_.id).toSet)
   }
 
-  /*
+  /**
    * Verifies that the metadata response is correct if the broker listeners are inconsistent (i.e. one broker has
    * more listeners than another) and the request is sent on the listener that exists in one broker.
    */

--- a/core/src/test/scala/unit/kafka/server/KafkaMetricReporterExceptionHandlingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaMetricReporterExceptionHandlingTest.scala
@@ -30,7 +30,7 @@ import org.junit.{Before, Test}
 import org.junit.After
 import java.util.concurrent.atomic.AtomicInteger
 
-/*
+/**
  * this test checks that a reporter that throws an exception will not affect other reporters
  * and will not affect the broker's message handling
  */

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -256,7 +256,7 @@ object JaasTestUtils {
     }
   }
 
-  /*
+  /**
    * Used for the static JAAS configuration and it uses the credentials for client#2
    */
   def kafkaClientSection(mechanism: Option[String], keytabLocation: Option[File]): JaasSection = {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
@@ -78,7 +78,7 @@ public final class TimeWindows extends Windows<TimeWindow> {
         this.maintainDurationMs = maintainDurationMs;
     }
 
-    /** Private constructor for preserving segments. Can be removed along with Windows.segments. **/
+    /** Private constructor for preserving segments. Can be removed along with Windows.segments. */
     @Deprecated
     private TimeWindows(final long sizeMs,
                         final long advanceMs,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-/*
+/**
  * Any classes (KTable, KStream, etc) extending this class should follow the serde specification precedence ordering as:
  *
  * 1) Overridden values via control objects (e.g. Materialized, Serialized, Consumed, etc)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/AbstractNotifyingBatchingRestoreCallback.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/AbstractNotifyingBatchingRestoreCallback.java
@@ -40,10 +40,9 @@ public abstract class AbstractNotifyingBatchingRestoreCallback implements Batchi
 
 
     /**
-     * @see StateRestoreListener#onRestoreStart(TopicPartition, String, long, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onRestoreStart(TopicPartition, String, long, long)
      */
     @Override
     public void onRestoreStart(final TopicPartition topicPartition,
@@ -55,10 +54,9 @@ public abstract class AbstractNotifyingBatchingRestoreCallback implements Batchi
 
 
     /**
-     * @see StateRestoreListener#onBatchRestored(TopicPartition, String, long, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onBatchRestored(TopicPartition, String, long, long)
      */
     @Override
     public void onBatchRestored(final TopicPartition topicPartition,
@@ -69,10 +67,9 @@ public abstract class AbstractNotifyingBatchingRestoreCallback implements Batchi
     }
 
     /**
-     * @see StateRestoreListener#onRestoreEnd(TopicPartition, String, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onRestoreEnd(TopicPartition, String, long)
      */
     @Override
     public void onRestoreEnd(final TopicPartition topicPartition,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/AbstractNotifyingRestoreCallback.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/AbstractNotifyingRestoreCallback.java
@@ -29,10 +29,9 @@ public abstract class AbstractNotifyingRestoreCallback implements StateRestoreCa
 
 
     /**
-     * @see StateRestoreListener#onRestoreStart(TopicPartition, String, long, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onRestoreStart(TopicPartition, String, long, long)
      */
     @Override
     public void onRestoreStart(final TopicPartition topicPartition,
@@ -44,10 +43,9 @@ public abstract class AbstractNotifyingRestoreCallback implements StateRestoreCa
 
 
     /**
-     * @see StateRestoreListener#onBatchRestored(TopicPartition, String, long, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onBatchRestored(TopicPartition, String, long, long)
      */
     @Override
     public void onBatchRestored(final TopicPartition topicPartition,
@@ -58,10 +56,9 @@ public abstract class AbstractNotifyingRestoreCallback implements StateRestoreCa
     }
 
     /**
-     * @see StateRestoreListener#onRestoreEnd(TopicPartition, String, long)
-     *
      * This method does nothing by default; if desired, subclasses should override it with custom functionality.
      *
+     * @see StateRestoreListener#onRestoreEnd(TopicPartition, String, long)
      */
     @Override
     public void onRestoreEnd(final TopicPartition topicPartition,

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -149,11 +149,11 @@ public interface ReadOnlyWindowStore<K, V> {
         throws IllegalArgumentException;
 
     /**
-    * Gets all the key-value pairs in the existing windows.
-    *
-    * @return an iterator over windowed key-value pairs {@code <Windowed<K>, value>}
-    * @throws InvalidStateStoreException if the store is not initialized
-    */
+     * Gets all the key-value pairs in the existing windows.
+     *
+     * @return an iterator over windowed key-value pairs {@code <Windowed<K>, value>}
+     * @throws InvalidStateStoreException if the store is not initialized
+     */
     KeyValueIterator<Windowed<K>, V> all();
     
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -726,7 +726,7 @@ public class ProcessorTopologyTest {
     /**
      * A custom timestamp extractor that extracts the timestamp from the record's value if the value is in ".*@[0-9]+"
      * format. Otherwise, it returns the record's timestamp or the default timestamp if the record's timestamp is negative.
-    */
+     */
     public static class CustomTimestampExtractor implements TimestampExtractor {
         private static final long DEFAULT_TIMESTAMP = 1000L;
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -269,7 +269,7 @@ public class VerifiableProducer implements AutoCloseable {
         }
     }
 
-    /** Returns a string to publish: ether 'valuePrefix'.'val' or 'val' **/
+    /** Returns a string to publish: ether 'valuePrefix'.'val' or 'val' */
     public String getValue(long val) {
         if (this.valuePrefix != null) {
             return String.format("%d.%d", this.valuePrefix, val);


### PR DESCRIPTION
Fixed a few Javadoc issues:

1) Do not end comments with `**/`

2) Align leading asterisks

3) Start comments with `/**` instead of `/*`
    Javadoc comments must start with `/**`.
    When starting with `/*`, Javadoc tools do not recognize those comments as Javadoc comments, it thinks they are simple block comments, and does not associate them with their class / member.

4) Fix dangling Javadoc comments

5) Avoid `@see` in the middle of Javadoc
    When the `@see` tag is in the middle of a Javadoc comment, the Javadoc tool thinks the rest of the comment is part of the `@see` description.
    There are two ways to fix this:
    - If we really want an `@see` tag, we can move it at the bottom of the comment, where tags are supposed to be.
    - When we want a link in the middle of the content, we can do: `See <a href="http://www.example.com">Link title</a>.`

6) Fix `@throws` syntax
An `@throws` declaration should be followed by the exception name, not by an `@link` or an `@see`.


I followed the Javadoc / Scaladoc guidelines as well as Stephen Colebourne's article about Javadoc coding standards: https://blog.joda.org/2012/11/javadoc-coding-standards.html .


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
