### PR TITLE
MINOR: use different key when create results for CreatePartitionsResponse in RequestResponseTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1482,7 +1482,7 @@ public class RequestResponseTest {
         Map<String, ApiError> results = new HashMap<>();
         results.put("my_topic", ApiError.fromThrowable(
                 new InvalidReplicaAssignmentException("The assigned brokers included an unknown broker")));
-        results.put("my_topic", ApiError.NONE);
+        results.put("my_other_topic", ApiError.NONE);
         return new CreatePartitionsResponse(42, results);
     }
 


### PR DESCRIPTION
The method createCreatePartitionsResponse put duplicate keys "my_topic" in the result map. So I use "my_other_topic" as second key to keep same with the method createCreatePartitionsRequest

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
