### PR TITLE
MINOR: Allow KafkaZkClient and ZooKeeperClient to wait for the underlying ZooKeeper client to fully close.

### DIFF
--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1421,6 +1421,15 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 
   /**
+   * Wait up to the provided timeoutMs this KafkaZKClient to close.
+   * Supplying a timeoutMs of 0 means to wait forever.
+   */
+  def closeAndWait(timeoutMs: Int): Boolean = {
+    zooKeeperClient.closeAndWait(timeoutMs)
+  }
+
+
+  /**
    * Get the committed offset for a topic partition and group
    * @param group the group we wish to get offset for
    * @param topicPartition the topic partition we wish to get the offset for

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -353,6 +353,17 @@ class ZooKeeperClient(connectString: String,
     info("Closed.")
   }
 
+  /**
+   * Wait up to the provided timeoutMs this ZooKeeperClient to close.
+   * Supplying a timeoutMs of 0 means to wait forever.
+   */
+  def closeAndWait(timeoutMs: Int): Boolean = {
+    close()
+    inWriteLock(initializationLock) {
+      zooKeeper.close(timeoutMs)
+    }
+  }
+
   def sessionId: Long = inReadLock(initializationLock) {
     zooKeeper.getSessionId
   }

--- a/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
@@ -20,6 +20,7 @@ package kafka.zk
 import javax.security.auth.login.Configuration
 
 import kafka.utils.{CoreUtils, Logging, TestUtils}
+import org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS
 import org.junit.{After, AfterClass, Before, BeforeClass}
 import org.junit.Assert._
 import org.apache.kafka.common.security.JaasUtils
@@ -63,9 +64,7 @@ abstract class ZooKeeperTestHarness extends Logging {
   @After
   def tearDown(): Unit = {
     if (zkClient != null) {
-      zkClient.close()
-      val closeTimeoutMs = 15 * 1000
-      assertTrue(s"Failed to close zkClient after ${closeTimeoutMs}ms", zkClient.closeAndWait(closeTimeoutMs))
+      assertTrue(s"Failed to close zkClient after ${DEFAULT_MAX_WAIT_MS}ms", zkClient.closeAndWait(Math.toIntExact(DEFAULT_MAX_WAIT_MS)))
     }
     if (zookeeper != null)
       CoreUtils.swallow(zookeeper.shutdown(), this)

--- a/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
@@ -62,8 +62,11 @@ abstract class ZooKeeperTestHarness extends Logging {
 
   @After
   def tearDown(): Unit = {
-    if (zkClient != null)
-     zkClient.close()
+    if (zkClient != null) {
+      zkClient.close()
+      val closeTimeoutMs = 15 * 1000
+      assertTrue(s"Failed to close zkClient after ${closeTimeoutMs}ms", zkClient.closeAndWait(closeTimeoutMs))
+    }
     if (zookeeper != null)
       CoreUtils.swallow(zookeeper.shutdown(), this)
     Configuration.setConfiguration(null)


### PR DESCRIPTION
Allow KafkaZkClient and ZooKeeperClient to wait for the underlying ZooKeeper client to fully close, including the shutdown of the ZooKeeper client's event thread and send thread. The ZooKeeperTestHarness is also extended to take advantage of this functionality. It will now assert that the close was successful as part of tearDown().

I had considered supplying the close timeout as an optional parameter on `close()`, but a zero value for the close timeout will block forever (implementation detail of `join()`). 