### PR TITLE
KAFKA-8715: fix timestamp bug for static member.id generation

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -365,7 +365,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       case None =>
         clientId + GroupMetadata.MemberIdDelimiter + UUID.randomUUID().toString
       case Some(instanceId) =>
-        instanceId + GroupMetadata.MemberIdDelimiter + time.milliseconds()
+        instanceId + GroupMetadata.MemberIdDelimiter + UUID.randomUUID().toString
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -365,7 +365,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       case None =>
         clientId + GroupMetadata.MemberIdDelimiter + UUID.randomUUID().toString
       case Some(instanceId) =>
-        instanceId + GroupMetadata.MemberIdDelimiter + currentStateTimestamp.get
+        instanceId + GroupMetadata.MemberIdDelimiter + time.milliseconds()
     }
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -874,7 +874,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def shouldGetDifferentStaticMemberIdBasedOnTimestamp(): Unit = {
+  def shouldGetDifferentStaticMemberIdAfterEachRejoin(): Unit = {
     val initialResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val timeAdvance = 1
@@ -884,9 +884,7 @@ class GroupCoordinatorTest {
 
       val joinGroupResult = staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
         leaderInstanceId, protocolType, protocols, clockAdvance = timeAdvance)
-      val joinTimeAsStr = (timer.time.milliseconds() - timeAdvance).toString
       assertTrue(joinGroupResult.memberId.startsWith(leaderInstanceId.get))
-      assertTrue(joinGroupResult.memberId.contains(joinTimeAsStr))
       assertNotEquals(lastMemberId, joinGroupResult.memberId)
       lastMemberId = joinGroupResult.memberId
     }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -874,6 +874,22 @@ class GroupCoordinatorTest {
   }
 
   @Test
+  def shouldGetDifferentStaticMemberIdBasedOnTimestamp() {
+    staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
+
+    val timeAdvance = 1
+    for (_ <- 1 to 20) {
+      EasyMock.reset(replicaManager)
+
+      val joinGroupResult = staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
+        leaderInstanceId, protocolType, protocols, clockAdvance = timeAdvance)
+      val joinTimeAsStr = (timer.time.milliseconds() - timeAdvance).toString
+      assertTrue(joinGroupResult.memberId.startsWith(leaderInstanceId.get))
+      assertTrue(joinGroupResult.memberId.contains(joinTimeAsStr))
+    }
+  }
+
+  @Test
   def testOffsetCommitDeadGroup() {
     val memberId = "memberId"
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -874,11 +874,12 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def shouldGetDifferentStaticMemberIdBasedOnTimestamp() {
-    staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
+  def shouldGetDifferentStaticMemberIdBasedOnTimestamp(): Unit = {
+    val initialResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val timeAdvance = 1
-    for (_ <- 1 to 20) {
+    var lastMemberId = initialResult.leaderId
+    for (_ <- 1 to 5) {
       EasyMock.reset(replicaManager)
 
       val joinGroupResult = staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
@@ -886,6 +887,8 @@ class GroupCoordinatorTest {
       val joinTimeAsStr = (timer.time.milliseconds() - timeAdvance).toString
       assertTrue(joinGroupResult.memberId.startsWith(leaderInstanceId.get))
       assertTrue(joinGroupResult.memberId.contains(joinTimeAsStr))
+      assertNotEquals(lastMemberId, joinGroupResult.memberId)
+      lastMemberId = joinGroupResult.memberId
     }
   }
 


### PR DESCRIPTION
The bug is that we accidentally used the loaded timestamp for the group instead of the real current time. Fix is made and unit test to make sure the timestamp is properly encoded within the returned member.id.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
