### PR TITLE
KAFKA-8526: logdir fallback on getOrCreateLog

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -733,7 +733,7 @@ class LogManager(logDirs: Seq[File],
     }
   }
 
-  private def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
+  protected def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
     val logDirPath = logDir.getAbsolutePath
     if (isLogDirOnline(logDirPath)) {
       val dir = new File(logDirPath, logDirName)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -733,7 +733,7 @@ class LogManager(logDirs: Seq[File],
     }
   }
 
-  protected def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
+  private def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
     val logDirPath = logDir.getAbsolutePath
     if (isLogDirOnline(logDirPath)) {
       val dir = new File(logDirPath, logDirName)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -733,7 +733,7 @@ class LogManager(logDirs: Seq[File],
     }
   }
 
-  private def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
+  private[log] def createLogDirectory(logDir: File, logDirName: String): Try[File] = {
     val logDirPath = logDir.getAbsolutePath
     if (isLogDirOnline(logDirPath)) {
       val dir = new File(logDirPath, logDirName)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -701,6 +701,7 @@ class LogManager(logDirs: Seq[File],
         }
 
         val logDir = logDirs
+          .toStream // to prevent actually mapping the whole list, lazy map
           .map(createLogDirectory(_, logDirName))
           .find(_.isSuccess)
           .getOrElse(Failure(new KafkaStorageException("No log directories available")))

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -744,7 +744,7 @@ class LogManager(logDirs: Seq[File],
         case e: IOException =>
           val msg = s"Error while creating log for $logDirName in dir $logDirPath"
           logDirFailureChannel.maybeAddOfflineLogDir(logDirPath, msg, e)
-          warn(e.getMessage, e)
+          warn(msg, e)
           Failure(new KafkaStorageException(msg, e))
       }
     } else {

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -704,7 +704,7 @@ class LogManager(logDirs: Seq[File],
           .toStream // to prevent actually mapping the whole list, lazy map
           .map(createLogDirectory(_, logDirName))
           .find(_.isSuccess)
-          .getOrElse(Failure(new KafkaStorageException("No log directories available")))
+          .getOrElse(Failure(new KafkaStorageException("No log directories available. Tried " + logDirs.map(_.getAbsolutePath).mkString(", "))))
           .get // If Failure, will throw
 
         val log = Log(

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -17,21 +17,18 @@
 
 package kafka.log
 
-import java.io.File
+import java.io._
+import java.nio.file.Files
 import java.util.{Collections, Properties}
 
 import kafka.server.FetchDataInfo
 import kafka.server.checkpoints.OffsetCheckpointFile
-import kafka.utils.TestUtils.{CreateLogDirectoryFn, CreateLogDirectoryOverride}
 import kafka.utils._
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.utils.Utils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-
-import scala.collection.mutable
-import scala.util.{Failure, Try}
 
 class LogManagerTest {
 
@@ -101,40 +98,29 @@ class LogManagerTest {
 
   @Test
   def testCreateLogWithLogDirFallback() {
-    // Configure a number of directories one level deeper in logDir,
-    // so they all get cleaned up in tearDown().
-    val dirs = (0 to 4)
+
+    // Configure a number of directories that will fail, and one that won't
+    // making it unlikely that the good log directory will be first choice.
+    val dirs = (0 to 100)
       .map(_.toString)
       .map(logDir.toPath.resolve(_).toFile)
+    val goodDir = dirs(88)
 
-    // Create a new LogManager with the configured directories and an overridden createLogDirectory.
-    // The first half of directories tried will fail, the rest goes through to super.createLogDirectory.
-    val brokenDirs = mutable.Set[File]()
-    def createLogDirectoryOverride(original: CreateLogDirectoryFn)(logDir: File, logDirName: String): Try[File] = {
-      if (brokenDirs.contains(logDir) || brokenDirs.size < dirs.length/2) {
-        brokenDirs.add(logDir)
-        Failure(new Throwable("broken dir"))
-      } else {
-        original.apply(logDir, logDirName)
-      }
-    }
     logManager.shutdown()
-    logManager = createLogManager(dirs, createLogDirectoryOverride = createLogDirectoryOverride)
+    logManager = createLogManager(dirs)
     logManager.startup()
 
-    // Request creating a new log.
-    // LogManager should try using all configured log directories until one succeeds.
-    logManager.getOrCreateLog(new TopicPartition(name, 0), logConfig, isNew = true)
+    // To simulate disk failure, delete log directories and replace them with files
+    // so that Files.createDirectories will fail.
+    dirs.filter(_ != goodDir).foreach { dir =>
+      Utils.delete(dir)
+      Files.createFile(dir.toPath)
+    }
 
-    // Verify that half the directories were considered broken,
-    assertEquals(dirs.length / 2, brokenDirs.size)
-
-    // and that exactly one log file was created,
-    val containsLogFile: File => Boolean = dir => new File(dir, name + "-0").exists()
-    assertEquals("More than one log file created", 1, dirs.count(containsLogFile))
-
-    // and that it wasn't created in one of the broken directories.
-    assertFalse(brokenDirs.exists(containsLogFile))
+    val log = logManager.getOrCreateLog(new TopicPartition(name, 0), logConfig, isNew = true)
+    val logFile = new File(goodDir, name + "-0")
+    assertTrue(logFile.exists)
+    log.appendAsLeader(TestUtils.singletonRecords("test".getBytes()), leaderEpoch = 0)
   }
 
   /**
@@ -379,15 +365,11 @@ class LogManagerTest {
     }
   }
 
-  private def createLogManager(logDirs: Seq[File] = Seq(this.logDir),
-                               createLogDirectoryOverride: CreateLogDirectoryOverride = original => original
-                              ): LogManager = {
+  private def createLogManager(logDirs: Seq[File] = Seq(this.logDir)): LogManager = {
     TestUtils.createLogManager(
       defaultConfig = logConfig,
       logDirs = logDirs,
-      time = this.time,
-      createLogDirectoryOverride = createLogDirectoryOverride
-    )
+      time = this.time)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -18,17 +18,23 @@
 package kafka.log
 
 import java.io._
-import java.nio.file.Files
 import java.util.{Collections, Properties}
 
 import kafka.server.FetchDataInfo
 import kafka.server.checkpoints.OffsetCheckpointFile
 import kafka.utils._
-import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{doAnswer, spy, when}
+import org.mockito.invocation.InvocationOnMock
+
+import scala.collection.mutable
+import scala.util.Failure
 
 class LogManagerTest {
 
@@ -98,29 +104,41 @@ class LogManagerTest {
 
   @Test
   def testCreateLogWithLogDirFallback() {
-
-    // Configure a number of directories that will fail, and one that won't
-    // making it unlikely that the good log directory will be first choice.
-    val dirs = (0 to 100)
+    // Configure a number of directories one level deeper in logDir,
+    // so they all get cleaned up in tearDown().
+    val dirs = (0 to 4)
       .map(_.toString)
       .map(logDir.toPath.resolve(_).toFile)
-    val goodDir = dirs(88)
 
+    // Create a new LogManager with the configured directories and an overridden createLogDirectory.
     logManager.shutdown()
-    logManager = createLogManager(dirs)
+    logManager = spy(createLogManager(dirs))
+    val brokenDirs = mutable.Set[File]()
+    doAnswer((invocation: InvocationOnMock) => {
+      // The first half of directories tried will fail, the rest goes through.
+      val logDir = invocation.getArgument[File](0)
+      if (brokenDirs.contains(logDir) || brokenDirs.size < dirs.length / 2) {
+        brokenDirs.add(logDir)
+        Failure(new Throwable("broken dir"))
+      } else {
+        invocation.callRealMethod()
+      }
+    }).when(logManager).createLogDirectory(any(), any())
     logManager.startup()
 
-    // To simulate disk failure, delete log directories and replace them with files
-    // so that Files.createDirectories will fail.
-    dirs.filter(_ != goodDir).foreach { dir =>
-      Utils.delete(dir)
-      Files.createFile(dir.toPath)
-    }
+    // Request creating a new log.
+    // LogManager should try using all configured log directories until one succeeds.
+    logManager.getOrCreateLog(new TopicPartition(name, 0), logConfig, isNew = true)
 
-    val log = logManager.getOrCreateLog(new TopicPartition(name, 0), logConfig, isNew = true)
-    val logFile = new File(goodDir, name + "-0")
-    assertTrue(logFile.exists)
-    log.appendAsLeader(TestUtils.singletonRecords("test".getBytes()), leaderEpoch = 0)
+    // Verify that half the directories were considered broken,
+    assertEquals(dirs.length / 2, brokenDirs.size)
+
+    // and that exactly one log file was created,
+    val containsLogFile: File => Boolean = dir => new File(dir, name + "-0").exists()
+    assertEquals("More than one log file created", 1, dirs.count(containsLogFile))
+
+    // and that it wasn't created in one of the broken directories.
+    assertFalse(brokenDirs.exists(containsLogFile))
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -17,7 +17,7 @@
 
 package kafka.utils
 
-import java.io.{File, _}
+import java.io._
 import java.nio._
 import java.nio.channels._
 import java.nio.charset.{Charset, StandardCharsets}
@@ -64,7 +64,6 @@ import org.scalatest.Assertions.fail
 import scala.collection.JavaConverters._
 import scala.collection.{Map, mutable}
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-import scala.util.Try
 
 /**
  * Utility functions to help with testing
@@ -1013,18 +1012,13 @@ object TestUtils extends Logging {
     }.mkString("\n")
   }
 
-  type CreateLogDirectoryFn = (File,String) => Try[File]
-  type CreateLogDirectoryOverride = CreateLogDirectoryFn => CreateLogDirectoryFn
-
   /**
    * Create new LogManager instance with default configuration for testing
    */
   def createLogManager(logDirs: Seq[File] = Seq.empty[File],
                        defaultConfig: LogConfig = LogConfig(),
                        cleanerConfig: CleanerConfig = CleanerConfig(enableCleaner = false),
-                       time: MockTime = new MockTime(),
-                       createLogDirectoryOverride: CreateLogDirectoryOverride = original => original
-                      ): LogManager = {
+                       time: MockTime = new MockTime()): LogManager = {
     new LogManager(logDirs = logDirs.map(_.getAbsoluteFile),
                    initialOfflineDirs = Array.empty[File],
                    topicConfigs = Map(),
@@ -1040,12 +1034,7 @@ object TestUtils extends Logging {
                    time = time,
                    brokerState = BrokerState(),
                    brokerTopicStats = new BrokerTopicStats,
-                   logDirFailureChannel = new LogDirFailureChannel(logDirs.size)) {
-      override def createLogDirectory(logDir: File, logDirName: String): Try[File] =
-        createLogDirectoryOverride
-          .apply(super.createLogDirectory)
-          .apply(logDir, logDirName)
-    }
+                   logDirFailureChannel = new LogDirFailureChannel(logDirs.size))
   }
 
   def produceMessages(servers: Seq[KafkaServer],


### PR DESCRIPTION
 LogManager#getOrCreateLog() selects a log dir for the new replica from
 _liveLogDirs, if disk failure is discovered at this point, before
 LogDirFailureHandler finds out, try using other log dirs before failing
 the operation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
