### PR TITLE
KAFKA-8800: Increase poll timeout in poll[Records]UntilTrue

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -769,7 +769,7 @@ object TestUtils extends Logging {
                     msg: => String,
                     waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
     waitUntilTrue(() => {
-      consumer.poll(Duration.ofMillis(50))
+      consumer.poll(Duration.ofMillis(100))
       action()
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }
@@ -779,7 +779,7 @@ object TestUtils extends Logging {
                                  msg: => String,
                                  waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
     waitUntilTrue(() => {
-      val records = consumer.poll(Duration.ofMillis(50))
+      val records = consumer.poll(Duration.ofMillis(100))
       action(records)
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }


### PR DESCRIPTION
I dug out this problem and found the following.

The failing method, `TestUtils#pollRecordsUntilTrue`, was added with commit 1e92b703. However, it calls `Consumer#poll(Duration)` which throws timeout if the given period is expired while fetching both of the metadata and records. (i.e., dislike to deprecated `Consumer#poll(long)` method.) For this reason, it is easy to fail and making the related tests flaky.

It seems like there are two approaches to fix this problem:

1. Increase the timeout duration (current PR)
2. Use a dedicated method to fetch the metadata.

How do you think? cc/ @mjsax

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
