### PR TITLE
 KIP-476: Add new getAdmin method to KafkaClientSupplier

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -36,10 +36,13 @@ public interface KafkaClientSupplier {
      *
      * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of {@link AdminClient}
-     * @deprecated Not used. Implement {@link #getAdmin} instead
+     * @deprecated Not called by Kafka Streams, which now uses {@link #getAdmin} instead.
      */
     @Deprecated
-    AdminClient getAdminClient(final Map<String, Object> config);
+    default AdminClient getAdminClient(final Map<String, Object> config) {
+        throw new UnsupportedOperationException("Direct use of this method is deprecated. " +
+            "The method will be removed in a future release.");
+    }
 
     /**
      * Create an {@link Admin} which is used for internal topic management.

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -41,6 +41,7 @@ public interface KafkaClientSupplier {
     @Deprecated
     default AdminClient getAdminClient(final Map<String, Object> config) {
         throw new UnsupportedOperationException("Direct use of this method is deprecated. " +
+            "Implementations of KafkaClientSupplier should implement the getAdmin method instead. " +
             "The method will be removed in a future release.");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -41,7 +41,7 @@ public interface KafkaClientSupplier {
     @Deprecated
     default AdminClient getAdminClient(final Map<String, Object> config) {
         throw new UnsupportedOperationException("Direct use of this method is deprecated. " +
-            "Implementations of KafkaClientSupplier should implement the getAdmin method instead. " +
+            "Implementations of KafkaClientSupplier should implement the getAdmin() method instead. " +
             "The method will be removed in a future release.");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
@@ -35,8 +36,21 @@ public interface KafkaClientSupplier {
      *
      * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of {@link AdminClient}
+     * @deprecated Not used. Implement {@link #getAdmin} instead
      */
+    @Deprecated
     AdminClient getAdminClient(final Map<String, Object> config);
+
+    /**
+     * Create an {@link Admin} which is used for internal topic management.
+     *
+     * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
+     * @return an instance of {@link Admin}
+     */
+    @SuppressWarnings("deprecation")
+    default Admin getAdmin(final Map<String, Object> config) {
+        return getAdminClient(config);
+    }
 
     /**
      * Create a {@link Producer} which is used to write records to sink topics.

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -710,7 +710,7 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         // use client id instead of thread client id since this admin client may be shared among threads
-        adminClient = clientSupplier.getAdminClient(config.getAdminConfigs(StreamThread.getSharedAdminClientId(clientId)));
+        adminClient = clientSupplier.getAdmin(config.getAdminConfigs(StreamThread.getSharedAdminClientId(clientId)));
 
         final Map<Long, StreamThread.State> threadState = new HashMap<>(threads.length);
         final ArrayList<StateStoreProvider> storeProviders = new ArrayList<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
@@ -32,7 +32,7 @@ public class DefaultKafkaClientSupplier implements KafkaClientSupplier {
     @Deprecated
     @Override
     public AdminClient getAdminClient(final Map<String, Object> config) {
-        return (AdminClient)getAdmin(config);
+        return (AdminClient) getAdmin(config);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.KafkaClientSupplier;
 
 public class DefaultKafkaClientSupplier implements KafkaClientSupplier {
-    @SuppressWarnings("deprecation")
+    @Deprecated
     @Override
     public AdminClient getAdminClient(final Map<String, Object> config) {
         return (AdminClient)getAdmin(config);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultKafkaClientSupplier.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -28,10 +29,16 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.KafkaClientSupplier;
 
 public class DefaultKafkaClientSupplier implements KafkaClientSupplier {
+    @SuppressWarnings("deprecation")
     @Override
     public AdminClient getAdminClient(final Map<String, Object> config) {
+        return (AdminClient)getAdmin(config);
+    }
+
+    @Override
+    public Admin getAdmin(final Map<String, Object> config) {
         // create a new client upon each call; but expect this call to be only triggered once so this should be fine
-        return AdminClient.create(config);
+        return Admin.create(config);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -246,7 +246,7 @@ public class StreamThreadTest {
             internalTopologyBuilder,
             config,
             clientSupplier,
-            clientSupplier.getAdminClient(config.getAdminConfigs(clientId)),
+            clientSupplier.getAdmin(config.getAdminConfigs(clientId)),
             processId,
             clientId,
             metrics,

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -56,8 +57,14 @@ public class MockClientSupplier implements KafkaClientSupplier {
         this.cluster = cluster;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AdminClient getAdminClient(final Map<String, Object> config) {
+        return (AdminClient)getAdmin(config);
+    }
+
+    @Override
+    public Admin getAdmin(final Map<String, Object> config) {
         return new MockAdminClient(cluster.nodes(), cluster.nodeById(0));
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -55,12 +54,6 @@ public class MockClientSupplier implements KafkaClientSupplier {
 
     public void setClusterForAdminClient(final Cluster cluster) {
         this.cluster = cluster;
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public AdminClient getAdminClient(final Map<String, Object> config) {
-        return (AdminClient)getAdmin(config);
     }
 
     @Override


### PR DESCRIPTION
[KIP-476 ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-476) saw the introduction of a new `Admin` interface to replace the use of the `AdminClient` abstract class.  A key driver for this was to allow the use of dynamic proxies for the admin client supplied to Kafka streams via the `KafkaClientSupplier`.

Unfortunately, it would be a binary incompatible change to change `KafkClientSupplier.getAdminClient` to return the `Admin` interface, rather than `AdminClient`. See https://github.com/apache/kafka/pull/7157 which reverted the change.

To avoid this, I've added a new method `getAdmin` and deprecated the old `getAdminClient`.

The new `getAdmin` method has a default implementation that simply calls the old `getAdminClient` method.  Both `DefaultKafkaClientSupplier` and `MockClientSupplier` implement the new method.  All KS code has been switched to call the new method.

This has the benefit of being binary compatible, but does leave users still needing to implement the, now deprecated, `getAdminClient` method, even though it's not called by KS code.

Thoughts?


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
