### PR TITLE
MINOR: system tests - avoid 'sasl.enabled.mechanisms' in listener overrides

### DIFF
--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -28,7 +28,7 @@ security.inter.broker.protocol={{ interbroker_listener.security_protocol }}
 {% endif %}
 
 {% for k, v in listener_security_config.client_listener_overrides.iteritems() %}
-{% if k.startswith('sasl.') and k != 'sasl.enabled.mechanisms' %}
+{% if k in ["connections.max.reauth.ms", "sasl.jaas.config", "sasl.login.callback.handler.class", "sasl.login.class", "sasl.server.callback.handler.class"] %}
 listener.name.{{ security_protocol.lower() }}.{{ security_config.client_sasl_mechanism.lower() }}.{{ k }}={{ v }}
 {% else %}
 listener.name.{{ security_protocol.lower() }}.{{ k }}={{ v }}

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -28,7 +28,7 @@ security.inter.broker.protocol={{ interbroker_listener.security_protocol }}
 {% endif %}
 
 {% for k, v in listener_security_config.client_listener_overrides.iteritems() %}
-{% if k.startswith('sasl.') %}
+{% if k.startswith('sasl.') and k != 'sasl.enabled.mechanisms' %}
 listener.name.{{ security_protocol.lower() }}.{{ security_config.client_sasl_mechanism.lower() }}.{{ k }}={{ v }}
 {% else %}
 listener.name.{{ security_protocol.lower() }}.{{ k }}={{ v }}


### PR DESCRIPTION
named listener config `sasl.enabled.mechanisms` should not be prefixed with sasl mechanism

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
