### PR TITLE
MINOR: Remove throttling logic from RecordAccumulator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -640,7 +640,7 @@ public final class RecordAccumulator {
     /**
      * The earliest absolute time a batch will expire (in milliseconds)
      */
-    public Long nextExpiryTimeMs() {
+    public long nextExpiryTimeMs() {
         return this.nextBatchExpiryTimeMs;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -793,8 +794,11 @@ public final class RecordAccumulator {
         muted.put(tp, Long.MAX_VALUE);
     }
 
-    public void unmutePartition(TopicPartition tp, long throttleUntilTimeMs) {
-        muted.put(tp, throttleUntilTimeMs);
+    public void unmutePartition(TopicPartition tp, Optional<Long> throttleUntilTimeMs) {
+        if (throttleUntilTimeMs.isPresent())
+            muted.put(tp, throttleUntilTimeMs.get());
+        else
+            muted.remove(tp);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -531,7 +531,6 @@ public class Sender implements Runnable {
      */
     private void handleProduceResponse(ClientResponse response, Map<TopicPartition, ProducerBatch> batches, long now) {
         RequestHeader requestHeader = response.requestHeader();
-        long receivedTimeMs = response.receivedTimeMs();
         int correlationId = requestHeader.correlationId();
         if (response.wasDisconnected()) {
             log.trace("Cancelled request with header {} due to node {} being disconnected",

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -53,7 +53,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -541,7 +541,7 @@ public class RecordAccumulatorTest {
             if (mute)
                 accum.mutePartition(tp1);
             else
-                accum.unmutePartition(tp1, Optional.empty());
+                accum.unmutePartition(tp1);
 
             // Advance the clock to expire the batch.
             time.sleep(deliveryTimeoutMs - lingerMs);
@@ -590,7 +590,7 @@ public class RecordAccumulatorTest {
         List<ProducerBatch> expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batches will be muted no matter if the partition is muted or not", 2, expiredBatches.size());
 
-        accum.unmutePartition(tp1, Optional.empty());
+        accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired earlier", 0, expiredBatches.size());
         assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
@@ -604,7 +604,7 @@ public class RecordAccumulatorTest {
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when metadata is still available and partition is muted", 0, expiredBatches.size());
 
-        accum.unmutePartition(tp1, Optional.empty());
+        accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired", 0, expiredBatches.size());
         assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
@@ -630,7 +630,7 @@ public class RecordAccumulatorTest {
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
 
-        accum.unmutePartition(tp1, Optional.empty());
+        accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired.", 0, expiredBatches.size());
 
@@ -646,7 +646,7 @@ public class RecordAccumulatorTest {
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
 
         long throttleTimeMs = 100L;
-        accum.unmutePartition(tp1, Optional.of(time.milliseconds() + throttleTimeMs));
+        accum.unmutePartition(tp1);
         // The batch shouldn't be expired yet.
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
@@ -679,7 +679,7 @@ public class RecordAccumulatorTest {
         assertEquals("No node should be ready", 0, result.readyNodes.size());
 
         // Test ready without muted partition
-        accum.unmutePartition(tp1, Optional.empty());
+        accum.unmutePartition(tp1);
         result = accum.ready(cluster, time.milliseconds());
         assertTrue("The batch should be ready", result.readyNodes.size() > 0);
 
@@ -689,7 +689,7 @@ public class RecordAccumulatorTest {
         assertEquals("No batch should have been drained", 0, drained.get(node1.id()).size());
 
         // Test drain without muted partition.
-        accum.unmutePartition(tp1, Optional.empty());
+        accum.unmutePartition(tp1);
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         assertTrue("The batch should have been drained.", drained.get(node1.id()).size() > 0);
     }
@@ -884,7 +884,7 @@ public class RecordAccumulatorTest {
             if (mute)
                 accum.mutePartition(tp1);
             else
-                accum.unmutePartition(tp1, Optional.empty());
+                accum.unmutePartition(tp1);
 
             // test expiration
             time.sleep(deliveryTimeoutMs - rtt);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -53,6 +53,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -540,7 +541,7 @@ public class RecordAccumulatorTest {
             if (mute)
                 accum.mutePartition(tp1);
             else
-                accum.unmutePartition(tp1, 0L);
+                accum.unmutePartition(tp1, Optional.empty());
 
             // Advance the clock to expire the batch.
             time.sleep(deliveryTimeoutMs - lingerMs);
@@ -589,7 +590,7 @@ public class RecordAccumulatorTest {
         List<ProducerBatch> expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batches will be muted no matter if the partition is muted or not", 2, expiredBatches.size());
 
-        accum.unmutePartition(tp1, 0L);
+        accum.unmutePartition(tp1, Optional.empty());
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired earlier", 0, expiredBatches.size());
         assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
@@ -603,7 +604,7 @@ public class RecordAccumulatorTest {
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when metadata is still available and partition is muted", 0, expiredBatches.size());
 
-        accum.unmutePartition(tp1, 0L);
+        accum.unmutePartition(tp1, Optional.empty());
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired", 0, expiredBatches.size());
         assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
@@ -629,7 +630,7 @@ public class RecordAccumulatorTest {
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
 
-        accum.unmutePartition(tp1, 0L);
+        accum.unmutePartition(tp1, Optional.empty());
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("All batches should have been expired.", 0, expiredBatches.size());
 
@@ -645,7 +646,7 @@ public class RecordAccumulatorTest {
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
 
         long throttleTimeMs = 100L;
-        accum.unmutePartition(tp1, time.milliseconds() + throttleTimeMs);
+        accum.unmutePartition(tp1, Optional.of(time.milliseconds() + throttleTimeMs));
         // The batch shouldn't be expired yet.
         expiredBatches = accum.expiredBatches(time.milliseconds());
         assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
@@ -678,7 +679,7 @@ public class RecordAccumulatorTest {
         assertEquals("No node should be ready", 0, result.readyNodes.size());
 
         // Test ready without muted partition
-        accum.unmutePartition(tp1, 0L);
+        accum.unmutePartition(tp1, Optional.empty());
         result = accum.ready(cluster, time.milliseconds());
         assertTrue("The batch should be ready", result.readyNodes.size() > 0);
 
@@ -688,7 +689,7 @@ public class RecordAccumulatorTest {
         assertEquals("No batch should have been drained", 0, drained.get(node1.id()).size());
 
         // Test drain without muted partition.
-        accum.unmutePartition(tp1, 0L);
+        accum.unmutePartition(tp1, Optional.empty());
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         assertTrue("The batch should have been drained.", drained.get(node1.id()).size() > 0);
     }
@@ -883,7 +884,7 @@ public class RecordAccumulatorTest {
             if (mute)
                 accum.mutePartition(tp1);
             else
-                accum.unmutePartition(tp1, 0L);
+                accum.unmutePartition(tp1, Optional.empty());
 
             // test expiration
             time.sleep(deliveryTimeoutMs - rtt);


### PR DESCRIPTION
This is redundant since `Sender` and `NetworkClient` handle throttling. It's
also confusing since the `RecordAccumulator` logic only applies when
`max.in.flight.requests.per.connection=1`.

In `Sender.sendProducerData`, the following code handles throttling:

```java
while (iter.hasNext()) {
    Node node = iter.next();
    if (!this.client.ready(node, now)) {
        iter.remove();
        notReadyTimeout = Math.min(notReadyTimeout, this.client.pollDelayMs(node, now));
    }
}
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)