### PR TITLE
KAFKA-8355: add static membership to range assignor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -51,9 +51,9 @@ import java.util.Map;
  * <li><code>C2 (was C1): [t0p0, t0p1, t1p0, t1p1] (before was [t0p2, t1p2])</code>
  * </ul>
  *
- * The assignment change was caused by the change of <code>member.id</code> relative order, and could be
- * mitigated by the introduction of static membership. Consumers will have individual instance ids
- * <code>I1</code>, <code>I2</code>. As long as
+ * The assignment change was caused by the change of <code>member.id</code> relative order, and
+ * can be avoided by setting the group.instance.id.
+ * Consumers will have individual instance ids <code>I1</code>, <code>I2</code>. As long as
  * 1. Number of members remain the same across generation
  * 2. Static members' identities persist across generation
  * 3. Subscription pattern doesn't change for any member

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -40,6 +40,29 @@ import java.util.Map;
  * <li><code>C0: [t0p0, t0p1, t1p0, t1p1]</code></li>
  * <li><code>C1: [t0p2, t1p2]</code></li>
  * </ul>
+ *
+ * Since the introduction of static membership, we could leverage <code>group.instance.id</code> to make the assignment behavior more sticky.
+ * For the above example, after one rolling bounce, group coordinator will attempt to assign new <code>member.id</code> towards consumers,
+ * for example <code>C0</code> -> <code>C3</code> <code>C1</code> -> <code>C2</code>.
+ *
+ * <p>The assignment could be completely shuffled to:
+ * <ul>
+ * <li><code>C3 (was C0): [t0p2, t1p2] (before was [t0p0, t0p1, t1p0, t1p1])</code>
+ * <li><code>C2 (was C1): [t0p0, t0p1, t1p0, t1p1] (before was [t0p2, t1p2])</code>
+ * </ul>
+ *
+ * The assignment change was caused by the change of <code>member.id</code> relative order, and could be
+ * mitigated by the introduction of static membership. Consumers will have individual instance ids
+ * <code>I1</code>, <code>I2</code>. As long as
+ * 1. Number of members remain the same across generation
+ * 2. Static members' identities persist across generation
+ * 3. Subscription pattern doesn't change for any member
+ *
+ * <p>The assignment will always be:
+ * <ul>
+ * <li><code>I0: [t0p0, t0p1, t1p0, t1p1]</code>
+ * <li><code>I1: [t0p2, t1p2]</code>
+ * </ul>
  */
 public class RangeAssignor extends AbstractPartitionAssignor {
 
@@ -48,27 +71,30 @@ public class RangeAssignor extends AbstractPartitionAssignor {
         return "range";
     }
 
-    private Map<String, List<String>> consumersPerTopic(Map<String, Subscription> consumerMetadata) {
-        Map<String, List<String>> res = new HashMap<>();
+    private Map<String, List<MemberInfo>> consumersPerTopic(Map<String, Subscription> consumerMetadata) {
+        Map<String, List<MemberInfo>> topicToConsumers = new HashMap<>();
         for (Map.Entry<String, Subscription> subscriptionEntry : consumerMetadata.entrySet()) {
             String consumerId = subscriptionEntry.getKey();
-            for (String topic : subscriptionEntry.getValue().topics())
-                put(res, topic, consumerId);
+            MemberInfo memberInfo = new MemberInfo(consumerId, subscriptionEntry.getValue().groupInstanceId());
+            for (String topic : subscriptionEntry.getValue().topics()) {
+                put(topicToConsumers, topic, memberInfo);
+            }
         }
-        return res;
+        return topicToConsumers;
     }
 
     @Override
     public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
                                                     Map<String, Subscription> subscriptions) {
-        Map<String, List<String>> consumersPerTopic = consumersPerTopic(subscriptions);
+        Map<String, List<MemberInfo>> consumersPerTopic = consumersPerTopic(subscriptions);
+
         Map<String, List<TopicPartition>> assignment = new HashMap<>();
         for (String memberId : subscriptions.keySet())
             assignment.put(memberId, new ArrayList<>());
 
-        for (Map.Entry<String, List<String>> topicEntry : consumersPerTopic.entrySet()) {
+        for (Map.Entry<String, List<MemberInfo>> topicEntry : consumersPerTopic.entrySet()) {
             String topic = topicEntry.getKey();
-            List<String> consumersForTopic = topicEntry.getValue();
+            List<MemberInfo> consumersForTopic = topicEntry.getValue();
 
             Integer numPartitionsForTopic = partitionsPerTopic.get(topic);
             if (numPartitionsForTopic == null)
@@ -83,10 +109,9 @@ public class RangeAssignor extends AbstractPartitionAssignor {
             for (int i = 0, n = consumersForTopic.size(); i < n; i++) {
                 int start = numPartitionsPerConsumer * i + Math.min(i, consumersWithExtraPartition);
                 int length = numPartitionsPerConsumer + (i + 1 > consumersWithExtraPartition ? 0 : 1);
-                assignment.get(consumersForTopic.get(i)).addAll(partitions.subList(start, start + length));
+                assignment.get(consumersForTopic.get(i).memberId).addAll(partitions.subList(start, start + length));
             }
         }
         return assignment;
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
@@ -77,7 +77,7 @@ import java.util.TreeSet;
  * After one rolling bounce, group coordinator will attempt to assign new <code>member.id</code> towards consumers,
  * for example <code>C0</code> -> <code>C5</code> <code>C1</code> -> <code>C3</code>, <code>C2</code> -> <code>C4</code>.
  *
- * <p>the assignment could be completely shuffled to:
+ * <p>The assignment could be completely shuffled to:
  * <ul>
  * <li><code>C3 (was C1): [t0p0, t1p0] (before was [t0p1, t1p1])</code>
  * <li><code>C4 (was C2): [t0p1, t1p1] (before was [t0p2, t1p2])</code>
@@ -88,6 +88,7 @@ import java.util.TreeSet;
  * <code>I1</code>, <code>I2</code>, <code>I3</code>. As long as
  * 1. Number of members remain the same across generation
  * 2. Static members' identities persist across generation
+ * 3. Subscription pattern doesn't change for any member
  *
  * <p>The assignment will always be:
  * <ul>

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -38,8 +38,6 @@ import static org.junit.Assert.assertTrue;
 public class RangeAssignorTest {
 
     private RangeAssignor assignor = new RangeAssignor();
-    private String consumerId = "consumer";
-    private String topic = "topic";
 
     // For plural tests
     private String topic1 = "topic1";
@@ -66,31 +64,30 @@ public class RangeAssignorTest {
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumerId, new Subscription(Collections.emptyList())));
+                Collections.singletonMap(consumer1, new Subscription(Collections.emptyList())));
 
-        assertEquals(Collections.singleton(consumerId), assignment.keySet());
-        assertTrue(assignment.get(consumerId).isEmpty());
+        assertEquals(Collections.singleton(consumer1), assignment.keySet());
+        assertTrue(assignment.get(consumer1).isEmpty());
     }
 
     @Test
     public void testOneConsumerNonexistentTopic() {
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
-        assertEquals(Collections.singleton(consumerId), assignment.keySet());
-        assertTrue(assignment.get(consumerId).isEmpty());
+                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
+        assertEquals(Collections.singleton(consumer1), assignment.keySet());
+        assertTrue(assignment.get(consumer1).isEmpty());
     }
 
     @Test
     public void testOneConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 0);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
+                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
 
-        assertEquals(Collections.singleton(consumerId), assignment.keySet());
-        assertAssignment(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
+        assertEquals(Collections.singleton(consumer1), assignment.keySet());
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer1));
     }
 
     @Test
