### PR TITLE
KAFKA-4212 & KAFKA-4273: RocksDB KV cache w/ TTL

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -113,6 +113,26 @@ public final class Stores {
     }
 
     /**
+     * Create a persistent {@link KeyValueBytesStoreSupplier} where the entries have an underlying TTL.
+     * <p>
+     * This store supplier can be passed into a {@link #keyValueStoreBuilder(KeyValueBytesStoreSupplier, Serde, Serde)}.
+     * If you have no need for the keys have a TTL, you should use
+     * {@link #persistentTimestampedKeyValueStore(String)} to create a store supplier instead.
+     * If you want to create a {@link TimestampedKeyValueStore} you should use
+     * {@link #persistentTimestampedKeyValueStore(String)} to create a store supplier instead.
+     *
+     * @param name  name of the store (cannot be {@code null})
+     * @param ttlInSeconds  TTL value in seconds
+     *
+     * @return an instance of a {@link KeyValueBytesStoreSupplier} that can be used
+     * to build a persistent key-value store
+     */
+    public static KeyValueBytesStoreSupplier persistentKeyValueTtlStore(final String name, final int ttlInSeconds) {
+        Objects.requireNonNull(name, "name cannot be null");
+        return new RocksDbKeyValueBytesStoreSupplier(name, ttlInSeconds);
+    }
+
+    /**
      * Create an in-memory {@link KeyValueBytesStoreSupplier}.
      * <p>
      * This store supplier can be passed into a {@link #keyValueStoreBuilder(KeyValueBytesStoreSupplier, Serde, Serde)}
@@ -453,6 +473,27 @@ public final class Stores {
                                                                                                       final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
         return new TimestampedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+    }
+
+    /**
+     * Creates a {@link StoreBuilder} that can be used to build a {@link KeyValueStore} with a TTL.
+     * <p>
+     * The provided supplier should <strong>not</strong> be a supplier for
+     * {@link TimestampedKeyValueStore TimestampedKeyValueStores}, and the underlying supplier <strong>should</strong>
+     * be a PersistentKeyValueStore with a TTL.
+     *
+     * @param supplier      a {@link KeyValueBytesStoreSupplier} (cannot be {@code null})
+     * @param keySerde      the key serde to use
+     * @param valueSerde    the value serde to use; if the serialized bytes is {@code null} for put operations,
+     *                      it is treated as delete
+     * @param <K>           key type
+     * @param <V>           value type
+     * @return an instance of a {@link StoreBuilder} that can build a {@link KeyValueStore} w/ an underlying TTL
+     */
+    public static <K, V> StoreBuilder<KeyValueStore<K, V>> keyValueTtlStoreBuilder(final KeyValueBytesStoreSupplier supplier,
+                                                                                final Serde<K> keySerde,
+                                                                                final Serde<V> valueSerde) {
+        return keyValueStoreBuilder(supplier, keySerde, valueSerde);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -78,7 +78,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
     private static final long BLOCK_CACHE_SIZE = 50 * 1024 * 1024L;
     private static final long BLOCK_SIZE = 4096L;
     private static final int MAX_WRITE_BUFFERS = 3;
-    private static final String DB_FILE_DIR = "rocksdb";
+    protected static final String DB_FILE_DIR = "rocksdb";
 
     final String name;
     private final String parentDir;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTTLStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTTLStore.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.TtlDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A persistent key-value store based on RocksDB with a TTL for entries
+ */
+public class RocksDBTTLStore extends RocksDBStore {
+
+    private int ttlInSeconds;
+
+    RocksDBTTLStore(final String name, final int ttlInSeconds) {
+        this(name, DB_FILE_DIR, ttlInSeconds);
+    }
+
+    RocksDBTTLStore(final String name,
+                    final String parentDir,
+                    final int ttlInSeconds) {
+        super(name, parentDir);
+        this.ttlInSeconds = ttlInSeconds;
+    }
+
+    void openRocksDB(final DBOptions dbOptions,
+                     final ColumnFamilyOptions columnFamilyOptions) {
+        final List<ColumnFamilyDescriptor> columnFamilyDescriptors
+            = Collections.singletonList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions));
+        final List<ColumnFamilyHandle> columnFamilies = new ArrayList<>(columnFamilyDescriptors.size());
+        final List<Integer> ttlValues = Collections.singletonList(ttlInSeconds);
+        try {
+            db = TtlDB.open(dbOptions, dbDir.getAbsolutePath(), columnFamilyDescriptors, columnFamilies, ttlValues, false);
+            dbAccessor = new SingleColumnFamilyAccessor(columnFamilies.get(0));
+        } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir.toString(), e);
+        }
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbKeyValueBytesStoreSupplier.java
@@ -24,11 +24,20 @@ public class RocksDbKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupp
 
     private final String name;
     private final boolean returnTimestampedStore;
