### PR TITLE
Consumer benchmark test for paused partitions

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -20,7 +20,7 @@ package kafka.tools
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.util
-import java.util.Properties
+import java.util.{Properties, Random}
 import java.util.concurrent.atomic.AtomicLong
 
 import com.typesafe.scalalogging.LazyLogging
@@ -33,7 +33,6 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.util.Random
 
 /**
  * Performance test for the full zookeeper consumer
@@ -236,7 +235,7 @@ object ConsumerPerformance extends LazyLogging {
     val groupIdOpt = parser.accepts("group", "The group id to consume on.")
       .withRequiredArg
       .describedAs("gid")
-      .defaultsTo("perf-consumer-" + Random.nextInt(100000))
+      .defaultsTo("perf-consumer-" + new Random().nextInt(100000))
       .ofType(classOf[String])
     val fetchSizeOpt = parser.accepts("fetch-size", "The amount of data to fetch in a single request.")
       .withRequiredArg

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -20,10 +20,11 @@ package kafka.tools
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.util
+import java.util.Properties
 import java.util.concurrent.atomic.AtomicLong
-import java.util.{Properties, Random}
 
 import com.typesafe.scalalogging.LazyLogging
+import joptsimple.util.RegexMatcher._
 import kafka.utils.{CommandLineUtils, ToolsUtils}
 import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, KafkaConsumer}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
@@ -32,6 +33,7 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.Random
 
 /**
  * Performance test for the full zookeeper consumer
@@ -107,15 +109,34 @@ object ConsumerPerformance extends LazyLogging {
     var lastMessagesRead = 0L
     var joinStart = 0L
     var joinTimeMsInSingleRound = 0L
+    val assignedPartitions = mutable.LinkedHashSet[TopicPartition]()
+    var pausedPartitions = List[TopicPartition]()
+    var pausedPartitionIter: Iterator[TopicPartition] = null // circular array
 
     consumer.subscribe(topics.asJava, new ConsumerRebalanceListener {
       def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
         joinTime.addAndGet(System.currentTimeMillis - joinStart)
         joinTimeMsInSingleRound += System.currentTimeMillis - joinStart
+        assignedPartitions ++= partitions.asScala
+        pausedPartitionIter = Iterator.continually(assignedPartitions).flatten
+
       }
       def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
         joinStart = System.currentTimeMillis
+        assignedPartitions --= partitions.asScala.toSet
+        pausedPartitionIter = Iterator.continually(assignedPartitions).flatten
       }})
+
+    def pausePartitions(): Unit = if (assignedPartitions.nonEmpty) {
+      val assignmentSize = assignedPartitions.size
+      val numPartitionsToPause = Math.ceil(assignmentSize * config.pausedPartitionsPercent).toInt
+      if (assignmentSize == numPartitionsToPause)
+        println(s"WARNING: Pausing all $assignmentSize partitions. No data will be consumed this poll.")
+      pausedPartitions = pausedPartitionIter.take(numPartitionsToPause).toList
+      if (pausedPartitions.nonEmpty) consumer.pause(pausedPartitions.asJava)
+    }
+
+    def resumePartitions(): Unit = if (pausedPartitions.nonEmpty) consumer.resume(pausedPartitions.asJava)
 
     // Now start the benchmark
     var currentTimeMillis = System.currentTimeMillis
@@ -123,8 +144,10 @@ object ConsumerPerformance extends LazyLogging {
     var lastConsumedTime = currentTimeMillis
 
     while (messagesRead < count && currentTimeMillis - lastConsumedTime <= timeout) {
+      if (config.pausedPartitionsPercent > 0) pausePartitions()
       val records = consumer.poll(Duration.ofMillis(100)).asScala
       currentTimeMillis = System.currentTimeMillis
+      if (config.pausedPartitionsPercent > 0) resumePartitions()
       if (records.nonEmpty)
         lastConsumedTime = currentTimeMillis
       for (record <- records) {
@@ -213,7 +236,7 @@ object ConsumerPerformance extends LazyLogging {
     val groupIdOpt = parser.accepts("group", "The group id to consume on.")
       .withRequiredArg
       .describedAs("gid")
-      .defaultsTo("perf-consumer-" + new Random().nextInt(100000))
+      .defaultsTo("perf-consumer-" + Random.nextInt(100000))
       .ofType(classOf[String])
     val fetchSizeOpt = parser.accepts("fetch-size", "The amount of data to fetch in a single request.")
       .withRequiredArg
@@ -249,6 +272,13 @@ object ConsumerPerformance extends LazyLogging {
       .describedAs("milliseconds")
       .ofType(classOf[Long])
       .defaultsTo(10000)
+    val pausedPartitionsOpt = parser.accepts("paused-partitions-percent", "The percentage [0-1] of subscribed " +
+      "partitions to pause each poll.")
+        .withOptionalArg()
+        .describedAs("percent")
+        .withValuesConvertedBy(regex("^0(\\.\\d+)?|1\\.0$")) // matches [0-1] with decimals
+        .ofType(classOf[Float])
+        .defaultsTo(0F)
 
     options = parser.parse(args: _*)
 
@@ -283,5 +313,6 @@ object ConsumerPerformance extends LazyLogging {
     val dateFormat = new SimpleDateFormat(options.valueOf(dateFormatOpt))
     val hideHeader = options.has(hideHeaderOpt)
     val recordFetchTimeoutMs = options.valueOf(recordFetchTimeoutOpt).longValue()
+    val pausedPartitionsPercent = options.valueOf(pausedPartitionsOpt).floatValue()
   }
 }

--- a/tests/kafkatest/benchmarks/core/benchmark_test.py
+++ b/tests/kafkatest/benchmarks/core/benchmark_test.py
@@ -236,10 +236,11 @@ class Benchmark(Test):
         return data
 
     @cluster(num_nodes=6)
-    @parametrize(security_protocol='SSL', interbroker_security_protocol='PLAINTEXT')
-    @matrix(security_protocol=['PLAINTEXT', 'SSL'], compression_type=["none", "snappy"])
+    @parametrize(paused_partitions_percent="0.8")
+    # @parametrize(security_protocol='SSL', interbroker_security_protocol='PLAINTEXT')
+    # @matrix(security_protocol=['PLAINTEXT', 'SSL'], compression_type=["none", "snappy"])
     def test_consumer_throughput(self, compression_type="none", security_protocol="PLAINTEXT",
-                                 interbroker_security_protocol=None, num_consumers=1,
+                                 interbroker_security_protocol=None, num_consumers=1, paused_partitions_percent="0",
                                  client_version=str(DEV_BRANCH), broker_version=str(DEV_BRANCH)):
         """
         Consume 10e6 100-byte messages with 1 or more consumers from a topic with 6 partitions
@@ -269,7 +270,7 @@ class Benchmark(Test):
 
         # consume
         self.consumer = ConsumerPerformanceService(
-            self.test_context, num_consumers, self.kafka,
+            self.test_context, num_consumers, paused_partitions_percent, self.kafka,
             topic=TOPIC_REP_THREE, messages=num_records)
         self.consumer.group = "test-consumer-group"
         self.consumer.run()

--- a/tests/kafkatest/benchmarks/core/benchmark_test.py
+++ b/tests/kafkatest/benchmarks/core/benchmark_test.py
@@ -222,7 +222,7 @@ class Benchmark(Test):
             }
         )
         self.consumer = ConsumerPerformanceService(
-            self.test_context, 1, self.kafka, topic=TOPIC_REP_THREE, messages=num_records)
+            self.test_context, 1, None, self.kafka, topic=TOPIC_REP_THREE, messages=num_records)
         Service.run_parallel(self.producer, self.consumer)
 
         data = {
@@ -236,9 +236,9 @@ class Benchmark(Test):
         return data
 
     @cluster(num_nodes=6)
+    @parametrize(security_protocol='SSL', interbroker_security_protocol='PLAINTEXT')
+    @matrix(security_protocol=['PLAINTEXT', 'SSL'], compression_type=["none", "snappy"])
     @parametrize(paused_partitions_percent="0.8")
-    # @parametrize(security_protocol='SSL', interbroker_security_protocol='PLAINTEXT')
-    # @matrix(security_protocol=['PLAINTEXT', 'SSL'], compression_type=["none", "snappy"])
     def test_consumer_throughput(self, compression_type="none", security_protocol="PLAINTEXT",
                                  interbroker_security_protocol=None, num_consumers=1, paused_partitions_percent="0",
                                  client_version=str(DEV_BRANCH), broker_version=str(DEV_BRANCH)):

--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -77,7 +77,7 @@ class PerformanceServiceTest(Test):
 
         # check basic run of consumer performance service
         self.consumer_perf = ConsumerPerformanceService(
-            self.test_context, 1, self.kafka, new_consumer=new_consumer,
+            self.test_context, 1, None, self.kafka, new_consumer=new_consumer,
             topic=self.topic, version=version, messages=self.num_records)
         self.consumer_perf.group = "test-consumer-group"
         self.consumer_perf.run()

--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -36,7 +36,7 @@ class ConsumerPerformanceService(PerformanceService):
 
         "fetch-size", "The amount of data to fetch in a single request."
 
-        "from-latest", "If the consumer does not already have an establishedoffset to consume from,
+        "from-latest", "If the consumer does not already have an established offset to consume from,
                         start with the latest message present in the log rather than the earliest message."
 
         "socket-buffer-size", "The size of the tcp RECV size."
@@ -46,6 +46,9 @@ class ConsumerPerformanceService(PerformanceService):
         "num-fetch-threads", "Number of fetcher threads. Defaults to 1"
 
         "new-consumer", "Use the new consumer implementation."
+
+        "paused-partitions-percent", "The percentage [0-1] of subscribed partitions to pause each poll."
+
         "consumer.config", "Consumer config properties file."
     """
 
@@ -70,13 +73,15 @@ class ConsumerPerformanceService(PerformanceService):
             "collect_default": True}
     }
 
-    def __init__(self, context, num_nodes, kafka, topic, messages, version=DEV_BRANCH, new_consumer=True, settings={}):
+    def __init__(self, context, num_nodes, paused_partitions_percent, kafka, topic, messages, version=DEV_BRANCH,
+                 new_consumer=True, settings={}):
         super(ConsumerPerformanceService, self).__init__(context, num_nodes)
         self.kafka = kafka
         self.security_config = kafka.security_config.client_config()
         self.topic = topic
         self.messages = messages
         self.new_consumer = new_consumer
+        self.paused_partitions_percent = paused_partitions_percent
         self.settings = settings
 
         assert version >= V_0_9_0_0 or (not new_consumer), \
@@ -132,6 +137,9 @@ class ConsumerPerformanceService(PerformanceService):
         if self.from_latest:
             args['from-latest'] = ""
 
+        if self.paused_partitions_percent is not None:
+            args['paused-partitions-percent'] = self.paused_partitions_percent
+
         return args
 
     def start_cmd(self, node):
@@ -181,6 +189,7 @@ class ConsumerPerformanceService(PerformanceService):
         self.logger.debug("Consumer performance %d command: %s", idx, cmd)
         last = None
         for line in node.account.ssh_capture(cmd):
+            print line
             last = line
 
         # Parse and save the last line's information

--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -189,7 +189,6 @@ class ConsumerPerformanceService(PerformanceService):
         self.logger.debug("Consumer performance %d command: %s", idx, cmd)
         last = None
         for line in node.account.ssh_capture(cmd):
-            print line
             last = line
 
         # Parse and save the last line's information


### PR DESCRIPTION
For details about this new Kafka Consumer benchmark test see Jira issue [KAFKA-8814](https://issues.apache.org/jira/browse/KAFKA-8814).  Original PR and Jira:

* PR: [KAFKA-7548: KafkaConsumer should not throw away already fetched data for paused partitions (v2)](https://github.com/apache/kafka/pull/6988)
* Jira: [KAFKA-7548](https://issues.apache.org/jira/browse/KAFKA-7548)

To recreate the tests from the Jira issue:

```
# Run on trunk
TC_PATHS="tests/kafkatest/benchmarks/core/benchmark_test.py::Benchmark.test_consumer_throughput" bash tests/docker/run_tests.sh
# Rebase onto tag 2.3.0
git rebase --onto 2.3.0 trunk
# Run on 2.3.0
TC_PATHS="tests/kafkatest/benchmarks/core/benchmark_test.py::Benchmark.test_consumer_throughput" bash tests/docker/run_tests.sh
```

@ijuma @hachikuji Please review at your convenience.