### PR TITLE
KAFKA-8753: expose the number of topics marked for deletion

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -109,6 +109,7 @@ class KafkaController(val config: KafkaConfig,
   @volatile private var preferredReplicaImbalanceCount = 0
   @volatile private var globalTopicCount = 0
   @volatile private var globalPartitionCount = 0
+  @volatile private var topicsToDeleteCount = 0
 
   /* single-thread scheduler to clean expired tokens */
   private val tokenCleanScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "delegation-token-cleaner")
@@ -152,6 +153,13 @@ class KafkaController(val config: KafkaConfig,
     "GlobalPartitionCount",
     new Gauge[Int] {
       def value: Int = globalPartitionCount
+    }
+  )
+
+  newGauge(
+    "TopicsToDeleteCount",
+    new Gauge[Int] {
+      def value: Int = topicsToDeleteCount
     }
   )
 
@@ -315,6 +323,7 @@ class KafkaController(val config: KafkaConfig,
     preferredReplicaImbalanceCount = 0
     globalTopicCount = 0
     globalPartitionCount = 0
+    topicsToDeleteCount = 0
 
     // stop token expiry check scheduler
     if (tokenCleanScheduler.isStarted)
@@ -1191,6 +1200,8 @@ class KafkaController(val config: KafkaConfig,
     globalTopicCount = if (!isActive) 0 else controllerContext.allTopics.size
 
     globalPartitionCount = if (!isActive) 0 else controllerContext.partitionLeadershipInfo.size
+
+    topicsToDeleteCount = if (!isActive) 0 else controllerContext.topicsToBeDeleted.size
   }
 
   // visible for testing

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1228,15 +1228,12 @@ class KafkaController(val config: KafkaConfig,
 
     globalPartitionCount = if (!isActive) 0 else controllerContext.partitionLeadershipInfo.size
 
-    topicsToDeleteCount = if (!isActive) 0 else {
-      (controllerContext.topicsToBeDeleted -- controllerContext.topicsIneligibleForDeletion).size
-    }
+    topicsToDeleteCount = if (!isActive) 0 else controllerContext.topicsToBeDeleted.size
 
     replicasToDeleteCount = if (!isActive) 0 else controllerContext.topicsToBeDeleted.map { topic =>
-      // For each enqueued topic, count the number of eligible replicas that are not yet deleted
+      // For each enqueued topic, count the number of replicas that are not yet deleted
       controllerContext.replicasForTopic(topic).count { replica =>
-        controllerContext.replicaState(replica) != ReplicaDeletionSuccessful &&
-        controllerContext.replicaState(replica) != ReplicaDeletionIneligible
+        controllerContext.replicaState(replica) != ReplicaDeletionSuccessful
       }
     }.sum
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -114,9 +114,6 @@ class KafkaController(val config: KafkaConfig,
   @volatile private var ineligibleTopicsToDeleteCount = 0
   @volatile private var ineligibleReplicasToDeleteCount = 0
 
-
-
-
   /* single-thread scheduler to clean expired tokens */
   private val tokenCleanScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "delegation-token-cleaner")
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1246,7 +1246,7 @@ class KafkaController(val config: KafkaConfig,
     ineligibleTopicsToDeleteCount = if (!isActive) 0 else controllerContext.topicsIneligibleForDeletion.size
 
     ineligibleReplicasToDeleteCount = if (!isActive) 0 else controllerContext.topicsToBeDeleted.map { topic =>
-      // For each enqueued topic, count the number of replicas not yet deleted
+      // For each enqueued topic, count the number of replicas that are ineligible
       controllerContext.replicasForTopic(topic).count { replica =>
         controllerContext.replicaState(replica) == ReplicaDeletionIneligible
       }

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -142,6 +142,9 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalTopicCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalPartitionCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsToDeleteCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasToDeleteCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsIneligibleToDeleteCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=ReplicasIneligibleToDeleteCount"), 1)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -141,6 +141,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalTopicCount"), 1)
     assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=GlobalPartitionCount"), 1)
+    assertEquals(metrics.keySet.asScala.count(_.getMBeanName == "kafka.controller:type=KafkaController,name=TopicsToDeleteCount"), 1)
   }
 
   /**

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -901,6 +901,26 @@
         <td>0</td>
       </tr>
       <tr>
+        <td>Pending topic deletes</td>
+        <td>kafka.controller:type=KafkaController,name=TopicsToDeleteCount</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Pending replica deletes</td>
+        <td>kafka.controller:type=KafkaController,name=ReplicasToDeleteCount</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Ineligible pending topic deletes</td>
+        <td>kafka.controller:type=KafkaController,name=TopicsIneligibleToDeleteCount</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Ineligible pending replica deletes</td>
+        <td>kafka.controller:type=KafkaController,name=ReplicasIneligibleToDeleteCount</td>
+        <td></td>
+      </tr>
+      <tr>
         <td>Partition counts</td>
         <td>kafka.server:type=ReplicaManager,name=PartitionCount</td>
         <td>mostly even across brokers</td>


### PR DESCRIPTION
This is the implementation for [KIP-503](https://cwiki.apache.org/confluence/display/KAFKA/KIP-503%3A+Add+metric+for+number+of+topics+marked+for+deletion)

When deleting a large number of topics, the Controller can get quite bogged down. One problem with this is the lack of visibility into the progress of the Controller. We can look into the ZK path for topics marked for deletion, but in a production environment this is inconvenient. This PR adds a JMX metric `kafka.controller:type=KafkaController,name=TopicsToDeleteCount` to make it easier to see how many topics are being deleted.