+    private final int ttlInSeconds;
 
     public RocksDbKeyValueBytesStoreSupplier(final String name,
                                              final boolean returnTimestampedStore) {
         this.name = name;
         this.returnTimestampedStore = returnTimestampedStore;
+        this.ttlInSeconds = 0;
+    }
+
+    public RocksDbKeyValueBytesStoreSupplier(final String name,
+                                             final int ttlInSeconds) {
+        this.name = name;
+        this.returnTimestampedStore = false;
+        this.ttlInSeconds = ttlInSeconds;
     }
 
     @Override
@@ -38,7 +47,8 @@ public class RocksDbKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupp
 
     @Override
     public KeyValueStore<Bytes, byte[]> get() {
-        return returnTimestampedStore ? new RocksDBTimestampedStore(name) : new RocksDBStore(name);
+        if (ttlInSeconds > 0) return new RocksDBTTLStore(name, ttlInSeconds);
+        else return returnTimestampedStore ? new RocksDBTimestampedStore(name) : new RocksDBStore(name);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTTLKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTTLKeyValueStoreTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.TestCondition;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.TtlDB;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class RocksDBTTLKeyValueStoreTest extends RocksDBKeyValueStoreTest {
+
+    final static private int TTL_IN_SECONDS = 1;
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+        final StoreBuilder storeBuilder = Stores.keyValueTtlStoreBuilder(
+                Stores.persistentKeyValueTtlStore("my-store", TTL_IN_SECONDS),
+                (Serde<K>) context.keySerde(),
+                (Serde<V>) context.valueSerde());
+
+        final StateStore store = storeBuilder.build();
+        store.init(context, store);
+        return (KeyValueStore<K, V>) store;
+    }
+
+    @Test
+    public void shouldDeleteRecordsWhenTTLIsReached() throws InterruptedException {
+        context.setTime(1L);
+        store.put(1, "hi");
+        store.put(2, "goodbye");
+        final KeyValueIterator<Integer, String> range = store.all();
+        assertEquals("hi", range.next().value);
+        assertEquals("goodbye", range.next().value);
+        assertFalse(range.hasNext());
+
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                compactDatabaseToTriggerDeletion();
+                return !store.all().hasNext();
+            }
+        }, TTL_IN_SECONDS * 1000 * 2, "Records must expire when TTL is set.");
+    }
+
+    /** With a TtlDB, values are only expunged during compaction once they've expired
+     *  See https://github.com/facebook/rocksdb/wiki/Time-to-Live for more details
+     */
+    private void compactDatabaseToTriggerDeletion() {
+        //We're casting repeatedly in order to get a handle on the underlying TTL RocksDB,
+        //so that we can trigger the compaction by hand
+        final TtlDB ttlDB = (TtlDB) ((RocksDBTTLStore) ((ChangeLoggingKeyValueBytesStore) ((MeteredKeyValueStore) store).wrapped()).wrapped()).db;
+        try {
+            ttlDB.compactRange();
+        } catch (final RocksDBException n) {
+            fail("Native RocksDBException exception thrown: " + n);
+        }
+    }
+
+}


### PR DESCRIPTION
*Expose a RocksDB KV cache with a TTL*

*Includes a passing unit test*