### PR TITLE
MINOR: Fix wrong debug log message

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -119,7 +119,7 @@ public class ProcessorStateManager implements StateManager {
             checkpointFile = null;
         }
 
-        log.debug("Created state store manager for task {} with the acquired state dir lock", taskId);
+        log.debug("Created state store manager for task {}", taskId);
     }
 
 


### PR DESCRIPTION
When a `ProcessorStateManager` is constructed a debug message is written to
the application logs that state the following:

"Created state store manager for task {} with the acquired state dir lock"

This is wrong because the the state store manager is created during
rebalancing but the the dir lock is acquired later on during execution
of `runOnce()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
