### PR TITLE
KAFKA-8610: Don't use /bin/bash in scripts

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -16,14 +16,14 @@
 
 if [ $# -lt 1 ];
 then
-        echo "USAGE: $0 [-daemon] connect-distributed.properties"
-        exit 1
+  echo "USAGE: $0 [-daemon] connect-distributed.properties"
+  exit 1
 fi
 
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -16,14 +16,14 @@
 
 if [ $# -lt 1 ];
 then
-        echo "USAGE: $0 [-daemon] connect-standalone.properties"
-        exit 1
+  echo "USAGE: $0 [-daemon] connect-standalone.properties"
+  exit 1
 fi
 
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then

--- a/bin/kafka-acls.sh
+++ b/bin/kafka-acls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-broker-api-versions.sh
+++ b/bin/kafka-broker-api-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-console-consumer.sh
+++ b/bin/kafka-console-consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
 exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleConsumer "$@"

--- a/bin/kafka-console-producer.sh
+++ b/bin/kafka-console-producer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
+
 exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"

--- a/bin/kafka-consumer-groups.sh
+++ b/bin/kafka-consumer-groups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-consumer-perf-test.sh
+++ b/bin/kafka-consumer-perf-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -17,4 +17,5 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
+
 exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerPerformance "$@"

--- a/bin/kafka-delegation-tokens.sh
+++ b/bin/kafka-delegation-tokens.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-delete-records.sh
+++ b/bin/kafka-delete-records.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-dump-log.sh
+++ b/bin/kafka-dump-log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-leader-election.sh
+++ b/bin/kafka-leader-election.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-log-dirs.sh
+++ b/bin/kafka-log-dirs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-mirror-maker.sh
+++ b/bin/kafka-mirror-maker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-preferred-replica-election.sh
+++ b/bin/kafka-preferred-replica-election.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
+
 exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"

--- a/bin/kafka-reassign-partitions.sh
+++ b/bin/kafka-reassign-partitions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-replica-verification.sh
+++ b/bin/kafka-replica-verification.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,19 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ $# -lt 1 ];
-then
-	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
-	exit 1
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
+  exit 1
 fi
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx1G -Xms1G"
+  export KAFKA_HEAP_OPTS="-Xmx1G -Xms1G"
 fi
 
 EXTRA_ARGS=${EXTRA_ARGS-'-name kafkaServer -loggc'}

--- a/bin/kafka-streams-application-reset.sh
+++ b/bin/kafka-streams-application-reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-topics.sh
+++ b/bin/kafka-topics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/kafka-verifiable-consumer.sh
+++ b/bin/kafka-verifiable-consumer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
+
 exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"

--- a/bin/kafka-verifiable-producer.sh
+++ b/bin/kafka-verifiable-producer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
+
 exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"

--- a/bin/trogdor.sh
+++ b/bin/trogdor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -30,7 +30,7 @@ Actions:
 EOF
 }
 
-if [[ $# -lt 1 ]]; then
+if [ $# -lt 1 ]; then
     usage
     exit 0
 fi

--- a/bin/zookeeper-security-migration.sh
+++ b/bin/zookeeper-security-migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,19 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ $# -lt 1 ];
-then
-	echo "USAGE: $0 [-daemon] zookeeper.properties"
-	exit 1
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 [-daemon] zookeeper.properties"
+  exit 1
 fi
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
+  export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
 fi
 
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
-    export KAFKA_HEAP_OPTS="-Xmx512M -Xms512M"
+  export KAFKA_HEAP_OPTS="-Xmx512M -Xms512M"
 fi
 
 EXTRA_ARGS=${EXTRA_ARGS-'-name zookeeper -loggc'}
@@ -34,11 +33,11 @@ EXTRA_ARGS=${EXTRA_ARGS-'-name zookeeper -loggc'}
 COMMAND=$1
 case $COMMAND in
   -daemon)
-     EXTRA_ARGS="-daemon "$EXTRA_ARGS
-     shift
-     ;;
- *)
-     ;;
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
 esac
 
 exec $base_dir/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -16,8 +16,8 @@
 
 if [ $# -lt 1 ];
 then
-	echo "USAGE: $0 zookeeper_host:port[/path] [-zk-tls-config-file file] [args...]"
-	exit 1
+  echo "USAGE: $0 zookeeper_host:port[/path] [-zk-tls-config-file file] [args...]"
+  exit 1
 fi
 
 exec $(dirname $0)/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"


### PR DESCRIPTION
Currently, the interpreters (i.e., `/bin/sh`, `/bin/bash`, and `#!/usr/bin/env bash`) and indentations in the scripts are not unified. This PR improves portability by unifying them to use `/bin/sh`.

It was validated with `shellcheck` and manual testing, but the more comprehensive test would be welcomed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