@@ -98,62 +95,56 @@ public class RangeAssignorTest {
         String otherTopic = "other";
 
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        partitionsPerTopic.put(topic1, 3);
         partitionsPerTopic.put(otherTopic, 3);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumerId, new Subscription(topics(topic))));
-        assertEquals(Collections.singleton(consumerId), assignment.keySet());
-        assertAssignment(partitions(tp(topic, 0), tp(topic, 1), tp(topic, 2)), assignment.get(consumerId));
+                Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
+        assertEquals(Collections.singleton(consumer1), assignment.keySet());
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic1, 2)), assignment.get(consumer1));
     }
 
     @Test
     public void testOneConsumerMultipleTopics() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
-                Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2))));
+                Collections.singletonMap(consumer1, new Subscription(topics(topic1, topic2))));
 
-        assertEquals(Collections.singleton(consumerId), assignment.keySet());
-        assertAssignment(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerId));
+        assertEquals(Collections.singleton(consumer1), assignment.keySet());
+        assertAssignment(partitions(tp(topic1, 0), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
     }
 
     @Test
     public void testTwoConsumersOneTopicOnePartition() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 0);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic)));
-        consumers.put(consumer2, new Subscription(topics(topic)));
+        consumers.put(consumer1, new Subscription(topics(topic1)));
+        consumers.put(consumer2, new Subscription(topics(topic1)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
-        assertAssignment(partitions(tp(topic, 0)), assignment.get(consumer1));
+        assertAssignment(partitions(tp(topic1, 0)), assignment.get(consumer1));
         assertAssignment(Collections.emptyList(), assignment.get(consumer2));
     }
 
 
     @Test
     public void testTwoConsumersOneTopicTwoPartitions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(2, 0);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        consumers.put(consumer1, new Subscription(topics(topic)));
-        consumers.put(consumer2, new Subscription(topics(topic)));
+        consumers.put(consumer1, new Subscription(topics(topic1)));
+        consumers.put(consumer2, new Subscription(topics(topic1)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
-        assertAssignment(partitions(tp(topic, 0)), assignment.get(consumer1));
-        assertAssignment(partitions(tp(topic, 1)), assignment.get(consumer2));
+        assertAssignment(partitions(tp(topic1, 0)), assignment.get(consumer1));
+        assertAssignment(partitions(tp(topic1, 1)), assignment.get(consumer2));
     }
 
     @Test
     public void testMultipleConsumersMixedTopics() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));
