### PR TITLE
MINOR: remove unnecessary #remove overrides

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/KeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/KeyValueIterator.java
@@ -23,9 +23,10 @@ import java.util.Iterator;
 
 /**
  * Iterator interface of {@link KeyValue}.
- *
+ * <p>
  * Users must call its {@code close} method explicitly upon completeness to release resources,
  * or use try-with-resources statement (available since JDK7) for this {@link Closeable} class.
+ * Note that {@code remove()} is not supported.
  *
  * @param <K> Type of keys
  * @param <V> Type of values

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMergedSortedCacheStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMergedSortedCacheStoreIterator.java
@@ -148,11 +148,6 @@ abstract class AbstractMergedSortedCacheStoreIterator<K, KS, V, VS> implements K
     }
 
     @Override
-    public void remove() {
-        throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
-    }
-
-    @Override
     public void close() {
         cacheIterator.close();
         storeIterator.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeKeyValueIterator.java
@@ -67,8 +67,4 @@ class CompositeKeyValueIterator<K, V, StoreType> implements KeyValueIterator<K, 
         return current.next();
     }
 
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException("Remove not supported");
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIterator.java
@@ -79,11 +79,6 @@ public class DelegatingPeekingKeyValueIterator<K, V> implements KeyValueIterator
     }
 
     @Override
-    public void remove() {
-        throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
-    }
-
-    @Override
     public KeyValue<K, V> peekNext() {
         if (!hasNext()) {
             throw new NoSuchElementException();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/FilteredCacheIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/FilteredCacheIterator.java
@@ -61,10 +61,6 @@ class FilteredCacheIterator implements PeekingKeyValueIterator<Bytes, LRUCacheEn
                 return KeyValue.pair(cacheFunction.key(next.key), next.value);
             }
 
-            @Override
-            public void remove() {
-                cacheIterator.remove();
-            }
         };
     }
 
@@ -93,11 +89,6 @@ class FilteredCacheIterator implements PeekingKeyValueIterator<Bytes, LRUCacheEn
         }
         return cacheIterator.next();
 
-    }
-
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -168,11 +168,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
         }
 
         @Override
-        public void remove() {
-            iter.remove();
-        }
-
-        @Override
         public void close() {
             // do nothing
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueIterators.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueIterators.java
@@ -46,9 +46,6 @@ class KeyValueIterators {
             throw new NoSuchElementException();
         }
 
-        @Override
-        public void remove() {
-        }
     }
 
     private static class EmptyWindowStoreIterator<V> extends EmptyKeyValueIterator<Long, V>

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -83,11 +83,6 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
         }
 
         @Override
-        public void remove() {
-            // do nothing
-        }
-
-        @Override
         public void close() {
             // do nothing
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -306,11 +306,6 @@ public class MeteredKeyValueStore<K, V>
         }
 
         @Override
-        public void remove() {
-            iter.remove();
-        }
-
-        @Override
         public void close() {
             try {
                 iter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
@@ -57,11 +57,6 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V> {
     }
 
     @Override
-    public void remove() {
-        iter.remove();
-    }
-
-    @Override
     public void close() {
         try {
             iter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
@@ -64,11 +64,6 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
     }
 
     @Override
-    public void remove() {
-        iter.remove();
-    }
-
-    @Override
     public void close() {
         try {
             iter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -342,11 +342,6 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
 
         @Override
-        public void remove() {
-            throw new UnsupportedOperationException("RocksDB iterator does not support remove()");
-        }
-
-        @Override
         public synchronized void close() {
             openIterators.remove(this);
             iterNoTimestamp.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbIterator.java
@@ -68,11 +68,6 @@ class RocksDbIterator extends AbstractIterator<KeyValue<Bytes, byte[]>> implemen
     }
 
     @Override
-    public void remove() {
-        throw new UnsupportedOperationException("RocksDB iterator does not support remove()");
-    }
-
-    @Override
     public synchronized void close() {
         openIterators.remove(this);
         iter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentIterator.java
@@ -47,6 +47,7 @@ class SegmentIterator<S extends Segment> implements KeyValueIterator<Bytes, byte
         this.to = to;
     }
 
+    @Override
     public void close() {
         if (currentIterator != null) {
             currentIterator.close();
@@ -92,14 +93,11 @@ class SegmentIterator<S extends Segment> implements KeyValueIterator<Bytes, byte
         return hasNext;
     }
 
+    @Override
     public KeyValue<Bytes, byte[]> next() {
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
         return currentIterator.next();
-    }
-
-    public void remove() {
-        throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -318,11 +318,6 @@ public class ThreadCache {
         }
 
         @Override
-        public void remove() {
-            throw new UnsupportedOperationException("remove not supported by MemoryLRUCacheBytesIterator");
-        }
-
-        @Override
         public void close() {
             // do nothing
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreIteratorWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreIteratorWrapper.java
@@ -67,11 +67,6 @@ class WindowStoreIteratorWrapper {
         }
 
         @Override
-        public void remove() {
-            throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
-        }
-
-        @Override
         public void close() {
             bytesIterator.close();
         }
@@ -102,11 +97,6 @@ class WindowStoreIteratorWrapper {
         public KeyValue<Windowed<Bytes>, byte[]> next() {
             final KeyValue<Bytes, byte[]> next = bytesIterator.next();
             return KeyValue.pair(WindowKeySchema.fromStoreBytesKey(next.key.get(), windowSize), next.value);
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedSessionStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedSessionStoreIterator.java
@@ -49,9 +49,4 @@ class WrappedSessionStoreIterator implements KeyValueIterator<Windowed<Bytes>, b
         final KeyValue<Bytes, byte[]> next = bytesIterator.next();
         return KeyValue.pair(SessionKeySchema.from(next.key), next.value);
     }
-
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException("remove() is not supported in " + getClass().getName());
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
@@ -45,10 +45,6 @@ public class NoOpWindowStore implements ReadOnlyWindowStore, StateStore {
         public KeyValue<Long, KeyValue> next() {
             throw new NoSuchElementException();
         }
-
-        @Override
-        public void remove() {
-        }
     }
 
     private static final WindowStoreIterator<KeyValue> EMPTY_WINDOW_STORE_ITERATOR = new EmptyWindowStoreIterator();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
@@ -121,11 +121,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
                 return iterator.next();
             }
 
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException("remove() not supported in " + getClass().getName());
-            }
         };
     }
 
@@ -168,11 +163,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
                 return iterator.next();
             }
 
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException("remove() not supported in " + getClass().getName());
-            }
         };
     }
 
@@ -219,11 +209,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
                 return iterator.next();
             }
 
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException("remove() not supported in " + getClass().getName());
-            }
         };
     }
 
@@ -297,11 +282,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
         @Override
         public KeyValue<Long, E> next() {
             return underlying.next();
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("remove() not supported in " + getClass().getName());
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/GenericInMemoryKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/GenericInMemoryKeyValueStore.java
@@ -172,11 +172,6 @@ public class GenericInMemoryKeyValueStore<K extends Comparable, V>
         }
 
         @Override
-        public void remove() {
-            iter.remove();
-        }
-
-        @Override
         public void close() {
             // do nothing
         }

--- a/streams/src/test/java/org/apache/kafka/test/GenericInMemoryTimestampedKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/GenericInMemoryTimestampedKeyValueStore.java
@@ -173,11 +173,6 @@ public class GenericInMemoryTimestampedKeyValueStore<K extends Comparable, V>
         }
 
         @Override
-        public void remove() {
-            iter.remove();
-        }
-
-        @Override
         public void close() {
             // do nothing
         }

--- a/streams/src/test/java/org/apache/kafka/test/KeyValueIteratorStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/KeyValueIteratorStub.java
@@ -49,8 +49,4 @@ public class KeyValueIteratorStub<K, V> implements KeyValueIterator<K, V> {
         return iterator.next();
     }
 
-    @Override
-    public void remove() {
-
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
@@ -83,10 +83,6 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
                     return it.next();
                 }
 
-                @Override
-                public void remove() {
-                    throw new UnsupportedOperationException();
-                }
             }
         );
     }


### PR DESCRIPTION
`Iterator#remove` has a default implementation that throws `UnsupportedOperatorException` so there's no need to override it with the same thing.

Should be cherry-picked back to whenever we switched to Java 8