### PR TITLE
system tests - adding listener overrides

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -27,6 +27,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from config import KafkaConfig
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka import config_property
+from kafkatest.services.kafka.listener_config import ListenerConfig
 from kafkatest.services.monitor.jmx import JmxMixin
 from kafkatest.services.security.minikdc import MiniKdc
 from kafkatest.services.security.security_config import SecurityConfig
@@ -49,28 +50,6 @@ class KafkaListener:
 
     def listener_security_protocol(self):
         return "%s:%s" % (self.name, self.security_protocol)
-
-class ListenerConfig:
-
-    def __init__(self, use_separate_interbroker_listener=False,
-                 client_listener_overrides={}, interbroker_listener_overrides={}):
-        """
-        :param bool use_separate_interbroker_listener - if set, will use a separate interbroker listener,
-        with security protocol set to interbroker_security_protocol value. If set, requires
-        interbroker_security_protocol to be provided.
-        Normally port name is the same as its security protocol, so setting security_protocol and
-        interbroker_security_protocol to the same value will lead to a single port being open and both client
-        and broker-to-broker communication will go over that port. This parameter allows
-        you to add an interbroker listener with the same security protocol as a client listener, but running on a
-        separate port.
-        :param dict client_listener_overrides - non-prefixed listener config overrides for named client listener
-        (for example 'sasl.jaas.config', 'ssl.keystore.location', 'sasl.login.callback.handler.class', etc).
-        :param dict interbroker_listener_overrides - non-prefixed listener config overrides for named interbroker
-        listener (for example 'sasl.jaas.config', 'ssl.keystore.location', 'sasl.login.callback.handler.class', etc).
-        """
-        self.use_separate_interbroker_listener = use_separate_interbroker_listener
-        self.client_listener_overrides = client_listener_overrides
-        self.interbroker_listener_overrides = interbroker_listener_overrides
 
 class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     PERSISTENT_ROOT = "/mnt/kafka"

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -27,9 +27,9 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from config import KafkaConfig
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka import config_property
-from kafkatest.services.kafka.listener_config import ListenerConfig
 from kafkatest.services.monitor.jmx import JmxMixin
 from kafkatest.services.security.minikdc import MiniKdc
+from kafkatest.services.security.listener_security_config import ListenerSecurityConfig
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.version import DEV_BRANCH, LATEST_0_10_0
 
@@ -94,7 +94,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
                  authorizer_class_name=None, topics=None, version=DEV_BRANCH, jmx_object_names=None,
                  jmx_attributes=None, zk_connect_timeout=5000, zk_session_timeout=6000, server_prop_overides=None, zk_chroot=None,
-                 listener_config=ListenerConfig()):
+                 listener_security_config=ListenerSecurityConfig()):
         """
         :param context: test context
         :param ZookeeperService zk:
@@ -111,7 +111,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param int zk_session_timeout:
         :param dict server_prop_overides: overrides for kafka.properties file
         :param zk_chroot:
-        :param ListenerConfig listener_config: listener config to use
+        :param ListenerSecurityConfig listener_security_config: listener config to use
         """
         Service.__init__(self, context, num_nodes)
         JmxMixin.__init__(self, num_nodes=num_nodes, jmx_object_names=jmx_object_names, jmx_attributes=(jmx_attributes or []),
@@ -131,7 +131,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.server_prop_overides = server_prop_overides
         self.log_level = "DEBUG"
         self.zk_chroot = zk_chroot
-        self.listener_config = listener_config
+        self.listener_security_config = listener_security_config
 
         #
         # In a heavily loaded and not very fast machine, it is
@@ -161,7 +161,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         }
 
         self.interbroker_listener = None
-        self.setup_interbroker_listener(interbroker_security_protocol, self.listener_config.use_separate_interbroker_listener)
+        self.setup_interbroker_listener(interbroker_security_protocol, self.listener_security_config.use_separate_interbroker_listener)
         self.interbroker_sasl_mechanism = interbroker_sasl_mechanism
 
         for node in self.nodes:
@@ -183,9 +183,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.setup_interbroker_listener(security_protocol, use_separate_listener=False)
 
     def setup_interbroker_listener(self, security_protocol, use_separate_listener=False):
-        self.listener_config.use_separate_interbroker_listener = use_separate_listener
+        self.listener_security_config.use_separate_interbroker_listener = use_separate_listener
 
-        if self.listener_config.use_separate_interbroker_listener:
+        if self.listener_security_config.use_separate_interbroker_listener:
             # do not close existing port here since it is not used exclusively for interbroker communication
             self.interbroker_listener = self.port_mappings[KafkaService.INTERBROKER_LISTENER_NAME]
             self.interbroker_listener.security_protocol = security_protocol
