### PR TITLE
KAFKA-8628: Auto-generated Kafka RPC code should be able to use zero-copy ByteBuffers

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -55,7 +55,7 @@
               files="AbstractRequest.java|KerberosLogin.java|WorkerSinkTaskTest.java|TransactionManagerTest.java|SenderTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest).java"/>
+              files="(BufferPool|Fetcher|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|FieldSpec).java"/>
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -55,7 +55,6 @@ import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.protocol.types.Type;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
@@ -113,11 +112,6 @@ import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.apache.kafka.common.protocol.types.Type.BYTES;
-import static org.apache.kafka.common.protocol.types.Type.NULLABLE_BYTES;
-import static org.apache.kafka.common.protocol.types.Type.RECORDS;
 
 /**
  * Identifiers for all the Kafka APIs
@@ -224,7 +218,6 @@ public enum ApiKeys {
 
     public final Schema[] requestSchemas;
     public final Schema[] responseSchemas;
-    public final boolean requiresDelayedAllocation;
 
     ApiKeys(int id, String name, Schema[] requestSchemas, Schema[] responseSchemas) {
         this(id, name, false, requestSchemas, responseSchemas);
@@ -254,14 +247,6 @@ public enum ApiKeys {
                 throw new IllegalStateException("Response schema for api " + name + " for version " + i + " is null");
         }
 
-        boolean requestRetainsBufferReference = false;
-        for (Schema requestVersionSchema : requestSchemas) {
-            if (retainsBufferReference(requestVersionSchema)) {
-                requestRetainsBufferReference = true;
-                break;
-            }
-        }
-        this.requiresDelayedAllocation = requestRetainsBufferReference;
         this.requestSchemas = requestSchemas;
         this.responseSchemas = responseSchemas;
     }
@@ -348,18 +333,4 @@ public enum ApiKeys {
     public static void main(String[] args) {
         System.out.println(toHtml());
     }
-
-    private static boolean retainsBufferReference(Schema schema) {
-        final AtomicBoolean hasBuffer = new AtomicBoolean(false);
-        Schema.Visitor detector = new Schema.Visitor() {
-            @Override
-            public void visit(Type field) {
-                if (field == BYTES || field == NULLABLE_BYTES || field == RECORDS)
-                    hasBuffer.set(true);
-            }
-        };
-        schema.walk(detector);
-        return hasBuffer.get();
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.protocol;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 public interface Readable {
@@ -24,7 +25,7 @@ public interface Readable {
     short readShort();
     int readInt();
     long readLong();
-    void readArray(byte[] arr);
+    void readRawBytes(byte[] arr);
 
     /**
      * Read a Kafka-delimited string from a byte buffer.  The UTF-8 string
@@ -37,7 +38,7 @@ public interface Readable {
             return null;
         }
         byte[] arr = new byte[length];
-        readArray(arr);
+        readRawBytes(arr);
         return new String(arr, StandardCharsets.UTF_8);
     }
 
@@ -45,13 +46,19 @@ public interface Readable {
      * Read a Kafka-delimited array from a byte buffer.  The array length is
      * stored in a four-byte short.
      */
