### PR TITLE
MINOR: add useConfiguredPartitioner and skipFlush options for ProduceBench

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -71,8 +71,8 @@ public class ProduceBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final TopicsSpec activeTopics;
     private final TopicsSpec inactiveTopics;
-    private final boolean noKeyNoPartition;
-    private final boolean noFlushOnThrottle;
+    private final boolean manualPartition;
+    private final boolean skipFlush;
 
     @JsonCreator
     public ProduceBenchSpec(@JsonProperty("startMs") long startMs,
@@ -89,8 +89,8 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                          @JsonProperty("activeTopics") TopicsSpec activeTopics,
                          @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics,
-                         @JsonProperty("noKeyNoPartition") boolean noKeyNoPartition, 
-                         @JsonProperty("noFlushOnThrottle") boolean noFlushOnThrottle) {
+                         @JsonProperty("manualPartition") boolean manualPartition, 
+                         @JsonProperty("skipFlush") boolean skipFlush) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
@@ -108,8 +108,8 @@ public class ProduceBenchSpec extends TaskSpec {
             TopicsSpec.EMPTY : activeTopics.immutableCopy();
         this.inactiveTopics = (inactiveTopics == null) ?
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
-        this.noKeyNoPartition = noKeyNoPartition;
-        this.noFlushOnThrottle = noFlushOnThrottle;
+        this.manualPartition = manualPartition;
+        this.skipFlush = skipFlush;
     }
 
     @JsonProperty
