### PR TITLE
MINOR: Fix ImplicitLinkedHashCollection.find()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
@@ -304,7 +304,7 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
      * @return                  The match index, or INVALID_INDEX if no match was found.
      */
     final private int findIndexOfEqualElement(Object key) {
-        if (key == null) {
+        if (key == null || size == 0) {
             return INVALID_INDEX;
         }
         int slot = slot(elements, key);
@@ -329,7 +329,6 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
      * @return      The matching element, or null if there were none.
      */
     final public E find(E key) {
-        if (size == 0) return null;
         int index = findIndexOfEqualElement(key);
         if (index == INVALID_INDEX) {
             return null;

--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
@@ -329,6 +329,7 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
      * @return      The matching element, or null if there were none.
      */
     final public E find(E key) {
+        if (size == 0) return null;
         int index = findIndexOfEqualElement(key);
         if (index == INVALID_INDEX) {
             return null;

--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollection.java
@@ -91,7 +91,7 @@ public class ImplicitLinkedHashMultiCollection<E extends ImplicitLinkedHashColle
      */
     @Override
     int findElementToRemove(Object key) {
-        if (key == null) {
+        if (key == null || size() == 0) {
             return INVALID_INDEX;
         }
         int slot = slot(elements, key);
@@ -120,7 +120,7 @@ public class ImplicitLinkedHashMultiCollection<E extends ImplicitLinkedHashColle
      * @return          All of the matching elements.
      */
     final public List<E> findAll(E key) {
-        if (key == null) {
+        if (key == null || size() == 0) {
             return Collections.<E>emptyList();
         }
         ArrayList<E> results = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -31,6 +31,7 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -271,7 +272,7 @@ public class ImplicitLinkedHashCollectionTest {
     @Test
     public void testEmptyListIterator() {
         ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
-        ListIterator iter = coll.valuesList().listIterator();
+        ListIterator<TestElement> iter = coll.valuesList().listIterator();
         assertFalse(iter.hasNext());
         assertFalse(iter.hasPrevious());
         assertEquals(0, iter.nextIndex());
@@ -513,6 +514,14 @@ public class ImplicitLinkedHashCollectionTest {
         assertNotEquals(coll2, coll3);
     }
 
+    @Test
+    public void testFindContainsRemoveOnEmptyCollection() {
+        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
+        assertNull(coll.find(new TestElement(2)));
+        assertFalse(coll.contains(new TestElement(2)));
+        assertFalse(coll.remove(new TestElement(2)));
+    }
+
     private void addRandomElement(Random random, LinkedHashSet<Integer> existing,
                                   ImplicitLinkedHashCollection<TestElement> set) {
         int next;
@@ -523,6 +532,7 @@ public class ImplicitLinkedHashCollectionTest {
         set.add(new TestElement(next));
     }
 
+    @SuppressWarnings("unlikely-arg-type")
     private void removeRandomElement(Random random, Collection<Integer> existing,
                                      ImplicitLinkedHashCollection<TestElement> coll) {
         int removeIdx = random.nextInt(existing.size());

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
@@ -46,9 +46,12 @@ public class ImplicitLinkedHashMultiCollectionTest {
     }
 
     @Test
-    public void testFindEmpty() {
-        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
+    public void testFindFindAllContainsRemoveOnEmptyCollection() {
+        ImplicitLinkedHashMultiCollection<TestElement> coll = new ImplicitLinkedHashMultiCollection<>();
         assertNull(coll.find(new TestElement(2)));
+        assertFalse(coll.contains(new TestElement(2)));
+        assertFalse(coll.remove(new TestElement(2)));
+        assertTrue(coll.findAll(new TestElement(2)).isEmpty());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -42,6 +43,12 @@ public class ImplicitLinkedHashMultiCollectionTest {
     public void testNullForbidden() {
         ImplicitLinkedHashMultiCollection<TestElement> multiSet = new ImplicitLinkedHashMultiCollection<>();
         assertFalse(multiSet.add(null));
+    }
+
+    @Test
+    public void testFindEmpty() {
+        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
+        assertNull(coll.find(new TestElement(2)));
     }
 
     @Test


### PR DESCRIPTION
When calling find() on an empty ImplicitLinkedHashCollection, it should return null instead of hitting a division by zero error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