-    default byte[] readNullableBytes() {
+    default byte[] readNullableByteArray() {
         int length = readInt();
         if (length < 0) {
             return null;
         }
         byte[] arr = new byte[length];
-        readArray(arr);
+        readRawBytes(arr);
         return arr;
     }
+
+    /**
+     * Read a bytes field into a ByteBuffer.  If possible, avoid copying the bytes,
+     * in favor of simply returning a reference into the containing object.
+     */
+    ByteBuffer readNullableByteBufferMaybeZeroCopy();
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Writable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Writable.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.protocol;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 public interface Writable {
@@ -24,7 +25,8 @@ public interface Writable {
     void writeShort(short val);
     void writeInt(int val);
     void writeLong(long val);
-    void writeArray(byte[] arr);
+    void writeRawBytes(byte[] arr);
+    void writeRawBytes(ByteBuffer buf);
 
     /**
      * Write a nullable byte array delimited by a four-byte length prefix.
@@ -42,7 +44,26 @@ public interface Writable {
      */
     default void writeBytes(byte[] arr) {
         writeInt(arr.length);
-        writeArray(arr);
+        writeRawBytes(arr);
+    }
+
+    /**
+     * Write a nullable byte array delimited by a four-byte length prefix.
+     */
+    default void writeNullableBytes(ByteBuffer buf) {
+        if (buf == null) {
+            writeInt(-1);
+        } else {
+            writeBytes(buf);
+        }
+    }
+
+    /**
+     * Write a byte array delimited by a four-byte length prefix.
+     */
+    default void writeBytes(ByteBuffer buf) {
+        writeInt(buf.remaining());
+        writeRawBytes(buf);
     }
 
     /**
@@ -66,6 +87,6 @@ public interface Writable {
                 Short.MAX_VALUE);
         }
         writeShort((short) arr.length);
-        writeArray(arr);
+        writeRawBytes(arr);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -375,7 +375,7 @@ public class SaslClientAuthenticator implements Authenticator {
                 ByteBuffer tokenBuf = ByteBuffer.wrap(saslToken);
                 if (saslAuthenticateVersion != DISABLE_KAFKA_SASL_AUTHENTICATE_HEADER) {
                     SaslAuthenticateRequestData data = new SaslAuthenticateRequestData()
-                            .setAuthBytes(tokenBuf.array());
+                            .setAuthBytes(tokenBuf);
                     SaslAuthenticateRequest request = new SaslAuthenticateRequest.Builder(data).build(saslAuthenticateVersion);
                     tokenBuf = request.serialize(nextRequestHeader(ApiKeys.SASL_AUTHENTICATE, saslAuthenticateVersion));
                 }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -449,7 +449,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
             try {
                 byte[] responseToken = saslServer.evaluateResponse(
-                        Utils.copyArray(saslAuthenticateRequest.data().authBytes()));
+                        Utils.toArray(saslAuthenticateRequest.data().authBytes()));
                 if (reauthInfo.reauthenticating() && saslServer.isComplete())
                     reauthInfo.ensurePrincipalUnchanged(principal());
                 // For versions with SASL_AUTHENTICATE header, send a response to SASL_AUTHENTICATE request even if token is empty.

--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteUtils.java
@@ -27,6 +27,9 @@ import java.nio.ByteBuffer;
  * This classes exposes low-level methods for reading/writing from byte streams or buffers.
  */
 public final class ByteUtils {
+    public static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
+    public static final byte[] EMPTY_ARRAY = new byte[0];
 
     private ByteUtils() {}
 
@@ -330,5 +333,39 @@ public final class ByteUtils {
     private static IllegalArgumentException illegalVarlongException(long value) {
         throw new IllegalArgumentException("Varlong is too long, most significant bit in the 10th byte is set, " +
                 "converted value: " + Long.toHexString(value));
+    }
+
+    public static String toHexString(byte[] buf) {
+        if (buf.length == 0) {
+            return "[]";
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(String.format("%02x", buf[0]));
+        int position = 1;
+        while (position < buf.length) {
+            builder.append(String.format(" %02x", buf[position++]));
+        } 
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public static String toHexString(ByteBuffer buf) {
+        if (buf.remaining() == 0) {
+            return "[]";
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        int position = buf.position();
+        try {
+            builder.append(String.format("%02x", buf.get()));
+            while (buf.hasRemaining()) {
+                builder.append(String.format(" %02x", buf.get()));
+            } 
+        } finally {
+            buf.position(position);
+        }
+        builder.append("]");
+        return builder.toString();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
@@ -24,9 +24,6 @@ import java.util.Comparator;
  * Utility class that handles immutable byte arrays.
  */
 public class Bytes implements Comparable<Bytes> {
-
-    public static final byte[] EMPTY = new byte[0];
-
     private static final char[] HEX_CHARS_UPPER = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
     private final byte[] bytes;

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
@@ -20,7 +20,7 @@
   // Version 1 is the same as version 0.
   "validVersions": "0-1",
   "fields": [
-    { "name": "Hmac", "type": "bytes", "versions": "0+",
+    { "name": "Hmac", "type": "bytes", "versions": "0+", "style": "zeroCopyByteBuffer",
       "about": "The HMAC of the delegation token to be expired." },
     { "name": "ExpiryTimePeriodMs", "type": "int64", "versions": "0+",
       "about": "The expiry time period in milliseconds." }

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -71,7 +71,7 @@
         ]},
         { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "ignorable": true,
           "about": "The preferred read replica for the consumer to use on its next fetch request"},
-        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "style": "zeroCopyByteBuffer",
           "about": "The record data." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/ProduceRequest.json
+++ b/clients/src/main/resources/common/message/ProduceRequest.json
@@ -44,7 +44,7 @@
         "about": "Each partition to produce to.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
-        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "style": "zeroCopyByteBuffer",
           "about": "The record data to be produced." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
@@ -20,7 +20,7 @@
   // Version 1 is the same as version 0.
   "validVersions": "0-1",
   "fields": [
-    { "name": "Hmac", "type": "bytes", "versions": "0+",
+    { "name": "Hmac", "type": "bytes", "versions": "0+", "style": "zeroCopyByteBuffer",
       "about": "The HMAC of the delegation token to be renewed." },
     { "name": "RenewPeriodMs", "type": "int64", "versions": "0+",
       "about": "The renewal time period in milliseconds." }

--- a/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
@@ -20,7 +20,7 @@
   // Version 1 is the same as version 0.
   "validVersions": "0-1",
   "fields": [
-    { "name": "AuthBytes", "type": "bytes", "versions": "0+",
+    { "name": "AuthBytes", "type": "bytes", "versions": "0+", "style": "zeroCopyByteBuffer",
       "about": "The SASL authentication bytes from the client, as defined by the SASL mechanism." }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.protocol;
 
+import org.apache.kafka.common.message.ApiMessageType;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -26,11 +27,18 @@ public class ProtoUtilsTest {
     public void testDelayedAllocationSchemaDetection() throws Exception {
         //verifies that schemas known to retain a reference to the underlying byte buffer are correctly detected.
         for (ApiKeys key : ApiKeys.values()) {
-            if (key == ApiKeys.PRODUCE || key == ApiKeys.JOIN_GROUP || key == ApiKeys.SYNC_GROUP || key == ApiKeys.SASL_AUTHENTICATE
-                || key == ApiKeys.EXPIRE_DELEGATION_TOKEN || key == ApiKeys.RENEW_DELEGATION_TOKEN) {
-                assertTrue(key + " should require delayed allocation", key.requiresDelayedAllocation);
-            } else {
-                assertFalse(key + " should not require delayed allocation", key.requiresDelayedAllocation);
+            switch (key) {
+                case PRODUCE:
+                case SASL_AUTHENTICATE:
+                case EXPIRE_DELEGATION_TOKEN:
+                case RENEW_DELEGATION_TOKEN:
+                    assertTrue(key + " should require delayed allocation",
+                            ApiMessageType.fromApiKey(key.id).requestContainsZeroCopyFields());
+                    break;
+                default:
+                    assertFalse(key + " should not require delayed allocation",
+                            ApiMessageType.fromApiKey(key.id).requestContainsZeroCopyFields());
+                    break;
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -99,6 +99,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
@@ -1180,7 +1181,7 @@ public class RequestResponseTest {
     }
 
     private SaslAuthenticateRequest createSaslAuthenticateRequest() {
-        SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(new byte[0]);
+        SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(ByteUtils.EMPTY_BUFFER);
         return new SaslAuthenticateRequest(data);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1802,7 +1802,7 @@ public class SaslAuthenticatorTest {
         String authString = "\u0000" + TestJaasConfig.USERNAME + "\u0000" + TestJaasConfig.PASSWORD;
         ByteBuffer authBuf = ByteBuffer.wrap(authString.getBytes("UTF-8"));
         if (enableSaslAuthenticateHeader) {
-            SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(authBuf.array());
+            SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(authBuf);
             SaslAuthenticateRequest request = new SaslAuthenticateRequest.Builder(data).build();
             sendKafkaRequestReceiveResponse(node, ApiKeys.SASL_AUTHENTICATE, request);
         } else {

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -229,4 +229,23 @@ public class ByteUtilsTest {
         assertEquals(value, ByteUtils.readVarlong(in));
     }
 
+    @Test
+    public void testArrayToHexString() {
+        assertEquals("[00 01 02 0e]", ByteUtils.toHexString(new byte[] {0, 1, 2, 14 }));
+        assertEquals("[ff]", ByteUtils.toHexString(new byte[] {-1}));
+        assertEquals("[]", ByteUtils.toHexString(new byte[] {}));
+        assertEquals("[]", ByteUtils.toHexString(ByteUtils.EMPTY_ARRAY));
+    }
+
+    @Test
+    public void testByteBufferToHexString() {
+        ByteBuffer buf1 = ByteBuffer.wrap(new byte[] {0, 1, 2, 14});
+        assertEquals("[00 01 02 0e]", ByteUtils.toHexString(buf1));
+        assertEquals("[00 01 02 0e]", ByteUtils.toHexString(buf1));
+        assertEquals("[ff]",
+                ByteUtils.toHexString(ByteBuffer.wrap(new byte[] {-1})));
+        assertEquals("[]",
+                ByteUtils.toHexString(ByteBuffer.wrap(new byte[] {})));
+        assertEquals("[]", ByteUtils.toHexString(ByteUtils.EMPTY_BUFFER));
+    }
 }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -53,8 +53,7 @@ import org.apache.kafka.common.requests.CreateAclsRequest.AclCreation
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType => AdminResourceType}
 import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrincipal, KafkaPrincipalBuilder, SecurityProtocol}
-import org.apache.kafka.common.utils.Sanitizer
-import org.apache.kafka.common.utils.SecurityUtils
+import org.apache.kafka.common.utils.{ByteUtils, Sanitizer, SecurityUtils}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
@@ -348,7 +347,7 @@ class RequestQuotaTest extends BaseRequestTest {
           new SaslHandshakeRequest.Builder(new SaslHandshakeRequestData().setMechanism("PLAIN"))
 
         case ApiKeys.SASL_AUTHENTICATE =>
-          new SaslAuthenticateRequest.Builder(new SaslAuthenticateRequestData().setAuthBytes(new Array[Byte](0)))
+          new SaslAuthenticateRequest.Builder(new SaslAuthenticateRequestData().setAuthBytes(ByteUtils.EMPTY_BUFFER))
 
         case ApiKeys.API_VERSIONS =>
           new ApiVersionsRequest.Builder

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -46,6 +46,8 @@ public final class FieldSpec {
 
     private final String about;
 
+    private final TranslationStyle style;
+
     @JsonCreator
     public FieldSpec(@JsonProperty("name") String name,
                      @JsonProperty("versions") String versions,
@@ -56,7 +58,8 @@ public final class FieldSpec {
                      @JsonProperty("default") String fieldDefault,
                      @JsonProperty("ignorable") boolean ignorable,
                      @JsonProperty("entityType") EntityType entityType,
-                     @JsonProperty("about") String about) {
+                     @JsonProperty("about") String about,
+                     @JsonProperty("style") TranslationStyle style) {
         this.name = Objects.requireNonNull(name);
         this.versions = Versions.parse(versions, null);
         if (this.versions == null) {
@@ -82,6 +85,15 @@ public final class FieldSpec {
         if (!this.fields().isEmpty()) {
             if (!this.type.isArray()) {
                 throw new RuntimeException("Non-array field " + name + " cannot have fields");
+            }
+        }
+        this.style = (style == null) ? TranslationStyle.DEFAULT : style;
+        if ((this.style == TranslationStyle.BYTE_ARRAY) ||
+                (this.style == TranslationStyle.ZERO_COPY_BYTE_BUFFER)) {
+            if (!this.type.isBytes()) {
+                throw new RuntimeException("Invalid translation style " + this.style +
+                        " for field " + this.name + ".  This style can only be used with fields " +
+                        " of type 'bytes', not " + this.type);
             }
         }
     }
@@ -153,5 +165,10 @@ public final class FieldSpec {
     @JsonProperty("about")
     public String about() {
         return about;
+    }
+
+    @JsonProperty("style")
+    public TranslationStyle style() {
+        return style;
     }
 }

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -53,6 +53,8 @@ public final class MessageGenerator {
 
     static final String WRITABLE_CLASS = "org.apache.kafka.common.protocol.Writable";
 
+    static final String OBJECTS_CLASS = "java.util.Objects";
+
     static final String ARRAYS_CLASS = "java.util.Arrays";
 
     static final String LIST_CLASS = "java.util.List";
@@ -77,11 +79,13 @@ public final class MessageGenerator {
 
     static final String STRUCT_CLASS = "org.apache.kafka.common.protocol.types.Struct";
 
-    static final String BYTES_CLASS = "org.apache.kafka.common.utils.Bytes";
-
     static final String REQUEST_SUFFIX = "Request";
 
     static final String RESPONSE_SUFFIX = "Response";
+
+    static final String BYTE_UTILS_CLASS = "org.apache.kafka.common.utils.ByteUtils";
+
+    static final String BYTE_BUFFER_CLASS = "java.nio.ByteBuffer";
 
     /**
      * The Jackson serializer we use for JSON objects.
@@ -110,13 +114,14 @@ public final class MessageGenerator {
                     String javaName = spec.generatedClassName() + JAVA_SUFFIX;
                     outputFileNames.add(javaName);
                     Path outputPath = Paths.get(outputDir, javaName);
+                    MessageDataGenerator generator;
                     try (BufferedWriter writer = Files.newBufferedWriter(outputPath)) {
-                        MessageDataGenerator generator = new MessageDataGenerator();
+                        generator = new MessageDataGenerator();
                         generator.generate(spec);
                         generator.write(writer);
                     }
                     numProcessed++;
-                    messageTypeGenerator.registerMessageType(spec);
+                    messageTypeGenerator.registerMessageType(spec, generator.containsZeroCopyFields());
                 } catch (Exception e) {
                     throw new RuntimeException("Exception while processing " + inputPath.toString(), e);
                 }

--- a/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
+++ b/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
@@ -30,10 +30,12 @@ import java.util.TreeSet;
 final class StructRegistry {
     private final Map<String, StructSpec> structSpecs;
     private final Set<String> commonStructNames;
+    private boolean containsZeroCopyFields;
 
     StructRegistry() {
         this.structSpecs = new TreeMap<>();
         this.commonStructNames = new TreeSet<>();
+        this.containsZeroCopyFields = false;
     }
 
     /**
@@ -52,6 +54,11 @@ final class StructRegistry {
             commonStructNames.add(struct.name());
         }
 
+        // Register inline structures contained in common structures.
+        for (StructSpec struct : message.commonStructs()) {
+            addStructSpecs(struct.fields());
+        }
+
         // Register inline structures.
         addStructSpecs(message.fields());
     }
@@ -59,6 +66,9 @@ final class StructRegistry {
     @SuppressWarnings("unchecked")
     private void addStructSpecs(List<FieldSpec> fields) {
         for (FieldSpec field : fields) {
+            if (field.style().equals(TranslationStyle.ZERO_COPY_BYTE_BUFFER)) {
+                containsZeroCopyFields = true;
+            }
             if (field.type().isStructArray()) {
                 FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
                 if (commonStructNames.contains(arrayType.elementName())) {
@@ -79,6 +89,10 @@ final class StructRegistry {
                 addStructSpecs(field.fields());
             }
         }
+    }
+
+    boolean containsZeroCopyFields() {
+        return containsZeroCopyFields;
     }
 
     /**

--- a/generator/src/main/java/org/apache/kafka/message/TranslationStyle.java
+++ b/generator/src/main/java/org/apache/kafka/message/TranslationStyle.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * TranslationStyle contains hints about how to translate various fields in
+ * an efficient way.  This does not affect what is sent on the wire.  It is
+ * just a hint for generating efficient Java code.
+ */
+public enum TranslationStyle {
+    /**
+     * Use the default translation style for this type.
+     */
+    @JsonProperty("default")
+    DEFAULT,
+
+    /**
+     * Translate this type as a byte array.
+     */
+    @JsonProperty("byteArray")
+    BYTE_ARRAY,
+
+    /**
+     * Translate this type as a zero-copy ByteBuffer.
+     *
+     * Zero-copy fields are more efficient for receiving or sending
+     * a lot of data.  However, they make memory management more complex
+     * because they hold a reference to the containing buffer, which
+     * cannot then be safely freed while they are in use.
+     */
+    @JsonProperty("zeroCopyByteBuffer")
+    ZERO_COPY_BYTE_BUFFER;
+}


### PR DESCRIPTION
It is often more efficient to deal with large fields of type "bytes" as ByteBuffer objects, rather than Java arrays.  ByteBuffers can be used in a "zero-copy" fashion, where they simply serve as pointers into already allocated memory.  This avoids the need to copy the data, as would be necessary when using a regular Java byte array.

There is a drawback to using zero-copy ByteBuffers, though: when they are used, the ByteBuffer from which we deserialized the request must remain valid until we're done with the request.  So the underlying buffer cannot be reused during this period.  Therefore, we don't want all bytes fields to show up as ByteBuffers.

This change adds a "style" field to the RPC specifications which allows specifying that a "bytes" field should be deserialized as a zero-copy ByteBuffer rather than as a byte array.