@@ -173,13 +173,13 @@ public class ProduceBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public boolean noKeyNoPartition() {
-        return noKeyNoPartition;
+    public boolean manualPartition() {
+        return manualPartition;
     }
 
     @JsonProperty
-    public boolean noFlushOnThrottle() {
-        return noFlushOnThrottle;
+    public boolean skipFlush() {
+        return skipFlush;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -71,6 +71,8 @@ public class ProduceBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final TopicsSpec activeTopics;
     private final TopicsSpec inactiveTopics;
+    private final boolean noKeyNoPartition;
+    private final boolean noFlushOnThrottle;
 
     @JsonCreator
     public ProduceBenchSpec(@JsonProperty("startMs") long startMs,
@@ -86,7 +88,9 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                          @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                          @JsonProperty("activeTopics") TopicsSpec activeTopics,
-                         @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics) {
+                         @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics,
+                         @JsonProperty("noKeyNoPartition") boolean noKeyNoPartition, 
+                         @JsonProperty("noFlushOnThrottle") boolean noFlushOnThrottle) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
@@ -104,6 +108,8 @@ public class ProduceBenchSpec extends TaskSpec {
             TopicsSpec.EMPTY : activeTopics.immutableCopy();
         this.inactiveTopics = (inactiveTopics == null) ?
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
+        this.noKeyNoPartition = noKeyNoPartition;
+        this.noFlushOnThrottle = noFlushOnThrottle;
     }
 
     @JsonProperty
@@ -164,6 +170,16 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public TopicsSpec inactiveTopics() {
         return inactiveTopics;
+    }
+
+    @JsonProperty
+    public boolean noKeyNoPartition() {
+        return noKeyNoPartition;
+    }
+
+    @JsonProperty
+    public boolean noFlushOnThrottle() {
+        return noFlushOnThrottle;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -71,7 +71,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final TopicsSpec activeTopics;
     private final TopicsSpec inactiveTopics;
-    private final boolean manualPartition;
+    private final boolean useConfiguredPartitioner;
     private final boolean skipFlush;
 
     @JsonCreator
@@ -89,7 +89,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                          @JsonProperty("activeTopics") TopicsSpec activeTopics,
                          @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics,
-                         @JsonProperty("manualPartition") boolean manualPartition, 
+                         @JsonProperty("useConfiguredPartitioner") boolean useConfiguredPartitioner, 
                          @JsonProperty("skipFlush") boolean skipFlush) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
@@ -108,7 +108,7 @@ public class ProduceBenchSpec extends TaskSpec {
             TopicsSpec.EMPTY : activeTopics.immutableCopy();
         this.inactiveTopics = (inactiveTopics == null) ?
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
-        this.manualPartition = manualPartition;
+        this.useConfiguredPartitioner = useConfiguredPartitioner;
         this.skipFlush = skipFlush;
     }
 
@@ -173,8 +173,8 @@ public class ProduceBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public boolean manualPartition() {
-        return manualPartition;
+    public boolean useConfiguredPartitioner() {
+        return useConfiguredPartitioner;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -294,7 +294,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
             TopicPartition partition = partitionsIterator.next();
             ProducerRecord<byte[], byte[]> record;
-            if (spec.manualPartition()) {
+            if (spec.useConfiguredPartitioner()) {
                 record = new ProducerRecord<>(
                     partition.topic(), keys.next(), values.next());
             } else {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -214,7 +214,11 @@ public class ProduceBenchWorker implements TaskWorker {
             this.producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
             this.keys = new PayloadIterator(spec.keyGenerator());
             this.values = new PayloadIterator(spec.valueGenerator());
-            this.throttle = new SendRecordsThrottle(perPeriod, producer);
+            if (spec.noFlushOnThrottle()) {
+                this.throttle = new Throttle(perPeriod, THROTTLE_PERIOD_MS);
+            } else {
+                this.throttle = new SendRecordsThrottle(perPeriod, producer);
+            }
         }
 
         @Override
@@ -289,8 +293,14 @@ public class ProduceBenchWorker implements TaskWorker {
                 partitionsIterator = activePartitions.iterator();
 
             TopicPartition partition = partitionsIterator.next();
-            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
-                partition.topic(), partition.partition(), keys.next(), values.next());
+            ProducerRecord<byte[], byte[]> record;
+            if (spec.noKeyNoPartition()) {
+                record = new ProducerRecord<>(
+                    partition.topic(), values.next());
+            } else {
+                record = new ProducerRecord<>(
+                    partition.topic(), partition.partition(), keys.next(), values.next());
+            }
             sendFuture = producer.send(record,
                 new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
             throttle.increment();

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -214,7 +214,7 @@ public class ProduceBenchWorker implements TaskWorker {
             this.producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
             this.keys = new PayloadIterator(spec.keyGenerator());
             this.values = new PayloadIterator(spec.valueGenerator());
-            if (spec.noFlushOnThrottle()) {
+            if (spec.skipFlush()) {
                 this.throttle = new Throttle(perPeriod, THROTTLE_PERIOD_MS);
             } else {
                 this.throttle = new SendRecordsThrottle(perPeriod, producer);
@@ -294,9 +294,9 @@ public class ProduceBenchWorker implements TaskWorker {
 
             TopicPartition partition = partitionsIterator.next();
             ProducerRecord<byte[], byte[]> record;
-            if (spec.noKeyNoPartition()) {
+            if (spec.manualPartition()) {
                 record = new ProducerRecord<>(
-                    partition.topic(), values.next());
+                    partition.topic(), keys.next(), values.next());
             } else {
                 record = new ProducerRecord<>(
                     partition.topic(), partition.partition(), keys.next(), values.next());

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -55,7 +55,7 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, null, 0, null));
         verify(new WorkerStopping(null, null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, Optional.empty(), null, null, null, null, null));
+            0, 0, null, null, Optional.empty(), null, null, null, null, null, false, false));
         verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null,
             0, null, null, 0));
         verify(new TopicsSpec());


### PR DESCRIPTION
Added a boolean to specify testing with no keys and pre-set partitions for records.
Also added a boolean to specify whether the batch is flushed by the throttle. Usually this is to prevent added latency measurements, but it prevents testing with linger.ms and other scenarios to fill batches.

Modified a test to include these new parameters--both set to false which was the default behavior.
All previous Trogdor ProduceBench tests will run as before if these fields are not specified.
