### PR TITLE
MINOR: Fix typos in upgrade guide

### DIFF
--- a/docs/streams/developer-guide/memory-mgmt.html
+++ b/docs/streams/developer-guide/memory-mgmt.html
@@ -41,7 +41,8 @@
       <ul class="simple">
         <li><a class="reference internal" href="#record-caches-in-the-dsl" id="id1">Record caches in the DSL</a></li>
         <li><a class="reference internal" href="#record-caches-in-the-processor-api" id="id2">Record caches in the Processor API</a></li>
-        <li><a class="reference internal" href="#other-memory-usage" id="id3">Other memory usage</a></li>
+        <li><a class="reference internal" href="#rocksdb" id="id3">RocksDB</a></li>
+        <li><a class="reference internal" href="#other-memory-usage" id="id4">Other memory usage</a></li>
       </ul>
     </div>
     <div class="section" id="record-caches-in-the-dsl">

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -127,7 +127,7 @@
 
     <p>
         RocksDB dependency was updated to version <code>5.18.3</code>.
-        The new version allows to specify more RocksDB configurations, including <code>WriteBufferManager</code> that help to limit RocksDB off-head memory usage.
+        The new version allows to specify more RocksDB configurations, including <code>WriteBufferManager</code> that helps to limit RocksDB off-heap memory usage.
         For more details please read <a href="https://issues.apache.org/jira/browse/KAFKA-8215">KAFKA-8215</a>.
     </p>
 

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -127,7 +127,7 @@
 
     <p>
         RocksDB dependency was updated to version <code>5.18.3</code>.
-        The new version allows to specify more RocksDB configurations, including <code>WriteBufferManager</code> that helps to limit RocksDB off-heap memory usage.
+        The new version allows to specify more RocksDB configurations, including <code>WriteBufferManager</code> which helps to limit RocksDB off-heap memory usage.
         For more details please read <a href="https://issues.apache.org/jira/browse/KAFKA-8215">KAFKA-8215</a>.
     </p>
 


### PR DESCRIPTION
Fixes some typos and adds a missing link to table of contents in memory-management section
