### PR TITLE
KAFKA-8736: Streams performance improvement, use isEmpty() rather tha…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -266,6 +266,10 @@ class NamedCache {
         return cache.size();
     }
 
+    public boolean isEmpty() {
+        return cache.isEmpty();
+    }
+
     synchronized Iterator<Map.Entry<Bytes, LRUNode>> subMapIterator(final Bytes from, final Bytes to) {
         return cache.subMap(from, true, to, true).entrySet().iterator();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -193,7 +193,7 @@ public class ThreadCache {
         }
         return new MemoryLRUCacheBytesIterator(cache.allIterator());
     }
-    
+
     public long size() {
         long size = 0;
         for (final NamedCache cache : caches.values()) {
@@ -235,7 +235,7 @@ public class ThreadCache {
             // a put on another cache. So even though the sizeInBytes() is
             // still > maxCacheSizeBytes there is nothing to evict from this
             // namespaced cache.
-            if (cache.size() == 0) {
+            if (cache.isEmpty()) {
                 return;
             }
             cache.evict();


### PR DESCRIPTION
…n size() == 0

According to https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html#size--, the size method has to traverse all elements to get a count. It looks like the count is being compared against 0 to determine if the map is empty; In this case, we don't need a full count. Instead, the isEmpty() method should be used, which just looks for one node.

No expected changes to unit or integration tests.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
