### PR TITLE
KAFKA-8651: Add predicate map to #branch

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -753,13 +753,26 @@ public interface KStream<K, V> {
      * A record will be dropped if none of the predicates evaluate to true.
      * This is a stateless record-by-record operation.
      *
-     * @param predicates the ordered list of {@link Predicate} instances
-     * @return multiple distinct substreams of this {@code KStream}
+     * @param predicates a Map of predicates names to {@link Predicate} instances
+     * @return a {@link Map} of predicate names to multiple distinct substreams of this {@code KStream}
      */
     @SuppressWarnings("unchecked")
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
 
-    Map<String, KStream<K, V>> branchMap(final Map<String, Predicate<? super K, ? super V>> predicates);
+    /**
+     * Creates an Map of {@Code Strings} to {@code KStream} from this stream by branching the records in the original stream based on
+     * the supplied predicates.
+     * Each record is evaluated against the supplied predicates, and predicates are evaluated in order.
+     * Each stream in the result array corresponds position-wise (index) to the predicate in the supplied predicates.
+     * The branching happens on first-match: A record in the original stream is assigned to the corresponding result
+     * stream for the first predicate that evaluates to true, and is assigned to this stream only.
+     * A record will be dropped if none of the predicates evaluate to true.
+     * This is a stateless record-by-record operation.
+     *
+     * @param predicates the ordered list of {@link Predicate} instances
+     * @return multiple distinct substreams of this {@code KStream}
+     */
+    Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicates);
 
     /**
      * Creates an array of {@code KStream} from this stream by branching the records in the original stream based on

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -759,7 +759,7 @@ public interface KStream<K, V> {
     @SuppressWarnings("unchecked")
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
 
-    Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicates);
+    Map<String, KStream<K, V>> branchMap(final Map<String, Predicate<? super K, ? super V>> predicates);
 
     /**
      * Creates an array of {@code KStream} from this stream by branching the records in the original stream based on

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -753,15 +753,15 @@ public interface KStream<K, V> {
      * A record will be dropped if none of the predicates evaluate to true.
      * This is a stateless record-by-record operation.
      *
-     * @param predicates a Map of predicates names to {@link Predicate} instances
-     * @return a {@link Map} of predicate names to multiple distinct substreams of this {@code KStream}
+     * @param predicates the ordered list of {@link Predicate} instances
+     * @return multiple distinct substreams of this {@code KStream}
      */
     @SuppressWarnings("unchecked")
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
 
     /**
-     * Creates an Map of {@Code Strings} to {@code KStream} from this stream by branching the records in the original stream based on
-     * the supplied predicates.
+     * Creates an Map of {@Code Strings} to {@code KStream} from this stream by branching the records in the original
+     * stream based on the supplied predicates.
      * Each record is evaluated against the supplied predicates, and predicates are evaluated in order.
      * Each stream in the result array corresponds position-wise (index) to the predicate in the supplied predicates.
      * The branching happens on first-match: A record in the original stream is assigned to the corresponding result
@@ -769,8 +769,8 @@ public interface KStream<K, V> {
      * A record will be dropped if none of the predicates evaluate to true.
      * This is a stateless record-by-record operation.
      *
-     * @param predicates the ordered list of {@link Predicate} instances
-     * @return multiple distinct substreams of this {@code KStream}
+     * @param predicates a Map of predicates names to {@link Predicate} instances
+     * @return a {@link Map} of predicate names to multiple distinct substreams of this {@code KStream}
      */
     Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicates);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import java.util.Map;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Serde;
@@ -757,6 +758,8 @@ public interface KStream<K, V> {
      */
     @SuppressWarnings("unchecked")
     KStream<K, V>[] branch(final Predicate<? super K, ? super V>... predicates);
+
+    Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicates);
 
     /**
      * Creates an array of {@code KStream} from this stream by branching the records in the original stream based on

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -383,6 +383,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         return branchChildren;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
     public Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicatesMap) {
         // extract predicates array
         Predicate<? super K, ? super V>[] predicates = (Predicate<? super K, ? super V>[]) predicatesMap.values().toArray();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -383,7 +383,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         return branchChildren;
     }
 
-    @Override
     public Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicatesMap) {
         // extract predicates array
         Predicate<? super K, ? super V>[] predicates = (Predicate<? super K, ? super V>[]) predicatesMap.values().toArray();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -385,8 +385,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @Override
     public Map<String, KStream<K, V>> branch(final Map<String, Predicate<? super K, ? super V>> predicatesMap) {
-        Map.Entry<String, Predicate<? super K, ? super V>>[] predicatesEntries = (Map.Entry<String, Predicate<? super K, ? super V>>[])predicatesMap.entrySet().toArray();
-
         // extract predicates array
         Predicate<? super K, ? super V>[] predicates = (Predicate<? super K, ? super V>[]) predicatesMap.values().toArray();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -472,7 +472,7 @@ public class KStreamImplTest {
         testStream.branch((Predicate) null);
     }
 
-
+    @Test
     public void shouldTranslatePredicateMap() {
         Map<String, Predicate<? super String, ? super String>> predicatesMap = new HashMap<>();
         Predicate predicateZero = new Predicate() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -461,7 +463,7 @@ public class KStreamImplTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldHaveAtLeastOnPredicateWhenBranching() {
+    public void shouldHaveAtLeastOnePredicateWhenBranching() {
         testStream.branch();
     }
 
@@ -469,6 +471,32 @@ public class KStreamImplTest {
     public void shouldCantHaveNullPredicate() {
         testStream.branch((Predicate) null);
     }
+
+
+    public void shouldTranslatePredicateMap() {
+        Map<String, Predicate<? super String, ? super String>> predicatesMap = new HashMap<>();
+        Predicate predicateZero = new Predicate() {
+            @Override
+            public boolean test(Object key, Object value) {
+                return false;
+            }
+        };
+        predicatesMap.put("zero", predicateZero);
+        Predicate predicateOne = new Predicate() {
+            @Override
+            public boolean test(Object key, Object value) {
+                return false;
+            }
+        };
+        predicatesMap.put("one", predicateOne);
+
+        Map<String, KStream<String, String>> stringKStreamMap = testStream.branchMap(predicatesMap);
+
+        assertEquals(stringKStreamMap.get("zero"), predicateZero);
+        assertEquals(stringKStreamMap.get("one"), predicateOne);
+    }
+
+
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullTopicOnThrough() {


### PR DESCRIPTION
Using #branch with an array is error prone and not readable, due to referencing the results by magic index offsets. So, we suggest to add an API that allows naming different branches, which is more natural.

See KIP (on it's way)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)