### PR TITLE
KAFKA-8745: DumpLogSegments doesn't show keys, when the message is null

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -218,18 +218,14 @@ object DumpLogSegments {
 
   private class DecoderMessageParser[K, V](keyDecoder: Decoder[K], valueDecoder: Decoder[V]) extends MessageParser[K, V] {
     override def parse(record: Record): (Option[K], Option[V]) = {
+      val key = if (record.hasKey)
+        Some(keyDecoder.fromBytes(Utils.readBytes(record.key)))
+      else
+        None
+
       if (!record.hasValue) {
-        val key = if (record.hasKey)
-          Some(keyDecoder.fromBytes(Utils.readBytes(record.key)))
-        else
-          None
         (key, None)
       } else {
-        val key = if (record.hasKey)
-          Some(keyDecoder.fromBytes(Utils.readBytes(record.key)))
-        else
-          None
-
         val payload = Some(valueDecoder.fromBytes(Utils.readBytes(record.value)))
 
         (key, payload)

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -219,7 +219,11 @@ object DumpLogSegments {
   private class DecoderMessageParser[K, V](keyDecoder: Decoder[K], valueDecoder: Decoder[V]) extends MessageParser[K, V] {
     override def parse(record: Record): (Option[K], Option[V]) = {
       if (!record.hasValue) {
-        (None, None)
+        val key = if (record.hasKey)
+          Some(keyDecoder.fromBytes(Utils.readBytes(record.key)))
+        else
+          None
+        (key, None)
       } else {
         val key = if (record.hasKey)
           Some(keyDecoder.fromBytes(Utils.readBytes(record.key)))

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -107,7 +107,7 @@ class DumpLogSegmentsTest {
       assertTrue(s"Data not printed: $output", lines.length > 2)
       val totalRecords = batches.map(_.records.size).sum
       var offset = 0
-      val batchClone = batches.clone()
+      val batchIterator = batches.iterator
       var batch : BatchInfo = null;
       (0 until totalRecords + batches.size).foreach { index =>
         val line = lines(lines.length - totalRecords - batches.size + index)
@@ -115,7 +115,7 @@ class DumpLogSegmentsTest {
         // only increment the offset if it's not a batch
         if (isBatch(index)) {
           assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: $offset lastOffset: "))
-          batch = batchClone.remove(0)
+          batch = batchIterator.next
         } else {
           assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.RecordIndent} offset: $offset"))
           if (checkKeysAndValues) {

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -58,25 +58,19 @@ class DumpLogSegmentsTest {
       logDirFailureChannel = new LogDirFailureChannel(10))
 
     val now = System.currentTimeMillis()
-    
-    
     val firstBatchRecords = (0 until 10).map { i => new SimpleRecord(now + i * 2, s"message key $i".getBytes, s"message value $i".getBytes)}
     batches += BatchInfo(firstBatchRecords, true, true)
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, firstBatchRecords: _*),
-      leaderEpoch = 0)
     val secondBatchRecords = (10 until 30).map { i => new SimpleRecord(now + i * 3, s"message key $i".getBytes, null)}
     batches += BatchInfo(secondBatchRecords, true, false)
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, secondBatchRecords: _*),
-      leaderEpoch = 0)
     val thirdBatchRecords = (30 until 50).map { i => new SimpleRecord(now + i * 5, null, s"message value $i".getBytes)}
     batches += BatchInfo(thirdBatchRecords, false, true)
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, thirdBatchRecords: _*),
-      leaderEpoch = 0)
     val fourthBatchRecords = (50 until 60).map { i => new SimpleRecord(now + i * 7, null)}
     batches += BatchInfo(fourthBatchRecords, false, false)
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, fourthBatchRecords: _*),
-      leaderEpoch = 0)
 
+    batches.foreach { batchInfo =>
+      log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, batchInfo.records: _*),
+        leaderEpoch = 0)
+    }
     // Flush, but don't close so that the indexes are not trimmed and contain some zero entries
     log.flush()
   }


### PR DESCRIPTION
Make sure to show the message key, even when the message value is null.

This changes the output of one of the tools. Is the output of the tool considered a public API? Does this need a discussion or a KIP?

Testing: Ran the tool on a compacted topic. Previously, the tool did not show any message keys for tombstone messages (messages where the value is null). Now, the tool shows message keys.
