### PR TITLE
MINOR: Improve KafkaController code

### DIFF
--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -151,7 +151,7 @@ class ZkNodeChangeNotificationListener(private val zkClient: KafkaZkClient,
     override def handleChildChange(): Unit = addChangeNotification
   }
 
-  object ZkStateChangeHandler extends  StateChangeHandler {
+  object ZkStateChangeHandler extends StateChangeHandler {
     override val name: String = StateChangeHandlers.zkNodeChangeListenerHandler(seqNodeRoot)
     override def afterInitializingSession(): Unit = addChangeNotification
   }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -388,7 +388,7 @@ class KafkaController(val config: KafkaConfig,
     // 3. check if reassignment of some partitions need to be restarted
     controllerContext.partitionsBeingReassigned.foreach {
       case (tp, context) =>
-        if (reassignmentContext.newReplicas.exists(newBrokersSet.contains))
+        if (context.newReplicas.exists(newBrokersSet.contains))
           onPartitionReassignment(tp, context)
     }
     // 4. check if topic deletion needs to be resumed. If at least one replica that belongs to the topic being deleted exists

--- a/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
@@ -40,6 +40,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   val overridingProps = new Properties()
   val metrics = new Metrics()
   overridingProps.put(KafkaConfig.NumPartitionsProp, numParts.toString)
+  overridingProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, true.toString)
 
   override def generateConfigs = TestUtils.createBrokerConfigs(numNodes, zkConnect)
     .map(KafkaConfig.fromProps(_, overridingProps))
@@ -81,7 +82,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
     }
     initialController.eventManager.put(illegalStateEvent)
     // Check that we have shutdown the scheduler (via onControllerResigned)
-    TestUtils.waitUntilTrue(() => !initialController.kafkaScheduler.isStarted, "Scheduler was not shutdown")
+    TestUtils.waitUntilTrue(() => !initialController.autoLeaderRebalanceScheduler.isStarted, "Scheduler was not shutdown")
     TestUtils.waitUntilTrue(() => !initialController.isActive, "Controller did not become inactive")
     latch.countDown()
     TestUtils.waitUntilTrue(() => Option(exceptionThrown.get()).isDefined, "handleIllegalState did not throw an exception")


### PR DESCRIPTION
I was reading through the KafkaController code (I only managed to go halfway through) and cleaning code along the way, figuring that if I find enough stuff it may be worth opening a minor PR to improve things. Well, here we are:

* Do not initialize the KafkaScheduler for auto preferred leader election when the functionality is configured to be off
* Add a constant for the empty controlled ID value of -1
* Some minor typo corrections, comment and code refactors
