### PR TITLE
KAFKA-8614: Rename the `responses` field of IncrementalAlterConfigsRe…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
@@ -20,7 +20,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.AlterConfigsResource;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
-import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResult;
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.types.Struct;
 
@@ -80,7 +80,7 @@ public class IncrementalAlterConfigsRequest extends AbstractRequest {
         IncrementalAlterConfigsResponseData response = new IncrementalAlterConfigsResponseData();
         ApiError apiError = ApiError.fromThrowable(e);
         for (AlterConfigsResource resource : data.resources()) {
-            response.responses().add(new AlterConfigsResourceResult()
+            response.resources().add(new AlterConfigsResourceResponse()
                     .setResourceName(resource.resourceName())
                     .setResourceType(resource.resourceType())
                     .setErrorCode(apiError.error().code())

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsRequest.java
@@ -80,7 +80,7 @@ public class IncrementalAlterConfigsRequest extends AbstractRequest {
         IncrementalAlterConfigsResponseData response = new IncrementalAlterConfigsResponseData();
         ApiError apiError = ApiError.fromThrowable(e);
         for (AlterConfigsResource resource : data.resources()) {
-            response.resources().add(new AlterConfigsResourceResponse()
+            response.responses().add(new AlterConfigsResourceResponse()
                     .setResourceName(resource.resourceName())
                     .setResourceType(resource.resourceType())
                     .setErrorCode(apiError.error().code())

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
-import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResult;
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -35,7 +35,7 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
         IncrementalAlterConfigsResponseData responseData = new IncrementalAlterConfigsResponseData();
         responseData.setThrottleTimeMs(requestThrottleMs);
         for (Map.Entry<ConfigResource, ApiError> entry : results.entrySet()) {
-            responseData.responses().add(new AlterConfigsResourceResult().
+            responseData.resources().add(new AlterConfigsResourceResponse().
                     setResourceName(entry.getKey().name()).
                     setResourceType(entry.getKey().type().id()).
                     setErrorCode(entry.getValue().error().code()).
@@ -46,7 +46,7 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
 
     public static Map<ConfigResource, ApiError> fromResponseData(final IncrementalAlterConfigsResponseData data) {
         Map<ConfigResource, ApiError> map = new HashMap<>();
-        for (AlterConfigsResourceResult result : data.responses()) {
+        for (AlterConfigsResourceResponse result : data.resources()) {
             map.put(new ConfigResource(ConfigResource.Type.forId(result.resourceType()), result.resourceName()),
                     new ApiError(Errors.forCode(result.errorCode()), result.errorMessage()));
         }
@@ -70,7 +70,7 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (AlterConfigsResourceResult result : data.responses()) {
+        for (AlterConfigsResourceResponse result : data.resources()) {
             Errors error = Errors.forCode(result.errorCode());
             counts.put(error, counts.getOrDefault(error, 0) + 1);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
@@ -35,7 +35,7 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
         IncrementalAlterConfigsResponseData responseData = new IncrementalAlterConfigsResponseData();
         responseData.setThrottleTimeMs(requestThrottleMs);
         for (Map.Entry<ConfigResource, ApiError> entry : results.entrySet()) {
-            responseData.resources().add(new AlterConfigsResourceResponse().
+            responseData.responses().add(new AlterConfigsResourceResponse().
                     setResourceName(entry.getKey().name()).
                     setResourceType(entry.getKey().type().id()).
                     setErrorCode(entry.getValue().error().code()).
@@ -46,9 +46,9 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
 
     public static Map<ConfigResource, ApiError> fromResponseData(final IncrementalAlterConfigsResponseData data) {
         Map<ConfigResource, ApiError> map = new HashMap<>();
-        for (AlterConfigsResourceResponse result : data.resources()) {
-            map.put(new ConfigResource(ConfigResource.Type.forId(result.resourceType()), result.resourceName()),
-                    new ApiError(Errors.forCode(result.errorCode()), result.errorMessage()));
+        for (AlterConfigsResourceResponse response : data.responses()) {
+            map.put(new ConfigResource(ConfigResource.Type.forId(response.resourceType()), response.resourceName()),
+                    new ApiError(Errors.forCode(response.errorCode()), response.errorMessage()));
         }
         return map;
     }
@@ -70,8 +70,8 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (AlterConfigsResourceResponse result : data.resources()) {
-            Errors error = Errors.forCode(result.errorCode());
+        for (AlterConfigsResourceResponse response : data.responses()) {
+            Errors error = Errors.forCode(response.errorCode());
             counts.put(error, counts.getOrDefault(error, 0) + 1);
         }
         return counts;

--- a/clients/src/main/resources/common/message/AlterConfigsResponse.json
+++ b/clients/src/main/resources/common/message/AlterConfigsResponse.json
@@ -22,7 +22,7 @@
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "Resources", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
+    { "name": "Responses", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
       "about": "The responses for each resource.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The resource error code." },

--- a/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
+++ b/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
@@ -21,7 +21,7 @@
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "responses", "type": "[]AlterConfigsResourceResult", "versions": "0+",
+    { "name": "Resources", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
       "about": "The responses for each resource.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The resource error code." },

--- a/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
+++ b/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
@@ -21,7 +21,7 @@
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "Resources", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
+    { "name": "Responses", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
       "about": "The responses for each resource.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The resource error code." },

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -60,7 +60,7 @@ import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroupMember;
 import org.apache.kafka.common.message.ElectLeadersResponseData.PartitionResult;
 import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult;
-import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResult;
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
@@ -1472,13 +1472,13 @@ public class KafkaAdminClientTest {
 
             //test error scenarios
             IncrementalAlterConfigsResponseData responseData =  new IncrementalAlterConfigsResponseData();
-            responseData.responses().add(new AlterConfigsResourceResult()
+            responseData.resources().add(new AlterConfigsResourceResponse()
                     .setResourceName("")
                     .setResourceType(ConfigResource.Type.BROKER.id())
                     .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code())
                     .setErrorMessage("authorization error"));
 
-            responseData.responses().add(new AlterConfigsResourceResult()
+            responseData.resources().add(new AlterConfigsResourceResponse()
                     .setResourceName("topic1")
                     .setResourceType(ConfigResource.Type.TOPIC.id())
                     .setErrorCode(Errors.INVALID_REQUEST.code())
@@ -1507,7 +1507,7 @@ public class KafkaAdminClientTest {
 
             // Test a call where there are no errors.
             responseData =  new IncrementalAlterConfigsResponseData();
-            responseData.responses().add(new AlterConfigsResourceResult()
+            responseData.resources().add(new AlterConfigsResourceResponse()
                     .setResourceName("")
                     .setResourceType(ConfigResource.Type.BROKER.id())
                     .setErrorCode(Errors.NONE.code())

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1472,13 +1472,13 @@ public class KafkaAdminClientTest {
 
             //test error scenarios
             IncrementalAlterConfigsResponseData responseData =  new IncrementalAlterConfigsResponseData();
-            responseData.resources().add(new AlterConfigsResourceResponse()
+            responseData.responses().add(new AlterConfigsResourceResponse()
                     .setResourceName("")
                     .setResourceType(ConfigResource.Type.BROKER.id())
                     .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code())
                     .setErrorMessage("authorization error"));
 
-            responseData.resources().add(new AlterConfigsResourceResponse()
+            responseData.responses().add(new AlterConfigsResourceResponse()
                     .setResourceName("topic1")
                     .setResourceType(ConfigResource.Type.TOPIC.id())
                     .setErrorCode(Errors.INVALID_REQUEST.code())
@@ -1507,7 +1507,7 @@ public class KafkaAdminClientTest {
 
             // Test a call where there are no errors.
             responseData =  new IncrementalAlterConfigsResponseData();
-            responseData.resources().add(new AlterConfigsResourceResponse()
+            responseData.responses().add(new AlterConfigsResourceResponse()
                     .setResourceName("")
                     .setResourceType(ConfigResource.Type.BROKER.id())
                     .setErrorCode(Errors.NONE.code())

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -59,7 +59,7 @@ import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.AlterConfigsResource;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.AlterableConfig;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
-import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResult;
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
@@ -1606,7 +1606,7 @@ public class RequestResponseTest {
     private IncrementalAlterConfigsResponse createIncrementalAlterConfigsResponse() {
         IncrementalAlterConfigsResponseData data = new IncrementalAlterConfigsResponseData();
 
-        data.responses().add(new AlterConfigsResourceResult()
+        data.resources().add(new AlterConfigsResourceResponse()
                 .setResourceName("testtopic")
                 .setResourceType(ResourceType.TOPIC.code())
                 .setErrorCode(Errors.INVALID_REQUEST.code())

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1606,7 +1606,7 @@ public class RequestResponseTest {
     private IncrementalAlterConfigsResponse createIncrementalAlterConfigsResponse() {
         IncrementalAlterConfigsResponseData data = new IncrementalAlterConfigsResponseData();
 
-        data.resources().add(new AlterConfigsResourceResponse()
+        data.responses().add(new AlterConfigsResourceResponse()
                 .setResourceName("testtopic")
                 .setResourceType(ResourceType.TOPIC.code())
                 .setErrorCode(Errors.INVALID_REQUEST.code())


### PR DESCRIPTION
…sponse to match AlterConfigs

This patch changes the name of the `responses` field of IncrementalAlterConfigsResponse to `Resources`. This makes it consistent with AlterConfigsResponse, which has a differently-named but structurally-identical field.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
