### PR TITLE
KAFKA-8741: optimize the use of mx4j web interface

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -183,6 +183,11 @@ if [  $JMX_PORT ]; then
   KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 
+# MX4J port to use
+if [  $MX4J_PORT ]; then
+  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dkafka_mx4jenable=true -Dmx4jport=$MX4J_PORT "
+fi
+
 # Log directory to use
 if [ "x$LOG_DIR" = "x" ]; then
   LOG_DIR="$base_dir/logs"

--- a/build.gradle
+++ b/build.gradle
@@ -681,6 +681,7 @@ project(':core') {
     }
     // ZooKeeperMain depends on commons-cli but declares the dependency as `provided`
     compile libs.commonsCli
+    compile libs.mx4jtools
 
     compileOnly libs.log4j
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -114,7 +114,8 @@ versions += [
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.0",
   zookeeper: "3.5.5",
-  zstd: "1.4.0-1"
+  zstd: "1.4.0-1",
+  mx4jtools: "3.0.1"
 ]
 
 libs += [
@@ -183,5 +184,6 @@ libs += [
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
   zstd: "com.github.luben:zstd-jni:$versions.zstd",
-  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient"
+  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient",
+  mx4jtools: "mx4j:mx4j-tools:$versions.mx4jtools"
 ]


### PR DESCRIPTION
1. Since mx4j-tools.jar is not packaged into the final released tgz file by default, we can't monitor kafka brokers by web inferface. If we want to do it, we must find a mx4j-tools.jar in the maven repository by our own and put it under the directory $KAFKA_HOME/libs, which is very inconvenient.
2. In Mx4jLoader, we read the property values of 'kafka_mx4jenable' and 'mx4jport' from system properties, but there is no way for us to set the switch and customize the port of mx4j-tools. We could add a configuration item in kafka-run-class.sh. For example, if MX4J_PORT is set, we add -Dkafka_mx4jenable=true -Dmx4jport=$MX4J_PORT into the start command.

testing strategy:
1. build the release tar.gz file
2. check if mx4j-tools.jar is under the directory of $kAFKA_HOME/libs 
3. start broker, and check if http://$broker_ip:$MX4J_PORT works.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
