### PR TITLE
KAFKA-4740 Fields of partition and offset in case of deserializer fails.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.DeserializationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.header.Headers;
@@ -76,6 +77,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
+
 import org.slf4j.Logger;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -1317,8 +1319,7 @@ public class Fetcher<K, V> implements Closeable {
                                         valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length,
                                         key, value, headers, leaderEpoch);
         } catch (RuntimeException e) {
-            throw new SerializationException("Error deserializing key/value for partition " + partition +
-                    " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);
+            throw new DeserializationException( partition,record, e);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/DeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DeserializationException.java
@@ -1,0 +1,39 @@
+package org.apache.kafka.common.errors;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.Record;
+
+/**
+ * DeserializationException is a SerializationException, with the metadata of the partition and record.
+ */
+public class DeserializationException extends SerializationException {
+
+	private final TopicPartition partition;
+	private final Record record;
+
+	public DeserializationException(TopicPartition partition, Record record, RuntimeException e) {
+		super(String
+				.format("Error deserializing key/value for partition %s at offset %d. If needed, please seek past the record to continue consumption.",
+						partition, record.offset()), e);
+		this.partition = partition;
+		this.record = record;
+	}
+
+	/**
+	 * The partition during deserializing
+	 *
+	 * @return
+	 */
+	public TopicPartition getPartition() {
+		return partition;
+	}
+
+	/**
+	 * The record during deserializing
+	 *
+	 * @return
+	 */
+	public Record getRecord() {
+		return record;
+	}
+}


### PR DESCRIPTION
 Partition and offset information are included as a part of the SerializationException.

Some consumers may choose to skip that offset, this metadata can be used for that purpose.

Since DeserializationException extends SerializationException, nothing should be broken.

