### PR TITLE
MINOR: Fix binary compatibility break in KafkaClientSupplier.getAdminClient

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams;
 
-import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.kstream.GlobalKTable;
@@ -31,12 +31,12 @@ import java.util.Map;
  */
 public interface KafkaClientSupplier {
     /**
-     * Create an {@link Admin} which is used for internal topic management.
+     * Create an {@link AdminClient} which is used for internal topic management.
      *
      * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
-     * @return an instance of {@link Admin}
+     * @return an instance of {@link AdminClient}
      */
-    Admin getAdminClient(final Map<String, Object> config);
+    AdminClient getAdminClient(final Map<String, Object> config);
 
     /**
      * Create a {@link Producer} which is used to write records to sink topics.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.Map;
 
-import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -29,9 +29,9 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 
 public class DefaultKafkaClientSupplier implements KafkaClientSupplier {
     @Override
-    public Admin getAdminClient(final Map<String, Object> config) {
+    public AdminClient getAdminClient(final Map<String, Object> config) {
         // create a new client upon each call; but expect this call to be only triggered once so this should be fine
-        return Admin.create(config);
+        return AdminClient.create(config);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.test;
 
-import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -57,7 +57,7 @@ public class MockClientSupplier implements KafkaClientSupplier {
     }
 
     @Override
-    public Admin getAdminClient(final Map<String, Object> config) {
+    public AdminClient getAdminClient(final Map<String, Object> config) {
         return new MockAdminClient(cluster.nodes(), cluster.nodeById(0));
     }
 


### PR DESCRIPTION
Changing the return type in an interface is a binary incompatible change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
