### PR TITLE
KAFKA-8802: ConcurrentSkipListMap shows performance regression in cache and in-memory store

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -17,8 +17,8 @@
 package org.apache.kafka.streams.state.internals;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private final String name;
-    private final ConcurrentNavigableMap<Bytes, byte[]> map = new ConcurrentSkipListMap<>();
+    private final NavigableMap<Bytes, byte[]> map = new TreeMap<>();
     private volatile boolean open = false;
     private long size = 0L; // SkipListMap#size is O(N) so we just do our best to track it
 
@@ -71,12 +71,12 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public byte[] get(final Bytes key) {
+    public synchronized byte[] get(final Bytes key) {
         return map.get(key);
     }
 
     @Override
-    public void put(final Bytes key, final byte[] value) {
+    public synchronized void put(final Bytes key, final byte[] value) {
         if (value == null) {
             size -= map.remove(key) == null ? 0 : 1;
         } else {
@@ -85,7 +85,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public byte[] putIfAbsent(final Bytes key, final byte[] value) {
+    public synchronized byte[] putIfAbsent(final Bytes key, final byte[] value) {
         final byte[] originalValue = get(key);
         if (originalValue == null) {
             put(key, value);
@@ -101,14 +101,14 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public byte[] delete(final Bytes key) {
+    public synchronized byte[] delete(final Bytes key) {
         final byte[] oldValue = map.remove(key);
         size -= oldValue == null ? 0 : 1;
         return oldValue;
     }
 
     @Override
-    public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+    public synchronized KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
 
         if (from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. "
@@ -123,7 +123,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     }
 
     @Override
-    public KeyValueIterator<Bytes, byte[]> all() {
+    public synchronized KeyValueIterator<Bytes, byte[]> all() {
         return new DelegatingPeekingKeyValueIterator<>(
             name,
             new InMemoryKeyValueIterator(map.entrySet().iterator()));

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.state.internals.NamedCache.LRUNode;
 import org.slf4j.Logger;
 
 import java.util.Collections;
@@ -181,17 +180,17 @@ public class ThreadCache {
     public MemoryLRUCacheBytesIterator range(final String namespace, final Bytes from, final Bytes to) {
         final NamedCache cache = getCache(namespace);
         if (cache == null) {
-            return new MemoryLRUCacheBytesIterator(Collections.emptyIterator());
+            return new MemoryLRUCacheBytesIterator(Collections.<Bytes>emptyIterator(), new NamedCache(namespace, this.metrics));
         }
-        return new MemoryLRUCacheBytesIterator(cache.subMapIterator(from, to));
+        return new MemoryLRUCacheBytesIterator(cache.keyRange(from, to), cache);
     }
 
     public MemoryLRUCacheBytesIterator all(final String namespace) {
         final NamedCache cache = getCache(namespace);
         if (cache == null) {
-            return new MemoryLRUCacheBytesIterator(Collections.emptyIterator());
+            return new MemoryLRUCacheBytesIterator(Collections.<Bytes>emptyIterator(), new NamedCache(namespace, this.metrics));
         }
-        return new MemoryLRUCacheBytesIterator(cache.allIterator());
+        return new MemoryLRUCacheBytesIterator(cache.allKeys(), cache);
     }
 
     public long size() {
@@ -261,11 +260,13 @@ public class ThreadCache {
     }
 
     static class MemoryLRUCacheBytesIterator implements PeekingKeyValueIterator<Bytes, LRUCacheEntry> {
-        private final Iterator<Map.Entry<Bytes, LRUNode>> underlying;
+        private final Iterator<Bytes> keys;
+        private final NamedCache cache;
         private KeyValue<Bytes, LRUCacheEntry> nextEntry;
 
-        MemoryLRUCacheBytesIterator(final Iterator<Map.Entry<Bytes, LRUNode>> underlying) {
-            this.underlying = underlying;
+        MemoryLRUCacheBytesIterator(final Iterator<Bytes> keys, final NamedCache cache) {
+            this.keys = keys;
+            this.cache = cache;
         }
 
         public Bytes peekNextKey() {
@@ -289,7 +290,7 @@ public class ThreadCache {
                 return true;
             }
 
-            while (underlying.hasNext() && nextEntry == null) {
+            while (keys.hasNext() && nextEntry == null) {
                 internalNext();
             }
 
@@ -307,9 +308,8 @@ public class ThreadCache {
         }
 
         private void internalNext() {
-            final Map.Entry<Bytes, LRUNode> mapEntry = underlying.next();
-            final Bytes cacheKey = mapEntry.getKey();
-            final LRUCacheEntry entry = mapEntry.getValue().entry();
+            final Bytes cacheKey = keys.next();
+            final LRUCacheEntry entry = cache.get(cacheKey);
             if (entry == null) {
                 return;
             }


### PR DESCRIPTION
Reverts the TreeMap -> ConcurrentSkipListMap change that caused a performance regression in 2.3, and fixes the ConcurrentModificationException by copying (just) the key set to iterate over