### PR TITLE
KAFKA-8585; Controller should change leader and isr optimistically

### DIFF
--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -24,7 +24,6 @@ import kafka.zk.KafkaZkClient
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
-import scala.collection.mutable
 
 abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends Logging {
   /**
@@ -290,7 +289,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       new StateChangeFailedException(s"Failed to change state of replica $replicaId for partition $tp: $reason")
     }
 
-    var results = Map.newBuilder[TopicPartition, LeaderIsrAndControllerEpoch]
+    val results = Map.newBuilder[TopicPartition, LeaderIsrAndControllerEpoch]
     var remaining = partitions
     while (remaining.nonEmpty) {
       val leaderAndIsrs = Map.newBuilder[TopicPartition, LeaderAndIsr]

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -22,11 +22,8 @@ import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import kafka.zk.KafkaZkClient
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
-import kafka.zk.TopicPartitionStateZNode
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
-import org.apache.zookeeper.KeeperException.Code
-import scala.collection.breakOut
 import scala.collection.mutable
 
 abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends Logging {
@@ -102,6 +99,8 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   extends ReplicaStateMachine(controllerContext) with Logging {
 
   private val controllerId = config.brokerId
+  private val util = new StateMachineUtil(controllerContext, zkClient)
+
   this.logIdent = s"[ReplicaStateMachine controllerId=$controllerId] "
 
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
@@ -268,6 +267,20 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     }
   }
 
+  private def collectCurrentLeaderAndIsrsForReplica(replicaId: Int,
+                                                    partitions: Seq[TopicPartition]): Map[TopicPartition, LeaderAndIsr] = {
+
+    val leaderAndIsrs = mutable.Buffer.empty[(TopicPartition, LeaderAndIsr)]
+    for (partition <- partitions) {
+      controllerContext.partitionLeadershipInfo.get(partition)
+        .filter(_.leaderAndIsr.isr.contains(replicaId))
+        .foreach { leaderAndIsrControllerEpoch =>
+          leaderAndIsrs.append((partition, leaderAndIsrControllerEpoch.leaderAndIsr))
+        }
+    }
+    leaderAndIsrs.toMap
+  }
+
   /**
    * Repeatedly attempt to remove a replica from the isr of multiple partitions until there are no more remaining partitions
    * to retry.
@@ -279,19 +292,43 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     replicaId: Int,
     partitions: Seq[TopicPartition]
   ): Map[TopicPartition, LeaderIsrAndControllerEpoch] = {
+
+    def logFailedOfflineStateChange(tp: TopicPartition, exception: Exception): Unit = {
+      val replica = PartitionAndReplica(tp, replicaId)
+      val currentState = controllerContext.replicaState(replica)
+      logFailedStateChange(replica, currentState, OfflineReplica, exception)
+    }
+
     var results = Map.empty[TopicPartition, LeaderIsrAndControllerEpoch]
     var remaining = partitions
     while (remaining.nonEmpty) {
-      val (finishedRemoval, removalsToRetry) = doRemoveReplicasFromIsr(replicaId, remaining)
+      val leaderAndIsrs = collectCurrentLeaderAndIsrsForReplica(replicaId, partitions)
+      val (finishedRemoval, removalsToRetry) = doRemoveReplicasFromIsr(replicaId, leaderAndIsrs)
       remaining = removalsToRetry
 
       finishedRemoval.foreach {
-        case (partition, Left(e)) =>
-            val replica = PartitionAndReplica(partition, replicaId)
-            val currentState = controllerContext.replicaState(replica)
-            logFailedStateChange(replica, currentState, OfflineReplica, e)
+        case (partition, Left(exception)) =>
+          logFailedOfflineStateChange(partition, exception)
+
         case (partition, Right(leaderIsrAndEpoch)) =>
           results += partition -> leaderIsrAndEpoch
+      }
+
+      if (remaining.nonEmpty) {
+        def stateChangeFailedException(tp: TopicPartition, reason: String): StateChangeFailedException = {
+          new StateChangeFailedException(s"Failed to change state of replica $replicaId for partition $tp: $reason")
+        }
+
+        val partitionsFailingUpdate = util.maybeUpdateLeaderAndIsr(remaining, stateChangeFailedException)
+        remaining = remaining.filter { tp =>
+          partitionsFailingUpdate.get(tp) match {
+            case Some(exception) =>
+              logFailedOfflineStateChange(tp, exception)
+              false
+            case None =>
+              true
+          }
+        }
       }
     }
     results
@@ -302,7 +339,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
    * Removing a replica from isr updates partition state in zookeeper.
    *
    * @param replicaId The replica being removed from isr of multiple partitions
-   * @param partitions The partitions from which we're trying to remove the replica from isr
+   * @param leaderAndIsrs FIXME
    * @return A tuple of two elements:
    *         1. The updated Right[LeaderIsrAndControllerEpochs] of all partitions for which we successfully
    *         removed the replica from isr. Or Left[Exception] corresponding to failed removals that should
@@ -312,22 +349,13 @@ class ZkReplicaStateMachine(config: KafkaConfig,
    */
   private def doRemoveReplicasFromIsr(
     replicaId: Int,
-    partitions: Seq[TopicPartition]
+    leaderAndIsrs: Map[TopicPartition, LeaderAndIsr]
   ): (Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]], Seq[TopicPartition]) = {
-    val (leaderAndIsrs, partitionsWithNoLeaderAndIsrInZk) = getTopicPartitionStatesFromZk(partitions)
-    val (leaderAndIsrsWithReplica, leaderAndIsrsWithoutReplica) = leaderAndIsrs.partition { case (_, result) =>
-      result.right.map { leaderAndIsr =>
-        leaderAndIsr.isr.contains(replicaId)
-      }.right.getOrElse(false)
-    }
-
-    val adjustedLeaderAndIsrs: Map[TopicPartition, LeaderAndIsr] = leaderAndIsrsWithReplica.flatMap {
-      case (partition, result) =>
-        result.right.toOption.map { leaderAndIsr =>
-          val newLeader = if (replicaId == leaderAndIsr.leader) LeaderAndIsr.NoLeader else leaderAndIsr.leader
-          val adjustedIsr = if (leaderAndIsr.isr.size == 1) leaderAndIsr.isr else leaderAndIsr.isr.filter(_ != replicaId)
-          partition -> leaderAndIsr.newLeaderAndIsr(newLeader, adjustedIsr)
-        }
+    val adjustedLeaderAndIsrs: Map[TopicPartition, LeaderAndIsr] = leaderAndIsrs.map {
+      case (partition, leaderAndIsr) =>
+        val newLeader = if (replicaId == leaderAndIsr.leader) LeaderAndIsr.NoLeader else leaderAndIsr.leader
+        val adjustedIsr = if (leaderAndIsr.isr.size == 1) leaderAndIsr.isr else leaderAndIsr.isr.filter(_ != replicaId)
+        partition -> leaderAndIsr.newLeaderAndIsr(newLeader, adjustedIsr)
     }
 
     val UpdateLeaderAndIsrResult(finishedPartitions, updatesToRetry) = zkClient.updateLeaderAndIsr(
@@ -336,19 +364,8 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       controllerContext.epochZkVersion
     )
 
-    val exceptionsForPartitionsWithNoLeaderAndIsrInZk: Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]] =
-      partitionsWithNoLeaderAndIsrInZk.flatMap { partition =>
-        if (!controllerContext.isTopicQueuedUpForDeletion(partition.topic)) {
-          val exception = new StateChangeFailedException(
-            s"Failed to change state of replica $replicaId for partition $partition since the leader and isr " +
-            "path in zookeeper is empty"
-          )
-          Option(partition -> Left(exception))
-        } else None
-      }(breakOut)
-
-    val leaderIsrAndControllerEpochs: Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]] =
-      (leaderAndIsrsWithoutReplica ++ finishedPartitions).map { case (partition, result: Either[Exception, LeaderAndIsr]) =>
+    val updatedLeaderIsrAndControllerEpochs: Map[TopicPartition, Either[Exception, LeaderIsrAndControllerEpoch]] =
+      finishedPartitions.map { case (partition, result: Either[Exception, LeaderAndIsr]) =>
         (
           partition,
           result.right.map { leaderAndIsr =>
@@ -356,64 +373,13 @@ class ZkReplicaStateMachine(config: KafkaConfig,
             controllerContext.partitionLeadershipInfo.put(partition, leaderIsrAndControllerEpoch)
             leaderIsrAndControllerEpoch
           }
-          )
+        )
       }
 
     (
-      leaderIsrAndControllerEpochs ++ exceptionsForPartitionsWithNoLeaderAndIsrInZk,
+      updatedLeaderIsrAndControllerEpochs,
       updatesToRetry
     )
-  }
-
-  /**
-   * Gets the partition state from zookeeper
-   * @param partitions the partitions whose state we want from zookeeper
-   * @return A tuple of two values:
-   *         1. The Right(LeaderAndIsrs) of partitions whose state we successfully read from zookeeper.
-   *         The Left(Exception) to failed zookeeper lookups or states whose controller epoch exceeds our current epoch
-   *         2. The partitions that had no leader and isr state in zookeeper. This happens if the controller
-   *         didn't finish partition initialization.
-   */
-  private def getTopicPartitionStatesFromZk(
-    partitions: Seq[TopicPartition]
-  ): (Map[TopicPartition, Either[Exception, LeaderAndIsr]], Seq[TopicPartition]) = {
-    val getDataResponses = try {
-      zkClient.getTopicPartitionStatesRaw(partitions)
-    } catch {
-      case e: Exception =>
-        return (partitions.map(_ -> Left(e))(breakOut), Seq.empty)
-    }
-
-    val partitionsWithNoLeaderAndIsrInZk = mutable.Buffer.empty[TopicPartition]
-    val result = mutable.Map.empty[TopicPartition, Either[Exception, LeaderAndIsr]]
-
-    getDataResponses.foreach { getDataResponse =>
-      val partition = getDataResponse.ctx.get.asInstanceOf[TopicPartition]
-      val _: Unit = if (getDataResponse.resultCode == Code.OK) {
-        TopicPartitionStateZNode.decode(getDataResponse.data, getDataResponse.stat) match {
-          case None =>
-            partitionsWithNoLeaderAndIsrInZk += partition
-          case Some(leaderIsrAndControllerEpoch) =>
-            if (leaderIsrAndControllerEpoch.controllerEpoch > controllerContext.epoch) {
-              val exception = new StateChangeFailedException(
-                "Leader and isr path written by another controller. This probably " +
-                s"means the current controller with epoch ${controllerContext.epoch} went through a soft failure and " +
-                s"another controller was elected with epoch ${leaderIsrAndControllerEpoch.controllerEpoch}. Aborting " +
-                "state change by this controller"
-              )
-              result += (partition -> Left(exception))
-            } else {
-              result += (partition -> Right(leaderIsrAndControllerEpoch.leaderAndIsr))
-            }
-        }
-      } else if (getDataResponse.resultCode == Code.NONODE) {
-        partitionsWithNoLeaderAndIsrInZk += partition
-      } else {
-        result += (partition -> Left(getDataResponse.resultException.get))
-      }
-    }
-
-    (result.toMap, partitionsWithNoLeaderAndIsrInZk)
   }
 
   private def logSuccessfulTransition(replicaId: Int, partition: TopicPartition, currState: ReplicaState, targetState: ReplicaState): Unit = {
@@ -428,7 +394,10 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     logFailedStateChange(replica, currState, targetState, e)
   }
 
