### PR TITLE
KAFKA-8648: Throw exception if bad --property sent to ConsoleConsumer

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -313,7 +313,7 @@ object ConsoleConsumer extends Logging {
     try {
       formatter.init(formatterArgs)
     } catch {
-      case e => CommandLineUtils.printUsageAndDie(parser, e.getMessage)
+      case e:IllegalArgumentException => CommandLineUtils.printUsageAndDie(parser, e.getMessage)
     }
 
     val topicOrFilterOpt = List(topicIdOpt, whitelistOpt).filter(options.has)


### PR DESCRIPTION
Doesn’t check ConsoleProducer
Doesn’t check properties sent to key/value deserialisers

Includes unit test, also adds a test for the Custom Value Deserializer option. Also includes a more reliable way to test for system exit, if the code under test might throw an illegal argument exception.

For example, if you try to use

`./bin/kafka-console-consumer --topic c3test --bootstrap-server $BROKER:9092 --property interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor`

It will fail saying: 
`Unrecognised arguments ({interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor}) passed to kafka.tools.DefaultMessageFormatter.`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)