@@ -173,9 +164,7 @@ public class RangeAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
@@ -188,61 +177,56 @@ public class RangeAssignorTest {
 
     @Test
     public void testTwoStaticConsumersTwoTopicsSixPartitions() {
-        // although consumer 2 has a higher rank than 1, the comparison happens on
+        // although consumer high has a higher rank than consumer low, the comparison happens on
         // instance id level.
-        String consumer1 = "consumer-b";
-        String consumer2 = "consumer-a";
+        String consumerIdLow = "consumer-b";
+        String consumerIdHigh = "consumer-a";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
-        Subscription consumer1Subscription = new Subscription(topics(topic1, topic2),
+        Subscription consumerLowSubscription = new Subscription(topics(topic1, topic2),
                                                               null,
                                                               Collections.emptyList());
-        consumer1Subscription.setGroupInstanceId(Optional.of(instance1));
-        consumers.put(consumer1, consumer1Subscription);
-        Subscription consumer2Subscription = new Subscription(topics(topic1, topic2),
+        consumerLowSubscription.setGroupInstanceId(Optional.of(instance1));
+        consumers.put(consumerIdLow, consumerLowSubscription);
+        Subscription consumerHighSubscription = new Subscription(topics(topic1, topic2),
                                                               null,
                                                               Collections.emptyList());
-        consumer2Subscription.setGroupInstanceId(Optional.of(instance2));
-        consumers.put(consumer2, consumer2Subscription);
+        consumerHighSubscription.setGroupInstanceId(Optional.of(instance2));
+        consumers.put(consumerIdHigh, consumerHighSubscription);
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
-        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
-        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerIdLow));
+        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumerIdHigh));
     }
 
     @Test
     public void testOneStaticConsumerAndOneDynamicConsumerTwoTopicsSixPartitions() {
-        // although consumer 2 has a higher rank than 1, consumer 1 will win the comparison
+        // although consumer high has a higher rank than low, consumer low will win the comparison
         // because it has instance id while consumer 2 doesn't.
-        String consumer1 = "consumer-b";
-        String consumer2 = "consumer-a";
+        String consumerIdLow = "consumer-b";
+        String consumerIdHigh = "consumer-a";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
 
-        Subscription consumer1Subscription = new Subscription(topics(topic1, topic2),
+        Subscription consumerLowSubscription = new Subscription(topics(topic1, topic2),
                                                               null,
                                                               Collections.emptyList());
-        consumer1Subscription.setGroupInstanceId(Optional.of(instance1));
-        consumers.put(consumer1, consumer1Subscription);
-        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+        consumerLowSubscription.setGroupInstanceId(Optional.of(instance1));
+        consumers.put(consumerIdLow, consumerLowSubscription);
+        consumers.put(consumerIdHigh, new Subscription(topics(topic1, topic2)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
-        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
-        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumerIdLow));
+        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumerIdHigh));
     }
 
     @Test
     public void testStaticMemberRangeAssignmentPersistent() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 5);
