### PR TITLE
Fix for a failing upgrade test

### DIFF
--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -21,7 +21,11 @@ listeners={{ listeners }}
 advertised.listeners={{ advertised_listeners }}
 listener.security.protocol.map={{ listener_security_protocol_map }}
 
+{% if node.version.supports_named_listeners() %}
 inter.broker.listener.name={{ interbroker_listener.name }}
+{% else %}
+security.inter.broker.protocol={{ interbroker_listener.security_protocol }}
+{% endif %}
 
 ssl.keystore.location=/mnt/security/test.keystore.jks
 ssl.keystore.password=test-ks-passwd

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -49,6 +49,9 @@ class KafkaVersion(LooseVersion):
         else:
             return LooseVersion.__str__(self)
 
+    def supports_named_listeners(self):
+        return self >= V_0_10_2_0
+
 
 def get_version(node=None):
     """Return the version attached to the given node.


### PR DESCRIPTION
Previous PR (https://github.com/apache/kafka/pull/6938) added partial support for named listeners to kafka.py. Though we did run full test suite, somehow we missed one of the upgrade tests.
Since upgrade tests start kafka from older versions, they may try to start it from a version that doesn't support named listeners yet. 
This PR addresses the issue by adding a method to `version.py` called `supports_named_listeners()` and calling that method from kafka.properties template. 
According to KIP-103 (KAFKA-4636), `inter.broker.listener.name` property was introduced in 0.10.2.0, so I used this value in `supports_named_listeners()` method.

Testing:
Verified that a previously failing test passes locally.
Ran upgrade tests on Jenkins - https://jenkins.confluent.io/job/system-test-kafka-branch-builder/2747, all green

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
