### PR TITLE
KAFKA-8670: Fix exception for kafka-topics.sh --describe without --topic mentioned

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -443,7 +443,7 @@ object TopicCommand extends Logging {
     // If no topic name was mentioned, do not need to throw exception.
     if (requestedTopic.isDefined && requireTopicExists && foundTopics.isEmpty) {
       // If given topic doesn't exist then throw exception
-      throw new IllegalArgumentException(s"Topics in [${foundTopics.mkString(",")}] does not exist")
+      throw new IllegalArgumentException(s"Topic '${requestedTopic.get}' does not exist as expected")
     }
   }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -354,8 +354,8 @@ object TopicCommand extends Logging {
 
     override def describeTopic(opts: TopicCommandOptions): Unit = {
       val topics = getTopics(opts.topic, opts.excludeInternalTopics)
-      val topicOptWithExits = opts.topic.isDefined && opts.ifExists
-      ensureTopicExists(topics, opts.topic, topicOptWithExits)
+      val requireTopicExists = opts.topic.isDefined && opts.ifExists
+      ensureTopicExists(topics, opts.topic, requireTopicExists)
       val liveBrokers = zkClient.getAllBrokersInCluster.map(_.id).toSet
       val describeOptions = new DescribeOptions(opts, liveBrokers)
       val adminZkClient = new AdminZkClient(zkClient)
@@ -433,17 +433,15 @@ object TopicCommand extends Logging {
   /**
     * ensures topic existence and throws exception if topic doesn't exist
     *
-    * @param opts
-    * @param topics
-    * @param topicOptWithExists
+    * @param foundTopics Topics that were found to match the requested topic name.
+    * @param requestedTopic Name of the topic that was requested.
+    * @param requireTopicExists Boolean flag indicating if the topic needs to exist for the operation to be successful.
     */
-  private def ensureTopicExists(topics: Seq[String], desiredTopicName: Option[String], topicOptWithExists: Boolean = false) = {
+  private def ensureTopicExists(foundTopics: Seq[String], requestedTopic: Option[String], requireTopicExists: Boolean = false) = {
     // If no topic name was mentioned, do not need to throw exception.
-    if (desiredTopicName.isDefined && topics.isEmpty && !topicOptWithExists) {
+    if (requestedTopic.isDefined && foundTopics.isEmpty && !requireTopicExists) {
       // If given topic doesn't exist then throw exception
-      if (desiredTopicName.isDefined) {
-        throw new IllegalArgumentException(s"Topics in [${topics.mkString(",")}] does not exist")
-      }
+      throw new IllegalArgumentException(s"Topics in [${foundTopics.mkString(",")}] does not exist")
     }
   }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -442,7 +442,7 @@ object TopicCommand extends Logging {
     if (desiredTopicName.isDefined && topics.isEmpty && !topicOptWithExists) {
       // If given topic doesn't exist then throw exception
       if (desiredTopicName.isDefined) {
-        throw new IllegalArgumentException(s"No topic matching name '${desiredTopicName.get}' found")
+        throw new IllegalArgumentException(s"Topics in [${topics.mkString(",")}] does not exist")
       }
     }
   }

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -354,8 +354,7 @@ object TopicCommand extends Logging {
 
     override def describeTopic(opts: TopicCommandOptions): Unit = {
       val topics = getTopics(opts.topic, opts.excludeInternalTopics)
-      val requireTopicExists = !(opts.topic.isDefined && opts.ifExists)
-      ensureTopicExists(topics, opts.topic, requireTopicExists)
+      ensureTopicExists(topics, opts.topic, !opts.ifExists)
       val liveBrokers = zkClient.getAllBrokersInCluster.map(_.id).toSet
       val describeOptions = new DescribeOptions(opts, liveBrokers)
       val adminZkClient = new AdminZkClient(zkClient)

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -416,6 +416,11 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
       topicService.describeTopic(describeOpts)
     }
 
+    // describe all topics
+    val describeOptsAllTopics = new TopicCommandOptions(Array())
+    // should not throw any error
+    topicService.describeTopic(describeOptsAllTopics)
+
     // describe topic that does not exist with --if-exists
     val describeOptsWithExists = new TopicCommandOptions(Array("--topic", testTopicName, "--if-exists"))
     // should not throw any error


### PR DESCRIPTION
If there are **no topics** in a cluster, kafka-topics.sh --describe without a --topic option should return empty list, not throw an exception.

We pass a boolean flag to `ensureTopicExists` method indicating whether to throw an exception if there are no topics in the cluster. In case of `kafka-topics.sh --describe`, the exception **should NOT** be thrown if either of these are true -
1. A `--topic` option was not passed to the CLI. In that case, the output should be empty.
2. A `--if-exists` option was passed to the CLI.
Earlier, the first condition was not part of the check. This bugfix adds the first condition mentioned above to the check.

**NOTE**: I have added the `desiredTopicName` argument to the ensureTopicExists to check if it is defined. I could have simply passed `!desiredTopicName.isDefined || topicOptWithExists` in case of describe and it would still fix this bug. However, to fix bug KAFKA-8053, we need to improve the error message of the exception. The `desiredTopicName` will be required to build this exception message. I have not combined that messaging fix with this one to keep the commits for two bugs separate.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

I added the necessary unit test to check for this case.
Also, I ran these commands. The output before and after my change are mentioned inline

**Describe without topic name - Before**
```
./kafka-topics.sh --zookeeper 10.0.32.180:2181,10.0.16.211:2181,10.0.0.220:2181 --describe
Error while executing topic command : Topics in [] does not exist
[2019-07-15 23:23:25,674] ERROR java.lang.IllegalArgumentException: Topics in [] does not exist
	at kafka.admin.TopicCommand$.kafka$admin$TopicCommand$$ensureTopicExists(TopicCommand.scala:416)
	at kafka.admin.TopicCommand$ZookeeperTopicService.describeTopic(TopicCommand.scala:332)
	at kafka.admin.TopicCommand$.main(TopicCommand.scala:66)
	at kafka.admin.TopicCommand.main(TopicCommand.scala)
 (kafka.admin.TopicCommand$)
```

**Describe without topic name - After (no output)**
```
./kafka-topics.sh --zookeeper 10.0.32.180:2181,10.0.16.211:2181,10.0.0.220:2181 --describe
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
