### PR TITLE
MINOR: Fix Streams metadata upgrade system test

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -57,10 +57,12 @@ fi
 
 # run ./gradlew copyDependantLibs to get all dependant jars in a local dir
 shopt -s nullglob
-for dir in "$base_dir"/core/build/dependant-libs-${SCALA_VERSION}*;
-do
-  CLASSPATH="$CLASSPATH:$dir/*"
-done
+if [ -z "$UPGRADE_KAFKA_STREAMS_TEST_VERSION" ]; then
+  for dir in "$base_dir"/core/build/dependant-libs-${SCALA_VERSION}*;
+  do
+    CLASSPATH="$CLASSPATH:$dir/*"
+  done
+fi
 
 for file in "$base_dir"/examples/build/libs/kafka-examples*.jar;
 do
@@ -110,6 +112,10 @@ else
       CLASSPATH="$file":"$CLASSPATH"
     fi
   done
+  if [ "$SHORT_VERSION_NO_DOTS" = "0100" ] || [ "$SHORT_VERSION_NO_DOTS" = "0101" ] ; then
+    CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zkclient-0.8.jar":"$CLASSPATH"
+    CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zookeeper-3.4.6.jar":"$CLASSPATH"
+  fi
 fi
 
 for file in "$rocksdb_lib_dir"/rocksdb*.jar;

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -112,9 +112,13 @@ else
       CLASSPATH="$file":"$CLASSPATH"
     fi
   done
-  if [ "$SHORT_VERSION_NO_DOTS" = "0100" ] || [ "$SHORT_VERSION_NO_DOTS" = "0101" ] ; then
+  if [ "$SHORT_VERSION_NO_DOTS" = "0100" ]; then
     CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zkclient-0.8.jar":"$CLASSPATH"
     CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zookeeper-3.4.6.jar":"$CLASSPATH"
+  fi
+  if [ "$SHORT_VERSION_NO_DOTS" = "0101" ]; then
+    CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zkclient-0.9.jar":"$CLASSPATH"
+    CLASSPATH="/opt/kafka-$UPGRADE_KAFKA_STREAMS_TEST_VERSION/libs/zookeeper-3.4.8.jar":"$CLASSPATH"
   fi
 fi
 


### PR DESCRIPTION
Recent ZK version bump broke the system test.

Kafka Streams depends on ZK in version 0.10.0 and 0.10.1. Previously, when running the system test we got the dependency added to the class path from the broker dependencies. With the ZK version bump, incorrect dependencies were added, resulting in class loading errors.

In this PR, we (1) remove core dependencies completely for the case we run an upgrade test, because Streams does not need those dependencies anyway. (2) For the case of running the upgrade test, we add the correct jars to the class path for 0.10.0 and 0.10.1 versions.

