### PR TITLE
KAFKA-7849: Fix the warning when using GlobalKTable  

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -50,7 +50,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class InternalTopologyBuilder {
 
@@ -1195,9 +1194,9 @@ public class InternalTopologyBuilder {
             final List<String> allSourceTopics = new ArrayList<>();
             if (!nodeToSourceTopics.isEmpty()) {
                 for (final List<String> topics : nodeToSourceTopics.values()) {
-                    final List<String> filteredTopics = filterAndRemoveGlobalSourceTopics(topics);
-                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(filteredTopics));
+                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(topics));
                 }
+                allSourceTopics.removeAll(globalTopics);
             }
             Collections.sort(allSourceTopics);
 
@@ -1205,12 +1204,6 @@ public class InternalTopologyBuilder {
         }
 
         return topicPattern;
-    }
-
-    private List<String> filterAndRemoveGlobalSourceTopics(final Collection<String> sourceTopics) {
-        return sourceTopics.stream()
-                .filter(topic -> !globalTopics.contains(topic))
-                .collect(Collectors.toList());
     }
 
     // package-private for testing only

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -50,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class InternalTopologyBuilder {
 
@@ -1194,7 +1195,8 @@ public class InternalTopologyBuilder {
             final List<String> allSourceTopics = new ArrayList<>();
             if (!nodeToSourceTopics.isEmpty()) {
                 for (final List<String> topics : nodeToSourceTopics.values()) {
-                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(topics));
+                    final List<String> filteredTopics = filterAndRemoveGlobalSourceTopics(topics);
+                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(filteredTopics));
                 }
             }
             Collections.sort(allSourceTopics);
@@ -1203,6 +1205,12 @@ public class InternalTopologyBuilder {
         }
 
         return topicPattern;
+    }
+
+    private List<String> filterAndRemoveGlobalSourceTopics(final Collection<String> sourceTopics) {
+        return sourceTopics.stream()
+                .filter(topic -> !globalTopics.contains(topic))
+                .collect(Collectors.toList());
     }
 
     // package-private for testing only

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -248,12 +248,19 @@ public class InternalTopologyBuilderTest {
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSource(null, "source-2", null, null, null, "topic-2");
-        builder.addGlobalStore(new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(), "globalSource", null, null, null, "globalTopic", "global-processor", new MockProcessorSupplier());
-
+        builder.addGlobalStore(
+                new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(),
+                "globalSource",
+                null,
+                null,
+                null,
+                "globalTopic",
+                "global-processor",
+                new MockProcessorSupplier());
 
         final Pattern expectedPattern = Pattern.compile("topic-1|topic-2");
 
-        assertEquals(expectedPattern.pattern(), builder.sourceTopicPattern().pattern());
+        assertThat(builder.sourceTopicPattern().pattern(), equalTo(expectedPattern.pattern()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -244,6 +244,19 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
+    public void testSourceTopicsWithGlobalTopics() {
+        builder.setApplicationId("X");
+        builder.addSource(null, "source-1", null, null, null, "topic-1");
+        builder.addSource(null, "source-2", null, null, null, "topic-2");
+        builder.addGlobalStore(new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(), "globalSource", null, null, null, "globalTopic", "global-processor", new MockProcessorSupplier());
+
+
+        final Pattern expectedPattern = Pattern.compile("topic-1|topic-2");
+
+        assertEquals(expectedPattern.pattern(), builder.sourceTopicPattern().pattern());
+    }
+
+    @Test
     public void testPatternSourceTopic() {
         final Pattern expectedPattern = Pattern.compile("topic-\\d");
         builder.addSource(null, "source-1", null, null, null, expectedPattern);


### PR DESCRIPTION
*More detailed description of your change,
This PR intend to fix the issue in KAFKA-7849 by filtering out the global topics from the main consumer, thus the main consumer won't subscribe to any of the global topics

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
