### PR TITLE
KAFKA-8788: Optimize client metadata handling with a large number of partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1526,7 +1526,7 @@ public class KafkaAdminClient extends AdminClient {
                     }
                     partitions.sort(Comparator.comparingInt(TopicPartitionInfo::partition));
                     TopicDescription topicDescription = new TopicDescription(topicName, isInternal, partitions,
-                        validAclOperations(response.data().topics().find(topicName).topicAuthorizedOperations()));
+                        validAclOperations(response.topicAuthorizedOperations(topicName)));
                     future.complete(topicDescription);
                 }
             }
@@ -1585,7 +1585,7 @@ public class KafkaAdminClient extends AdminClient {
                 controllerFuture.complete(controller(response));
                 clusterIdFuture.complete(response.clusterId());
                 authorizedOperationsFuture.complete(
-                        validAclOperations(response.data().clusterAuthorizedOperations()));
+                        validAclOperations(response.clusterAuthorizedOperations()));
             }
 
             private Node controller(MetadataResponse response) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1526,7 +1526,7 @@ public class KafkaAdminClient extends AdminClient {
                     }
                     partitions.sort(Comparator.comparingInt(TopicPartitionInfo::partition));
                     TopicDescription topicDescription = new TopicDescription(topicName, isInternal, partitions,
-                        validAclOperations(response.topicAuthorizedOperations(topicName)));
+                        validAclOperations(response.topicAuthorizedOperations(topicName).get()));
                     future.complete(topicDescription);
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -108,23 +108,57 @@ public final class Cluster {
 
         // Index the nodes for quick lookup
         Map<Integer, Node> tmpNodesById = new HashMap<>();
-        for (Node node : nodes)
+        Map<Integer, List<PartitionInfo>> tmpPartitionsByNode = new HashMap<>(nodes.size());
+        for (Node node : nodes) {
             tmpNodesById.put(node.id(), node);
+            // Populate the map here to make it easy to add the partitions per node efficiently when iterating over
+            // the partitions
+            tmpPartitionsByNode.put(node.id(), new ArrayList<>());
+        }
         this.nodesById = Collections.unmodifiableMap(tmpNodesById);
 
         // index the partition infos by topic, topic+partition, and node
+        // note that this code is performance sensitive if there are a large number of partitions so we are careful
+        // to avoid unnecessary work
         Map<TopicPartition, PartitionInfo> tmpPartitionsByTopicPartition = new HashMap<>(partitions.size());
         Map<String, List<PartitionInfo>> tmpPartitionsByTopic = new HashMap<>();
-        Map<String, List<PartitionInfo>> tmpAvailablePartitionsByTopic = new HashMap<>();
-        Map<Integer, List<PartitionInfo>> tmpPartitionsByNode = new HashMap<>();
         for (PartitionInfo p : partitions) {
             tmpPartitionsByTopicPartition.put(new TopicPartition(p.topic(), p.partition()), p);
-            tmpPartitionsByTopic.merge(p.topic(), Collections.singletonList(p), Utils::concatListsUnmodifiable);
+            List<PartitionInfo> partitionsForTopic = tmpPartitionsByTopic.get(p.topic());
+            if (partitionsForTopic == null) {
+                partitionsForTopic = new ArrayList<>();
+                tmpPartitionsByTopic.put(p.topic(), partitionsForTopic);
+            }
+            partitionsForTopic.add(p);
             if (p.leader() != null) {
-                tmpAvailablePartitionsByTopic.merge(p.topic(), Collections.singletonList(p), Utils::concatListsUnmodifiable);
-                tmpPartitionsByNode.merge(p.leader().id(), Collections.singletonList(p), Utils::concatListsUnmodifiable);
+                List<PartitionInfo> partitionsForNode = Utils.notNull(tmpPartitionsByNode.get(p.leader().id()));
+                partitionsForNode.add(p);
             }
         }
+
+        // Populate `tmpAvailablePartitionsByTopic` and update the values of `tmpPartitionsByTopic` to contain
+        // unmodifiable lists
+        Map<String, List<PartitionInfo>> tmpAvailablePartitionsByTopic = new HashMap<>(tmpPartitionsByTopic.size());
+        for (Map.Entry<String, List<PartitionInfo>> entry : tmpPartitionsByTopic.entrySet()) {
+            String topic = entry.getKey();
+            List<PartitionInfo> partitionsForTopic = Collections.unmodifiableList(entry.getValue());
+            tmpPartitionsByTopic.put(topic, partitionsForTopic);
+            // Optimise for the common case where all partitions are available
+            boolean foundUnavailablePartition = partitionsForTopic.stream().anyMatch(p -> p.leader() == null);
+            List<PartitionInfo> availablePartitionsForTopic;
+            if (foundUnavailablePartition) {
+                availablePartitionsForTopic = new ArrayList<>(partitionsForTopic.size());
+                for (PartitionInfo p : partitionsForTopic) {
+                    if (p.leader() != null)
+                        availablePartitionsForTopic.add(p);
+                }
+                availablePartitionsForTopic = Collections.unmodifiableList(availablePartitionsForTopic);
+            } else {
+                availablePartitionsForTopic = partitionsForTopic;
+            }
+            tmpAvailablePartitionsByTopic.put(topic, availablePartitionsForTopic);
+        }
+
         this.partitionsByTopicPartition = Collections.unmodifiableMap(tmpPartitionsByTopicPartition);
         this.partitionsByTopic = Collections.unmodifiableMap(tmpPartitionsByTopic);
         this.availablePartitionsByTopic = Collections.unmodifiableMap(tmpAvailablePartitionsByTopic);

--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -136,6 +136,11 @@ public final class Cluster {
             }
         }
 
