### PR TITLE
KAFKA-8705: Remove parent node after leaving loop to prevent NPE

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -378,6 +379,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     private void maybeUpdateKeyChangingRepartitionNodeMap() {
         final Map<StreamsGraphNode, Set<StreamsGraphNode>> mergeNodesToKeyChangers = new HashMap<>();
+        final Set<StreamsGraphNode> mergeNodeKeyChangingParentsToRemove = new HashSet<>();
         for (final StreamsGraphNode mergeNode : mergeNodes) {
             mergeNodesToKeyChangers.put(mergeNode, new LinkedHashSet<>());
             final Collection<StreamsGraphNode> keys = keyChangingOperationsToOptimizableRepartitionNodes.keySet();
@@ -395,10 +397,13 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             final LinkedHashSet<OptimizableRepartitionNode> repartitionNodes = new LinkedHashSet<>();
             for (final StreamsGraphNode keyChangingParent : keyChangingParents) {
                 repartitionNodes.addAll(keyChangingOperationsToOptimizableRepartitionNodes.get(keyChangingParent));
-                keyChangingOperationsToOptimizableRepartitionNodes.remove(keyChangingParent);
+                mergeNodeKeyChangingParentsToRemove.add(keyChangingParent);
             }
-
             keyChangingOperationsToOptimizableRepartitionNodes.put(mergeKey, repartitionNodes);
+        }
+
+        for (final StreamsGraphNode mergeNodeKeyChangingParent : mergeNodeKeyChangingParentsToRemove) {
+            keyChangingOperationsToOptimizableRepartitionNodes.remove(mergeNodeKeyChangingParent);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -122,6 +123,28 @@ public class StreamsGraphTest {
         assertEquals(0, getCountOfRepartitionTopicsFound(attemptedOptimize.describe().toString()));
         assertEquals(0, getCountOfRepartitionTopicsFound(noOptimziation.describe().toString()));
 
+    }
+
+    @Test
+    public void shouldOptimizeSeveralMergeNodesWithCommonKeyChangingParent() {
+        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+        final KStream<Integer, Integer> parentStream = streamsBuilder.stream("input_topic", Consumed.with(Serdes.Integer(), Serdes.Integer()))
+            .selectKey(Integer::sum);
+
+        final KStream<Integer, Integer> childStream1 = parentStream.mapValues(v -> v + 1);
+        final KStream<Integer, Integer> childStream2 = parentStream.mapValues(v -> v + 2);
+        final KStream<Integer, Integer> childStream3 = parentStream.mapValues(v -> v + 3);
+
+        childStream1
+            .merge(childStream2)
+            .merge(childStream3)
+            .to("output_topic");
+
+        final Properties properties = new Properties();
+        properties.setProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+        final Topology topology = streamsBuilder.build(properties);
+
+        assertEquals(expectedMergeOptimizedTopology, topology.describe().toString());
     }
 
     private Topology getTopologyWithChangingValuesAfterChangingKey(final String optimizeConfig) {
@@ -241,5 +264,31 @@ public class StreamsGraphTest {
                                           + "      <-- KSTREAM-FILTER-0000000007\n"
                                           + "    Sink: KSTREAM-SINK-0000000009 (topic: output-topic)\n"
                                           + "      <-- KSTREAM-MAPVALUES-0000000008\n\n";
+
+
+    private String expectedMergeOptimizedTopology = "Topologies:\n" +
+        "   Sub-topology: 0\n" +
+        "    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])\n" +
+        "      --> KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-KEY-SELECT-0000000001 (stores: [])\n" +
+        "      --> KSTREAM-MAPVALUES-0000000002, KSTREAM-MAPVALUES-0000000003, KSTREAM-MAPVALUES-0000000004\n" +
+        "      <-- KSTREAM-SOURCE-0000000000\n" +
+        "    Processor: KSTREAM-MAPVALUES-0000000002 (stores: [])\n" +
+        "      --> KSTREAM-MERGE-0000000005\n" +
+        "      <-- KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-MAPVALUES-0000000003 (stores: [])\n" +
+        "      --> KSTREAM-MERGE-0000000005\n" +
+        "      <-- KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-MAPVALUES-0000000004 (stores: [])\n" +
+        "      --> KSTREAM-MERGE-0000000006\n" +
+        "      <-- KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-MERGE-0000000005 (stores: [])\n" +
+        "      --> KSTREAM-MERGE-0000000006\n" +
+        "      <-- KSTREAM-MAPVALUES-0000000002, KSTREAM-MAPVALUES-0000000003\n" +
+        "    Processor: KSTREAM-MERGE-0000000006 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000007\n" +
+        "      <-- KSTREAM-MERGE-0000000005, KSTREAM-MAPVALUES-0000000004\n" +
+        "    Sink: KSTREAM-SINK-0000000007 (topic: output_topic)\n" +
+        "      <-- KSTREAM-MERGE-0000000006\n\n";
 
 }


### PR DESCRIPTION
Fixes case where multiple children merged from a key-changing node causes an NPE.

I've updated the tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
