### PR TITLE
MINOR: Use dynamic port in RestServerTest

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -82,6 +82,12 @@ public class RestServerTest {
         return workerProps;
     }
 
+    private Map<String, String> workerPropsWithDynamicPort() {
+        Map<String, String> workerProps = baseWorkerProps();
+        workerProps.put(WorkerConfig.LISTENERS_CONFIG, "HTTP://localhost:0");
+        return workerProps;
+    }
+
     @Test
     public void testCORSEnabled() throws IOException {
         checkCORSRequest("*", "http://bar.com", "http://bar.com", "PUT");
@@ -115,7 +121,7 @@ public class RestServerTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testAdvertisedUri() {
-        // Advertised URI from listeenrs without protocol
+        // Advertised URI from listeners without protocol
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
         DistributedConfig config = new DistributedConfig(configMap);
@@ -162,7 +168,7 @@ public class RestServerTest {
 
     @Test
     public void testOptionsDoesNotIncludeWadlOutput() throws IOException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
+        Map<String, String> configMap = new HashMap<>(workerPropsWithDynamicPort());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
         EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
@@ -197,7 +203,7 @@ public class RestServerTest {
 
     public void checkCORSRequest(String corsDomain, String origin, String expectedHeader, String method)
         throws IOException {
-        Map<String, String> workerProps = baseWorkerProps();
+        Map<String, String> workerProps = workerPropsWithDynamicPort();
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, corsDomain);
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
@@ -252,7 +258,7 @@ public class RestServerTest {
 
     @Test
     public void testStandaloneConfig() throws IOException  {
-        Map<String, String> workerProps = baseWorkerProps();
+        Map<String, String> workerProps = workerPropsWithDynamicPort();
         workerProps.put("offset.storage.file.filename", "/tmp");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -78,13 +78,8 @@ public class RestServerTest {
         workerProps.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
-
-        return workerProps;
-    }
-
-    private Map<String, String> workerPropsWithDynamicPort() {
-        Map<String, String> workerProps = baseWorkerProps();
         workerProps.put(WorkerConfig.LISTENERS_CONFIG, "HTTP://localhost:0");
+
         return workerProps;
     }
 
@@ -111,6 +106,7 @@ public class RestServerTest {
 
         // Build listener from hostname and port
         configMap = new HashMap<>(baseWorkerProps());
+        configMap.remove(WorkerConfig.LISTENERS_CONFIG);
         configMap.put(WorkerConfig.REST_HOST_NAME_CONFIG, "my-hostname");
         configMap.put(WorkerConfig.REST_PORT_CONFIG, "8080");
         config = new DistributedConfig(configMap);
@@ -159,6 +155,7 @@ public class RestServerTest {
 
         // listener from hostname and port
         configMap = new HashMap<>(baseWorkerProps());
+        configMap.remove(WorkerConfig.LISTENERS_CONFIG);
         configMap.put(WorkerConfig.REST_HOST_NAME_CONFIG, "my-hostname");
         configMap.put(WorkerConfig.REST_PORT_CONFIG, "8080");
         config = new DistributedConfig(configMap);
@@ -168,7 +165,7 @@ public class RestServerTest {
 
     @Test
     public void testOptionsDoesNotIncludeWadlOutput() throws IOException {
-        Map<String, String> configMap = new HashMap<>(workerPropsWithDynamicPort());
+        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
         EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
@@ -203,7 +200,7 @@ public class RestServerTest {
 
     public void checkCORSRequest(String corsDomain, String origin, String expectedHeader, String method)
         throws IOException {
-        Map<String, String> workerProps = workerPropsWithDynamicPort();
+        Map<String, String> workerProps = baseWorkerProps();
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, corsDomain);
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
@@ -258,7 +255,7 @@ public class RestServerTest {
 
     @Test
     public void testStandaloneConfig() throws IOException  {
-        Map<String, String> workerProps = workerPropsWithDynamicPort();
+        Map<String, String> workerProps = baseWorkerProps();
         workerProps.put("offset.storage.file.filename", "/tmp");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
 


### PR DESCRIPTION
We have seen some failures recently in `RestServerTest`. It's the usual problem with reliance on static ports. 
```
Caused by: java.io.IOException: Failed to bind to 0.0.0.0/0.0.0.0:8083
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:346)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:308)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.server.Server.doStart(Server.java:396)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.apache.kafka.connect.runtime.rest.RestServer.initializeServer(RestServer.java:178)
	... 56 more
Caused by: java.net.BindException: Address already in use
```
This patch makes the chosen port dynamic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
