### PR TITLE
KAFKA-8789: kafka-console-consumer timeout-ms setting behaves incorrectly with older client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -88,6 +88,11 @@ public interface Consumer<K, V> extends Closeable {
     ConsumerRecords<K, V> poll(Duration timeout);
 
     /**
+     * @see KafkaConsumer#poll(Duration, boolean)
+     */
+    ConsumerRecords<K, V> poll(Duration timeout, boolean includeMetadataInTimeout);
+
+    /**
      * @see KafkaConsumer#commitSync()
      */
     void commitSync();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1206,6 +1206,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         return poll(time.timer(timeout), true);
     }
 
+    @Override
+    public ConsumerRecords<K, V> poll(final Duration timeout, final boolean includeMetadataInTimeout) {
+        return poll(time.timer(timeout), includeMetadataInTimeout);
+    }
+
     /**
      * @throws KafkaException if the rebalance callback throws exception
      */

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -390,7 +390,7 @@ object ConsoleConsumer extends Logging {
   private[tools] class ConsumerWrapper(topic: Option[String], partitionId: Option[Int], offset: Option[Long], whitelist: Option[String],
                                        consumer: Consumer[Array[Byte], Array[Byte]], val timeoutMs: Long = Long.MaxValue) {
     consumerInit()
-    var recordIter = Collections.emptyList[ConsumerRecord[Array[Byte], Array[Byte]]]().iterator()
+    var recordIter = consumer.poll(Duration.ofMillis(0L), false).iterator
 
     def consumerInit(): Unit = {
       (topic, partitionId, offset, whitelist) match {


### PR DESCRIPTION
This is a draft implementation of [KAFKA-8789](https://issues.apache.org/jira/browse/KAFKA-8789). I dug out the problem and found the following.

Before 2.1.0 (Confluent Platform 5.1.x, 8a78d764), `ConsoleConsumer.ConsumerWrapper#recordIter` was initialized with `consumer.poll(0)`, which in turn calls `KafkaConsumer#poll(Timer, includeMetadataInTimeout = false)` and fetches metadata regardless of timeout.

However, this code was removed while removing the deprecated `KafkaConsumer#poll(long)`. So, `ConsoleConsumer.ConsumerWrapper#receive` now fetches metadata just before starting consuming, with timeout limitation. If an insufficient timeout is given, it calls the following methods and finally ends with `TimeoutException`.

`KafkaConsumer#poll(Duration, boolean)`
-> `KafkaConsumer#updateAssignmentMetadataIfNeeded(Timer)`
-> `KafkaConsumer#updateFetchPositions`
-> `ConsumerCoordinator#refreshCommittedOffsetsIfNeeded`
-> `ConsumerCoordinator#fetchCommittedOffsets`
-> `ConsumerNetworkClient#poll(RequestFuture, Timer)`
-> `ConsumerNetworkClient#poll(Timer, PollCondition)`
-> `ConsumerNetworkClient#poll(Timer, PollCondition, boolean)`
-> `ConsumerNetworkClient#failExpiredRequests`

To make this tool to work like before 2.1.0, we need to add a method to update `KafkaConsumer`'s metadata before starting polling. I can't be certain what approach would be the best, I added `Consumer#poll(Duration, boolean)` as a temporal workaround. (That is, this PR will be updated following the related KIP discussion.)

cc/ @hachikuji @viktorsomogyi @ijuma @HeartSaVioR

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)