### PR TITLE
MINOR. Replace Utils::readFileAsString method to read file as stream

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -617,12 +617,9 @@ public final class Utils {
      * This allows the program to read from a regular file as well as from a pipe/fifo.
      */
     public static String readFileAsString(String path) throws IOException {
-        try {
-            byte[] allBytes = Files.readAllBytes(Paths.get(path));
-            return new String(allBytes, StandardCharsets.UTF_8);
-        } catch (IOException ex) {
-            throw new RuntimeException("Unable to read file " + path, ex);
-        }
+        log.debug("Reading file {}", path);
+        byte[] allBytes = Files.readAllBytes(Paths.get(path));
+        return new String(allBytes, StandardCharsets.UTF_8);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -31,9 +31,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -615,40 +613,16 @@ public final class Utils {
     }
 
     /**
-     * Read a file as string and return the content. Unlike {@link Utils#readFileAsString(String)}, the file
-     * will be treated as a stream and a character is read at a time. This allows the program to read from say
-     * a FIFO (opened with S_IFIFO flag), where size of file is not known in advance.
+     * Read a file as string and return the content. The file is treated as a stream and no seek is performed.
+     * This allows the program to read from a regular file as well as from a pipe/fifo.
      */
-    public static String readFileStreamAsString(String path) {
-        return readFileStreamAsString(path, Charset.defaultCharset());
-    }
-
-    public static String readFileStreamAsString(String path, Charset charset) {
-        if (charset == null) charset = Charset.defaultCharset();
+    public static String readFileAsString(String path) throws IOException {
         try {
             byte[] allBytes = Files.readAllBytes(Paths.get(path));
-            return new String(allBytes, charset);
+            return new String(allBytes, StandardCharsets.UTF_8);
         } catch (IOException ex) {
             throw new RuntimeException("Unable to read file " + path, ex);
         }
-    }
-
-    /**
-     * Attempt to read a file as a string
-     * @throws IOException
-     */
-    public static String readFileAsString(String path, Charset charset) throws IOException {
-        if (charset == null) charset = Charset.defaultCharset();
-
-        try (FileChannel fc = FileChannel.open(Paths.get(path))) {
-            MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-            return charset.decode(bb).toString();
-        }
-
-    }
-
-    public static String readFileAsString(String path) throws IOException {
-        return Utils.readFileAsString(path, Charset.defaultCharset());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -612,6 +613,24 @@ public final class Utils {
      */
     public static byte[] readBytes(ByteBuffer buffer) {
         return Utils.readBytes(buffer, 0, buffer.limit());
+    }
+
+    /**
+     * Read a file as string and return the content. Unlike {@link Utils#readFileAsString(String)}, the file
+     * will be treated as a stream and a character is read at a time. This allows the program to read from say
+     * a FIFO (opened with S_IFIFO flag), where size of file is not known in advance.
+     */
+    public static String readFileStreamAsString(String path) {
+        StringBuilder fileText = new StringBuilder();
+        try (FileInputStream fileInputStream = new FileInputStream(path)) {
+            int nextChar;
+            while ((nextChar = fileInputStream.read()) != -1) {
+                fileText.append((char) nextChar);
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to read file " + path, ex);
+        }
+        return fileText.toString();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -627,7 +627,7 @@ public final class Utils {
             while ((nextChar = fileInputStream.read()) != -1) {
                 fileText.append((char) nextChar);
             }
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             throw new RuntimeException("Unable to read file " + path, ex);
         }
         return fileText.toString();

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -617,9 +617,12 @@ public final class Utils {
      * This allows the program to read from a regular file as well as from a pipe/fifo.
      */
     public static String readFileAsString(String path) throws IOException {
-        log.debug("Reading file {}", path);
-        byte[] allBytes = Files.readAllBytes(Paths.get(path));
-        return new String(allBytes, StandardCharsets.UTF_8);
+        try {
+            byte[] allBytes = Files.readAllBytes(Paths.get(path));
+            return new String(allBytes, StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            throw new IOException("Unable to read file " + path, ex);
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -24,7 +24,6 @@ import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -621,16 +620,17 @@ public final class Utils {
      * a FIFO (opened with S_IFIFO flag), where size of file is not known in advance.
      */
     public static String readFileStreamAsString(String path) {
-        StringBuilder fileText = new StringBuilder();
-        try (FileInputStream fileInputStream = new FileInputStream(path)) {
-            int nextChar;
-            while ((nextChar = fileInputStream.read()) != -1) {
-                fileText.append((char) nextChar);
-            }
+        return readFileStreamAsString(path, Charset.defaultCharset());
+    }
+
+    public static String readFileStreamAsString(String path, Charset charset) {
+        if (charset == null) charset = Charset.defaultCharset();
+        try {
+            byte[] allBytes = Files.readAllBytes(Paths.get(path));
+            return new String(allBytes, charset);
         } catch (IOException ex) {
             throw new RuntimeException("Unable to read file " + path, ex);
         }
-        return fileText.toString();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -264,12 +264,9 @@ public class UtilsTest {
         this.subTest(buffer);
     }
 
-    /**
-     * Test to read a simple file as string.
-     */
     @Test
     public void testFileAsStringSimpleFile() throws IOException {
-        File tempFile = File.createTempFile("UtilsTestTempFlie", ".tmp");
+        File tempFile = TestUtils.tempFile();
         try {
             String testContent = "Test Content";
             Files.write(tempFile.toPath(), testContent.getBytes());

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -277,9 +277,10 @@ public class UtilsTest {
     }
 
     /**
-     * Test to read content of named pipe as string.
+     * Test to read content of named pipe as string. As reading/writing to a pipe can block,
+     * timeout test after a minute (test finishes within 100 ms normally).
      */
-    @Test
+    @Test(timeout = 60 * 1000)
     public void testFileAsStringNamedPipe() throws Exception {
 
         // Create a temporary name for named pipe
@@ -303,7 +304,7 @@ public class UtilsTest {
                 try {
                     Files.write(fifo.toPath(), testFileContent.getBytes());
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    fail("Error when producing to fifo : " + e.getMessage());
                 }
             }, "FIFO-Producer");
             producerThread.start();
@@ -312,7 +313,7 @@ public class UtilsTest {
         } finally {
             Files.deleteIfExists(fifo.toPath());
             if (producerThread != null) {
-                producerThread.join(60 * 1000); // Wait for a min for thread to terminate
+                producerThread.join(30 * 1000); // Wait for thread to terminate
                 assertFalse(producerThread.isAlive());
             }
         }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -86,7 +86,7 @@ object ReassignPartitionsCommand extends Logging {
 
   def verifyAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val jsonFile = opts.options.valueOf(opts.reassignmentJsonFileOpt)
-    val jsonString = Utils.readFileStreamAsString(jsonFile)
+    val jsonString = Utils.readFileAsString(jsonFile)
     verifyAssignment(zkClient, adminClientOpt, jsonString)
   }
 
@@ -198,7 +198,7 @@ object ReassignPartitionsCommand extends Logging {
 
   def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val reassignmentJsonFile =  opts.options.valueOf(opts.reassignmentJsonFileOpt)
-    val reassignmentJsonString = Utils.readFileStreamAsString(reassignmentJsonFile)
+    val reassignmentJsonString = Utils.readFileAsString(reassignmentJsonFile)
     val interBrokerThrottle = opts.options.valueOf(opts.interBrokerThrottleOpt)
     val replicaAlterLogDirsThrottle = opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt)
     val timeoutMs = opts.options.valueOf(opts.timeoutOpt)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -86,7 +86,7 @@ object ReassignPartitionsCommand extends Logging {
 
   def verifyAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val jsonFile = opts.options.valueOf(opts.reassignmentJsonFileOpt)
-    val jsonString = Utils.readFileAsString(jsonFile)
+    val jsonString = Utils.readFileStreamAsString(jsonFile)
     verifyAssignment(zkClient, adminClientOpt, jsonString)
   }
 
@@ -198,7 +198,7 @@ object ReassignPartitionsCommand extends Logging {
 
   def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val reassignmentJsonFile =  opts.options.valueOf(opts.reassignmentJsonFileOpt)
-    val reassignmentJsonString = Utils.readFileAsString(reassignmentJsonFile)
+    val reassignmentJsonString = Utils.readFileStreamAsString(reassignmentJsonFile)
     val interBrokerThrottle = opts.options.valueOf(opts.interBrokerThrottleOpt)
     val replicaAlterLogDirsThrottle = opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt)
     val timeoutMs = opts.options.valueOf(opts.timeoutOpt)


### PR DESCRIPTION
The current Utils::readFileAsString method creates a FileChannel and
memory maps file and copies its content to a String and returns it. But
that means that we need to know the size of the file in advance. This
precludes us from reading files whose size is not known in advance, i.e.
any file opened with flag S_IFIFO.

This change updates the method to use stream to read the content of the file.
It has couple of practical advantages:

1. Allows bash process substitution to pass in strings as file. So we can
say `./bin/kafka-reassign-partitions.sh --reassignment-json-file <(echo
"reassignment json")

2. When adding systest for commands that take file, we don't have to
create real physical file. Instead we can just dump the content of the
file on the command line.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
