### PR TITLE
MINOR: Avoid unnecessary leaderFor calls when ProducerBatch queue empty

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -460,9 +460,8 @@ public final class RecordAccumulator {
         for (Map.Entry<TopicPartition, Deque<ProducerBatch>> entry : this.batches.entrySet()) {
             Deque<ProducerBatch> deque = entry.getValue();
             synchronized (deque) {
-                // When producing to a large number of partitions, this path is hot, deques are often empty.
-                // When there are no batches in the deque, we do not need to perform any
-                // other conditional leadership, mute, or readiness checks
+                // When producing to a large number of partitions, this path is hot and deques are often empty.
+                // We check whether a batch exists fisrt to avoid the more expensive ones whenever possible.
                 ProducerBatch batch = deque.peekFirst();
                 if (batch != null) {
                     TopicPartition part = entry.getKey();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -460,6 +460,8 @@ public final class RecordAccumulator {
         for (Map.Entry<TopicPartition, Deque<ProducerBatch>> entry : this.batches.entrySet()) {
             Deque<ProducerBatch> deque = entry.getValue();
             synchronized (deque) {
+                // When producing to a large number of partitions, this path is hot, deques are often empty and the empty
+                // deque check is cheaper than the leaderFor check.
                 if (!deque.isEmpty()) {
                     TopicPartition part = entry.getKey();
                     Node leader = cluster.leaderFor(part);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -461,7 +461,7 @@ public final class RecordAccumulator {
             Deque<ProducerBatch> deque = entry.getValue();
             synchronized (deque) {
                 // When producing to a large number of partitions, this path is hot and deques are often empty.
-                // We check whether a batch exists fisrt to avoid the more expensive ones whenever possible.
+                // We check whether a batch exists first to avoid the more expensive checks whenever possible.
                 ProducerBatch batch = deque.peekFirst();
                 if (batch != null) {
                     TopicPartition part = entry.getKey();


### PR DESCRIPTION
The RecordAccumulator ready calls `leaderFor` unnecessarily when the ProducerBatch
queue is empty. When producing to many partitions, the queue is often empty and the
`leaderFor` call can be expensive in comparison. Remove the unnecessary call.