### PR TITLE
KAFKA-8635: Skip client poll in Sender loop when no request is sent

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -944,6 +944,9 @@ public class TransactionManager {
     }
 
     private void lookupCoordinator(FindCoordinatorRequest.CoordinatorType type, String coordinatorKey) {
+        if (type == null)
+            return;
+
         switch (type) {
             case GROUP:
                 consumerGroupCoordinator = null;
@@ -1057,8 +1060,7 @@ public class TransactionManager {
                 clearInFlightCorrelationId();
                 if (response.wasDisconnected()) {
                     log.debug("Disconnected from {}. Will retry.", response.destination());
-                    if (this.needsCoordinator())
-                        lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
+                    lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
                     reenqueue();
                 } else if (response.versionMismatch() != null) {
                     fatalError(response.versionMismatch());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -944,9 +944,6 @@ public class TransactionManager {
     }
 
     private void lookupCoordinator(FindCoordinatorRequest.CoordinatorType type, String coordinatorKey) {
-        if (type == null)
-            return;
-
         switch (type) {
             case GROUP:
                 consumerGroupCoordinator = null;
@@ -1060,7 +1057,8 @@ public class TransactionManager {
                 clearInFlightCorrelationId();
                 if (response.wasDisconnected()) {
                     log.debug("Disconnected from {}. Will retry.", response.destination());
-                    lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
+                    if (this.needsCoordinator())
+                        lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
                     reenqueue();
                 } else if (response.versionMismatch() != null) {
                     fatalError(response.versionMismatch());


### PR DESCRIPTION
This patch changes maybeSendTransactionalRequest to handle both sending and polling transactional requests (and renames it to maybeSendAndPollTransactionalRequest), and skips the call to poll if no request is actually sent. It also removes the inner loop inside maybeSendAndPollTransactionalRequest and relies on the main Sender loop for retries.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
