### PR TITLE
KAFKA-8670: Fix kafka-topics.sh --describe without --topic when cluster has no topics.

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -354,8 +354,8 @@ object TopicCommand extends Logging {
 
     override def describeTopic(opts: TopicCommandOptions): Unit = {
       val topics = getTopics(opts.topic, opts.excludeInternalTopics)
-      val topicOptWithExits = opts.topic.isDefined && opts.ifExists
-      ensureTopicExists(topics, topicOptWithExits)
+      val shouldIgnoreNoTopics = !opts.topic.isDefined || opts.ifExists
+      ensureTopicExists(topics, shouldIgnoreNoTopics)
       val liveBrokers = zkClient.getAllBrokersInCluster.map(_.id).toSet
       val describeOptions = new DescribeOptions(opts, liveBrokers)
       val adminZkClient = new AdminZkClient(zkClient)
@@ -437,8 +437,8 @@ object TopicCommand extends Logging {
     * @param topics
     * @param topicOptWithExists
     */
-  private def ensureTopicExists(topics: Seq[String], topicOptWithExists: Boolean = false) = {
-    if (topics.isEmpty && !topicOptWithExists) {
+  private def ensureTopicExists(topics: Seq[String], shouldIgnoreNoTopics: Boolean = false) = {
+    if (!shouldIgnoreNoTopics && topics.isEmpty) {
       // If given topic doesn't exist then throw exception
       throw new IllegalArgumentException(s"Topics in [${topics.mkString(",")}] does not exist")
     }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -416,6 +416,11 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
       topicService.describeTopic(describeOpts)
     }
 
+    // describe all topics
+    val describeOptsAllTopics = new TopicCommandOptions(Array())
+    // should not throw any error
+    topicService.describeTopic(describeOptsAllTopics)
+
     // describe topic that does not exist with --if-exists
     val describeOptsWithExists = new TopicCommandOptions(Array("--topic", testTopicName, "--if-exists"))
     // should not throw any error


### PR DESCRIPTION
If there are no topics in a cluster, kafka-topics.sh --describe without
a --topic option should return empty list, not throw an exception.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

We pass a boolean flag to `ensureTopicExists` method indicating whether to throw an exception if there are no topics in the cluster. In case of `kafka-topics.sh --describe`, the exception **should NOT** be thrown if either of these are true -
1. A `--topic` option was not passed to the CLI. In that case, the output should be empty.
2. A `--if-exists` option was passed to the CLI.

Earlier, the first condition was not part of the check. This bugfix adds the first condition mentioned above to the check.

I added the necessary unit test to check for this case.

Also, I created a Kafka cluster, and without creating any topics on it, ran 
```
./kafka-topics.sh --zookeeper <zookeeper ip and port> --describe
```

This did not throw any exception, like it used to earlier.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