+        // Update the values of `tmpPartitionsByNode` to contain unmodifiable lists
+        for (Map.Entry<Integer, List<PartitionInfo>> entry : tmpPartitionsByNode.entrySet()) {
+            tmpPartitionsByNode.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+        }
+
         // Populate `tmpAvailablePartitionsByTopic` and update the values of `tmpPartitionsByTopic` to contain
         // unmodifiable lists
         Map<String, List<PartitionInfo>> tmpAvailablePartitionsByTopic = new HashMap<>(tmpPartitionsByTopic.size());

--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.common;
 
-import org.apache.kafka.common.utils.Utils;
-
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -131,7 +129,9 @@ public final class Cluster {
             }
             partitionsForTopic.add(p);
             if (p.leader() != null) {
-                List<PartitionInfo> partitionsForNode = Utils.notNull(tmpPartitionsByNode.get(p.leader().id()));
+                // The broker guarantees that if a partition has a non-null leader, it is one of the brokers returned
+                // in the metadata response
+                List<PartitionInfo> partitionsForNode = Objects.requireNonNull(tmpPartitionsByNode.get(p.leader().id()));
                 partitionsForNode.add(p);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -74,10 +74,6 @@ public class MetadataResponse extends AbstractResponse {
         return data.toStruct(version);
     }
 
-    public MetadataResponseData data() {
-        return data;
-    }
-
     @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
@@ -134,6 +130,14 @@ public class MetadataResponse extends AbstractResponse {
         }
         return new Cluster(data.clusterId(), brokers(), partitions, topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED),
                 topicsByError(Errors.INVALID_TOPIC_EXCEPTION), internalTopics, controller());
