### PR TITLE
MINOR: Eliminate unnecessary map operations in RecordAccumulator.isMuted

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -276,10 +276,10 @@ public final class RecordAccumulator {
 
     private boolean isMuted(TopicPartition tp, long now) {
         Long throttleUntilTime = muted.get(tp);
-        boolean result = throttleUntilTime != null && throttleUntilTime > now;
-        if (!result)
+        boolean unmute = throttleUntilTime != null && now >= throttleUntilTime;
+        if (unmute)
             muted.remove(tp);
-        return result;
+        return unmute;
     }
 
     public void resetNextBatchExpiryTime() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -275,8 +275,8 @@ public final class RecordAccumulator {
     }
 
     private boolean isMuted(TopicPartition tp, long now) {
-        Long time = muted.get(tp);
-        boolean result = time != null && time > now;
+        Long throttleUntilTime = muted.get(tp);
+        boolean result = throttleUntilTime != null && throttleUntilTime > now;
         if (!result)
             muted.remove(tp);
         return result;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -275,6 +275,7 @@ public final class RecordAccumulator {
     }
 
     private boolean isMuted(TopicPartition tp, long now) {
+        // Take care to avoid unnecessary map look-ups because this method is a hotspot with a large number of partitions
         Long throttleUntilTime = muted.get(tp);
         if (throttleUntilTime == null)
             return false;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -276,10 +276,15 @@ public final class RecordAccumulator {
 
     private boolean isMuted(TopicPartition tp, long now) {
         Long throttleUntilTime = muted.get(tp);
-        boolean unmute = throttleUntilTime != null && now >= throttleUntilTime;
-        if (unmute)
+        if (throttleUntilTime == null)
+            return false;
+
+        if (now >= throttleUntilTime) {
             muted.remove(tp);
-        return unmute;
+            return false;
+        }
+        
+        return true;
     }
 
     public void resetNextBatchExpiryTime() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -275,7 +275,8 @@ public final class RecordAccumulator {
     }
 
     private boolean isMuted(TopicPartition tp, long now) {
-        boolean result = muted.containsKey(tp) && muted.get(tp) > now;
+        Long time = muted.get(tp);
+        boolean result = time != null && time > now;
         if (!result)
             muted.remove(tp);
         return result;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -275,7 +275,8 @@ public final class RecordAccumulator {
     }
 
     private boolean isMuted(TopicPartition tp, long now) {
-        // Take care to avoid unnecessary map look-ups because this method is a hotspot with a large number of partitions
+        // Take care to avoid unnecessary map look-ups because this method is a hotspot if producing to a
+        // large number of partitions
         Long throttleUntilTime = muted.get(tp);
         if (throttleUntilTime == null)
             return false;


### PR DESCRIPTION
Avoids calling both `containsKey` and `get` from isMuted, when only a single get is necessary.
Also avoid calling `remove` unless necessary. This could be a reduction of map operations
from 3 to 1. 

isMuted showed up as a hotspot in profiling when using the producer with high numbers of partitions.