### PR TITLE
KAFKA-8453: AdminClient describeTopic should handle partition level errors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1502,13 +1502,19 @@ public class KafkaAdminClient extends AdminClient {
                 MetadataResponse response = (MetadataResponse) abstractResponse;
                 // Handle server responses for particular topics.
                 Cluster cluster = response.cluster();
-                Map<String, Errors> errors = response.errors();
+                Map<String, Errors> topicErrors = response.errors();
+                Map<String, Set<Errors>> partitionErrors = response.partitionErrors();
                 for (Map.Entry<String, KafkaFutureImpl<TopicDescription>> entry : topicFutures.entrySet()) {
                     String topicName = entry.getKey();
                     KafkaFutureImpl<TopicDescription> future = entry.getValue();
-                    Errors topicError = errors.get(topicName);
+                    Errors topicError = topicErrors.get(topicName);
                     if (topicError != null) {
                         future.completeExceptionally(topicError.exception());
+                        continue;
+                    }
+                    Set<Errors> partitionError = partitionErrors.get(topicName);
+                    if (partitionError != null && partitionError.contains(Errors.LISTENER_NOT_FOUND)) {
+                        future.completeExceptionally(Errors.LISTENER_NOT_FOUND.exception());
                         continue;
                     }
                     if (!cluster.topics().contains(topicName)) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
  * Possible partition-level error codes:
  *  LeaderNotAvailable (5)
  *  ReplicaNotAvailable (9)
+ *  ListenerNotFound (72)
  */
 public class MetadataResponse extends AbstractResponse {
     public static final int NO_CONTROLLER_ID = -1;
@@ -113,6 +114,24 @@ public class MetadataResponse extends AbstractResponse {
         for (MetadataResponseTopic metadata : data.topics()) {
             if (metadata.errorCode() != Errors.NONE.code())
                 errors.put(metadata.name(), Errors.forCode(metadata.errorCode()));
+        }
+        return errors;
+    }
+
+    /**
+     * Return a map from topic to its partition metadata errors.
+     */
+    public Map<String, Set<Errors>> partitionErrors() {
+        Map<String, Set<Errors>> errors = new HashMap<>();
+        for (MetadataResponseTopic topicMetadata : data.topics()) {
+            String topic = topicMetadata.name();
+            Set<Errors> errorSet = new HashSet<>();
+            for (MetadataResponsePartition partitionMetadata : topicMetadata.partitions()) {
+                Errors partitionError = Errors.forCode(partitionMetadata.errorCode());
+                if (partitionError != Errors.NONE)
+                    errorSet.add(partitionError);
+            }
+            errors.put(topic, errorSet);
         }
         return errors;
     }

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1494,8 +1494,9 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     servers(broker2).shutdown()
     TestUtils.waitForBrokersOutOfIsr(client, Set(partition1), Set(broker2))
     servers(broker1).shutdown()
+    // No leaders on partition 1, 2
     TestUtils.waitForLeaderToBecome(client, partition1, None)
-    TestUtils.waitForLeaderToBecome(client, partition2, Some(broker3))
+    TestUtils.waitForLeaderToBecome(client, partition2, None)
     servers(broker2).startup()
 
     val electResult = client.electLeaders(ElectionType.UNCLEAN, null)
@@ -1619,8 +1620,9 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     servers(broker2).shutdown()
     TestUtils.waitForBrokersOutOfIsr(client, Set(partition1), Set(broker2))
     servers(broker1).shutdown()
+    // No leaders on partition 1, 2
     TestUtils.waitForLeaderToBecome(client, partition1, None)
-    TestUtils.waitForLeaderToBecome(client, partition2, Some(broker3))
+    TestUtils.waitForLeaderToBecome(client, partition1, None)
     servers(broker2).startup()
 
     val electResult = client.electLeaders(ElectionType.UNCLEAN, Set(partition1, partition2).asJava)

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -22,7 +22,7 @@ import kafka.utils.{CoreUtils, Logging, ShutdownableThread, TestUtils}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.GroupMaxSizeReachedException
+import org.apache.kafka.common.errors.{GroupMaxSizeReachedException, ListenerNotFoundException}
 import org.apache.kafka.common.message.FindCoordinatorRequestData
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FindCoordinatorRequest, FindCoordinatorResponse}
@@ -324,8 +324,9 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
       restartDeadBrokers()
     }
 
+    // collect raised exceptions, except ListenerNotFoundException
     def raisedExceptions: Seq[Throwable] = {
-      consumerPollers.flatten(_.thrownException)
+      consumerPollers.flatten(_.thrownException).filterNot(_.isInstanceOf[ListenerNotFoundException])
     }
 
     // we are waiting for the group to rebalance and one member to get kicked

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -47,7 +47,7 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{KafkaFuture, TopicPartition}
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.errors.{ListenerNotFoundException, RetriableException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.network.{ListenerName, Mode}
@@ -1466,16 +1466,26 @@ object TestUtils extends Logging {
   }
 
   def currentLeader(client: Admin, topicPartition: TopicPartition): Option[Int] = {
-    Option(
-      client
-        .describeTopics(Arrays.asList(topicPartition.topic))
-        .all
-        .get
-        .get(topicPartition.topic)
-        .partitions
-        .get(topicPartition.partition)
-        .leader
-    ).map(_.id)
+    val maybeCurrentLeader = try {
+      Option(
+        client
+          .describeTopics(Collections.singleton(topicPartition.topic))
+          .all
+          .get
+          .get(topicPartition.topic)
+          .partitions
+          .get(topicPartition.partition)
+          .leader
+      )
+    } catch {
+      case e: ExecutionException =>
+        if (e.getCause.isInstanceOf[ListenerNotFoundException]) {
+          None
+        } else {
+          throw e
+        }
+    }
+    maybeCurrentLeader.map(_.id)
   }
 
   def waitForLeaderToBecome(client: Admin, topicPartition: TopicPartition, leader: Option[Int]): Unit = {


### PR DESCRIPTION
Here is the draft fix. The approach is simple:

1. Add a new method, `MetadataResponse#partitionErrors`, which returns a map from topic to the set of its partition errors. (It follows how `MetadataResponse#topicMetadata` does.)
2. `Call#handleResponse` in `KafkaAdminClient#describeTopics` now uses both of topic level error map and partition level error map; if there is `ListenerNotFound` error in partition level error map, it calls `KafkaFuture#completeExceptionally`.

However, since it now throws a new Exception, it brokes following tests which are related to the leader election.

- `kafka.server.DynamicBrokerReconfigurationTest.testUncleanLeaderElectionEnable`
- `kafka.api.AdminClientIntegrationTest.testElectUncleanLeadersAndNoop`
- `kafka.api.AdminClientIntegrationTest.testElectUncleanLeadersForManyPartitions`
- `kafka.api.AdminClientIntegrationTest.testElectUncleanLeadersForAllPartitions`
- `kafka.api.AdminClientIntegrationTest.testElectUncleanLeadersForOnePartition`
- `kafka.api.AdminClientIntegrationTest.testElectUncleanLeadersWhenNoLiveBrokers`
- `kafka.api.SaslSslAdminClientIntegrationTest.testElectUncleanLeadersAndNoop`
- `kafka.api.SaslSslAdminClientIntegrationTest.testElectUncleanLeadersForManyPartitions`
- `kafka.api.SaslSslAdminClientIntegrationTest.testElectUncleanLeadersForAllPartitions`
- `kafka.api.SaslSslAdminClientIntegrationTest.testElectUncleanLeadersForOnePartition`
- `kafka.api.SaslSslAdminClientIntegrationTest.testElectUncleanLeadersWhenNoLiveBrokers`
- `kafka.admin.TopicCommandWithAdminClientTest.testDescribeUnavailablePartitions`
- `kafka.admin.TopicCommandWithAdminClientTest.testDescribeUnderMinIsrPartitionsMixed`

Which approach would be appropriate to fix the problem above? Do you have something in mind?

cc/ @hachikuji

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