-        partitionsPerTopic.put(topic2, 4);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 4);
+
         Map<String, Subscription> consumers = new HashMap<>();
         for (MemberInfo m : staticMemberInfos) {
             Subscription subscription = new Subscription(topics(topic1, topic2),
@@ -279,9 +263,7 @@ public class RangeAssignorTest {
 
     @Test
     public void testStaticMemberRangeAssignmentPersistentAfterMemberIdChanges() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 5);
-        partitionsPerTopic.put(topic2, 5);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 5);
 
         Map<String, Subscription> consumers = new HashMap<>();
         for (MemberInfo m : staticMemberInfos) {
@@ -333,6 +315,13 @@ public class RangeAssignorTest {
     private void assertAssignment(List<TopicPartition> expected, List<TopicPartition> actual) {
         // order doesn't matter for assignment, so convert to a set
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    private Map<String, Integer> setupPartitionsPerTopicWithTwoTopics(int numberOfPartitions1, int numberOfPartitions2) {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, numberOfPartitions1);
+        partitionsPerTopic.put(topic2, numberOfPartitions2);
+        return partitionsPerTopic;
     }
 
     private static List<String> topics(String... topics) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -81,7 +81,8 @@ public class RangeAssignorTest {
 
     @Test
     public void testOneConsumerOneTopic() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 0);
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 3);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumer1, new Subscription(topics(topic1))));
@@ -117,7 +118,8 @@ public class RangeAssignorTest {
 
     @Test
     public void testTwoConsumersOneTopicOnePartition() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 0);
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 1);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));
@@ -131,7 +133,8 @@ public class RangeAssignorTest {
 
     @Test
     public void testTwoConsumersOneTopicTwoPartitions() {
-        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(2, 0);
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -17,15 +17,19 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -176,6 +180,190 @@ public class RangeAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
         assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+    }
+
+    @Test
+    public void testTwoStaticConsumersTwoTopicsSixPartitions() {
+        // although consumer 2 has a higher rank than 1, the comparison happens on
+        // instance id level.
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer-b";
+        String instance1 = "instance1";
+        String consumer2 = "consumer-a";
+        String instance2 = "instance2";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 3);
+        partitionsPerTopic.put(topic2, 3);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        Subscription consumer1Subscription = new Subscription(topics(topic1, topic2),
+                                                              null,
+                                                              Collections.emptyList());
+        consumer1Subscription.setGroupInstanceId(Optional.of(instance1));
+        consumers.put(consumer1, consumer1Subscription);
+        Subscription consumer2Subscription = new Subscription(topics(topic1, topic2),
+                                                              null,
+                                                              Collections.emptyList());
+        consumer2Subscription.setGroupInstanceId(Optional.of(instance2));
+        consumers.put(consumer2, consumer2Subscription);
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
+        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+    }
+
+    @Test
+    public void testOneStaticConsumerAndOneDynamicConsumerTwoTopicsSixPartitions() {
+        // although consumer 2 has a higher rank than 1, consumer 1 will win the comparison
+        // because it has instance id while consumer 2 doesn't.
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer-b";
+        String instance1 = "instance1";
+        String consumer2 = "consumer-a";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 3);
+        partitionsPerTopic.put(topic2, 3);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+
+        Subscription consumer1Subscription = new Subscription(topics(topic1, topic2),
+                                                              null,
+                                                              Collections.emptyList());
+        consumer1Subscription.setGroupInstanceId(Optional.of(instance1));
+        consumers.put(consumer1, consumer1Subscription);
+        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
+        assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+    }
+
+    @Test
+    public void testStaticMemberRangeAssignmentPersistent() {
+        // Have 3 static members instance1, instance2, instance3 to be persistent
+        // across generations. Their assignment shall be the same.
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String instance1 = "instance1";
+        String consumer2 = "consumer2";
+        String instance2 = "instance2";
+        String consumer3 = "consumer3";
+        String instance3 = "instance3";
+
+        List<MemberInfo> staticMemberInfos = new ArrayList<>();
+        staticMemberInfos.add(new MemberInfo(consumer1, Optional.of(instance1)));
+        staticMemberInfos.add(new MemberInfo(consumer2, Optional.of(instance2)));
+        staticMemberInfos.add(new MemberInfo(consumer3, Optional.of(instance3)));
+
+        // Consumer 4 is a dynamic member.
+        String consumer4 = "consumer4";
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 5);
+        partitionsPerTopic.put(topic2, 4);
+        Map<String, Subscription> consumers = new HashMap<>();
+        for (MemberInfo m : staticMemberInfos) {
+            Subscription subscription = new Subscription(topics(topic1, topic2),
+                                                         null,
+                                                         Collections.emptyList());
+            subscription.setGroupInstanceId(m.groupInstanceId);
+            consumers.put(m.memberId, subscription);
+        }
+        consumers.put(consumer4, new Subscription(topics(topic1, topic2)));
+
+        Map<String, List<TopicPartition>> expectedAssignment = new HashMap<>();
+        expectedAssignment.put(consumer1, partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0)));
+        expectedAssignment.put(consumer2, partitions(tp(topic1, 2), tp(topic2, 1)));
+        expectedAssignment.put(consumer3, partitions(tp(topic1, 3), tp(topic2, 2)));
+        expectedAssignment.put(consumer4, partitions(tp(topic1, 4), tp(topic2, 3)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertEquals(expectedAssignment, assignment);
+
+        // Replace dynamic member 4 with a new dynamic member 5.
+        consumers.remove(consumer4);
+        String consumer5 = "consumer5";
+        consumers.put(consumer5, new Subscription(topics(topic1, topic2)));
+
+        expectedAssignment.remove(consumer4);
+        expectedAssignment.put(consumer5, partitions(tp(topic1, 4), tp(topic2, 3)));
+        assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertEquals(expectedAssignment, assignment);
+    }
+
+    @Test
+    public void testStaticMemberRangeAssignmentPersistentAfterMemberIdChanges() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String instance1 = "instance1";
+        String consumer2 = "consumer2";
+        String instance2 = "instance2";
+        String consumer3 = "consumer3";
+        String instance3 = "instance3";
+        Map<String, String> memberIdToInstanceId = new HashMap<>();
+        memberIdToInstanceId.put(consumer1, instance1);
+        memberIdToInstanceId.put(consumer2, instance2);
+        memberIdToInstanceId.put(consumer3, instance3);
+
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, 5);
+        partitionsPerTopic.put(topic2, 5);
+        List<MemberInfo> staticMemberInfos = new ArrayList<>();
+        for (Map.Entry<String, String> entry : memberIdToInstanceId.entrySet()) {
+            staticMemberInfos.add(new MemberInfo(entry.getKey(), Optional.of(entry.getValue())));
+        }
+        Map<String, Subscription> consumers = new HashMap<>();
+        for (MemberInfo m : staticMemberInfos) {
+            Subscription subscription = new Subscription(topics(topic1, topic2),
+                                                         null,
+                                                         Collections.emptyList());
+            subscription.setGroupInstanceId(m.groupInstanceId);
+            consumers.put(m.memberId, subscription);
+        }
+        Map<String, List<TopicPartition>> expectedInstanceAssignment = new HashMap<>();
+        expectedInstanceAssignment.put(instance1,
+                                       partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)));
+        expectedInstanceAssignment.put(instance2,
+                                       partitions(tp(topic1, 2), tp(topic1, 3), tp(topic2, 2), tp(topic2, 3)));
+        expectedInstanceAssignment.put(instance3,
+                                       partitions(tp(topic1, 4), tp(topic2, 4)));
+
+        Map<String, List<TopicPartition>> staticAssignment =
+            checkStaticAssignment(assignor, partitionsPerTopic, consumers, expectedInstanceAssignment);
+
+        // Now switch the member.id fields for each member info, the assignment should
+        // stay the same as last time.
+        String consumer4 = "consumer4";
+        String consumer5 = "consumer5";
+        consumers.put(consumer4, consumers.get(consumer3));
+        consumers.remove(consumer3);
+        consumers.put(consumer5, consumers.get(consumer2));
+        consumers.remove(consumer2);
+
+        Map<String, List<TopicPartition>> newStaticAssignment =
+            checkStaticAssignment(assignor, partitionsPerTopic, consumers, expectedInstanceAssignment);
+
+        assertEquals(staticAssignment, newStaticAssignment);
+    }
+
+    static Map<String, List<TopicPartition>> checkStaticAssignment(AbstractPartitionAssignor assignor,
+                                                                   Map<String, Integer> partitionsPerTopic,
+                                                                  Map<String, Subscription> consumers,
+                                                                  Map<String, List<TopicPartition>> expectedInstanceAssignment) {
+        Map<String, List<TopicPartition>> assignmentByMemberId = assignor.assign(partitionsPerTopic, consumers);
+        Map<String, List<TopicPartition>> assignmentByInstanceId = new HashMap<>();
+        for (Map.Entry<String, Subscription> entry : consumers.entrySet()) {
+            String memberId = entry.getKey();
+            Optional<String> instanceId = entry.getValue().groupInstanceId();
+            instanceId.ifPresent(id -> assignmentByInstanceId.put(id, assignmentByMemberId.get(memberId)));
+        }
+        assertEquals(expectedInstanceAssignment, assignmentByInstanceId);
+        return assignmentByInstanceId;
     }
 
     private void assertAssignment(List<TopicPartition> expected, List<TopicPartition> actual) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