-  private def logFailedStateChange(replica: PartitionAndReplica, currState: ReplicaState, targetState: ReplicaState, t: Throwable): Unit = {
+  private def logFailedStateChange(replica: PartitionAndReplica,
+                                   currState: ReplicaState,
+                                   targetState: ReplicaState,
+                                   t: Throwable): Unit = {
     stateChangeLogger.withControllerEpoch(controllerContext.epoch)
       .error(s"Controller $controllerId epoch ${controllerContext.epoch} initiated state change of replica ${replica.replica} " +
         s"for partition ${replica.topicPartition} from $currState to $targetState failed", t)

--- a/core/src/main/scala/kafka/controller/StateMachineUtil.scala
+++ b/core/src/main/scala/kafka/controller/StateMachineUtil.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.controller
+
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.TopicPartition
+
+import scala.collection.mutable
+
+class StateMachineUtil(controllerContext: ControllerContext, zkClient: KafkaZkClient) {
+
+  def maybeUpdateLeaderAndIsr(partitions: Seq[TopicPartition],
+                              stateChangeError: (TopicPartition, String) => Exception): Map[TopicPartition, Exception] = {
+    val partitionStates = try {
+      zkClient.fetchPartitionStates(partitions)
+    } catch {
+      case e: Exception =>
+        return partitions.map(tp => tp -> e).toMap
+    }
+
+    val errors = mutable.Map.empty[TopicPartition, Exception]
+    partitionStates.foreach {
+      case (tp, Some(leaderIsrAndControllerEpoch)) =>
+        if (leaderIsrAndControllerEpoch.controllerEpoch > controllerContext.epoch) {
+          val failureReason = s"Leader and ISR path of $tp written by another controller. This probably " +
+            s"means the current controller with epoch ${controllerContext.epoch} went through a soft failure and " +
+            s"another controller was elected with epoch ${leaderIsrAndControllerEpoch.controllerEpoch}."
+          errors.put(tp, stateChangeError(tp, failureReason))
+        } else {
+          controllerContext.partitionLeadershipInfo.put(tp, leaderIsrAndControllerEpoch)
+        }
+
+      case (tp, None) =>
+        val failureReason = if (controllerContext.isTopicQueuedUpForDeletion(tp.topic)) {
+          s"The topic ${tp.topic} is pending deletion."
+        } else {
+          s"The leader and ISR path in zookeeper is empty"
+        }
+        errors.put(tp, stateChangeError(tp, failureReason))
+    }
+
+    errors.toMap
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -754,10 +754,10 @@ class PartitionTest {
     }
 
     assertThrows[IllegalArgumentException] {
-      val replica = partition.getOrCreateReplica(brokerId)
+      partition.getOrCreateReplica(brokerId)
     }
 
-    val remoteReplicaId = brokerId + 1;
+    val remoteReplicaId = brokerId + 1
     val replica = partition.getOrCreateReplica(remoteReplicaId)
     assertEquals(replica.brokerId, remoteReplicaId)
     assertEquals(replica.topicPartition, partition.topicPartition)

--- a/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
+++ b/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
@@ -21,7 +21,7 @@ import kafka.common.StateChangeFailedException
 import kafka.controller.Election._
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.{breakOut, mutable}
+import scala.collection.breakOut
 
 class MockPartitionStateMachine(controllerContext: ControllerContext,
                                 uncleanLeaderElectionEnabled: Boolean)
@@ -69,33 +69,38 @@ class MockPartitionStateMachine(controllerContext: ControllerContext,
     partitions: Seq[TopicPartition],
     leaderElectionStrategy: PartitionLeaderElectionStrategy
   ): Map[TopicPartition, Either[Throwable, LeaderAndIsr]] = {
-    val failedElections = mutable.Map.empty[TopicPartition, Either[Throwable, LeaderAndIsr]]
-    val validLeaderAndIsrs = mutable.Buffer.empty[(TopicPartition, LeaderAndIsr)]
+    val leaderIsrAndControllerEpochPerPartition = partitions.map { partition =>
+      partition -> controllerContext.partitionLeadershipInfo(partition)
+    }
 
-    for (partition <- partitions) {
-      val leaderIsrAndControllerEpoch = controllerContext.partitionLeadershipInfo(partition)
-      if (leaderIsrAndControllerEpoch.controllerEpoch > controllerContext.epoch) {
-        val failMsg = s"Aborted leader election for partition $partition since the LeaderAndIsr path was " +
-          s"already written by another controller. This probably means that the current controller went through " +
-          s"a soft failure and another controller was elected with epoch ${leaderIsrAndControllerEpoch.controllerEpoch}."
-        failedElections.put(partition, Left(new StateChangeFailedException(failMsg)))
-      } else {
-        validLeaderAndIsrs.append((partition, leaderIsrAndControllerEpoch.leaderAndIsr))
-      }
+    val (invalidPartitionsForElection, validPartitionsForElection) = leaderIsrAndControllerEpochPerPartition.partition { case (_, leaderIsrAndControllerEpoch) =>
+      leaderIsrAndControllerEpoch.controllerEpoch > controllerContext.epoch
+    }
+
+    val validPartitionsLeaderAndIsrs = validPartitionsForElection.map { case (tp, leaderIsrAndControllerEpoch) =>
+      tp -> leaderIsrAndControllerEpoch.leaderAndIsr
+    }
+
+    val failedElections = invalidPartitionsForElection.map { case (partition, leaderIsrAndControllerEpoch) =>
+      val failMsg = s"aborted leader election for partition $partition since the LeaderAndIsr path was " +
+        s"already written by another controller. This probably means that the current controller went through " +
+        s"a soft failure and another controller was elected with epoch ${leaderIsrAndControllerEpoch.controllerEpoch}."
+
+      partition -> Left(new StateChangeFailedException(failMsg))
     }
 
     val electionResults = leaderElectionStrategy match {
       case OfflinePartitionLeaderElectionStrategy(isUnclean) =>
-        val partitionsWithUncleanLeaderElectionState = validLeaderAndIsrs.map { case (partition, leaderAndIsr) =>
-          (partition, Some(leaderAndIsr), isUnclean || uncleanLeaderElectionEnabled)
+        val partitionsWithUncleanLeaderElectionState = validPartitionsForElection.map { case (partition, leaderIsrAndControllerEpoch) =>
+          (partition, Some(leaderIsrAndControllerEpoch.leaderAndIsr), isUnclean || uncleanLeaderElectionEnabled)
         }
         leaderForOffline(controllerContext, partitionsWithUncleanLeaderElectionState)
       case ReassignPartitionLeaderElectionStrategy =>
-        leaderForReassign(controllerContext, validLeaderAndIsrs)
+        leaderForReassign(controllerContext, validPartitionsLeaderAndIsrs)
       case PreferredReplicaPartitionLeaderElectionStrategy =>
-        leaderForPreferredReplica(controllerContext, validLeaderAndIsrs)
+        leaderForPreferredReplica(controllerContext, validPartitionsLeaderAndIsrs)
       case ControlledShutdownPartitionLeaderElectionStrategy =>
-        leaderForControlledShutdown(controllerContext, validLeaderAndIsrs)
+        leaderForControlledShutdown(controllerContext, validPartitionsLeaderAndIsrs)
     }
 
     val results: Map[TopicPartition, Either[Exception, LeaderAndIsr]] = electionResults.map { electionResult =>


### PR DESCRIPTION
Since it has the cached leader and ISR state, the controller can optimistically assume it has the latest state when performing an update and save a little latency. If the state was changed by the leader, it can do the lookup and retry.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
