### PR TITLE
KAFKA-8412: Still a nullpointer exception thrown on shutdown whi…

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -265,8 +265,10 @@
     <subpackage name="processor">
       <subpackage name="internals">
         <allow pkg="com.fasterxml.jackson" />
+        <allow pkg="kafka.utils" />
         <allow pkg="org.apache.zookeeper" />
         <allow pkg="org.apache.zookeeper" />
+        <allow pkg="org.apache.log4j" />
         <subpackage name="testutil">
           <allow pkg="org.apache.log4j" />
         </subpackage>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -332,15 +332,30 @@ abstract class AssignedTasks<T extends Task> {
     void close(final boolean clean) {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
 
-        final List<T> nonSuspendedTasks = new ArrayList<>();
-        nonSuspendedTasks.addAll(created.values());
-        nonSuspendedTasks.addAll(running.values());
-        for (final T task : nonSuspendedTasks) {
-            closeTask(clean, false, task, firstException);
-        }
-
-        for (final T task : suspended.values()) {
-            closeTask(clean, true, task, firstException);
+        for(final T task: allTasks()) {
+            try {
+                if (suspended.containsKey(task.id())) {
+                    task.closeSuspended(clean, false, null);
+                } else {
+                    task.close(clean, false);
+                }
+            } catch (final TaskMigratedException e) {
+                log.info("Failed to close {} {} since it got migrated to another thread already. " +
+                    "Closing it as zombie and move on.", taskTypeName, task.id());
+                firstException.compareAndSet(null, closeZombieTask(task));
+            } catch (final RuntimeException t) {
+                log.error("Failed while closing {} {} due to the following error:",
+                    task.getClass().getSimpleName(),
+                    task.id(),
+                    t);
+                if (clean) {
+                    if (!closeUnclean(task)) {
+                        firstException.compareAndSet(null, t);
+                    }
+                } else {
+                    firstException.compareAndSet(null, t);
+                }
+            }
         }
 
         clear();
@@ -348,33 +363,6 @@ abstract class AssignedTasks<T extends Task> {
         final RuntimeException fatalException = firstException.get();
         if (fatalException != null) {
             throw fatalException;
-        }
-    }
-
-    private void closeTask(final boolean clean, final boolean isSuspended, final T task,
-        final AtomicReference<RuntimeException> firstException) {
-        try {
-            if (isSuspended) {
-                task.closeSuspended(clean, false, null);
-            } else {
-                task.close(clean, false);
-            }
-        } catch (final TaskMigratedException e) {
-            log.info("Failed to close {} {} since it got migrated to another thread already. " +
-                "Closing it as zombie and move on.", taskTypeName, task.id());
-            firstException.compareAndSet(null, closeZombieTask(task));
-        } catch (final RuntimeException t) {
-            log.error("Failed while closing {} {} due to the following error:",
-                task.getClass().getSimpleName(),
-                task.id(),
-                t);
-            if (clean) {
-                if (!closeUnclean(task)) {
-                    firstException.compareAndSet(null, t);
-                }
-            } else {
-                firstException.compareAndSet(null, t);
-            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -332,7 +332,7 @@ abstract class AssignedTasks<T extends Task> {
     void close(final boolean clean) {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
 
-        for(final T task: allTasks()) {
+        for (final T task: allTasks()) {
             try {
                 if (suspended.containsKey(task.id())) {
                     task.closeSuspended(clean, false, null);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
@@ -52,7 +52,6 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
-import scala.collection.immutable.List;
 
 public class AssignedStreamsTasksTest {
 
@@ -540,9 +539,8 @@ public class AssignedStreamsTasksTest {
             LogCaptureAppender.setClassLoggerLevel(AssignedStreamsTasks.class, previousLevel);
             LogCaptureAppender.unregister(appender);
         }
-        final List<LoggingEvent> errorList = appender.getMessages().toList();
-        if (!errorList.isEmpty()) {
-            final LoggingEvent firstError = errorList.iterator().next();
+        if (!appender.getMessages().isEmpty()) {
+            final LoggingEvent firstError = appender.getMessages().head();
             final String firstErrorCause =
                 firstError.getThrowableStrRep() != null
                     ? String.join("\n", firstError.getThrowableStrRep())
@@ -551,7 +549,7 @@ public class AssignedStreamsTasksTest {
             final String failMsg =
                 String.format("Expected no ERROR message while closing assignedTasks, but got %d. " +
                     "First error: %s. Cause: %s",
-                    errorList.size(),
+                    appender.getMessages().size(),
                     firstError.getMessage(),
                     firstErrorCause);
             fail(failMsg);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
@@ -17,26 +17,42 @@
 
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.errors.TaskMigratedException;
-import org.apache.kafka.streams.processor.TaskId;
-import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import kafka.utils.LogCaptureAppender;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.test.MockSourceNode;
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import scala.collection.immutable.List;
 
 public class AssignedStreamsTasksTest {
 
@@ -449,6 +465,97 @@ public class AssignedStreamsTasksTest {
 
         assertThat(assignedTasks.punctuate(), equalTo(1));
         EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldCloseCleanlyWithSuspendedTaskAndEOS() {
+        final String topic = "topic";
+
+        final Deserializer<byte[]> deserializer = Serdes.ByteArray().deserializer();
+        final Serializer<byte[]> serializer = Serdes.ByteArray().serializer();
+
+        final MockConsumer<byte[], byte[]> consumer =
+            new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        final MockProducer<byte[], byte[]> producer =
+            new MockProducer<>(false, serializer, serializer);
+
+        final MockSourceNode<byte[], byte[]> source = new MockSourceNode<>(
+            new String[] {"topic"},
+            deserializer,
+            deserializer);
+
+        final ChangelogReader changelogReader = new MockChangelogReader();
+
+        final ProcessorTopology topology = new ProcessorTopology(
+            Collections.singletonList(source),
+            Collections.singletonMap(topic, source),
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            Collections.emptySet());
+
+        final Set<TopicPartition> partitions = Collections.singleton(
+            new TopicPartition(topic, 1));
+
+        final Metrics metrics = new Metrics(new MetricConfig().recordLevel(RecordingLevel.DEBUG));
+
+        final StreamsMetricsImpl streamsMetrics = new MockStreamsMetrics(metrics);
+
+        final MockTime time = new MockTime();
+
+        final StateDirectory stateDirectory = new StateDirectory(
+            StreamTaskTest.createConfig(true),
+            time,
+            true);
+
+        final StreamTask task = new StreamTask(
+            new TaskId(0, 0),
+            partitions,
+            topology,
+            consumer,
+            changelogReader,
+            StreamTaskTest.createConfig(true),
+            streamsMetrics,
+            stateDirectory,
+            null,
+            time,
+            () -> producer);
+
+        assignedTasks.addNewTask(task);
+        assignedTasks.initializeNewTasks();
+        assertNull(assignedTasks.suspend());
+
+        // We have to test for close failure by looking at the logs because the current close
+        // logic suppresses the raised exception in AssignedTasks.close. It's not clear if this
+        // is the intended behavior.
+        //
+        // Also note that capturing the failure through this side effect is very brittle.
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+        final Level previousLevel =
+            LogCaptureAppender.setClassLoggerLevel(AssignedStreamsTasks.class, Level.ERROR);
+        try {
+            assignedTasks.close(true);
+        } finally {
+            LogCaptureAppender.setClassLoggerLevel(AssignedStreamsTasks.class, previousLevel);
+            LogCaptureAppender.unregister(appender);
+        }
+        final List<LoggingEvent> errorList = appender.getMessages().toList();
+        if (!errorList.isEmpty()) {
+            final LoggingEvent firstError = errorList.iterator().next();
+            final String firstErrorCause =
+                firstError.getThrowableStrRep() != null
+                    ? String.join("\n", firstError.getThrowableStrRep())
+                    : "N/A";
+
+            final String failMsg =
+                String.format("Expected no ERROR message while closing assignedTasks, but got %d. " +
+                    "First error: %s. Cause: %s",
+                    errorList.size(),
+                    firstError.getMessage(),
+                    firstErrorCause);
+            fail(failMsg);
+        }
     }
 
     private void addAndInitTask() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -89,6 +89,8 @@ import static org.junit.Assert.fail;
 
 public class StreamTaskTest {
 
+    private static final File BASE_DIR = TestUtils.tempDirectory();
+
     private final Serializer<Integer> intSerializer = Serdes.Integer().serializer();
     private final Serializer<byte[]> bytesSerializer = Serdes.ByteArray().serializer();
     private final Deserializer<Integer> intDeserializer = Serdes.Integer().deserializer();
@@ -140,7 +142,6 @@ public class StreamTaskTest {
     private final StreamsMetricsImpl streamsMetrics = new MockStreamsMetrics(metrics);
     private final TaskId taskId00 = new TaskId(0, 0);
     private final MockTime time = new MockTime();
-    private final File baseDir = TestUtils.tempDirectory();
     private StateDirectory stateDirectory;
     private StreamTask task;
     private long punctuatedAt;
@@ -175,10 +176,11 @@ public class StreamTaskTest {
                                      Collections.emptySet());
     }
 
-    private StreamsConfig createConfig(final boolean enableEoS) {
+    // Exposed to make it easier to create StreamTask config from other tests.
+    static StreamsConfig createConfig(final boolean enableEoS) {
         final String canonicalPath;
         try {
-            canonicalPath = baseDir.getCanonicalPath();
+            canonicalPath = BASE_DIR.getCanonicalPath();
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
@@ -210,7 +212,7 @@ public class StreamTaskTest {
                 }
             }
         } finally {
-            Utils.delete(baseDir);
+            Utils.delete(BASE_DIR);
         }
     }
 


### PR DESCRIPTION
…le flushing before closing producers

Prior to this change an NPE is raised when calling AssignedTasks.close
under the following conditions:

1. EOS is enabled
2. The task was in a suspended state

The cause for the NPE is that when a clean close is requested for a
StreamTask the StreamTask tries to commit. However, in the suspended
state there is no producer so ultimately an NPE is thrown for the
contained RecordCollector in flush.

It is my opinion that in the long term, this (and probably other
surprising state interactions) could be cleaned up by consolidating
state into one place instead of spreading it across AssignedTasks,
StreamTask, and AbstractTask. However, that is a much larger, more risky
change, and this issue is currently considered minor.

The fix put forth in this commit is to have AssignedTasks call
closeSuspended when it knows the underlying StreamTask is suspended.

Currently the only externally visible way to detect this problem in test
seems to be via logging. This is because the NPE is logged but then
suppressed under the following sequence:

RecordCollectorImpl.flush:266
    - throws NPE (producer is null)

StreamTask.suspend:578
    - goes through the finally block and then reraises the NPE

StreamTask.close:706
    - catches the NPE, calls closeSuspended with the NPE

StreamTask.closeSuspended:676
    - rethrows the NPE after some cleanup

AssignedTasks.close:341
    - catches and logs the exception
    - tries a "dirty" close (clean = true) which succeeds
    - firstException is NOT set because the test `!closeUnclean(task)`
      does not hold.

It seems this is not the intended behavior? If so, I will happily
correct that and stop using logging as a way to detect failure.

Otherwise this commit does not currently pass checkstyle because I'm
using blacklisted imports: `LogCaptureAppender` and its various
dependencies from `log4j`. I would appreciate guidance as to whether we
should whitelist these or use another technique for detection.

Note also that this test is quite involved. I could have just tested
that AssignedTasks calls closeSuspended when appropriate, but that is
testing, IMO, a detail of the implementation and doesn't actually verify
we reproduced the original problem as it was described. I feel much more
confident that we are reproducing the behavior - and we can test exactly
the conditions that lead to it - when testing across AssignedTasks and
StreamTask. I believe this is an additional support for the argument of
eventually consolidating the state split across classes.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
