### PR TITLE
KAFKA-7548: KafkaConsumer should not throw away already fetched data for paused partitions (v2)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1269,7 +1269,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         client.poll(pollTimer, () -> {
             // since a fetch might be completed by the background thread, we need this poll condition
             // to ensure that we do not block unnecessarily in poll()
-            return !fetcher.hasCompletedFetches();
+            return !fetcher.hasAvailableFetches();
         });
         timer.update(pollTimer.currentTimeMs());
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -81,7 +81,6 @@ import org.slf4j.helpers.MessageFormatter;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -94,7 +93,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -142,8 +140,7 @@ public class Fetcher<K, V> implements Closeable {
     private final ConsumerMetadata metadata;
     private final FetchManagerMetrics sensors;
     private final SubscriptionState subscriptions;
-    private final ConcurrentLinkedQueue<CompletedFetch> completedFetches;
-    private final ConcurrentLinkedQueue<PartitionRecords> parsedFetchesCache;
+    private final ConcurrentLinkedQueue<PartitionRecords> completedFetches;
     private final BufferSupplier decompressionBufferSupplier = BufferSupplier.create();
     private final Deserializer<K> keyDeserializer;
     private final Deserializer<V> valueDeserializer;
@@ -193,7 +190,6 @@ public class Fetcher<K, V> implements Closeable {
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
         this.completedFetches = new ConcurrentLinkedQueue<>();
-        this.parsedFetchesCache = new ConcurrentLinkedQueue<>();
         this.sensors = new FetchManagerMetrics(metrics, metricsRegistry);
         this.retryBackoffMs = retryBackoffMs;
         this.requestTimeoutMs = requestTimeoutMs;
@@ -225,11 +221,6 @@ public class Fetcher<K, V> implements Closeable {
      */
     public boolean hasCompletedFetches() {
         return !completedFetches.isEmpty();
-    }
-
-    // Visibilty for testing
-    protected boolean hasParsedFetchesCache() {
-        return !parsedFetchesCache.isEmpty();
     }
 
     /**
@@ -300,8 +291,11 @@ public class Fetcher<K, V> implements Closeable {
 
                                             log.debug("Fetch {} at offset {} for partition {} returned fetch data {}",
                                                     isolationLevel, fetchOffset, partition, fetchData);
-                                            completedFetches.add(new CompletedFetch(partition, fetchOffset, fetchData, metricAggregator,
-                                                    resp.requestHeader().apiVersion()));
+
+                                            CompletedFetch completedFetch = new CompletedFetch(partition, fetchOffset,
+                                                    fetchData, metricAggregator, resp.requestHeader().apiVersion());
+
+                                            completedFetches.add(parseCompletedFetch(completedFetch));
                                         }
                                     }
 
@@ -586,37 +580,34 @@ public class Fetcher<K, V> implements Closeable {
      */
     public Map<TopicPartition, List<ConsumerRecord<K, V>>> fetchedRecords() {
         Map<TopicPartition, List<ConsumerRecord<K, V>>> fetched = new HashMap<>();
-        Queue<CompletedFetch> pausedCompletedFetches = new ArrayDeque<>();
-        Queue<PartitionRecords> pausedParsedRecordsCache = new ArrayDeque<>();
         int recordsRemaining = maxPollRecords;
 
         try {
             while (recordsRemaining > 0) {
                 if (nextInLineRecords == null || nextInLineRecords.isFetched) {
-                    nextInLineRecords = maybeGetParsedFetchFromCache(pausedParsedRecordsCache);
+                    PartitionRecords records = maybeGetPartitionRecords();
 
-                    if (nextInLineRecords == null) {
-                        CompletedFetch completedFetch = maybeGetCompletedFetch(pausedCompletedFetches);
+                    if (records == null) break;
 
-                        if (completedFetch == null) break;
-
+                    if (records.notInitialized()) {
                         try {
-                            nextInLineRecords = parseCompletedFetch(completedFetch);
+                            nextInLineRecords = initializePartitionRecords(records);
                         } catch (Exception e) {
                             // Remove a completedFetch upon a parse with exception if (1) it contains no records, and
                             // (2) there are no fetched records with actual content preceding this exception.
                             // The first condition ensures that the completedFetches is not stuck with the same completedFetch
                             // in cases such as the TopicAuthorizationException, and the second condition ensures that no
                             // potential data loss due to an exception in a following record.
-                            FetchResponse.PartitionData partition = completedFetch.partitionData;
+                            FetchResponse.PartitionData partition = records.completedFetch.partitionData;
                             if (fetched.isEmpty() && (partition.records == null || partition.records.sizeInBytes() == 0)) {
-                                completedFetches.poll();
+                                completedFetches.remove(records);
                             }
                             throw e;
                         }
-                        completedFetches.poll();
+                    } else {
+                        nextInLineRecords = records;
                     }
-
+                    completedFetches.remove(records);
                 } else {
                     List<ConsumerRecord<K, V>> records = fetchRecords(nextInLineRecords, recordsRemaining);
 
@@ -641,61 +632,27 @@ public class Fetcher<K, V> implements Closeable {
         } catch (KafkaException e) {
             if (fetched.isEmpty())
                 throw e;
-        } finally {
-            // add any partitions that were paused back to queues to be re-evaluated in the next poll
-            completedFetches.addAll(pausedCompletedFetches);
-            parsedFetchesCache.addAll(pausedParsedRecordsCache);
         }
 
         return fetched;
     }
 
     /**
-     * Find the first non-paused parsed fetch of partition records. Parsed fetches of partition records are cached when
-     * they belong to a paused partition. They are cached so that they can be returned in the next poll when the
-     * partition may be resumed. Any parsed fetches that are still paused are added back to the cache after this poll
-     * for fetched records.
-     * @return A parsed fetch of partition records or null.
+     * Return the next PartitionRecords from the queue of completed fetches. If the records belong to a partition that
+     * is currently paused then moved on to the next. If the queue is empty or all partitions are paused then return
+     * null.
      */
-    private PartitionRecords maybeGetParsedFetchFromCache(Queue<PartitionRecords> pausedParsedRecordsCache) {
-        PartitionRecords records = parsedFetchesCache.peek();
-        if (records == null) return null;
-
-        do {
+    private PartitionRecords maybeGetPartitionRecords() {
+        PartitionRecords partRecords = null;
+        for (PartitionRecords records : completedFetches) {
             if (subscriptions.isPaused(records.partition)) {
-                log.debug("Caching a previously parsed completed fetch for partition {} because it is still paused", records.partition);
-                pausedParsedRecordsCache.add(parsedFetchesCache.poll());
-                records = parsedFetchesCache.peek();
+                log.debug("Skipping the completed fetch for partition {} because its partition is paused", records.partition);
             } else {
-                log.debug("A previously parsed completed fetch for partition {} is no longer paused and will be returned", records.partition);
-                parsedFetchesCache.poll();
+                partRecords = records;
                 break;
             }
-        } while (records != null);
-
-        return records;
-    }
-
-    /**
-     * Find the first completed fetch that belongs to a non-paused partition and return it. Record all paused completed
-     * fetches to be added back to the completed fetches queue after this poll for fetched records.
-     * @return A completed fetch or null.
-     */
-    private CompletedFetch maybeGetCompletedFetch(Queue<CompletedFetch> pausedCompletedFetches) {
-        CompletedFetch completedFetch = completedFetches.peek();
-        if (completedFetch == null) return null;
-
-        do {
-            if (subscriptions.isPaused(completedFetch.partition)) {
-                log.debug("Returning the completed fetch for partition {} to the back of the queue because its partitions are paused", completedFetch.partition);
-                pausedCompletedFetches.add(completedFetches.poll());
-                completedFetch = completedFetches.peek();
-            } else {
-                break;
-            }
-        } while (completedFetch != null);
-
-        return completedFetch;
+        }
+        return partRecords;
     }
 
     private List<ConsumerRecord<K, V>> fetchRecords(PartitionRecords partitionRecords, int maxRecords) {
@@ -709,11 +666,11 @@ public class Fetcher<K, V> implements Closeable {
             log.debug("Not returning fetched records for assigned partition {} since it is no longer fetchable",
                     partitionRecords.partition);
 
-            // when the partition is paused we cache the records instead of draining them so that they can be returned
-            // on a subsequent poll if the partition is resumed
+            // when the partition is paused we add the records back to the completedFetches queue instead of draining
+            // them so that they can be returned on a subsequent poll if the partition is resumed at that time
             if (subscriptions.isPaused(partitionRecords.partition)) {
-                log.debug("Caching fetched records for assigned partition {} because it is paused", partitionRecords.partition);
-                parsedFetchesCache.add(partitionRecords);
+                log.debug("Skipping fetching records for assigned partition {} because it is paused", partitionRecords.partition);
+                completedFetches.add(partitionRecords);
                 nextInLineRecords = null;
                 return emptyList();
             }
@@ -1107,11 +1064,8 @@ public class Fetcher<K, V> implements Closeable {
         if (nextInLineRecords != null && !nextInLineRecords.isFetched) {
             exclude.add(nextInLineRecords.partition);
         }
-        for (CompletedFetch completedFetch : completedFetches) {
+        for (PartitionRecords completedFetch : completedFetches) {
             exclude.add(completedFetch.partition);
-        }
-        for (PartitionRecords records : parsedFetchesCache) {
-            exclude.add(records.partition);
         }
         return subscriptions.fetchablePartitions(tp -> !exclude.contains(tp));
     }
@@ -1210,9 +1164,21 @@ public class Fetcher<K, V> implements Closeable {
     }
 
     /**
-     * The callback for fetch completion
+     * Parse a PartitionRecords object from a CompletedFetch
      */
     private PartitionRecords parseCompletedFetch(CompletedFetch completedFetch) {
+        TopicPartition tp = completedFetch.partition;
+        FetchResponse.PartitionData<Records> partition = completedFetch.partitionData;
+
+        Iterator<? extends RecordBatch> batches = partition.records.batches().iterator();
+        return new PartitionRecords(tp, completedFetch, batches);
+    }
+
+    /**
+     * Initialize a PartitionRecords object.
+     */
+    private PartitionRecords initializePartitionRecords(PartitionRecords partitionRecordsToInitialize) {
+        CompletedFetch completedFetch = partitionRecordsToInitialize.completedFetch;
         TopicPartition tp = completedFetch.partition;
         FetchResponse.PartitionData<Records> partition = completedFetch.partitionData;
         long fetchOffset = completedFetch.fetchedOffset;
@@ -1220,10 +1186,9 @@ public class Fetcher<K, V> implements Closeable {
         Errors error = partition.error;
 
         try {
-            if (!subscriptions.isFetchable(tp)) {
-                // this can happen when a rebalance happened or a partition consumption paused
-                // while fetch is still in-flight
-                log.debug("Ignoring fetched records for partition {} since it is no longer fetchable", tp);
+            if (!subscriptions.hasValidPosition(tp)) {
+                // this can happen when a rebalance happened while fetch is still in-flight
+                log.debug("Ignoring fetched records for partition {} since it no longer has valid position", tp);
             } else if (error == Errors.NONE) {
                 // we are interested in this fetch only if the beginning offset matches the
                 // current consumed position
@@ -1237,7 +1202,7 @@ public class Fetcher<K, V> implements Closeable {
                 log.trace("Preparing to read {} bytes of data for partition {} with offset {}",
                         partition.records.sizeInBytes(), tp, position);
                 Iterator<? extends RecordBatch> batches = partition.records.batches().iterator();
-                partitionRecords = new PartitionRecords(tp, completedFetch, batches);
+                partitionRecords = partitionRecordsToInitialize;
 
                 if (!batches.hasNext() && partition.records.sizeInBytes() > 0) {
                     if (completedFetch.responseVersion < 3) {
@@ -1281,6 +1246,8 @@ public class Fetcher<K, V> implements Closeable {
                     });
                 }
 
+
+                partitionRecordsToInitialize.initialized = true;
             } else if (error == Errors.NOT_LEADER_FOR_PARTITION ||
                        error == Errors.REPLICA_NOT_AVAILABLE ||
                        error == Errors.KAFKA_STORAGE_ERROR ||
@@ -1371,21 +1338,13 @@ public class Fetcher<K, V> implements Closeable {
      * @param assignedPartitions  newly assigned {@link TopicPartition}
      */
     public void clearBufferedDataForUnassignedPartitions(Collection<TopicPartition> assignedPartitions) {
-        Iterator<CompletedFetch> completedFetchesItr = completedFetches.iterator();
+        Iterator<PartitionRecords> completedFetchesItr = completedFetches.iterator();
         while (completedFetchesItr.hasNext()) {
-            TopicPartition tp = completedFetchesItr.next().partition;
-            if (!assignedPartitions.contains(tp)) {
-                completedFetchesItr.remove();
-            }
-        }
-
-        Iterator<PartitionRecords> parsedFetchesCacheItr = parsedFetchesCache.iterator();
-        while (parsedFetchesCacheItr.hasNext()) {
-            PartitionRecords records = parsedFetchesCacheItr.next();
+            PartitionRecords records = completedFetchesItr.next();
             TopicPartition tp = records.partition;
             if (!assignedPartitions.contains(tp)) {
                 records.drain();
-                parsedFetchesCacheItr.remove();
+                completedFetchesItr.remove();
             }
         }
 
@@ -1394,8 +1353,6 @@ public class Fetcher<K, V> implements Closeable {
             nextInLineRecords = null;
         }
     }
-
-
 
     /**
      * Clear the buffered data which are not a part of newly assigned topics
@@ -1443,6 +1400,7 @@ public class Fetcher<K, V> implements Closeable {
         private boolean isFetched = false;
         private Exception cachedRecordException = null;
         private boolean corruptLastRecord = false;
+        private boolean initialized = false;
 
         private PartitionRecords(TopicPartition partition,
                                  CompletedFetch completedFetch,
@@ -1643,6 +1601,10 @@ public class Fetcher<K, V> implements Closeable {
 
             Record firstRecord = batchIterator.next();
             return ControlRecordType.ABORT == ControlRecordType.parse(firstRecord.key());
+        }
+
+        private boolean notInitialized() {
+            return !this.initialized;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -218,11 +218,20 @@ public class Fetcher<K, V> implements Closeable {
     }
 
     /**
-     * Return whether we have any completed fetches pending return to the user. This method is thread-safe.
+     * Return whether we have any completed fetches pending return to the user. This method is thread-safe. Has
+     * visibility for testing.
      * @return true if there are completed fetches, false otherwise
      */
-    public boolean hasCompletedFetches() {
+    protected boolean hasCompletedFetches() {
         return !completedFetches.isEmpty();
+    }
+
+    /**
+     * Return whether we have any completed fetches that are fetchable. This method is thread-safe.
+     * @return true if there are completed fetches that can be returned, false otherwise
+     */
+    public boolean hasAvailableFetches() {
+        return completedFetches.stream().anyMatch(fetch -> subscriptions.isFetchable(fetch.partition));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -327,7 +327,6 @@ public class FetcherTest {
 
         fetcher.clearBufferedDataForUnassignedPartitions(newAssignedTopicPartitions);
         assertFalse(fetcher.hasCompletedFetches());
-        assertFalse(fetcher.hasParsedFetchesCache());
     }
 
     @Test
@@ -999,7 +998,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testPartialFetchOnParsedFetchCache() {
+    public void testPartialFetchWithPausedPartitions() {
         // this test sends creates a completed fetch with 3 records and a max poll of 2 records to assert
         // that a fetch that must be returned over at least 2 polls can be cached successfully when its partition is
         // paused, then returned successfully after its been resumed again later
@@ -1017,7 +1016,7 @@ public class FetcherTest {
         fetchedRecords = fetchedRecords();
 
         assertEquals("Should return 2 records from fetch with 3 records", 2, fetchedRecords.get(tp0).size());
-        assertFalse("Should have no cached parsed fetches", fetcher.hasParsedFetchesCache());
+        assertFalse("Should have no completed fetches", fetcher.hasCompletedFetches());
 
         subscriptions.pause(tp0);
         consumerClient.poll(time.timer(0));
@@ -1025,7 +1024,7 @@ public class FetcherTest {
         fetchedRecords = fetchedRecords();
 
         assertEquals("Should return no records for paused partitions", 0, fetchedRecords.size());
-        assertTrue("Should have 1 entry in the parsed fetches cache", fetcher.hasParsedFetchesCache());
+        assertTrue("Should have 1 entry in completed fetches", fetcher.hasCompletedFetches());
 
         subscriptions.resume(tp0);
 
@@ -1034,7 +1033,7 @@ public class FetcherTest {
         fetchedRecords = fetchedRecords();
 
         assertEquals("Should return last remaining record", 1, fetchedRecords.get(tp0).size());
-        assertFalse("Should have no cached parsed fetches", fetcher.hasParsedFetchesCache());
+        assertFalse("Should have no completed fetches", fetcher.hasCompletedFetches());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -914,10 +914,13 @@ public class FetcherTest {
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
         assertEquals("Should not return any records when partition is paused", 0, fetchedRecords.size());
         assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
+        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
         assertNull(fetchedRecords.get(tp0));
         assertEquals(0, fetcher.sendFetches());
 
         subscriptions.resume(tp0);
+
+        assertTrue("Should have available (non-paused) completed fetches", fetcher.hasAvailableFetches());
 
         consumerClient.poll(time.timer(0));
         fetchedRecords = fetchedRecords();
@@ -995,6 +998,7 @@ public class FetcherTest {
         fetchedRecords = fetchedRecords();
         assertEquals("Should return no records for all paused partitions", 0, fetchedRecords.size());
         assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
+        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
     }
 
     @Test
@@ -1025,6 +1029,7 @@ public class FetcherTest {
 
         assertEquals("Should return no records for paused partitions", 0, fetchedRecords.size());
         assertTrue("Should have 1 entry in completed fetches", fetcher.hasCompletedFetches());
+        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
 
         subscriptions.resume(tp0);
 


### PR DESCRIPTION
This is an updated implementation of #5844 by @MayureshGharat (with Mayuresh's permission).

> Today when we call KafkaConsumer.poll(), it will fetch data from Kafka asynchronously and is put in to a local buffer (completedFetches).
>
> If now we pause some TopicPartitions and call KafkaConsumer.poll(), we might throw away any buffered data that we might have in the local buffer for these TopicPartitions. Generally, if an application is calling pause on some TopicPartitions, it is likely to resume those TopicPartitions in near future, which would require KafkaConsumer to re-issue a fetch for the same data that it had buffered earlier for these TopicPartitions. This is a wasted effort from the application's point of view.

I've reviewed the original PR's feedback from @hachikuji and reimplemented this solution to add completed fetches that belong to paused partitions back to the queue.  I also rebased against the latest trunk which caused more changes as a result of subscription event handlers being removed from the fetcher class.

You can find more details in my updated notes in the original Jira issue [KAFKA-7548](https://issues.apache.org/jira/browse/KAFKA-7548).