### PR TITLE
MINOR: Tolerate limited data loss for upgrade tests with old message format

### DIFF
--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -131,7 +131,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
 
         # With older message formats before KIP-101, message loss may occur due to truncation
         # after leader change. Tolerate limited data loss for this case to avoid transient test failures.
-        self.data_loss_tolerance = 0 if from_kafka_version >= V_0_11_0_0 else 100
+        self.may_truncate_acked_records = False if from_kafka_version >= V_0_11_0_0 else True
 
         new_consumer = from_kafka_version >= V_0_9_0_0
         # TODO - reduce the timeout

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import LATEST_0_8_2, LATEST_0_9, LATEST_0_10, LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, V_0_9_0_0, DEV_BRANCH, KafkaVersion
+from kafkatest.version import LATEST_0_8_2, LATEST_0_9, LATEST_0_10, LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, V_0_9_0_0, V_0_11_0_0, DEV_BRANCH, KafkaVersion
 
 class TestUpgrade(ProduceConsumeValidateTest):
 
@@ -128,6 +128,10 @@ class TestUpgrade(ProduceConsumeValidateTest):
 
         if from_kafka_version <= LATEST_0_10_0:
             assert self.kafka.cluster_id() is None
+
+        # With older message formats before KIP-101, message loss may occur due to truncation
+        # after leader change. Tolerate limited data loss for this case to avoid transient test failures.
+        self.data_loss_tolerance = 0 if from_kafka_version >= V_0_11_0_0 else 100
 
         new_consumer = from_kafka_version >= V_0_9_0_0
         # TODO - reduce the timeout

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -48,7 +48,7 @@ class ProduceConsumeValidateTest(Test):
         self.enable_idempotence = False
 
         # Allow tests to tolerate some data loss by overriding this for tests using older message formats
-        self.data_loss_tolerance = 0
+        self.may_truncate_acked_records = False
 
     def start_producer_and_consumer(self):
         # Start background producer and consumer
@@ -129,7 +129,7 @@ class ProduceConsumeValidateTest(Test):
 
         succeeded, error_msg = validate_delivery(self.producer.acked, messages_consumed,
                                                  self.enable_idempotence, check_lost_data,
-                                                 self.data_loss_tolerance)
+                                                 self.may_truncate_acked_records)
 
         # Collect all logs if validation fails
         if not succeeded:

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -47,6 +47,9 @@ class ProduceConsumeValidateTest(Test):
         self.consumer_init_timeout_sec = 0
         self.enable_idempotence = False
 
+        # Allow tests to tolerate some data loss by overriding this for tests using older message formats
+        self.data_loss_tolerance = 0
+
     def start_producer_and_consumer(self):
         # Start background producer and consumer
         self.consumer.start()
@@ -125,7 +128,8 @@ class ProduceConsumeValidateTest(Test):
             return self.kafka.search_data_files(self.topic, missing_records)
 
         succeeded, error_msg = validate_delivery(self.producer.acked, messages_consumed,
-                                                 self.enable_idempotence, check_lost_data)
+                                                 self.enable_idempotence, check_lost_data,
+                                                 self.data_loss_tolerance)
 
         # Collect all logs if validation fails
         if not succeeded:

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -163,7 +163,8 @@ def validate_delivery(acked, consumed, idempotence_enabled=False, check_lost_dat
             # These records won't be in the data logs. Tolerate limited data loss for this case.
             if len(missing) < max_truncate_count and len(data_lost) == len(missing):
                msg += "The %s missing messages were not present in Kafka's data files. This suggests data loss " \
-                   "due to truncation. The messages lost: %s\n" % (len(data_lost), str(data_lost))
+                   "due to truncation, which is possible with older message formats and hence are ignored " \
+                   "by this test. The messages lost: %s\n" % (len(data_lost), str(data_lost))
             else:
                 msg = annotate_data_lost(data_lost, msg, len(to_validate))
                 success = False

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -14,6 +14,7 @@
 
 from kafkatest import __version__ as __kafkatest_version__
 
+import math
 import re
 import time
 
@@ -137,7 +138,7 @@ def annotate_data_lost(data_lost, msg, number_validated):
             "This suggests they were lost on their way to the consumer." % number_validated
     return msg
 
-def validate_delivery(acked, consumed, idempotence_enabled=False, check_lost_data=None, data_loss_tolerance=0):
+def validate_delivery(acked, consumed, idempotence_enabled=False, check_lost_data=None, may_truncate_acked_records=False):
     """Check that each acked message was consumed."""
     success = True
     msg = ""
@@ -149,19 +150,25 @@ def validate_delivery(acked, consumed, idempotence_enabled=False, check_lost_dat
     # Were all acked messages consumed?
     if len(missing) > 0:
         msg = annotate_missing_msgs(missing, acked, consumed, msg)
-        success = False
         
         # Did we miss anything due to data loss?
         if check_lost_data:
-            to_validate = list(missing)[0:1000 if len(missing) > 1000 else len(missing)]
+            max_truncate_count = 100 if may_truncate_acked_records else 0
+            max_validate_count = max(1000, max_truncate_count)
+
+            to_validate = list(missing)[0:min(len(missing), max_validate_count)]
             data_lost = check_lost_data(to_validate)
 
             # With older versions of message format before KIP-101, data loss could occur due to truncation.
             # These records won't be in the data logs. Tolerate limited data loss for this case.
-            if len(data_lost) == len(to_validate) and len(missing) <= data_loss_tolerance:
-                success = True
+            if len(missing) < max_truncate_count and len(data_lost) == len(missing):
+               msg += "The %s missing messages were not present in Kafka's data files. This suggests data loss " \
+                   "due to truncation. The messages lost: %s\n" % (len(data_lost), str(data_lost))
             else:
                 msg = annotate_data_lost(data_lost, msg, len(to_validate))
+                success = False
+        else:
+            success = False
 
     # Are there duplicates?
     if len(set(consumed)) != len(consumed):


### PR DESCRIPTION
We see transient test failures in system tests for upgrade scenarios when older message formats prior to KIP-101 are used. Since we need to continue to test these versions, tolerate a small amount of data loss in those tests. We will still be testing that upgrade works and most messages are successfully delivered.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