@@ -200,7 +200,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                                 zk_sasl=self.zk.zk_sasl,
                                 client_sasl_mechanism=self.client_sasl_mechanism,
                                 interbroker_sasl_mechanism=self.interbroker_sasl_mechanism,
-                                listener_config=self.listener_config)
+                                listener_security_config=self.listener_security_config)
         for port in self.port_mappings.values():
             if port.open:
                 config.enable_security_protocol(port.security_protocol)
@@ -282,7 +282,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         #load template configs as dictionary
         config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
                                  security_config=self.security_config, num_nodes=self.num_nodes,
-                                 listener_config=self.listener_config)
+                                 listener_security_config=self.listener_security_config)
 
         configs = dict( l.rstrip().split('=', 1) for l in config_template.split('\n')
                         if not l.startswith("#") and "=" in l )

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -92,6 +92,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT, interbroker_security_protocol=SecurityConfig.PLAINTEXT,
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
+                 client_listener_overrides={}, interbroker_listener_overrides={},
                  authorizer_class_name=None, topics=None, version=DEV_BRANCH, jmx_object_names=None,
                  jmx_attributes=None, zk_connect_timeout=5000, zk_session_timeout=6000, server_prop_overides=None, zk_chroot=None,
                  use_separate_interbroker_listener=False):
@@ -128,6 +129,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         self.security_protocol = security_protocol
         self.client_sasl_mechanism = client_sasl_mechanism
+        self.client_listener_overrides = client_listener_overrides
+        self.interbroker_listener_overrides = interbroker_listener_overrides
         self.topics = topics
         self.minikdc = None
         self.authorizer_class_name = authorizer_class_name
@@ -286,7 +289,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         #load template configs as dictionary
         config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
-                                 security_config=self.security_config, num_nodes=self.num_nodes)
+                                 security_config=self.security_config, num_nodes=self.num_nodes,
+                                 client_listener_overrides=self.client_listener_overrides,
+                                 interbroker_listener_overrides=self.interbroker_listener_overrides)
 
         configs = dict( l.rstrip().split('=', 1) for l in config_template.split('\n')
                         if not l.startswith("#") and "=" in l )

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -208,7 +208,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         config = SecurityConfig(self.context, self.security_protocol, self.interbroker_listener.security_protocol,
                                 zk_sasl=self.zk.zk_sasl,
                                 client_sasl_mechanism=self.client_sasl_mechanism,
-                                interbroker_sasl_mechanism=self.interbroker_sasl_mechanism)
+                                interbroker_sasl_mechanism=self.interbroker_sasl_mechanism,
+                                client_listener_overrides=self.client_listener_overrides,
+                                interbroker_listener_overrides=self.interbroker_listener_overrides)
         for port in self.port_mappings.values():
             if port.open:
                 config.enable_security_protocol(port.security_protocol)

--- a/tests/kafkatest/services/kafka/listener_config.py
+++ b/tests/kafkatest/services/kafka/listener_config.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ListenerConfig:
+
+    def __init__(self, use_separate_interbroker_listener=False,
+                 client_listener_overrides={}, interbroker_listener_overrides={}):
+        """
+        :param bool use_separate_interbroker_listener - if set, will use a separate interbroker listener,
+        with security protocol set to interbroker_security_protocol value. If set, requires
+        interbroker_security_protocol to be provided.
+        Normally port name is the same as its security protocol, so setting security_protocol and
+        interbroker_security_protocol to the same value will lead to a single port being open and both client
+        and broker-to-broker communication will go over that port. This parameter allows
+        you to add an interbroker listener with the same security protocol as a client listener, but running on a
+        separate port.
+        :param dict client_listener_overrides - non-prefixed listener config overrides for named client listener
+        (for example 'sasl.jaas.config', 'ssl.keystore.location', 'sasl.login.callback.handler.class', etc).
+        :param dict interbroker_listener_overrides - non-prefixed listener config overrides for named interbroker
+        listener (for example 'sasl.jaas.config', 'ssl.keystore.location', 'sasl.login.callback.handler.class', etc).
+        """
+        self.use_separate_interbroker_listener = use_separate_interbroker_listener
+        self.client_listener_overrides = client_listener_overrides
+        self.interbroker_listener_overrides = interbroker_listener_overrides

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -23,6 +23,16 @@ listener.security.protocol.map={{ listener_security_protocol_map }}
 
 inter.broker.listener.name={{ interbroker_listener.name }}
 