@@ -317,7 +317,9 @@ public class RoundRobinAssignorTest {
         }
 
         Map<String, List<TopicPartition>> staticAssignment =
-            checkStaticAssignment(assignor, partitionsPerTopic, consumers, expectedInstanceAssignment);
+            checkStaticAssignment(assignor, partitionsPerTopic, consumers);
+        assertEquals(expectedInstanceAssignment, staticAssignment);
+
         memberIdToInstanceId.clear();
 
         // Now switch the member.id fields for each member info, the assignment should
@@ -329,8 +331,7 @@ public class RoundRobinAssignorTest {
         consumers.put(consumer5, consumers.get(consumer2));
         consumers.remove(consumer2);
         Map<String, List<TopicPartition>> newStaticAssignment =
-            checkStaticAssignment(assignor, partitionsPerTopic, consumers, expectedInstanceAssignment);
-
+            checkStaticAssignment(assignor, partitionsPerTopic, consumers);
         assertEquals(staticAssignment, newStaticAssignment);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
@@ -40,6 +40,9 @@ public class RoundRobinAssignorTest {
     private String topic = "topic";
     private String consumerId = "consumer";
 
+    private String topic1 = "topic1";
+    private String topic2 = "topic2";
+
     @Test
     public void testOneConsumerNoTopic() {
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
@@ -85,12 +88,7 @@ public class RoundRobinAssignorTest {
 
     @Test
     public void testOneConsumerMultipleTopics() {
-        String topic1 = "topic1";
-        String topic2 = "topic2";
-
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(1, 2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2))));
@@ -139,9 +137,7 @@ public class RoundRobinAssignorTest {
         String consumer2 = "consumer2";
         String consumer3 = "consumer3";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));
@@ -161,9 +157,7 @@ public class RoundRobinAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
@@ -185,9 +179,7 @@ public class RoundRobinAssignorTest {
         String consumer2 = "consumer-a";
         String instance2 = "instance2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
         Subscription consumer1Subscription = new Subscription(topics(topic1, topic2), null);
@@ -205,15 +197,11 @@ public class RoundRobinAssignorTest {
     public void testOneStaticConsumerAndOneDynamicConsumerTwoTopicsSixPartitions() {
         // although consumer 2 has a higher rank than 1, consumer 1 will win the comparison
         // because it has instance id while consumer 2 doesn't.
-        String topic1 = "topic1";
-        String topic2 = "topic2";
         String consumer1 = "consumer-b";
         String instance1 = "instance1";
         String consumer2 = "consumer-a";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
 
         Map<String, Subscription> consumers = new HashMap<>();
 
@@ -231,8 +219,6 @@ public class RoundRobinAssignorTest {
     public void testStaticMemberRoundRobinAssignmentPersistent() {
         // Have 3 static members instance1, instance2, instance3 to be persistent
         // across generations. Their assignment shall be the same.
-        String topic1 = "topic1";
-        String topic2 = "topic2";
         String consumer1 = "consumer1";
         String instance1 = "instance1";
         String consumer2 = "consumer2";
@@ -248,9 +234,8 @@ public class RoundRobinAssignorTest {
         // Consumer 4 is a dynamic member.
         String consumer4 = "consumer4";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(3, 3);
+
         Map<String, Subscription> consumers = new HashMap<>();
         for (MemberInfo m : staticMemberInfos) {
             Subscription subscription = new Subscription(topics(topic1, topic2), null);
@@ -281,8 +266,6 @@ public class RoundRobinAssignorTest {
 
     @Test
     public void testStaticMemberRoundRobinAssignmentPersistentAfterMemberIdChanges() {
-        String topic1 = "topic1";
-        String topic2 = "topic2";
         String consumer1 = "consumer1";
         String instance1 = "instance1";
         String consumer2 = "consumer2";
@@ -294,9 +277,8 @@ public class RoundRobinAssignorTest {
         memberIdToInstanceId.put(consumer2, instance2);
         memberIdToInstanceId.put(consumer3, instance3);
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 5);
-        partitionsPerTopic.put(topic2, 5);
+        Map<String, Integer> partitionsPerTopic = setupPartitionsPerTopicWithTwoTopics(5, 5);
+
         Map<String, List<TopicPartition>> expectedInstanceAssignment = new HashMap<>();
         expectedInstanceAssignment.put(instance1,
                                        partitions(tp(topic1, 0), tp(topic1, 3), tp(topic2, 1), tp(topic2, 4)));
@@ -345,5 +327,12 @@ public class RoundRobinAssignorTest {
 
     private static TopicPartition tp(String topic, int partition) {
         return new TopicPartition(topic, partition);
+    }
+
+    private Map<String, Integer> setupPartitionsPerTopicWithTwoTopics(int numberOfPartitions1, int numberOfPartitions2) {
+        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic1, numberOfPartitions1);
+        partitionsPerTopic.put(topic2, numberOfPartitions2);
+        return partitionsPerTopic;
     }
 }


### PR DESCRIPTION
The purpose of this PR is to add static membership support for range assignor. More details for the motivation in [here](https://github.com/apache/kafka/pull/6815). 

Similar to round robin assignor, if we are capable of persisting member identity across generations, we will reach a much more stable assignment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
