### PR TITLE
MINOR: Small cleanups in TopicCommand describe handling

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -109,7 +109,7 @@ object TopicCommand extends Logging {
     }
 
     def hasUnderMinIsrPartitions: Boolean = {
-      minIsrCount.exists(isr.size < _)
+      leader.isEmpty || minIsrCount.exists(isr.size < _)
     }
 
     def isAtMinIsrPartitions: Boolean =  {

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -142,8 +142,8 @@ object TopicCommand extends Logging {
       print("\tTopic: " + topic)
       print("\tPartition: " + info.partition)
       print("\tLeader: " + (if (hasLeader) info.leader.id else "none"))
-      print("\tReplicas: " + info.replicas.asScala.mkString(","))
-      print("\tIsr: " + info.isr.asScala.mkString(","))
+      print("\tReplicas: " + info.replicas.asScala.map(_.id).mkString(","))
+      print("\tIsr: " + info.isr.asScala.map(_.id).mkString(","))
       print(if (markedForDeletion) "\tMarkedForDeletion: true" else "")
       println()
     }

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -122,7 +122,7 @@ object TopicCommand extends Logging {
       info.isr.size < info.replicas.size
     }
 
-    def hasLeader: Boolean = {
+    private def hasLeader: Boolean = {
       info.leader != null
     }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -28,8 +28,7 @@ import kafka.utils.Implicits._
 import kafka.utils._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.CommonClientConfigs
-import org.apache.kafka.clients.{admin => jadmin}
-import org.apache.kafka.clients.admin.{Admin, ListTopicsOptions, NewPartitions, NewTopic, AdminClient => JAdminClient}
+import org.apache.kafka.clients.admin.{Admin, ListTopicsOptions, NewPartitions, NewTopic, AdminClient => JAdminClient, Config => JConfig}
 import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo}
 import org.apache.kafka.common.config.ConfigResource.Type
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
@@ -95,7 +94,7 @@ object TopicCommand extends Logging {
 
   case class PartitionDescription(topic: String,
                                   info: TopicPartitionInfo,
-                                  config: Option[jadmin.Config],
+                                  config: Option[JConfig],
                                   markedForDeletion: Boolean) {
 
     private def minIsrCount: Option[Int] = {

--- a/core/src/main/scala/kafka/api/LeaderAndIsr.scala
+++ b/core/src/main/scala/kafka/api/LeaderAndIsr.scala
@@ -40,6 +40,10 @@ case class LeaderAndIsr(leader: Int,
 
   def newEpochAndZkVersion = newLeaderAndIsr(leader, isr)
 
+  def leaderOpt: Option[Int] = {
+    if (leader == LeaderAndIsr.NoLeader) None else Some(leader)
+  }
+
   override def toString: String = {
     s"LeaderAndIsr(leader=$leader, leaderEpoch=$leaderEpoch, isr=$isr, zkVersion=$zkVersion)"
   }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -290,14 +290,14 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
 
     val output = TestUtils.grabConsoleOutput(
       topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
-    assertTrue("The output should contain the modified config", output.contains("Configs:cleanup.policy=compact"))
+    assertTrue("The output should contain the modified config", output.contains("Configs: cleanup.policy=compact"))
 
     topicService.alterTopic(new TopicCommandOptions(
       Array("--topic", testTopicName, "--config", "cleanup.policy=delete")))
 
     val output2 = TestUtils.grabConsoleOutput(
       topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
-    assertTrue("The output should contain the modified config", output2.contains("Configs:cleanup.policy=delete"))
+    assertTrue("The output should contain the modified config", output2.contains("Configs: cleanup.policy=delete"))
   }
 
   @Test


### PR DESCRIPTION
This patch contains a few small cleanups to make topic describe logic a little clearer. It also fixes a minor inconsistency in the output between the --zookeeper and --bootstrap-server behavior when the leader is unknown. Previously we printed -1 when --zookeeper was used, and now we print "none." The patch consolidates the output logic for describing topics and partitions in order to avoid inconsistencies like this in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
