### PR TITLE
KAFKA-8637: WriteBatch objects leak off-heap memory

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -211,6 +211,7 @@ public class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
                 final KeyValueSegment segment = entry.getKey();
                 final WriteBatch batch = entry.getValue();
                 segment.write(batch);
+                batch.close();
             }
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error restoring batch to store " + this.name, e);


### PR DESCRIPTION
[7050](https://github.com/apache/kafka/pull/7050) for branch 2.2, to be cherry-picked back to 2.1