### PR TITLE
MINOR: Fix issue where the Trogdor Coordinator tracks its own node as an agent

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/common/Node.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/Node.java
@@ -37,7 +37,11 @@ public interface Node {
         }
 
         public static int getTrogdorAgentPort(Node node) {
-            return getIntConfig(node, Platform.Config.TROGDOR_AGENT_PORT, Agent.DEFAULT_PORT);
+            return getTrogdorAgentPort(node, Agent.DEFAULT_PORT);
+        }
+
+        public static int getTrogdorAgentPort(Node node, int defaultValue) {
+            return getIntConfig(node, Platform.Config.TROGDOR_AGENT_PORT, defaultValue);
         }
 
         public static int getTrogdorCoordinatorPort(Node node) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -137,7 +137,15 @@ public final class TaskManager {
         this.nodeManagers = new HashMap<>();
         this.nextWorkerId = firstWorkerId;
         for (Node node : platform.topology().nodes().values()) {
-            if (Node.Util.getTrogdorAgentPort(node) > 0) {
+            boolean agentIsSet;
+            if (node == platform.curNode()) {
+                // if the coordinator is running on this node, assume that no agent is configured on the
+                // same node without an explicit port configuration
+                agentIsSet = Node.Util.getTrogdorAgentPort(node, -1) > 0;
+            } else {
+                agentIsSet = Node.Util.getTrogdorAgentPort(node) > 0;
+            }
+            if (agentIsSet) {
                 this.nodeManagers.put(node.name(), new NodeManager(node, this));
             }
         }


### PR DESCRIPTION
The Trogdor coordinator would erroneously think that every node in the defined topology is an Agent and check its `/agent/status` endpoint. Since the Coordinator is defined in the topology, it would send requests to itself on a typically invalid default port which only timed out