### PR TITLE
MINOR: Split at first occurrence of '=' in kafka.py props parsing (cherry-pick on 2.0)

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -221,7 +221,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
                                  security_config=self.security_config, num_nodes=self.num_nodes)
 
-        configs = dict( l.rstrip().split('=') for l in config_template.split('\n')
+        configs = dict( l.rstrip().split('=', 1) for l in config_template.split('\n')
                         if not l.startswith("#") and "=" in l )
 
         #load specific test override configs


### PR DESCRIPTION
This also cherry picks the fix that was missed when #6949 cherry-picked the changes introduced by #5226 to branch 2.0. The original message of the fix is as follows: 

This is a fix to #5226 to account for config properties that have an
equal char in the value.   Otherwise if there is one
equal char in the value the following error occurs:

dictionary update sequence element #XX has length 3; 2 is required

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
