### PR TITLE
KAFKA-8465:make sure that the copy of the same topic is evenly distributed across a broker's disk.

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -690,7 +690,7 @@ class LogManager(logDirs: Seq[File],
           if (preferredLogDir != null)
             List(new File(preferredLogDir))
           else
-            nextLogDirs()
+            nextLogDirs(topicPartition)
         }
 
         val logDirName = {
@@ -884,24 +884,56 @@ class LogManager(logDirs: Seq[File],
     removedLog
   }
 
+  case class AllLogCount(topicCount: Int, dirCount: Int)
+
+  private def nextLogDirByTopic(topicPartition: TopicPartition): List[File] = {
+    val logCountByTopic = mutable.Map[String, Int]()
+    allLogs.map { log =>
+      if (topicPartition.topic.equals(log.topicPartition.topic)) {
+        if (logCountByTopic.contains(log.dir.getParent)) {
+          logCountByTopic.put(log.dir.getParent, logCountByTopic(log.dir.getParent) + 1)
+        } else {
+          logCountByTopic.put(log.dir.getParent, 1)
+        }
+      } else {
+        if (!logCountByTopic.contains(log.dir.getParent)) {
+          logCountByTopic.put(log.dir.getParent, 0)
+        }
+      }
+    }
+
+    val logCounts = allLogs.groupBy(_.dir.getParent).mapValues(_.size)
+    val zeros = _liveLogDirs.asScala.map(dir => (dir.getPath, 0)).toMap
+    val dirCounts = (zeros ++ logCounts).toBuffer
+
+    val allLogCounts = dirCounts.map { dir =>
+      (dir._1, new AllLogCount(logCountByTopic.getOrElse(dir._1, 0), dir._2))
+    }
+
+    val leastLoaded = allLogCounts.toSeq.sortWith((dir1, dir2) => {
+      if (dir1._2.topicCount < dir2._2.topicCount) true
+      else if (dir1._2.topicCount > dir2._2.topicCount) false
+      else {
+        dir1._2.dirCount < dir2._2.dirCount
+      }
+    })
+
+    leastLoaded.map{dir=>
+      new File(dir._1)
+    }.toList
+  }
+
+
   /**
    * Provides the full ordered list of suggested directories for the next partition.
    * Currently this is done by calculating the number of partitions in each directory and then sorting the
    * data directories by fewest partitions.
    */
-  private def nextLogDirs(): List[File] = {
+  private def nextLogDirs(topicPartition: TopicPartition): List[File] = {
     if(_liveLogDirs.size == 1) {
       List(_liveLogDirs.peek())
     } else {
-      // count the number of logs in each parent directory (including 0 for empty directories
-      val logCounts = allLogs.groupBy(_.dir.getParent).mapValues(_.size)
-      val zeros = _liveLogDirs.asScala.map(dir => (dir.getPath, 0)).toMap
-      val dirCounts = (zeros ++ logCounts).toBuffer
-
-      // choose the directory with the least logs in it
-      dirCounts.sortBy(_._2).map {
-        case (path: String, _: Int) => new File(path)
-      }.toList
+      nextLogDirByTopic(topicPartition)
     }
   }
 


### PR DESCRIPTION
Make sure that the copy of the same topic is evenly distributed across a broker's disk.
When some partiton's replication is assigned to a broker, which disks should these copies be placed on the broker? The original strategy is to allocate according to the number of partiitons。This strategy will result in uneven disk allocation for the topic dimension.
In order to solve this problem, we propose an improved strategy: first ensure that the number of partitions of each disk in the topic dimension is even. If the number of partitions of a topic on two disks is equal, then sort according to the total number of partitions on the disk. Select a disk with the least number of partitions to store the current replication.