### PR TITLE
MINOR: Make AbstractConfig logger protected

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -40,7 +40,7 @@ import java.util.TreeMap;
  */
 public class AbstractConfig {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /* configs for which values have been requested, used to detect unused configs */
     private final Set<String> used;


### PR DESCRIPTION
Inherited configs (Producer, Consumer, Streams, Kafka, Log) could use the logger of the AbstractConfig as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
