### PR TITLE
MINOR: improve StreamsBrokerDownResilienceTest debuggability

### DIFF
--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -67,7 +67,7 @@ class BaseStreamsTest(KafkaTest):
 
         wait_until(lambda: producer.num_acked >= num_messages,
                    timeout_sec=timeout_sec,
-                   err_msg="At %s failed to send messages " % test_state)
+                   err_msg="At %s failed to send messages. Expected: %s, actual: %s " % (test_state, num_messages, producer.num_acked))
 
     def assert_consume(self, client_id, test_state, topic, num_messages=5, timeout_sec=60):
         consumer = self.get_consumer(client_id, topic, num_messages)
@@ -75,7 +75,7 @@ class BaseStreamsTest(KafkaTest):
 
         wait_until(lambda: consumer.total_consumed() >= num_messages,
                    timeout_sec=timeout_sec,
-                   err_msg="At %s streams did not process messages in %s seconds " % (test_state, timeout_sec))
+                   err_msg="At %s streams did not process messages in %s seconds. Expected: %s, actual: %s " % (test_state, timeout_sec, num_messages, consumer.total_consumed()))
 
     @staticmethod
     def get_configs(extra_configs=""):


### PR DESCRIPTION
We have encountered some recent failure on this test and couldn't debug further due to the fact that we have no clue of the time when data flows in between different components. Adding the time when record gets processed on stream could help us better triage issue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
