### PR TITLE
KAFKA-8722: Data crc check repair

### DIFF
--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -166,18 +166,15 @@ private[kafka] object LogValidator {
 
     records.deepEntries(true, BufferSupplier.NO_CACHING).asScala.foreach { logEntry =>
       val record = logEntry.record
+      record.ensureValid()
       validateKey(record, compactedTopic)
 
       if (record.magic > Record.MAGIC_VALUE_V0 && messageFormatVersion > Record.MAGIC_VALUE_V0) {
         // Validate the timestamp
         validateTimestamp(record, now, messageTimestampType, messageTimestampDiffMaxMs)
         // Check if we need to overwrite offset, no in place assignment situation 3
-        if (logEntry.offset != expectedInnerOffset.getAndIncrement()){
+        if (logEntry.offset != expectedInnerOffset.getAndIncrement())
           inPlaceAssignment = false
-          if (record.magic() == messageFormatVersion) {
-            record.ensureValid()
-          }
-        }
         if (record.timestamp > maxTimestamp)
           maxTimestamp = record.timestamp
       }

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -172,8 +172,12 @@ private[kafka] object LogValidator {
         // Validate the timestamp
         validateTimestamp(record, now, messageTimestampType, messageTimestampDiffMaxMs)
         // Check if we need to overwrite offset, no in place assignment situation 3
-        if (logEntry.offset != expectedInnerOffset.getAndIncrement())
+        if (logEntry.offset != expectedInnerOffset.getAndIncrement()){
           inPlaceAssignment = false
+          if (record.magic() == messageFormatVersion) {
+            record.ensureValid()
+          }
+        }
         if (record.timestamp > maxTimestamp)
           maxTimestamp = record.timestamp
       }

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -202,9 +202,6 @@ private[kafka] object LogValidator {
         shallowOffsetOfMaxTimestamp = info.shallowOffsetOfMaxTimestamp,
         messageSizeMaybeChanged = true)
     } else {
-      // ensure the inner messages are valid
-      validatedRecords.foreach(_.ensureValid)
-
       // we can update the wrapper message only and write the compressed payload as is
       val entry = records.shallowEntries.iterator.next()
       val offset = offsetCounter.addAndGet(validatedRecords.size) - 1


### PR DESCRIPTION
In our production environment, when we consume kafka's topic data in an operating program, we found an error:

org.apache.kafka.common.KafkaException: Record for partition rl_dqn_debug_example-49 at offset 2911287689 is invalid, cause: Record is corrupt (stored crc = 3580880396, computed crc = 1701403171)
at org.apache.kafka.clients.consumer.internals.Fetcher.parseRecord(Fetcher.java:869)
at org.apache.kafka.clients.consumer.internals.Fetcher.parseCompletedFetch(Fetcher.java:788)
at org.apache.kafka.clients.consumer.internals.Fetcher.fetchedRecords(Fetcher.java:480)
at org.apache.kafka.clients.consumer.KafkaConsumer.pollOnce(KafkaConsumer.java:1188)
at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1046)
at kafka.consumer.NewShinyConsumer.receive(BaseConsumer.scala:88)
at kafka.tools.ConsoleConsumer$.process(ConsoleConsumer.scala:120)
at kafka.tools.ConsoleConsumer$.run(ConsoleConsumer.scala:75)
at kafka.tools.ConsoleConsumer$.main(ConsoleConsumer.scala:50)
at kafka.tools.ConsoleConsumer.main(ConsoleConsumer.scala)
At this point we used the kafka.tools.DumpLogSegments tool to parse the disk log file and found that there was indeed dirty data.
By looking at the code, I found that in some cases kafka would not verify the data and write it to disk, so we fixed it.
We found that when record.offset is not equal to the offset we are expecting, kafka will set the variable inPlaceAssignment to false. When inPlaceAssignment is false, data will not be verified.