### PR TITLE
KAFKA-8794: Deprecate DescribeLogDirsResponse.[LogDirInfo, ReplicaInfo]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -88,20 +88,47 @@ public class DescribeLogDirsResponse extends AbstractResponse {
         return new DescribeLogDirsResponse(ApiKeys.DESCRIBE_LOG_DIRS.responseSchema(version).read(buffer), version);
     }
 
-    // Note this class is part of the public API, reachable from Admin.describeLogDirs()
     /**
-     * Possible error code:
+     * State of a LogDir, (possibly) with an error code. Possible error codes are:
+     * <p><ul>
+     *   <li>KAFKA_STORAGE_ERROR (56)
+     *   <li>UNKNOWN (-1)
+     * </ul><p>
      *
-     * KAFKA_STORAGE_ERROR (56)
-     * UNKNOWN (-1)
+     * @deprecated Since 2.6. Use {@link org.apache.kafka.clients.admin.DescribeLogDirsResult.LogDirInfo} instead.
      */
+    @Deprecated
     static public class LogDirInfo {
         public final Errors error;
+
+        /**
+         * @deprecated Since 2.6. Use {@link LogDirInfo#tpToReplicaInfos} instead.
+         */
+        @Deprecated
         public final Map<TopicPartition, ReplicaInfo> replicaInfos;
+
+        public final Map<TopicPartition, org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo> tpToReplicaInfos;
+
+        /**
+         * Convert Map&lt;{@link org.apache.kafka.common.TopicPartition}, {@link org.apache.kafka.common.requests.DescribeLogDirsResponse.ReplicaInfo}&gt; into
+         * Map&lt;{@link org.apache.kafka.common.TopicPartition}, {@link org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo}&gt;.
+         */
+        private static Map<TopicPartition, org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo> convert(Map<TopicPartition, ReplicaInfo> map) {
+            Map<TopicPartition, org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo> ret = new HashMap<>();
+
+            for (Map.Entry<TopicPartition, ReplicaInfo> entry : map.entrySet()) {
+                ReplicaInfo replicaInfo = entry.getValue();
+                ret.put(entry.getKey(),
+                    new org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo(replicaInfo.size, replicaInfo.offsetLag, replicaInfo.isFuture));
+            }
+
+            return ret;
+        }
 
         public LogDirInfo(Errors error, Map<TopicPartition, ReplicaInfo> replicaInfos) {
             this.error = error;
             this.replicaInfos = replicaInfos;
+            this.tpToReplicaInfos = convert(replicaInfos);
         }
 
         @Override
@@ -116,7 +143,12 @@ public class DescribeLogDirsResponse extends AbstractResponse {
         }
     }
 
-    // Note this class is part of the public API, reachable from Admin.describeLogDirs()
+    /**
+     * State of a replica.
+     *
+     * @deprecated Since 2.6. Use {@link org.apache.kafka.clients.admin.DescribeLogDirsResult.ReplicaInfo} instead.
+     **/
+    @Deprecated
     static public class ReplicaInfo {
 
         public final long size;

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -493,7 +493,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     result.values.get(brokerId).get().forEach {
       case (logDirName, logDirInfo) => {
         logDirs.add(logDirName)
-        logDirInfo.replicaInfos.forEach {
+        logDirInfo.tpToReplicaInfos.forEach {
           case (part, info) =>
             if (info.isFuture) {
               futureLogDirs.put(part, logDirName)

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -183,12 +183,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val expectedPartitions = partitionsByBroker(brokerId)
       val logDirInfos = logDirInfosByBroker.get(brokerId)
       val replicaInfos = logDirInfos.asScala.flatMap { case (_, logDirInfo) =>
-        logDirInfo.replicaInfos.asScala
+        logDirInfo.tpToReplicaInfos.asScala
       }.filter { case (k, _) => k.topic == topic }
 
       assertEquals(expectedPartitions.toSet, replicaInfos.keys.map(_.partition).toSet)
       logDirInfos.forEach { (logDir, logDirInfo) =>
-        logDirInfo.replicaInfos.asScala.keys.foreach(tp =>
+        logDirInfo.tpToReplicaInfos.asScala.keys.foreach(tp =>
           assertEquals(server.logManager.getLog(tp).get.dir.getParent, logDir)
         )
       }

--- a/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
@@ -50,11 +50,11 @@ class DescribeLogDirsRequestTest extends BaseRequestTest {
 
     assertEquals(logDirCount, logDirInfos.size())
     assertEquals(Errors.KAFKA_STORAGE_ERROR, logDirInfos.get(offlineDir).error)
-    assertEquals(0, logDirInfos.get(offlineDir).replicaInfos.size())
+    assertEquals(0, logDirInfos.get(offlineDir).tpToReplicaInfos.size())
 
     assertEquals(Errors.NONE, logDirInfos.get(onlineDir).error)
-    val replicaInfo0 = logDirInfos.get(onlineDir).replicaInfos.get(tp0)
-    val replicaInfo1 = logDirInfos.get(onlineDir).replicaInfos.get(tp1)
+    val replicaInfo0 = logDirInfos.get(onlineDir).tpToReplicaInfos.get(tp0)
+    val replicaInfo1 = logDirInfos.get(onlineDir).tpToReplicaInfos.get(tp1)
     val log0 = servers.head.logManager.getLog(tp0).get
     val log1 = servers.head.logManager.getLog(tp1).get
     assertEquals(log0.size, replicaInfo0.size)

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
@@ -18,11 +18,11 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeLogDirsResult;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Time;
@@ -120,11 +120,11 @@ public class PurgeRepartitionTopicIntegrationTest {
             time.sleep(PURGE_INTERVAL_MS);
 
             try {
-                final Collection<DescribeLogDirsResponse.LogDirInfo> logDirInfo =
+                final Collection<DescribeLogDirsResult.LogDirInfo> logDirInfo =
                     adminClient.describeLogDirs(Collections.singleton(0)).values().get(0).get().values();
 
-                for (final DescribeLogDirsResponse.LogDirInfo partitionInfo : logDirInfo) {
-                    final DescribeLogDirsResponse.ReplicaInfo replicaInfo =
+                for (final DescribeLogDirsResult.LogDirInfo partitionInfo : logDirInfo) {
+                    final DescribeLogDirsResult.ReplicaInfo replicaInfo =
                         partitionInfo.replicaInfos.get(new TopicPartition(REPARTITION_TOPIC, 0));
                     if (replicaInfo != null && verifier.verify(replicaInfo.size)) {
                         return true;


### PR DESCRIPTION
I found this glitch while I was working on some monitoring system.

note:

- [Javadoc of `DescribeLogDirsResult` (2.3.0)](https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/admin/DescribeLogDirsResult.html): does not provide link to `org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo`.
- [Javadoc of `DescribeReplicaLogDirsResult` (2.3.0)](https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.html): provides link to [`DescribeReplicaLogDirsResult.ReplicaLogDirInfo
`](https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.ReplicaLogDirInfo.html)

cc/ @hachikuji

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
