### PR TITLE
KAFKA-8731: InMemorySessionStore throws NullPointerException on startup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -120,7 +120,15 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     @Override
     public void remove(final Windowed<Bytes> sessionKey) {
         final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(sessionKey.window().end());
+        if (keyMap == null) {
+            return;
+        }
+
         final ConcurrentNavigableMap<Long, byte[]> startTimeMap = keyMap.get(sessionKey.key());
+        if (startTimeMap == null) {
+            return;
+        }
+
         startTimeMap.remove(sessionKey.window().start());
 
         if (startTimeMap.isEmpty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -473,8 +473,8 @@ public abstract class SessionBytesStoreTest {
     }
 
     @Test
-    public void shouldNotThrowRemovingNonexistentKey() {
-        sessionStore.put(new Windowed<>("a", new SessionWindow(0, 1)), 0L);
+    public void shouldNotThrowExceptionRemovingNonexistentKey() {
+        sessionStore.remove(new Windowed<>("a", new SessionWindow(0, 1)));
     }
 
     @Test(expected = NullPointerException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -472,6 +472,11 @@ public abstract class SessionBytesStoreTest {
         assertThat(messages, hasItem("Skipping record for expired segment."));
     }
 
+    @Test
+    public void shouldNotThrowRemovingNonexistentKey() {
+        sessionStore.put(new Windowed<>("a", new SessionWindow(0, 1)), 0L);
+    }
+
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionOnFindSessionsNullKey() {
         sessionStore.findSessions(null, 1L, 2L);


### PR DESCRIPTION
Should be cherry-picked to 2.3