### PR TITLE
KAFKA-5876: [WIP]IQ should throw different exceptions for different errors

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/FatalStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/FatalStateStoreException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class FatalStateStoreException extends InvalidStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public FatalStateStoreException(final String message) {
+        super(message);
+    }
+
+    public FatalStateStoreException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/RetryableStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/RetryableStateStoreException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class RetryableStateStoreException extends InvalidStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RetryableStateStoreException(final String message) {
+        super(message);
+    }
+
+    public RetryableStateStoreException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class StateStoreMigratedException extends RetryableStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StateStoreMigratedException(final String message) {
+        super(message);
+    }
+
+    public StateStoreMigratedException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class StateStoreNotAvailableException extends FatalStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StateStoreNotAvailableException(final String message) {
+        super(message);
+    }
+
+    public StateStoreNotAvailableException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadNotRunningException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadNotRunningException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class StreamThreadNotRunningException extends FatalStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StreamThreadNotRunningException(final String message) {
+        super(message);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadNotStartedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadNotStartedException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class StreamThreadNotStartedException extends RetryableStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StreamThreadNotStartedException(final String message) {
+        super(message);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadRebalancingException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamThreadRebalancingException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class StreamThreadRebalancingException extends RetryableStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StreamThreadRebalancingException(final String message) {
+        super(message);
+    }
+
+    public StreamThreadRebalancingException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/EmptyStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/EmptyStateStoreException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors.internals;
+
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+
+public class EmptyStateStoreException extends InvalidStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EmptyStateStoreException(final String message) {
+        super(message);
+    }
+
+    public EmptyStateStoreException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/StateStoreClosedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/StateStoreClosedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors.internals;
+
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+
+public class StateStoreClosedException extends InvalidStateStoreException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StateStoreClosedException(final String message) {
+        super(message);
+    }
+
+    public StateStoreClosedException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
+import org.apache.kafka.streams.state.internals.ConsumeKafkaStreams;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,9 +92,10 @@ public final class QueryableStoreTypes {
         return new SessionStoreType<>();
     }
 
-    private static abstract class QueryableStoreTypeMatcher<T> implements QueryableStoreType<T> {
+    private static abstract class QueryableStoreTypeMatcher<T> implements QueryableStoreType<T>, ConsumeKafkaStreams {
 
         private final Set<Class> matchTo;
+        protected KafkaStreams streams;
 
         QueryableStoreTypeMatcher(final Set<Class> matchTo) {
             this.matchTo = matchTo;
@@ -109,6 +111,11 @@ public final class QueryableStoreTypes {
             }
             return true;
         }
+
+        @Override
+        public void accept(final KafkaStreams streams) {
+            this.streams = streams;
+        }
     }
 
     public static class KeyValueStoreType<K, V> extends QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, V>> {
@@ -120,7 +127,7 @@ public final class QueryableStoreTypes {
         @Override
         public ReadOnlyKeyValueStore<K, V> create(final StateStoreProvider storeProvider,
                                                   final String storeName) {
-            return new CompositeReadOnlyKeyValueStore<>(storeProvider, this, storeName);
+            return new CompositeReadOnlyKeyValueStore<>(streams, storeProvider, this, storeName);
         }
 
     }
@@ -137,7 +144,7 @@ public final class QueryableStoreTypes {
         @Override
         public ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> create(final StateStoreProvider storeProvider,
                                                                      final String storeName) {
-            return new CompositeReadOnlyKeyValueStore<>(storeProvider, this, storeName);
+            return new CompositeReadOnlyKeyValueStore<>(streams, storeProvider, this, storeName);
         }
     }
 
@@ -150,7 +157,7 @@ public final class QueryableStoreTypes {
         @Override
         public ReadOnlyWindowStore<K, V> create(final StateStoreProvider storeProvider,
                                                 final String storeName) {
-            return new CompositeReadOnlyWindowStore<>(storeProvider, this, storeName);
+            return new CompositeReadOnlyWindowStore<>(streams, storeProvider, this, storeName);
         }
     }
 
@@ -166,7 +173,7 @@ public final class QueryableStoreTypes {
         @Override
         public ReadOnlyWindowStore<K, ValueAndTimestamp<V>> create(final StateStoreProvider storeProvider,
                                                                    final String storeName) {
-            return new CompositeReadOnlyWindowStore<>(storeProvider, this, storeName);
+            return new CompositeReadOnlyWindowStore<>(streams, storeProvider, this, storeName);
         }
     }
 
@@ -179,7 +186,7 @@ public final class QueryableStoreTypes {
         @Override
         public ReadOnlySessionStore<K, V> create(final StateStoreProvider storeProvider,
                                                  final String storeName) {
-            return new CompositeReadOnlySessionStore<>(storeProvider, this, storeName);
+            return new CompositeReadOnlySessionStore<>(streams, storeProvider, this, storeName);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ConsumeKafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ConsumeKafkaStreams.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KafkaStreams;
+
+public interface ConsumeKafkaStreams {
+    void accept(final KafkaStreams streams);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -42,7 +42,7 @@ public class GlobalStateStoreProvider implements StateStoreProvider {
             return Collections.emptyList();
         }
         if (!store.isOpen()) {
-            throw new InvalidStateStoreException("the state store, " + storeName + ", is not open.");
+            throw new StateStoreClosedException("the state store, " + storeName + ", is not open.");
         }
         if (store instanceof TimestampedKeyValueStore && queryableStoreType instanceof QueryableStoreTypes.KeyValueStoreType) {
             return (List<T>) Collections.singletonList(new ReadOnlyKeyValueStoreFacade((TimestampedKeyValueStore<Object, Object>) store));

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.AbstractNotifyingBatchingRestoreCallback;
 import org.apache.kafka.streams.processor.BatchingStateRestoreCallback;
@@ -229,7 +229,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
 
     private void validateStoreOpen() {
         if (!open) {
-            throw new InvalidStateStoreException("Store " + name + " is currently closed");
+            throw new StateStoreClosedException("Store " + name + " is currently closed");
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
@@ -292,7 +292,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         @Override
         public synchronized boolean hasNext() {
             if (!open) {
-                throw new InvalidStateStoreException(String.format("RocksDB iterator for store %s has closed", storeName));
+                throw new StateStoreClosedException(String.format("RocksDB iterator for store %s has closed", storeName));
             }
             return super.hasNext();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.rocksdb.RocksIterator;
 
@@ -47,7 +47,7 @@ class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implemen
     @Override
     public synchronized boolean hasNext() {
         if (!open) {
-            throw new InvalidStateStoreException(String.format("RocksDB iterator for store %s has closed", storeName));
+            throw new StateStoreClosedException(String.format("RocksDB iterator for store %s has closed", storeName));
         }
         return super.hasNext();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentIterator.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import java.util.Iterator;
@@ -75,7 +75,7 @@ class SegmentIterator<S extends Segment> implements KeyValueIterator<Bytes, byte
                 } else {
                     currentIterator = currentSegment.range(from, to);
                 }
-            } catch (final InvalidStateStoreException e) {
+            } catch (final StateStoreClosedException e) {
                 // segment may have been closed so we ignore it.
             }
         }
@@ -86,7 +86,7 @@ class SegmentIterator<S extends Segment> implements KeyValueIterator<Bytes, byte
         boolean hasNext = false;
         try {
             hasNext = hasNextCondition.hasNext(currentIterator);
-        } catch (final InvalidStateStoreException e) {
+        } catch (final StateStoreClosedException e) {
             //already closed so ignore
         }
         return hasNext;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StreamThreadNotRunningException;
+import org.apache.kafka.streams.errors.StreamThreadRebalancingException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+
+import java.util.Objects;
+
+final public class StateStoreUtils {
+
+    private StateStoreUtils() {
+    }
+
+    static public InvalidStateStoreException wrapExceptionFromStateStoreProvider(final KafkaStreams streams,
+                                                                                 final InvalidStateStoreException e) {
+        Objects.requireNonNull(streams);
+        if (e instanceof StreamThreadNotRunningException) {
+            if (streams.state() == KafkaStreams.State.RUNNING || streams.state() == KafkaStreams.State.REBALANCING) {
+                return new StreamThreadRebalancingException(e.getMessage(), e);
+            } else {
+                return e;
+            }
+        } else if (e instanceof StateStoreClosedException || e instanceof EmptyStateStoreException) {
+            if (streams.state() == KafkaStreams.State.RUNNING ||
+                    streams.state() == KafkaStreams.State.REBALANCING) {
+                return new StateStoreMigratedException(e.getMessage(), e);
+            } else {    // PENDING_SHUTDOWN || NOT_RUNNING || ERROR
+                return new StateStoreNotAvailableException(e.getMessage(), e);
+            }
+        } else {
+            return e;
+        }
+    }
+
+    static InvalidStateStoreException wrapStateStoreClosedException(final KafkaStreams streams,
+                                                                    final StateStoreClosedException e,
+                                                                    final String storeName) {
+        Objects.requireNonNull(streams);
+        if (streams.state() == KafkaStreams.State.RUNNING || streams.state() == KafkaStreams.State.REBALANCING) {
+            return new StateStoreMigratedException("State store [" + storeName + "] is not available anymore" +
+                                                   " and may have been migrated to another instance; " +
+                                                   "please re-discover its location from the state metadata." +
+                                                   "Original error message: " + e.toString());
+        } else {    // PENDING_SHUTDOWN | NOT_RUNNING | ERROR
+            return new StateStoreNotAvailableException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -16,7 +16,9 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StreamThreadNotRunningException;
+import org.apache.kafka.streams.errors.StreamThreadNotStartedException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -46,8 +48,10 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
-        if (!streamThread.isRunningAndNotRebalancing()) {
-            throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the stream thread is " +
+        if (streamThread.state() == StreamThread.State.CREATED) {
+            throw new StreamThreadNotStartedException("The stream thread state not started.");
+        } else if (!streamThread.isRunningAndNotRebalancing()) {
+            throw new StreamThreadNotRunningException("Cannot get state store " + storeName + " because the stream thread is " +
                     streamThread.state() + ", not RUNNING");
         }
         final List<T> stores = new ArrayList<>();
@@ -55,7 +59,7 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
             final StateStore store = streamTask.getStore(storeName);
             if (store != null && queryableStoreType.accepts(store)) {
                 if (!store.isOpen()) {
-                    throw new InvalidStateStoreException("Cannot get state store " + storeName + " for task " + streamTask +
+                    throw new StateStoreClosedException("Cannot get state store " + storeName + " for task " + streamTask +
                             " because the store is not open. The state store may have migrated to another instances.");
                 }
                 if (store instanceof TimestampedKeyValueStore && queryableStoreType instanceof QueryableStoreTypes.KeyValueStoreType) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
@@ -75,7 +75,7 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
 
     void validateStoreOpen() {
         if (!wrapped.isOpen()) {
-            throw new InvalidStateStoreException("Store " + wrapped.name() + " is currently closed.");
+            throw new StateStoreClosedException("Store " + wrapped.name() + " is currently closed.");
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
@@ -50,7 +50,7 @@ public class WrappingStoreProvider implements StateStoreProvider {
             allStores.addAll(stores);
         }
         if (allStores.isEmpty()) {
-            throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
+            throw new EmptyStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
         }
         return allStores;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
@@ -275,43 +275,43 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         assertEquals(0, cache.size());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToGetFromClosedCachingStore() {
         store.close();
         store.get(bytesKey("a"));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToWriteToClosedCachingStore() {
         store.close();
         store.put(bytesKey("a"), bytesValue("a"));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDoRangeQueryOnClosedCachingStore() {
         store.close();
         store.range(bytesKey("a"), bytesKey("b"));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDoAllQueryOnClosedCachingStore() {
         store.close();
         store.all();
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDoGetApproxSizeOnClosedCachingStore() {
         store.close();
         store.approximateNumEntries();
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDoPutAllClosedCachingStore() {
         store.close();
         store.putAll(Collections.singletonList(KeyValue.pair(bytesKey("a"), bytesValue("a"))));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDoPutIfAbsentClosedCachingStore() {
         store.close();
         store.putIfAbsent(bytesKey("b"), bytesValue("c"));
@@ -362,7 +362,7 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         assertEquals(underlyingStore, store.wrapped());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToDeleteFromClosedCachingStore() {
         store.close();
         store.delete(bytesKey("key"));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
@@ -389,25 +389,25 @@ public class CachingSessionStoreTest {
         assertEquals(0, cache.size());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToFetchFromClosedCachingStore() {
         cachingStore.close();
         cachingStore.fetch(keyA);
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToFindMergeSessionFromClosedCachingStore() {
         cachingStore.close();
         cachingStore.findSessions(keyA, 0, Long.MAX_VALUE);
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToRemoveFromClosedCachingStore() {
         cachingStore.close();
         cachingStore.remove(new Windowed<>(keyA, new SessionWindow(0, 0)));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToPutIntoClosedCachingStore() {
         cachingStore.close();
         cachingStore.put(new Windowed<>(keyA, new SessionWindow(0, 0)), "1".getBytes());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
 import org.apache.kafka.streams.kstream.Transformer;
@@ -477,19 +477,19 @@ public class CachingWindowStoreTest {
         assertEquals(0, cache.size());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToFetchFromClosedCachingStore() {
         cachingStore.close();
         cachingStore.fetch(bytesKey("a"), ofEpochMilli(0), ofEpochMilli(10));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToFetchRangeFromClosedCachingStore() {
         cachingStore.close();
         cachingStore.fetch(bytesKey("a"), bytesKey("b"), ofEpochMilli(0), ofEpochMilli(10));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowIfTryingToWriteToClosedCachingStore() {
         cachingStore.close();
         cachingStore.put(bytesKey("a"), bytesValue("a"));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
@@ -29,6 +30,7 @@ import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,7 +64,8 @@ public class CompositeReadOnlyKeyValueStoreTest {
         otherUnderlyingStore = newStoreInstance();
         stubProviderOne.addStore("other-store", otherUnderlyingStore);
 
-        theStore = new CompositeReadOnlyKeyValueStore<>(
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(KafkaStreams.State.RUNNING);
+        theStore = new CompositeReadOnlyKeyValueStore<>(streams,
             new WrappingStoreProvider(Arrays.<StateStoreProvider>asList(stubProviderOne, stubProviderTwo)),
                                         QueryableStoreTypes.<String, String>keyValueStore(),
                                         storeName);
@@ -291,7 +294,8 @@ public class CompositeReadOnlyKeyValueStoreTest {
     }
 
     private CompositeReadOnlyKeyValueStore<Object, Object> rebalancing() {
-        return new CompositeReadOnlyKeyValueStore<>(new WrappingStoreProvider(Collections.<StateStoreProvider>singletonList(new StateStoreProviderStub(true))),
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(KafkaStreams.State.RUNNING);
+        return new CompositeReadOnlyKeyValueStore<>(streams, new WrappingStoreProvider(Collections.<StateStoreProvider>singletonList(new StateStoreProviderStub(true))),
                 QueryableStoreTypes.keyValueStore(), storeName);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -53,8 +54,8 @@ public class CompositeReadOnlySessionStoreTest {
         stubProviderOne.addStore(storeName, underlyingSessionStore);
         stubProviderOne.addStore("other-session-store", otherUnderlyingStore);
 
-
-        sessionStore = new CompositeReadOnlySessionStore<>(
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(KafkaStreams.State.RUNNING);
+        sessionStore = new CompositeReadOnlySessionStore<>(streams,
                 new WrappingStoreProvider(Arrays.<StateStoreProvider>asList(stubProviderOne, stubProviderTwo)),
                 QueryableStoreTypes.<String, Long>sessionStore(), storeName);
     }
@@ -107,8 +108,9 @@ public class CompositeReadOnlySessionStoreTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(KafkaStreams.State.RUNNING);
         final CompositeReadOnlySessionStore<String, String> store =
-            new CompositeReadOnlySessionStore<>(
+            new CompositeReadOnlySessionStore<>(streams,
                 new StateStoreProviderStub(true),
                 QueryableStoreTypes.sessionStore(),
                 "whateva");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
@@ -116,7 +116,7 @@ public class GlobalStateStoreProviderTest {
         assertTrue(stores.isEmpty());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowExceptionIfStoreIsntOpen() {
         final NoOpReadOnlyStore<Object, Object> store = new NoOpReadOnlyStore<>();
         store.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingKeyValueStoreTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StreamThreadNotRunningException;
+import org.apache.kafka.streams.errors.StreamThreadRebalancingException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.ReadOnlyKeyValueStoreStub;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public class InvalidStateStoreExceptionWrappingKeyValueStoreTest {
+
+    private final String storeName = "my-store";
+
+    @Before
+    public void before() {
+
+    }
+
+    @Test
+    public void shouldWrapStateStoreClosedException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.REBALANCING,
+                StateStoreClosedException.class, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.PENDING_SHUTDOWN,
+                StateStoreClosedException.class, StateStoreNotAvailableException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStore(State.REBALANCING, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStore(State.PENDING_SHUTDOWN, StateStoreNotAvailableException.class);
+    }
+
+    @Test
+    public void shouldWrapEmptyStateStoreException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.REBALANCING,
+                EmptyStateStoreException.class, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.PENDING_SHUTDOWN,
+                EmptyStateStoreException.class, StateStoreNotAvailableException.class);
+    }
+
+    @Test
+    public void shouldWrapStreamThreadNotRunningException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.REBALANCING,
+                StreamThreadNotRunningException.class, StreamThreadRebalancingException.class);
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(State.PENDING_SHUTDOWN,
+                StreamThreadNotRunningException.class, StreamThreadNotRunningException.class);
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                                      final Class<? extends InvalidStateStoreException> throwExceptionClass,
+                                                                      final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromStateStoreProvider(streamState, throwExceptionClass, expectExceptionClass,
+            store -> store.get("anything"));
+        verifyThrowExceptionFromStateStoreProvider(streamState, throwExceptionClass, expectExceptionClass,
+            store -> store.approximateNumEntries());
+        verifyThrowExceptionFromStateStoreProvider(streamState, throwExceptionClass, expectExceptionClass,
+            store -> store.range("anything", "something"));
+        verifyThrowExceptionFromStateStoreProvider(streamState, throwExceptionClass, expectExceptionClass,
+            store -> store.all());
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStore(final KafkaStreams.State streamState,
+                                                              final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromStateStore(streamState, expectExceptionClass,
+            store -> store.get("anything"));
+        verifyThrowExceptionFromStateStore(streamState, expectExceptionClass,
+            store -> store.approximateNumEntries());
+        verifyThrowExceptionFromStateStore(streamState, expectExceptionClass,
+            store -> StreamsTestUtils.toList(store.range("anything", "something")));
+        verifyThrowExceptionFromStateStore(streamState, expectExceptionClass,
+            store -> StreamsTestUtils.toList(store.all()));
+    }
+
+    private <K, V> void verifyThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                            final Class<? extends InvalidStateStoreException> throwExceptionClass,
+                                                            final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                            final Consumer<ReadOnlyKeyValueStore<K, V>> storeConsumer) {
+        try {
+            final List<StateStoreProvider> providers = Collections.singletonList(new StateStoreProviderStub(throwExceptionClass));
+            final CompositeReadOnlyKeyValueStore<K, V> store = createKeyValueStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+            fail("Should have thrown " + expectExceptionClass.getSimpleName());
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+    private <K, V> void verifyThrowExceptionFromStateStore(final KafkaStreams.State streamState,
+                                                    final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                    final Consumer<ReadOnlyKeyValueStore<K, V>> storeConsumer) {
+        try {
+            final ReadOnlyKeyValueStoreStub keyValueStoreStub = new ReadOnlyKeyValueStoreStub(storeName);
+
+            final StateStoreProviderStub providerStub = new StateStoreProviderStub(false);
+            providerStub.addStore(storeName, keyValueStoreStub);
+            keyValueStoreStub.close();      // close store to raise exception
+
+            final List<StateStoreProvider> providers = Collections.singletonList(providerStub);
+            final CompositeReadOnlyKeyValueStore<K, V> store = createKeyValueStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+            fail("Should have thrown " + expectExceptionClass.getSimpleName() + " with key value store");
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+    private static <K, V> CompositeReadOnlyKeyValueStore<K, V> createKeyValueStore(final KafkaStreams.State streamState,
+                                                                            final List<StateStoreProvider> providers,
+                                                                            final String storeName) {
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(streamState);
+        return new CompositeReadOnlyKeyValueStore<>(streams, new WrappingStoreProvider(providers),
+                QueryableStoreTypes.keyValueStore(), storeName);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingSessionStoreTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KafkaStreams;
+import static org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StreamThreadNotRunningException;
+import org.apache.kafka.streams.errors.StreamThreadRebalancingException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
+import org.apache.kafka.test.ReadOnlySessionStoreStub;
+import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class InvalidStateStoreExceptionWrappingSessionStoreTest {
+
+    private final String storeName = "session-store";
+
+    @Before
+    public void before() {
+    }
+
+
+    @Test
+    public void shouldWrapStateStoreClosedException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.REBALANCING,
+                StateStoreClosedException.class, StateStoreMigratedException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.PENDING_SHUTDOWN,
+                StateStoreClosedException.class, StateStoreNotAvailableException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStore(State.REBALANCING, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStore(State.PENDING_SHUTDOWN, StateStoreNotAvailableException.class);
+    }
+
+    @Test
+    public void shouldWrapEmptyStateStoreException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.REBALANCING,
+                EmptyStateStoreException.class, StateStoreMigratedException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.PENDING_SHUTDOWN,
+                EmptyStateStoreException.class, StateStoreNotAvailableException.class);
+    }
+
+    @Test
+    public void shouldWrapStreamThreadNotRunningException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.REBALANCING,
+                StreamThreadNotRunningException.class,
+                StreamThreadRebalancingException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.PENDING_SHUTDOWN,
+                StreamThreadNotRunningException.class,
+                StreamThreadNotRunningException.class);
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                                      final Class<? extends InvalidStateStoreException> actualExceptionClass,
+                                                                      final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            sessionStore -> sessionStore.fetch("a"));
+
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            sessionStore -> StreamsTestUtils.toList(sessionStore.fetch("a", "b")));
+
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStore(final KafkaStreams.State streamState,
+                                                              final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            sessionStore -> sessionStore.fetch("a"));
+
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            sessionStore -> StreamsTestUtils.toList(sessionStore.fetch("a", "b"))
+        );
+    }
+
+
+    private <K, V> void verifyThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                                   final Class<? extends InvalidStateStoreException> throwExceptionClass,
+                                                                   final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                                   final Consumer<ReadOnlySessionStore<K, V>> storeConsumer) {
+        try {
+            final List<StateStoreProvider> providers = Collections.singletonList(new StateStoreProviderStub(throwExceptionClass));
+            final CompositeReadOnlySessionStore<K, V> store = createSessionStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+            fail("Should have thrown " + expectExceptionClass.getSimpleName());
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+
+    private <K, V> void verifyThrowExceptionFromSateStore(final KafkaStreams.State streamState,
+                                                          final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                          final Consumer<ReadOnlySessionStore<K, V>> storeConsumer) {
+        try {
+            final ReadOnlySessionStoreStub<K, V> sessionStoreStub = new ReadOnlySessionStoreStub<>();
+            final StateStoreProviderStub providerStub = new StateStoreProviderStub(false);
+            providerStub.addStore(storeName, sessionStoreStub);
+            sessionStoreStub.close();       // close store to raise exception
+
+            final List<StateStoreProvider> providers = Collections.singletonList(providerStub);
+            final CompositeReadOnlySessionStore<K, V> store = createSessionStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+            fail("Should have thrown " + expectExceptionClass.getSimpleName() + " with session store");
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+    private static <K, V> CompositeReadOnlySessionStore<K, V> createSessionStore(final KafkaStreams.State streamState,
+                                                                          final List<StateStoreProvider> providers,
+                                                                          final String storeName) {
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(streamState);
+        return new CompositeReadOnlySessionStore<>(streams, new WrappingStoreProvider(providers),
+                QueryableStoreTypes.sessionStore(), storeName);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InvalidStateStoreExceptionWrappingWindowStoreTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.time.Instant.ofEpochMilli;
+import static org.apache.kafka.streams.KafkaStreams.State;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class InvalidStateStoreExceptionWrappingWindowStoreTest {
+
+    private static final long WINDOW_SIZE = 30_000;
+    private final String storeName = "window-store";
+
+    @Before
+    public void before() {
+
+    }
+
+    @Test
+    public void shouldWrapStateStoreClosedException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.REBALANCING,
+                StateStoreClosedException.class, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.PENDING_SHUTDOWN,
+                StateStoreClosedException.class, StateStoreNotAvailableException.class);
+
+        verifyAllMethodsThrowExceptionFromStateStore(State.REBALANCING, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStore(State.PENDING_SHUTDOWN, StateStoreNotAvailableException.class);
+    }
+
+    @Test
+    public void shouldWrapEmptyStateStoreException() {
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.REBALANCING,
+                EmptyStateStoreException.class, StateStoreMigratedException.class);
+        verifyAllMethodsThrowExceptionFromStateStoreProvider(KafkaStreams.State.PENDING_SHUTDOWN,
+                EmptyStateStoreException.class, StateStoreNotAvailableException.class);
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                                      final Class<? extends InvalidStateStoreException> actualExceptionClass,
+                                                                      final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            windowStore -> windowStore.fetch("key", 0));
+
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetch("key", ofEpochMilli(1), ofEpochMilli(10)))
+        );
+
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetch("a", "b", ofEpochMilli(1), ofEpochMilli(10)))
+        );
+
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.all()));
+
+        verifyThrowExceptionFromStateStoreProvider(streamState, actualExceptionClass, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetchAll(ofEpochMilli(1), ofEpochMilli(10))));
+
+    }
+
+    private void verifyAllMethodsThrowExceptionFromStateStore(final KafkaStreams.State streamState,
+                                                              final Class<? extends InvalidStateStoreException> expectExceptionClass) {
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            windowStore -> windowStore.fetch("key", 0));
+
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetch("key", ofEpochMilli(1), ofEpochMilli(10)))
+        );
+
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetch("a", "b", ofEpochMilli(1), ofEpochMilli(10)))
+        );
+
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.all()));
+
+        verifyThrowExceptionFromSateStore(streamState, expectExceptionClass,
+            windowStore -> StreamsTestUtils.toList(windowStore.fetchAll(ofEpochMilli(1), ofEpochMilli(10))));
+
+    }
+
+
+    private <K, V> void verifyThrowExceptionFromStateStoreProvider(final KafkaStreams.State streamState,
+                                                            final Class<? extends InvalidStateStoreException> throwExceptionClass,
+                                                            final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                            final Consumer<ReadOnlyWindowStore<K, V>> storeConsumer) {
+        try {
+            final List<StateStoreProvider> providers = Collections.singletonList(new StateStoreProviderStub(throwExceptionClass));
+            final CompositeReadOnlyWindowStore<K, V> store = createWindowStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+            fail("Should have thrown " + expectExceptionClass.getSimpleName());
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+    private <K, V> void verifyThrowExceptionFromSateStore(final KafkaStreams.State streamState,
+                                                   final Class<? extends InvalidStateStoreException> expectExceptionClass,
+                                                   final Consumer<ReadOnlyWindowStore<K, V>> storeConsumer) {
+        try {
+            final ReadOnlyWindowStoreStub<K, V> windowStoreStub = new ReadOnlyWindowStoreStub<>(WINDOW_SIZE);
+            final StateStoreProviderStub providerStub = new StateStoreProviderStub(false);
+            providerStub.addStore(storeName, windowStoreStub);
+            windowStoreStub.close();       // close store to raise exception
+
+            final List<StateStoreProvider> providers = Collections.singletonList(providerStub);
+            final CompositeReadOnlyWindowStore<K, V> store = createWindowStore(streamState, providers, storeName);
+            storeConsumer.accept(store);
+
+            fail("Should have thrown " + expectExceptionClass.getSimpleName() + " with window store");
+        } catch (final InvalidStateStoreException e) {
+            assertThat(e, instanceOf(expectExceptionClass));
+        }
+    }
+
+
+    private static <K, V> CompositeReadOnlyWindowStore<K, V> createWindowStore(final KafkaStreams.State streamState,
+                                                                               final List<StateStoreProvider> providers,
+                                                                               final String storeName) {
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(streamState);
+        return new CompositeReadOnlyWindowStore<>(streams, new WrappingStoreProvider(providers),
+                QueryableStoreTypes.windowStore(), storeName);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -17,12 +17,14 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,12 +42,13 @@ public class QueryableStoreProviderTest {
 
     @Before
     public void before() {
+        final KafkaStreams streams = StreamsTestUtils.mockStreams(KafkaStreams.State.RUNNING);
         final StateStoreProviderStub theStoreProvider = new StateStoreProviderStub(false);
         theStoreProvider.addStore(keyValueStore, new NoOpReadOnlyStore<>());
         theStoreProvider.addStore(windowStore, new NoOpWindowStore());
         globalStateStores = new HashMap<>();
         storeProvider =
-            new QueryableStoreProvider(
+            new QueryableStoreProvider(streams,
                     Collections.<StateStoreProvider>singletonList(theStoreProvider), new GlobalStateStoreProvider(globalStateStores));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -101,29 +101,29 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         try {
             iteratorOne.hasNext();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
+            fail("should have thrown StateStoreClosedException on closed store");
+        } catch (final StateStoreClosedException e) {
             // ok
         }
 
         try {
             iteratorOne.next();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
+            fail("should have thrown StateStoreClosedException on closed store");
+        } catch (final StateStoreClosedException e) {
             // ok
         }
 
         try {
             iteratorTwo.hasNext();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
+            fail("should have thrown StateStoreClosedException on closed store");
+        } catch (final StateStoreClosedException e) {
             // ok
         }
 
         try {
             iteratorTwo.next();
-            fail("should have thrown InvalidStateStoreException on closed store");
-        } catch (final InvalidStateStoreException e) {
+            fail("should have thrown StateStoreClosedException on closed store");
+        } catch (final StateStoreClosedException e) {
             // ok
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -26,7 +26,8 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyWrapper;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+import org.apache.kafka.streams.errors.StreamThreadNotRunningException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
@@ -246,28 +247,28 @@ public class StreamThreadStateStoreProviderTest {
         }
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
         provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
         provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
         provider.stores("window-store", QueryableStoreTypes.windowStore());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StateStoreClosedException.class)
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
@@ -291,7 +292,7 @@ public class StreamThreadStateStoreProviderTest {
         );
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = StreamThreadNotRunningException.class)
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
         provider.stores("kv-store", QueryableStoreTypes.keyValueStore());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.EmptyStateStoreException;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -74,7 +74,7 @@ public class WrappingStoreProviderTest {
         assertEquals(2, windowStores.size());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test(expected = EmptyStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNoStoreOfTypeFound() {
         wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.keyValueStore());
     }

--- a/streams/src/test/java/org/apache/kafka/test/ReadOnlyKeyValueStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/ReadOnlyKeyValueStoreStub.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.internals.DelegatingPeekingKeyValueIterator;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class ReadOnlyKeyValueStoreStub<K, V> implements ReadOnlyKeyValueStore<K, V>, StateStore {
+    private final String name;
+    private Map<K, V> map = new HashMap<>();
+    private boolean open = true;
+
+    public ReadOnlyKeyValueStoreStub(final String name) {
+        this.name = name;
+    }
+
+    private void validateStoreOpen() {
+        if (!open) {
+            throw new StateStoreClosedException("not open");
+        }
+    }
+    @Override
+    public V get(K key) {
+        validateStoreOpen();
+        return map.get(key);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> range(K from, K to) {
+        validateStoreOpen();
+        return null;
+    }
+
+    @Override
+    public KeyValueIterator<K, V> all() {
+        validateStoreOpen();
+        final KeyValueIterator<K, V> underlying = new KeyValueIteratorStub(name, map.entrySet().iterator());
+        return new DelegatingPeekingKeyValueIterator<>(name, underlying);
+    }
+
+    @Override
+    public long approximateNumEntries() {
+        validateStoreOpen();
+        return map.size();
+    }
+
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public void init(ProcessorContext context, StateStore root) {
+
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+
+    @Override
+    public boolean persistent() {
+        return false;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+
+
+    private class KeyValueIteratorStub implements KeyValueIterator<K, V> {
+        private final Iterator<Map.Entry<K, V>> iter;
+        private final String storeName;
+        private volatile boolean open = true;
+
+        KeyValueIteratorStub(final String storeName, final Iterator<Map.Entry<K, V>> iter) {
+            this.storeName = storeName;
+            this.iter = iter;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (!open) {
+                throw new StateStoreClosedException(String.format("RocksDB iterator for store %s has closed", storeName));
+            }
+            return iter.hasNext();
+        }
+
+        @Override
+        public KeyValue<K, V> next() {
+            final Map.Entry<K, V> entry = iter.next();
+            return new KeyValue<>(entry.getKey(), entry.getValue());
+        }
+
+        @Override
+        public void remove() {
+            iter.remove();
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+
+        @Override
+        public K peekNextKey() {
+            throw new UnsupportedOperationException("peekNextKey() not supported in " + getClass().getName());
+        }
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.internals.StateStoreClosedException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
@@ -45,7 +45,7 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
     @Override
     public KeyValueIterator<Windowed<K>, V> fetch(final K key) {
         if (!open) {
-            throw new InvalidStateStoreException("not open");
+            throw new StateStoreClosedException("not open");
         }
         if (!sessions.containsKey(key)) {
             return new KeyValueIteratorStub<>(Collections.<KeyValue<Windowed<K>, V>>emptyIterator());
@@ -56,7 +56,7 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
     @Override
     public KeyValueIterator<Windowed<K>, V> fetch(final K from, final K to) {
         if (!open) {
-            throw new InvalidStateStoreException("not open");
+            throw new StateStoreClosedException("not open");
         }
         if (sessions.subMap(from, true, to, true).isEmpty()) {
             return new KeyValueIteratorStub<>(Collections.<KeyValue<Windowed<K>, V>>emptyIterator());
@@ -108,7 +108,7 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
 
     @Override
     public void close() {
-
+        open = false;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -21,9 +21,11 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.easymock.EasyMock;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -173,4 +175,12 @@ public final class StreamsTestUtils {
             return metric;
         }
     }
+
+    public static KafkaStreams mockStreams(KafkaStreams.State state) {
+        final KafkaStreams kafkaStreams = EasyMock.createNiceMock(KafkaStreams.class);
+        EasyMock.expect(kafkaStreams.state()).andStubReturn(state);
+        EasyMock.replay(kafkaStreams);
+        return kafkaStreams;
+    }
+
 }


### PR DESCRIPTION
This PR is used for KIP-216 discussion:
[KIP-216: IQ should throw different exceptions for different errors](https://cwiki.apache.org/confluence/display/KAFKA/KIP-216%3A+IQ+should+throw+different+exceptions+for+different+errors)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
