### PR TITLE
MINOR: always call onPartitionsLost in eager rebalancing

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -649,7 +649,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             memberId.equals(Generation.NO_GENERATION.memberId)) {
             revokedPartitions = new HashSet<>(subscriptions.assignedPartitions());
 
-            if (!revokedPartitions.isEmpty()) {
+            if (!revokedPartitions.isEmpty() || protocol == RebalanceProtocol.EAGER) {
                 log.info("Giving away all assigned partitions as lost since generation has been reset," +
                     "indicating that consumer is no longer part of the group");
                 exception = invokePartitionsLost(revokedPartitions);


### PR DESCRIPTION
Users may be relying on the notification of a rebalance beginning, for example as Streams does with its FSM. If we don't call `onPartitionsLost` with empty partition set, users will only see `onPartitionsAssigned` as the first callback in a rebalance.

On the other hand, it does seem to make sense to reserve `onPartitionsLost` for "abnormal" conditions like missing a generation