### PR TITLE
 KAFKA-8179: PartitionAssignorAdapter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -29,7 +29,7 @@ import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResult;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
 import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
-import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.Cluster;
@@ -2724,7 +2724,7 @@ public class KafkaAdminClient extends AdminClient {
                     for (DescribedGroupMember groupMember : members) {
                         Set<TopicPartition> partitions = Collections.emptySet();
                         if (groupMember.memberAssignment().length > 0) {
-                            final ConsumerPartitionAssignor.Assignment assignment = ConsumerProtocol.
+                            final Assignment assignment = ConsumerProtocol.
                                 deserializeAssignment(ByteBuffer.wrap(groupMember.memberAssignment()));
                             partitions = new HashSet<>(assignment.partitions());
                         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -102,7 +102,7 @@ public class ConsumerConfig extends AbstractConfig {
      * <code>partition.assignment.strategy</code>
      */
     public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
-    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "A list of class names or class types of the supported assignors responsible for the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used. Implementing the <code>org.apache.kafka.clients.consumer.ConsumerPartitionAssignor</code> interface allows you to plug in a custom assignment strategy.";
+    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "A list of class names or class types, ordered by preference, of supported assignors responsible for the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used. Implementing the <code>org.apache.kafka.clients.consumer.ConsumerPartitionAssignor</code> interface allows you to plug in a custom assignment strategy.";
 
     /**
      * <code>auto.offset.reset</code>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -102,7 +102,7 @@ public class ConsumerConfig extends AbstractConfig {
      * <code>partition.assignment.strategy</code>
      */
     public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
-    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "The class name or class type of the assignor implementing the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used.";
+    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "A list of class names or class types of the supported assignors responsible for the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used. Implementing the <code>org.apache.kafka.clients.consumer.ConsumerPartitionAssignor</code> interface allows you to plug in a custom assignment strategy.";
 
     /**
      * <code>auto.offset.reset</code>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -102,7 +102,7 @@ public class ConsumerConfig extends AbstractConfig {
      * <code>partition.assignment.strategy</code>
      */
     public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
-    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "The class name or class type of the assignor implementing the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used. A custom assignor that implements ConsumerPartitionAssignor can be plugged in";
+    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "The class name or class type of the assignor implementing the partition assignment strategy that the client will use to distribute partition ownership amongst consumer instances when group management is used.";
 
     /**
      * <code>auto.offset.reset</code>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -46,7 +46,7 @@ public interface ConsumerPartitionAssignor {
      *
      * @param topics Topics subscribed to through {@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(java.util.Collection)}
      *               and variants
-     * @return optional join subscription user data
+     * @return optional subscription user data
      */
     default ByteBuffer subscriptionUserData(Set<String> topics) {
         return null;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -46,7 +46,7 @@ public interface ConsumerPartitionAssignor {
      *
      * @param topics Topics subscribed to through {@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(java.util.Collection)}
      *               and variants
-     * @return optional subscription user data
+     * @return nullable subscription user data
      */
     default ByteBuffer subscriptionUserData(Set<String> topics) {
         return null;
@@ -55,11 +55,11 @@ public interface ConsumerPartitionAssignor {
     /**
      * Perform the group assignment given the member subscriptions and current cluster metadata.
      * @param metadata Current topic/broker metadata known by consumer
-     * @param subscriptions Subscriptions from all members including metadata provided through {@link #subscriptionUserData(Set)}
+     * @param groupSubscription Subscriptions from all members including metadata provided through {@link #subscriptionUserData(Set)}
      * @return A map from the members to their respective assignments. This should have one entry
      *         for each member in the input subscription map.
      */
-    GroupAssignment assign(Cluster metadata, GroupSubscription subscriptions);
+    GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscription);
 
     /**
      * Callback which is invoked when a group member receives its assignment from the leader.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -44,6 +44,8 @@ public interface ConsumerPartitionAssignor {
      * Return serialized data that will be included in the {@link Subscription} sent to the leader
      * and can be leveraged in {@link #assign(Cluster, GroupSubscription)} ((e.g. local host/rack information)
      *
+     * @param topics Topics subscribed to through {@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(java.util.Collection)}
+     *               and variants
      * @return optional join subscription user data
      */
     default ByteBuffer subscriptionUserData(Set<String> topics) {
@@ -54,7 +56,7 @@ public interface ConsumerPartitionAssignor {
      * Perform the group assignment given the member subscriptions and current cluster metadata.
      * @param metadata Current topic/broker metadata known by consumer
      * @param subscriptions Subscriptions from all members including metadata provided through {@link #subscriptionUserData(Set)}
-     * @return A map from the members to their respective assignment. This should have one entry
+     * @return A map from the members to their respective assignments. This should have one entry
      *         for each member in the input subscription map.
      */
     GroupAssignment assign(Cluster metadata, GroupSubscription subscriptions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -766,7 +766,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     retryBackoffMs,
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                     heartbeatIntervalMs); //Will avoid blocking an extended period of time to prevent heartbeat thread starvation
-            this.assignors = PartitionAssignorAdapter.getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
+
+            this.assignors = PartitionAssignorAdapter.getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), config.originals());
 
             // no coordinator will be constructed for the default (null) group id
             this.coordinator = groupId == null ? null :

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.FetcherMetricsRegistry;
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.internals.PartitionAssignorAdapter;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
@@ -765,9 +766,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     retryBackoffMs,
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                     heartbeatIntervalMs); //Will avoid blocking an extended period of time to prevent heartbeat thread starvation
-            this.assignors = config.getConfiguredInstances(
-                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
-                    ConsumerPartitionAssignor.class);
+            this.assignors = PartitionAssignorAdapter.getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
 
             // no coordinator will be constructed for the default (null) group id
             this.coordinator = groupId == null ? null :

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -31,7 +31,6 @@ import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.FetcherMetricsRegistry;
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.internals.PartitionAssignorAdapter;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import static org.apache.kafka.clients.consumer.internals.PartitionAssignorAdapter.getAssignorInstances;
+
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
@@ -767,7 +769,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                     heartbeatIntervalMs); //Will avoid blocking an extended period of time to prevent heartbeat thread starvation
 
-            this.assignors = PartitionAssignorAdapter.getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), config.originals());
+            this.assignors = getAssignorInstances(config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), config.originals());
 
             // no coordinator will be constructed for the default (null) group id
             this.coordinator = groupId == null ? null :

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -48,8 +48,8 @@ public abstract class AbstractPartitionAssignor implements ConsumerPartitionAssi
                                                              Map<String, Subscription> subscriptions);
 
     @Override
-    public GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscriptions) {
-        Map<String, Subscription> subscriptions = groupSubscriptions.groupSubscription();
+    public GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscription) {
+        Map<String, Subscription> subscriptions = groupSubscription.groupSubscription();
         Set<String> allSubscribedTopics = new HashSet<>();
         for (Map.Entry<String, Subscription> subscriptionEntry : subscriptions.entrySet())
             allSubscribedTopics.addAll(subscriptionEntry.getValue().topics());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -204,8 +204,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         this.joinedSubscription = subscriptions.subscription();
         JoinGroupRequestData.JoinGroupRequestProtocolCollection protocolSet = new JoinGroupRequestData.JoinGroupRequestProtocolCollection();
 
+        List<String> topics = new ArrayList<>(joinedSubscription);
         for (ConsumerPartitionAssignor assignor : assignors) {
-            Subscription subscription = new Subscription(new ArrayList<>(joinedSubscription),
+            Subscription subscription = new Subscription(topics,
                                                          assignor.subscriptionUserData(joinedSubscription),
                                                          subscriptions.assignedPartitionsList());
             ByteBuffer metadata = ConsumerProtocol.serializeSubscription(subscription);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
@@ -36,6 +36,9 @@ import java.util.Set;
  * assignment decisions. For this, you can override {@link #subscription(Set)} and provide custom
  * userData in the returned Subscription. For example, to have a rack-aware assignor, an implementation
  * can use this user data to forward the rackId belonging to each member.
+ *
+ * This interface has been deprecated in 2.4, custom assignors should now implement
+ * {@link org.apache.kafka.clients.consumer.ConsumerPartitionAssignor}
  */
 @Deprecated
 public interface PartitionAssignor {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
@@ -69,7 +69,7 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
         return new PartitionAssignor.Assignment(newAssignment.partitions(), newAssignment.userData());
     }
 
-    private Map<String, PartitionAssignor.Subscription> toOldGroupSubscription(GroupSubscription newSubscriptions) {
+    private static Map<String, PartitionAssignor.Subscription> toOldGroupSubscription(GroupSubscription newSubscriptions) {
         Map<String, PartitionAssignor.Subscription> oldSubscriptions = new HashMap<>();
         for (Map.Entry<String, Subscription> entry : newSubscriptions.groupSubscription().entrySet()) {
             String member = entry.getKey();
@@ -80,7 +80,7 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
         return oldSubscriptions;
     }
 
-    private GroupAssignment toNewGroupAssignment(Map<String, PartitionAssignor.Assignment> oldAssignments) {
+    private static GroupAssignment toNewGroupAssignment(Map<String, PartitionAssignor.Assignment> oldAssignments) {
         Map<String, Assignment> newAssignments = new HashMap<>();
         for (Map.Entry<String, PartitionAssignor.Assignment> entry : oldAssignments.entrySet()) {
             String member = entry.getKey();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer.internals;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +47,8 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
     }
 
     @Override
-    public GroupAssignment assign(Cluster metadata, GroupSubscription subscriptions) {
-        return oldToNewGroupAssignment(oldAssignor.assign(metadata, newToOldGroupSubscription(subscriptions)));
+    public GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscription) {
+        return oldToNewGroupAssignment(oldAssignor.assign(metadata, newToOldGroupSubscription(groupSubscription)));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
@@ -52,7 +52,7 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
 
     @Override
     public void onAssignment(Assignment assignment, ConsumerGroupMetadata metadata) {
-        oldAssignor.onAssignment(oldToNewAssignment(assignment), metadata.generationId());
+        oldAssignor.onAssignment(newToOldAssignment(assignment), metadata.generationId());
     }
 
     @Override
@@ -60,7 +60,7 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
         return oldAssignor.name();
     }
 
-    private static PartitionAssignor.Assignment oldToNewAssignment(Assignment assignment) {
+    private static PartitionAssignor.Assignment newToOldAssignment(Assignment assignment) {
         return new PartitionAssignor.Assignment(assignment.partitions(), assignment.userData());
     }
 
@@ -85,13 +85,13 @@ public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
         return new GroupAssignment(newAssignments);
     }
 
-    public static List<ConsumerPartitionAssignor> getAssignorInstances(List<String> classNames) {
+    public static List<ConsumerPartitionAssignor> getAssignorInstances(List<String> assignorClasses) {
         List<ConsumerPartitionAssignor> assignors = new ArrayList<>();
 
-        if (classNames == null)
+        if (assignorClasses == null)
             return assignors;
 
-        for (Object klass : classNames) {
+        for (Object klass : assignorClasses) {
             // first try to get the class if passed in as a string
             if (klass instanceof String) {
                 try {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("deprecation")
+public class PartitionAssignorAdapter implements ConsumerPartitionAssignor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionAssignorAdapter.class);
+    private final PartitionAssignor oldAssignor;
+
+    PartitionAssignorAdapter(PartitionAssignor oldAssignor) {
+        this.oldAssignor = oldAssignor;
+    }
+
+    @Override
+    public ByteBuffer subscriptionUserData(Set<String> topics) {
+        return oldAssignor.subscription(topics).userData();
+    }
+
+    @Override
+    public GroupAssignment assign(Cluster metadata, GroupSubscription subscriptions) {
+        return oldToNewGroupAssignment(oldAssignor.assign(metadata, newToOldGroupSubscription(subscriptions)));
+    }
+
+    @Override
+    public void onAssignment(Assignment assignment, ConsumerGroupMetadata metadata) {
+        oldAssignor.onAssignment(oldToNewAssignment(assignment), metadata.generationId());
+    }
+
+    @Override
+    public String name() {
+        return oldAssignor.name();
+    }
+
+    private static PartitionAssignor.Assignment oldToNewAssignment(Assignment assignment) {
+        return new PartitionAssignor.Assignment(assignment.partitions(), assignment.userData());
+    }
+
+    private Map<String, PartitionAssignor.Subscription> newToOldGroupSubscription(GroupSubscription subscriptions) {
+        Map<String, PartitionAssignor.Subscription> oldSubscriptions = new HashMap<>();
+        for (Map.Entry<String, Subscription> entry : subscriptions.groupSubscription().entrySet()) {
+            String member = entry.getKey();
+            Subscription newSubscription = entry.getValue();
+            oldSubscriptions.put(member, new PartitionAssignor.Subscription(
+                newSubscription.topics(), newSubscription.userData()));
+        }
+        return oldSubscriptions;
+    }
+
+    private GroupAssignment oldToNewGroupAssignment(Map<String, PartitionAssignor.Assignment> assignments) {
+        Map<String, Assignment> newAssignments = new HashMap<>();
+        for (Map.Entry<String, PartitionAssignor.Assignment> entry : assignments.entrySet()) {
+            String member = entry.getKey();
+            PartitionAssignor.Assignment oldAssignment = entry.getValue();
+            newAssignments.put(member, new Assignment(oldAssignment.partitions(), oldAssignment.userData()));
+        }
+        return new GroupAssignment(newAssignments);
+    }
+
+    public static List<ConsumerPartitionAssignor> getAssignorInstances(List<String> classNames) {
+        List<ConsumerPartitionAssignor> assignorInstances = new ArrayList<>();
+        Class<ConsumerPartitionAssignor> newClass = ConsumerPartitionAssignor.class;
+        Class<PartitionAssignor> oldClass = PartitionAssignor.class;
+
+        if (classNames == null)
+            return assignorInstances;
+
+        for (Object klass : classNames) {
+            Object assignor;
+            if (klass instanceof String) {
+                try {
+                    assignor = Utils.newInstance((String) klass, newClass);
+                } catch (ClassCastException maybeOldAssignor) {
+                    try {
+                        assignor = Utils.newInstance((String) klass, oldClass);
+                    } catch (ClassNotFoundException noAssignorFound) {
+                        throw new KafkaException(klass + " ClassNotFoundException exception occurred", noAssignorFound);
+                    }
+                } catch (ClassNotFoundException noAssignorFound) {
+                    throw new KafkaException(klass + " ClassNotFoundException exception occurred", noAssignorFound);
+                }
+
+            } else if (klass instanceof Class<?>) {
+                assignor = Utils.newInstance((Class<?>) klass);
+            } else {
+                throw new KafkaException("List contains element of type " + klass.getClass().getName() + ", expected String or Class");
+            }
+
+            if (newClass.isInstance(assignor)) {
+                assignorInstances.add(newClass.cast(assignor));
+            } else if (oldClass.isInstance(assignor)) {
+                assignorInstances.add(new PartitionAssignorAdapter(oldClass.cast(assignor)));
+                LOG.warn("The PartitionAssignor interface has been deprecated, please implement the ConsumerPartitionAssignor interface instead.");
+            } else {
+                throw new KafkaException(klass + " is not an instance of " + oldClass.getName()
+                    + " or an instance of " + newClass.getName());
+            }
+        }
+        return assignorInstances;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -27,9 +27,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.GroupSubscription;
@@ -105,9 +107,9 @@ public class PartitionAssignorAdapterTest {
         ConsumerPartitionAssignor oldAssignor = getAssignorInstances(classNames, Collections.emptyMap()).get(0);
 
         TopicPartition tp = new TopicPartition("tp", 1);
-        Assignment newAssignment = new Assignment(Arrays.asList(tp), null);
+        Assignment newAssignment = new Assignment(Arrays.asList(tp));
 
-        oldAssignor.onAssignment(newAssignment, null);
+        oldAssignor.onAssignment(newAssignment, new ConsumerGroupMetadata("", 1, "", Optional.empty()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -58,9 +58,9 @@ public class PartitionAssignorAdapterTest {
     }
 
     @Test
-    public void shouldThrowClassCastExceptionOnNonAssignor() {
+    public void shouldThrowKafkaExceptionOnNonAssignor() {
         classNames = Arrays.asList(NotAnAssignor.class.getName());
-        assertThrows(ClassCastException.class, () -> PartitionAssignorAdapter.getAssignorInstances(classNames));
+        assertThrows(KafkaException.class, () -> PartitionAssignorAdapter.getAssignorInstances(classNames));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import static org.apache.kafka.clients.consumer.internals.PartitionAssignorAdapter.getAssignorInstances;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,27 +48,27 @@ public class PartitionAssignorAdapterTest {
     @Test
     public void shouldInstantiateNewAssignors() {
         classNames = Arrays.asList(StickyAssignor.class.getName());
-        List<ConsumerPartitionAssignor> assignors = PartitionAssignorAdapter.getAssignorInstances(classNames);
+        List<ConsumerPartitionAssignor> assignors = getAssignorInstances(classNames, Collections.emptyMap());
         assertTrue(assignorClass.isInstance(assignors.get(0)));
     }
 
     @Test
     public void shouldAdaptOldAssignors() {
         classNames = Arrays.asList(OldPartitionAssignor.class.getName());
-        List<ConsumerPartitionAssignor> assignors = PartitionAssignorAdapter.getAssignorInstances(classNames);
+        List<ConsumerPartitionAssignor> assignors = getAssignorInstances(classNames, Collections.emptyMap());
         assertTrue(adapterClass.isInstance(assignors.get(0)));
     }
 
     @Test
     public void shouldThrowKafkaExceptionOnNonAssignor() {
         classNames = Arrays.asList(NotAnAssignor.class.getName());
-        assertThrows(KafkaException.class, () -> PartitionAssignorAdapter.getAssignorInstances(classNames));
+        assertThrows(KafkaException.class, () -> getAssignorInstances(classNames, Collections.emptyMap()));
     }
 
     @Test
     public void shouldThrowKafkaExceptionOnAssignorNotFound() {
         classNames = Arrays.asList("Non-existent assignor");
-        assertThrows(KafkaException.class, () -> PartitionAssignorAdapter.getAssignorInstances(classNames));
+        assertThrows(KafkaException.class, () -> getAssignorInstances(classNames, Collections.emptyMap()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+import org.apache.kafka.common.Cluster;
+import org.junit.Test;
+
+public class PartitionAssignorAdapterTest {
+
+    private List<String> classNames;
+
+    @Test
+    public void shouldInstantiateNewAssignors() {
+        classNames = Arrays.asList(StickyAssignor.class.getName());
+        List<ConsumerPartitionAssignor> assignors = PartitionAssignorAdapter.getAssignorInstances(classNames);
+        assertFalse(assignors.isEmpty());
+    }
+
+    @Test
+    public void shouldAdaptOldAssignors() {
+        classNames = Arrays.asList(OldPartitionAssignor.class.getName());
+        List<ConsumerPartitionAssignor> assignors = PartitionAssignorAdapter.getAssignorInstances(classNames);
+        assertFalse(assignors.isEmpty());
+    }
+
+    @Test
+    public void shouldThrowOnNonAssignor() {
+        classNames = Arrays.asList(NotAnAssignor.class.getName());
+        assertThrows(ClassCastException.class, () -> PartitionAssignorAdapter.getAssignorInstances(classNames));
+    }
+
+    @SuppressWarnings("deprecation")
+    public static class OldPartitionAssignor implements PartitionAssignor {
+
+        @Override
+        public Subscription subscription(Set<String> topics) {
+            return new Subscription(new ArrayList<>(topics), null);
+        }
+
+        @Override
+        public Map<String, Assignment> assign(Cluster metadata, Map<String, Subscription> subscriptions) {
+            return new HashMap<>();
+        }
+
+        @Override
+        public void onAssignment(Assignment assignment) {
+        }
+
+        @Override
+        public String name() {
+            return "old-assignor";
+        }
+    }
+
+    public static class NotAnAssignor {
+
+        public NotAnAssignor() {
+            throw new IllegalStateException("Should not have been instantiated!");
+        }
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -157,7 +157,7 @@ public class PartitionAssignorAdapterTest {
                 }
                 assignments.put(entry.getKey(), new Assignment(partitions, null));
             }
-           return assignments;
+            return assignments;
         }
 
         @Override

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -30,7 +30,7 @@
         unauthorized topic was changed similarly.
     </li>
     <li>The internal <code>PartitionAssignor</code> interface has been deprecated and replaced with a new <code>ConsumerPartitionAssignor</code> in the public API. Users
-        implementing a custom PartitionAssignor should migrate to the new interface, though an adapter has been added to temporarily support old assignor implementations. </li>
+        implementing a custom PartitionAssignor should migrate to the new interface as soon as possible.</li>
 </ul>
 
 <h4><a id="upgrade_2_3_0" href="#upgrade_2_3_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, 2.0.x or 2.1.x or 2.2.x to 2.3.0</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -29,6 +29,8 @@
         avoid potential misuse. The constructor <code>TopicAuthorizationException(String)</code> which was previously used for a single
         unauthorized topic was changed similarly.
     </li>
+    <li>The internal <code>PartitionAssignor</code> interface has been deprecated and replaced with a new <code>ConsumerPartitionAssignor</code> in the public API. Users
+        implementing a custom PartitionAssignor should migrate to the new interface, though an adapter has been added to temporarily support old assignor implementations. </li>
 </ul>
 
 <h4><a id="upgrade_2_3_0" href="#upgrade_2_3_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, 2.0.x or 2.1.x or 2.2.x to 2.3.0</a></h4>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -373,8 +373,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * 3. within each client, tasks are assigned to consumer clients in round-robin manner.
      */
     @Override
-    public GroupAssignment assign(final Cluster metadata, final GroupSubscription groupSubscriptions) {
-        final Map<String, Subscription> subscriptions = groupSubscriptions.groupSubscription();
+    public GroupAssignment assign(final Cluster metadata, final GroupSubscription groupSubscription) {
+        final Map<String, Subscription> subscriptions = groupSubscription.groupSubscription();
         // construct the client metadata from the decoded subscription info
         final Map<UUID, ClientMetadata> clientMetadataMap = new HashMap<>();
         final Set<String> futureConsumers = new HashSet<>();


### PR DESCRIPTION
Follow up to [new PartitionAssignor interface](https://issues.apache.org/jira/browse/KAFKA-8703) merged in [7108](https://github.com/apache/kafka/pull/7108) is merged

Adds a PartitionAssignorAdapter class to [maintain backwards compatibility](https://issues.apache.org/jira/browse/KAFKA-8704)
