### PR TITLE
MINOR: Assert ExecutionException details in testCreatePartitions

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -741,7 +741,6 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       altered = alterResult.values.get(topic2).get
     } catch {
       case e: ExecutionException =>
-      case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException])
         assertEquals("Topic currently has 3 partitions, which is higher than the requested 2.", e.getCause.getMessage)
         // assert that the topic2 still has 3 partitions


### PR DESCRIPTION
Due to the accidental duplication of `case e: ExecutionException`,
the verification code was not actually running.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
