### PR TITLE
KAFKA-8637: WriteBatch objects leak off-heap memory

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -233,6 +233,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
                 final S segment = entry.getKey();
                 final WriteBatch batch = entry.getValue();
                 segment.write(batch);
+                batch.close();
             }
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error restoring batch to store " + this.name, e);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -403,10 +403,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
         }
 
         dbAccessor.close();
-        db.close();
         userSpecifiedOptions.close();
         wOptions.close();
         fOptions.close();
+        db.close();
         filter.close();
         cache.close();
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -403,10 +403,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
         }
 
         dbAccessor.close();
+        db.close();
         userSpecifiedOptions.close();
         wOptions.close();
         fOptions.close();
-        db.close();
         filter.close();
         cache.close();
 


### PR DESCRIPTION
Should be cherry-picked back to 2.3 (picked from 2.2 to 2.1 in  [7077](https://github.com/apache/kafka/pull/7077) )