+    }
+
+    public int topicAuthorizedOperations(String topicName) {
+        return data.topics().find(topicName).topicAuthorizedOperations();
+    }
+
+    public int clusterAuthorizedOperations() {
+        return data.clusterAuthorizedOperations();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -185,6 +185,7 @@ public class MetadataResponse extends AbstractResponse {
      * @return the topicMetadata
      */
     public Collection<TopicMetadata> topicMetadata() {
+        Map<Integer, Node> brokersMap = brokersMap();
         List<TopicMetadata> topicMetadataList = new ArrayList<>();
         for (MetadataResponseTopic topicMetadata : data.topics()) {
             Errors topicError = Errors.forCode(topicMetadata.errorCode());
@@ -197,10 +198,10 @@ public class MetadataResponse extends AbstractResponse {
                 int partitionIndex = partitionMetadata.partitionIndex();
                 int leader = partitionMetadata.leaderId();
                 Optional<Integer> leaderEpoch = RequestUtils.getLeaderEpoch(partitionMetadata.leaderEpoch());
-                Node leaderNode = leader == -1 ? null : brokersMap().get(leader);
-                List<Node> replicaNodes = convertToNodes(brokersMap(), partitionMetadata.replicaNodes());
-                List<Node> isrNodes = convertToNodes(brokersMap(), partitionMetadata.isrNodes());
-                List<Node> offlineNodes = convertToNodes(brokersMap(), partitionMetadata.offlineReplicas());
+                Node leaderNode = leader == -1 ? null : brokersMap.get(leader);
+                List<Node> replicaNodes = convertToNodes(brokersMap, partitionMetadata.replicaNodes());
+                List<Node> isrNodes = convertToNodes(brokersMap, partitionMetadata.isrNodes());
+                List<Node> offlineNodes = convertToNodes(brokersMap, partitionMetadata.offlineReplicas());
                 partitionMetadataList.add(new PartitionMetadata(partitionError, partitionIndex, leaderNode, leaderEpoch,
                     replicaNodes, isrNodes, offlineNodes));
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -390,13 +390,13 @@ public class MetadataResponse extends AbstractResponse {
                                                    int clusterAuthorizedOperations) {
         MetadataResponseData responseData = new MetadataResponseData();
         responseData.setThrottleTimeMs(throttleTimeMs);
-        brokers.forEach(broker -> {
+        brokers.forEach(broker ->
             responseData.brokers().add(new MetadataResponseBroker()
                 .setNodeId(broker.id())
                 .setHost(broker.host())
                 .setPort(broker.port())
-                .setRack(broker.rack()));
-        });
+                .setRack(broker.rack()))
+        );
 
         responseData.setClusterId(clusterId);
         responseData.setControllerId(controllerId);

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -385,7 +385,7 @@ public class MetadataResponse extends AbstractResponse {
         }
     }
 
-    public static MetadataResponse prepareResponse(int throttleTimeMs, List<Node> brokers, String clusterId,
+    public static MetadataResponse prepareResponse(int throttleTimeMs, Collection<Node> brokers, String clusterId,
                                                    int controllerId, List<TopicMetadata> topicMetadataList,
                                                    int clusterAuthorizedOperations) {
         MetadataResponseData responseData = new MetadataResponseData();
@@ -425,13 +425,13 @@ public class MetadataResponse extends AbstractResponse {
         return new MetadataResponse(responseData);
     }
 
-    public static MetadataResponse prepareResponse(int throttleTimeMs, List<Node> brokers, String clusterId,
+    public static MetadataResponse prepareResponse(int throttleTimeMs, Collection<Node> brokers, String clusterId,
                                                    int controllerId, List<TopicMetadata> topicMetadataList) {
         return prepareResponse(throttleTimeMs, brokers, clusterId, controllerId, topicMetadataList,
                 MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED);
     }
 
-    public static MetadataResponse prepareResponse(List<Node> brokers, String clusterId, int controllerId,
+    public static MetadataResponse prepareResponse(Collection<Node> brokers, String clusterId, int controllerId,
                                                    List<TopicMetadata> topicMetadata) {
         return prepareResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, brokers, clusterId, controllerId, topicMetadata);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -132,10 +132,20 @@ public class MetadataResponse extends AbstractResponse {
                 topicsByError(Errors.INVALID_TOPIC_EXCEPTION), internalTopics, controller());
     }
 
-    public int topicAuthorizedOperations(String topicName) {
-        return data.topics().find(topicName).topicAuthorizedOperations();
+    /**
+     * Returns a 32-bit bitfield to represent authorized operations for this topic.
+     */
+    public Optional<Integer> topicAuthorizedOperations(String topicName) {
+        MetadataResponseTopic topic = data.topics().find(topicName);
+        if (topic == null)
+            return Optional.empty();
+        else
+            return Optional.of(topic.topicAuthorizedOperations());
     }
 
+    /**
+     * Returns a 32-bit bitfield to represent authorized operations for this cluster.
+     */
     public int clusterAuthorizedOperations() {
         return data.clusterAuthorizedOperations();
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1939,7 +1939,7 @@ public class FetcherTest {
         }
         Node controller = originalResponse.controller();
         MetadataResponse altered = MetadataResponse.prepareResponse(
-            (List<Node>) originalResponse.brokers(),
+            originalResponse.brokers(),
             originalResponse.clusterId(),
             controller != null ? controller.id() : MetadataResponse.NO_CONTROLLER_ID,
             altTopics);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/StickyPartitionCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/StickyPartitionCacheTest.java
@@ -32,7 +32,8 @@ public class StickyPartitionCacheTest {
     private final static Node[] NODES = new Node[] {
         new Node(0, "localhost", 99),
         new Node(1, "localhost", 100),
-        new Node(12, "localhost", 101)
+        new Node(2, "localhost", 101),
+        new Node(11, "localhost", 102)
     };
     final static String TOPIC_A = "topicA";
     final static String TOPIC_B = "topicB";
@@ -46,7 +47,7 @@ public class StickyPartitionCacheTest {
             new PartitionInfo(TOPIC_B, 0, NODES[0], NODES, NODES)
         );
         Cluster testCluster = new Cluster("clusterId", asList(NODES), allPartitions,
-            Collections.<String>emptySet(), Collections.<String>emptySet());
+            Collections.emptySet(), Collections.emptySet());
         StickyPartitionCache stickyPartitionCache = new StickyPartitionCache();
 
         int partA = stickyPartitionCache.partition(TOPIC_A, testCluster);
@@ -81,8 +82,8 @@ public class StickyPartitionCacheTest {
             new PartitionInfo(TOPIC_C, 0, null, NODES, NODES)
         );
         
-        Cluster testCluster = new Cluster("clusterId", asList(NODES[0], NODES[1]), allPartitions,
-            Collections.<String>emptySet(), Collections.<String>emptySet());
+        Cluster testCluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), allPartitions,
+            Collections.emptySet(), Collections.emptySet());
         StickyPartitionCache stickyPartitionCache = new StickyPartitionCache();
         
         // Assure we never choose partition 1 because it is unavailable.


### PR DESCRIPTION
Credit to @lbradstreet for profiling the producer with a large number of partitions.

Cache `topicMetadata`, `brokers` and `controller` in the `MetadataResponse`
the first time it's needed avoid unnecessary recomputation. We were previously
computing`brokersMap` 4 times per partition in one code path that was invoked from
multiple places. This is a regression introduced via a42f16f980 and first released
in 2.3.0.

The `Cluster` constructor became significantly more allocation heavy due to
2c44e77e2f20, first released in 2.2.0. Replaced `merge` calls with more verbose,
but more efficient code. Added a test to verify that the returned collections are
unmodifiable.

Add `topicAuthorizedOperations` and `clusterAuthorizedOperations` to
`MetadataResponse` and remove `data()` method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