+{% for k, v in client_listener_overrides.iteritems() %}
+listener.name.{{ security_protocol.lower() }}.{{ security_config.client_sasl_mechanism.lower() }}.{{ k }}={{ v }}
+{% endfor %}
+
+{% if interbroker_listener.name != security_protocol %}
+{% for k, v in interbroker_listener_overrides.iteritems() %}
+listener.name.{{ interbroker_listener.name.lower() }}.{{ security_config.interbroker_sasl_mechanism.lower() }}.{{ k }}={{ v }}
+{% endfor %}
+{% endif %}
+
 ssl.keystore.location=/mnt/security/test.keystore.jks
 ssl.keystore.password=test-ks-passwd
 ssl.key.password=test-key-passwd

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -23,7 +23,7 @@ listener.security.protocol.map={{ listener_security_protocol_map }}
 
 inter.broker.listener.name={{ interbroker_listener.name }}
 
-{% for k, v in listener_config.client_listener_overrides.iteritems() %}
+{% for k, v in listener_security_config.client_listener_overrides.iteritems() %}
 {% if k.startswith('sasl.') %}
 listener.name.{{ security_protocol.lower() }}.{{ security_config.client_sasl_mechanism.lower() }}.{{ k }}={{ v }}
 {% else %}
@@ -32,7 +32,7 @@ listener.name.{{ security_protocol.lower() }}.{{ k }}={{ v }}
 {% endfor %}
 
 {% if interbroker_listener.name != security_protocol %}
-{% for k, v in listener_config.interbroker_listener_overrides.iteritems() %}
+{% for k, v in listener_security_config.interbroker_listener_overrides.iteritems() %}
 {% if k.startswith('sasl.') %}
 listener.name.{{ interbroker_listener.name.lower() }}.{{ security_config.interbroker_sasl_mechanism.lower() }}.{{ k }}={{ v }}
 {% else %}

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -23,13 +23,21 @@ listener.security.protocol.map={{ listener_security_protocol_map }}
 
 inter.broker.listener.name={{ interbroker_listener.name }}
 
-{% for k, v in client_listener_overrides.iteritems() %}
+{% for k, v in listener_config.client_listener_overrides.iteritems() %}
+{% if k.startswith('sasl.') %}
 listener.name.{{ security_protocol.lower() }}.{{ security_config.client_sasl_mechanism.lower() }}.{{ k }}={{ v }}
+{% else %}
+listener.name.{{ security_protocol.lower() }}.{{ k }}={{ v }}
+{% endif %}
 {% endfor %}
 
 {% if interbroker_listener.name != security_protocol %}
-{% for k, v in interbroker_listener_overrides.iteritems() %}
+{% for k, v in listener_config.interbroker_listener_overrides.iteritems() %}
+{% if k.startswith('sasl.') %}
 listener.name.{{ interbroker_listener.name.lower() }}.{{ security_config.interbroker_sasl_mechanism.lower() }}.{{ k }}={{ v }}
+{% else %}
+listener.name.{{ interbroker_listener.name.lower() }}.{{ k }}={{ v }}
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/tests/kafkatest/services/security/listener_security_config.py
+++ b/tests/kafkatest/services/security/listener_security_config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class ListenerConfig:
+class ListenerSecurityConfig:
 
     def __init__(self, use_separate_interbroker_listener=False,
                  client_listener_overrides={}, interbroker_listener_overrides={}):

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -18,7 +18,7 @@ import subprocess
 from tempfile import mkdtemp
 from shutil import rmtree
 from ducktape.template import TemplateRenderer
-from kafkatest.services.kafka import ListenerConfig
+from kafkatest.services.kafka.kafka import ListenerConfig
 from kafkatest.services.security.minikdc import MiniKdc
 import itertools
 

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -18,8 +18,8 @@ import subprocess
 from tempfile import mkdtemp
 from shutil import rmtree
 from ducktape.template import TemplateRenderer
-from kafkatest.services.kafka.kafka import ListenerConfig
 from kafkatest.services.security.minikdc import MiniKdc
+from kafkatest.services.kafka.listener_config import ListenerConfig
 import itertools
 
 

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -19,7 +19,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from ducktape.template import TemplateRenderer
 from kafkatest.services.security.minikdc import MiniKdc
-from kafkatest.services.kafka.listener_config import ListenerConfig
+from kafkatest.services.security.listener_security_config import ListenerSecurityConfig
 import itertools
 
 
