### PR TITLE
MINOR: trivial cleanups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -603,15 +603,6 @@ public final class Utils {
     }
 
     /**
-     * Print an error message and shutdown the JVM
-     * @param message The error message
-     */
-    public static void croak(String message) {
-        System.err.println(message);
-        Exit.exit(1);
-    }
-
-    /**
      * Read a buffer into a Byte array for the given offset and length
      */
     public static byte[] readBytes(ByteBuffer buffer, int offset, int length) {
@@ -868,7 +859,6 @@ public final class Utils {
             }
         }
     }
-
 
     /**
      * A cheap way to deterministically convert a number to a positive value. When the input is

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 
@@ -56,7 +55,7 @@ public class ByteBufferLogInputStreamTest {
     }
 
     @Test(expected = CorruptRecordException.class)
-    public void iteratorRaisesOnTooSmallRecords() throws IOException {
+    public void iteratorRaisesOnTooSmallRecords() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
         builder.append(15L, "a".getBytes(), "1".getBytes());
@@ -79,7 +78,7 @@ public class ByteBufferLogInputStreamTest {
     }
 
     @Test(expected = CorruptRecordException.class)
-    public void iteratorRaisesOnInvalidMagic() throws IOException {
+    public void iteratorRaisesOnInvalidMagic() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
         builder.append(15L, "a".getBytes(), "1".getBytes());
@@ -102,7 +101,7 @@ public class ByteBufferLogInputStreamTest {
     }
 
     @Test(expected = CorruptRecordException.class)
-    public void iteratorRaisesOnTooLargeRecords() throws IOException {
+    public void iteratorRaisesOnTooLargeRecords() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
         builder.append(15L, "a".getBytes(), "1".getBytes());

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -104,7 +104,7 @@ case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] 
   def randomSegmentJitter: Long =
     if (segmentJitterMs == 0) 0 else Utils.abs(scala.util.Random.nextInt()) % math.min(segmentJitterMs, segmentMs)
 
-  def maxSegmentMs :Long = {
+  def maxSegmentMs: Long = {
     if (compact && maxCompactionLagMs > 0) math.min(maxCompactionLagMs, segmentMs)
     else segmentMs
   }

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -1178,7 +1178,7 @@ class LogValidatorTest {
   }
 
   private def createTwoBatchedRecords(magicValue: Byte,
-                                      timestamp: Long = RecordBatch.NO_TIMESTAMP,
+                                      timestamp: Long,
                                       codec: CompressionType): MemoryRecords = {
     val buf = ByteBuffer.allocate(2048)
     var builder = MemoryRecords.builder(buf, magicValue, codec, TimestampType.CREATE_TIME, 0L)
@@ -1191,16 +1191,6 @@ class LogValidatorTest {
 
     buf.flip()
     MemoryRecords.readableRecords(buf.slice())
-  }
-
-  private def createDiscontinuousOffsetRecords(magicValue: Byte,
-                                               codec: CompressionType): MemoryRecords = {
-    val buf = ByteBuffer.allocate(512)
-    val builder = MemoryRecords.builder(buf, magicValue, codec, TimestampType.CREATE_TIME, 0L)
-    builder.appendWithOffset(0, RecordBatch.NO_TIMESTAMP, null, "hello".getBytes)
-    builder.appendWithOffset(2, RecordBatch.NO_TIMESTAMP, null, "there".getBytes)
-    builder.appendWithOffset(3, RecordBatch.NO_TIMESTAMP, null, "beautiful".getBytes)
-    builder.build()
   }
 
   /* check that offsets are assigned consecutively from the given base offset */

--- a/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
@@ -22,7 +22,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 class TransactionIndexTest extends JUnitSuite {
   var file: File = _

--- a/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import kafka.utils.Json
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.{Assert, Test}
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 import scala.collection.JavaConverters._
 
 class AclTest extends JUnitSuite {


### PR DESCRIPTION
- Remove unused method: `LogValidatorTest#createDiscontinuousOffsetRecords`
- Remove unused default argument: `LogValidatorTest#createTwoBatchedRecords`
- Remove unused local value: `PartitionTest#testGetReplica`
- Remove unused local value: `ReplicaAlterLogDirsThreadTest#shouldTruncateToInitialFetchOffsetIfReplicaReturnsUndefinedOffset`
- Remove unused local value: `ReplicaFetcherThreadTest#shouldTruncateToInitialFetchOffsetIfLeaderReturnsUndefinedOffset`
- Remove unthrown exceptions: `ByteBufferLogInputStreamTest` (RuntimeExceptions are thrown here.)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
