### PR TITLE
KAFKA-8713: JsonConverter NULL Values are replaced by default values even in NULLABLE fields

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -582,8 +582,8 @@ public class JsonConverter implements Converter, HeaderConverter {
         if (logicalValue == null) {
             if (schema == null) // Any schema is valid and we don't have a default, so treat this as an optional schema
                 return null;
-            // Value `null` is valid for an optional filed, even though the filed has a default value.
-            // Only when field is required, the converter return default value fallback when value is `null`.
+            // Value `null` is valid for an optional field, even though the field has a default value.
+            // Return a default value fallback instead of `null` when the field is actually required
             if (schema.isOptional())
                 return JsonNodeFactory.instance.nullNode();
             if (schema.defaultValue() != null)

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -582,10 +582,12 @@ public class JsonConverter implements Converter, HeaderConverter {
         if (logicalValue == null) {
             if (schema == null) // Any schema is valid and we don't have a default, so treat this as an optional schema
                 return null;
-            if (schema.defaultValue() != null)
-                return convertToJson(schema, schema.defaultValue());
+            // Value `null` is valid for an optional filed, even though the filed has a default value.
+            // Only when field is required, the converter return default value fallback when value is `null`.
             if (schema.isOptional())
                 return JsonNodeFactory.instance.nullNode();
+            if (schema.defaultValue() != null)
+                return convertToJson(schema, schema.defaultValue());
             throw new DataException("Conversion error: null value for field that is required and has no default value");
         }
 

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -786,8 +786,8 @@ public class JsonConverterTest {
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectHeader(TOPIC, "headerName", "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
     }
 
-    // Value `null` is valid for an optional filed, even though the filed has a default value.
-    // Only when field is required, the converter return default value fallback when value is `null`.
+    // Value `null` is valid for an optional field, even though the field has a default value.
+    // Return a default value fallback instead of `null` when the field is actually required.
 
     @Test
     public void nullValueWithDefaultValueAndOptionalToJson() {

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -786,6 +786,24 @@ public class JsonConverterTest {
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectHeader(TOPIC, "headerName", "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
     }
 
+    // Value `null` is valid for an optional filed, even though the filed has a default value.
+    // Only when field is required, the converter return default value fallback when value is `null`.
+
+    @Test
+    public void nullValueWithDefaultValueAndOptionalToJson() {
+        Schema schema = SchemaBuilder.string().optional().defaultValue("default-string").build();
+        JsonNode converted = parse(converter.fromConnectData(TOPIC, schema, null));
+        JsonNode expected = parse("{\"schema\":{\"type\":\"string\",\"optional\":true,\"default\":\"default-string\"},\"payload\":null}");
+        assertEquals(expected, converted);
+    }
+
+    @Test
+    public void nullValueWithDefaultValueAndRequiredToJson() {
+        Schema schema = SchemaBuilder.string().required().defaultValue("default-string").build();
+        JsonNode converted = parse(converter.fromConnectData(TOPIC, schema, null));
+        JsonNode expected = parse("{\"schema\":{\"type\":\"string\",\"optional\":false,\"default\":\"default-string\"},\"payload\":\"default-string\"}");
+        assertEquals(expected, converted);
+    }
 
     private JsonNode parse(byte[] json) {
         try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8713

This should not be merged without an approved KIP.

Update Mar 18 2020
Create [KIP-581: Value of optional null field which has default value](https://cwiki.apache.org/confluence/display/KAFKA/KIP-581%3A+Value+of+optional+null+field+which+has+default+value)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
