### PR TITLE
Fix for resolving variables for dynamic config as per KIP-421

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/config/provider/MockFileConfigProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/MockFileConfigProvider.java
@@ -24,6 +24,6 @@ public class MockFileConfigProvider extends FileConfigProvider {
 
     @Override
     protected Reader reader(String path) throws IOException {
-        return new StringReader("key=testKey\npassword=randomPassword");
+        return new StringReader("key=testKey\npassword=randomPassword\na=b");
     }
 }

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -134,6 +134,15 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--delete-config", "a"))
     createOpts.checkArgs()
 
+    // For alter add config verify variable values are resolved
+    createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+      "--entity-name", "x",
+      "--entity-type", entityType,
+      "--alter",
+      "--add-config", "config.providers=file,config.providers.file.class=org.apache.kafka.common.config.provider.MockFileConfigProvider,a=${file:path:a},c=d",
+      "--delete-config", "a"))
+    createOpts.checkArgs()
+
     val addedProps = ConfigCommand.parseConfigsToBeAdded(createOpts)
     assertEquals(2, addedProps.size())
     assertEquals("b", addedProps.getProperty("a"))


### PR DESCRIPTION
In add/alter new configs for DynamicConfigs it does not go through the KafkaConfig
eg: bin/kafka-configs --bootstrap-server localhost:9092 --entity-type brokers --entity-name 0 --alter --add-config log.cleaner.threads=2
However the bootstrap-server localhost is parsed through the kafkaConfig to create the adminClient but not the log.cleaner.thread. 

As the configs are not parsed using the KafkaConfig if we pass variables in configs they are bot resolved at run time.

In order to resolve the variables in alterConfig/addConfigs flow we need to parse the new configs  using KafkaConfig before they are parsed.