### PR TITLE
KAFKA-8746: Kibosh must handle an empty JSON string from Trogdor

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -71,8 +71,8 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.2.1-test.jar" -o /opt/kafka-2.2.1/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.3.0-test.jar" -o /opt/kafka-2.3.0/libs/kafka-streams-2.3.0-test.jar
 
 # The version of Kibosh to use for testing.
-# If you update this, also update vagrant/base.sy
-ARG KIBOSH_VERSION="d85ac3ec44be0700efe605c16289fd901cfdaa13"
+# If you update this, also update vagrant/base.sh
+ARG KIBOSH_VERSION="8841dd392e6fbf02986e2fb1f1ebf04df344b65a"
 
 # Install Kibosh
 RUN apt-get install fuse

--- a/tests/kafkatest/services/trogdor/kibosh.py
+++ b/tests/kafkatest/services/trogdor/kibosh.py
@@ -133,9 +133,12 @@ class KiboshService(Service):
         :param node:        The node.
         :param spec:        An array of FaultSpec objects describing the faults.
         """
-        fault_array = [spec.kibosh_message for spec in specs]
-        obj = { 'faults': fault_array }
-        obj_json = json.dumps(obj)
+        if len(specs) == 0:
+            obj_json = "{}"
+        else:
+            fault_array = [spec.kibosh_message for spec in specs]
+            obj = { 'faults': fault_array }
+            obj_json = json.dumps(obj)
         node.account.create_file(self.control_path, obj_json)
 
     def get_fault_json(self, node):

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -18,7 +18,7 @@ set -ex
 
 # The version of Kibosh to use for testing.
 # If you update this, also update tests/docker/Dockerfile
-export KIBOSH_VERSION=d85ac3ec44be0700efe605c16289fd901cfdaa13
+export KIBOSH_VERSION=8841dd392e6fbf02986e2fb1f1ebf04df344b65a
 
 path_to_jdk_cache() {
   jdk_version=$1


### PR DESCRIPTION
When Trogdor wants to clear all the faults injected to Kibosh, it sends the empty JSON object {}. However, Kibosh expects {"faults":[]} instead. Kibosh should handle the empty JSON object, since that's consistent with how Trogdor handles empty JSON fields in general (if they're empty, they can be omitted). We should also have a test for this.