@@ -114,7 +114,7 @@ class SecurityConfig(TemplateRenderer):
     def __init__(self, context, security_protocol=None, interbroker_security_protocol=None,
                  client_sasl_mechanism=SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SASL_MECHANISM_GSSAPI,
                  zk_sasl=False, template_props="", static_jaas_conf=True, jaas_override_variables=None,
-                 listener_config=ListenerConfig()):
+                 listener_security_config=ListenerSecurityConfig()):
         """
         Initialize the security properties for the node and copy
         keystore and truststore to the remote node if the transport protocol 
@@ -146,7 +146,7 @@ class SecurityConfig(TemplateRenderer):
         self.has_ssl = self.is_ssl(security_protocol) or self.is_ssl(interbroker_security_protocol)
         self.zk_sasl = zk_sasl
         self.static_jaas_conf = static_jaas_conf
-        self.listener_config = listener_config
+        self.listener_security_config = listener_security_config
         self.properties = {
             'security.protocol' : security_protocol,
             'ssl.keystore.location' : SecurityConfig.KEYSTORE_PATH,
@@ -159,7 +159,7 @@ class SecurityConfig(TemplateRenderer):
             'sasl.mechanism.inter.broker.protocol' : interbroker_sasl_mechanism,
             'sasl.kerberos.service.name' : 'kafka'
         }
-        self.properties.update(self.listener_config.client_listener_overrides)
+        self.properties.update(self.listener_security_config.client_listener_overrides)
         self.jaas_override_variables = jaas_override_variables or {}
 
     def client_config(self, template_props="", node=None, jaas_override_variables=None):
@@ -174,7 +174,7 @@ class SecurityConfig(TemplateRenderer):
                               template_props=template_props,
                               static_jaas_conf=static_jaas_conf,
                               jaas_override_variables=jaas_override_variables,
-                              listener_config=self.listener_config)
+                              listener_security_config=self.listener_security_config)
 
     def enable_security_protocol(self, security_protocol):
         self.has_sasl = self.has_sasl or self.is_sasl(security_protocol)

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -18,6 +18,7 @@ import subprocess
 from tempfile import mkdtemp
 from shutil import rmtree
 from ducktape.template import TemplateRenderer
+from kafkatest.services.kafka import ListenerConfig
 from kafkatest.services.security.minikdc import MiniKdc
 import itertools
 
@@ -112,8 +113,8 @@ class SecurityConfig(TemplateRenderer):
 
     def __init__(self, context, security_protocol=None, interbroker_security_protocol=None,
                  client_sasl_mechanism=SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SASL_MECHANISM_GSSAPI,
-                 client_listener_overrides={}, interbroker_listener_overrides={},
-                 zk_sasl=False, template_props="", static_jaas_conf=True, jaas_override_variables=None):
+                 zk_sasl=False, template_props="", static_jaas_conf=True, jaas_override_variables=None,
+                 listener_config=ListenerConfig()):
         """
         Initialize the security properties for the node and copy
         keystore and truststore to the remote node if the transport protocol 
@@ -141,12 +142,11 @@ class SecurityConfig(TemplateRenderer):
         if interbroker_security_protocol is None:
             interbroker_security_protocol = security_protocol
         self.interbroker_security_protocol = interbroker_security_protocol
-        self.client_listener_overrides = client_listener_overrides
-        self.interbroker_listener_overrides = interbroker_listener_overrides
         self.has_sasl = self.is_sasl(security_protocol) or self.is_sasl(interbroker_security_protocol) or zk_sasl
         self.has_ssl = self.is_ssl(security_protocol) or self.is_ssl(interbroker_security_protocol)
         self.zk_sasl = zk_sasl
         self.static_jaas_conf = static_jaas_conf
+        self.listener_config = listener_config
         self.properties = {
             'security.protocol' : security_protocol,
             'ssl.keystore.location' : SecurityConfig.KEYSTORE_PATH,
@@ -159,7 +159,7 @@ class SecurityConfig(TemplateRenderer):
             'sasl.mechanism.inter.broker.protocol' : interbroker_sasl_mechanism,
             'sasl.kerberos.service.name' : 'kafka'
         }
-        self.properties.update(self.client_listener_overrides)
+        self.properties.update(self.listener_config.client_listener_overrides)
         self.jaas_override_variables = jaas_override_variables or {}
 
     def client_config(self, template_props="", node=None, jaas_override_variables=None):
@@ -171,10 +171,10 @@ class SecurityConfig(TemplateRenderer):
         static_jaas_conf = node is None or (self.has_sasl and self.has_ssl)
         return SecurityConfig(self.context, self.security_protocol,
                               client_sasl_mechanism=self.client_sasl_mechanism,
-                              client_listener_overrides=self.client_listener_overrides,
                               template_props=template_props,
                               static_jaas_conf=static_jaas_conf,
-                              jaas_override_variables=jaas_override_variables)
+                              jaas_override_variables=jaas_override_variables,
+                              listener_config=self.listener_config)
 
     def enable_security_protocol(self, security_protocol):
         self.has_sasl = self.has_sasl or self.is_sasl(security_protocol)


### PR DESCRIPTION
### what
Now that we have an abstraction for listeners, people should be allowed to pass in certain overrides for their listeners. This allows a user to override both client & interbroker listeners with a dictionary of configs.

### why
There may be certain listener configs a user would want to override. Currently, to do so, they would either have to completely override all listener configs OR try to shoehorn an override based on the name of the security-protocol or an internal constant. This makes things a bit cleaner such that we handle the prefixing and simply add on some additional configs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
