### PR TITLE
KAFKA-8391, KAFKA-8661: Improve flaky Connect rebalance integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -124,7 +124,7 @@ public class MonitorableSinkConnector extends TestSinkConnector {
         @Override
         public void put(Collection<SinkRecord> records) {
             for (SinkRecord rec : records) {
-                taskHandle.record();
+                taskHandle.record(rec.topic());
                 TopicPartition tp = cachedTopicPartitions
                         .computeIfAbsent(rec.topic(), v -> new HashMap<>())
                         .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -127,7 +127,7 @@ public class MonitorableSourceConnector extends TestSourceConnector {
                 if (throttler.shouldThrottle(seqno - startingSeqno, System.currentTimeMillis())) {
                     throttler.throttle();
                 }
-                taskHandle.record(batchSize);
+                taskHandle.record(topicName, batchSize);
                 return LongStream.range(0, batchSize)
                         .mapToObj(i -> new SourceRecord(
                                 Collections.singletonMap("task.id", taskId),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -179,6 +179,8 @@ public class RebalanceSourceConnectorsIntegrationTest {
         props.put(TOPIC_CONFIG, anotherTopic);
         connect.configureConnector(CONNECTOR_NAME, props);
 
+        assertTrue(connect.kafka().allBrokersRunning());
+
         // Wait for the connector *and tasks* to be restarted
         assertTrue("Failed to alter connector configuration and see connector and tasks restart "
                    + "within " + CONNECTOR_SETUP_DURATION_MS + "ms",
@@ -187,6 +189,8 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // And wait for Connect to show the connectors and tasks are running
         waitForCondition(() -> this.assertConnectorAndTasksRunning(CONNECTOR_NAME, NUM_TASKS).orElse(false),
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
+
+        assertTrue(connect.kafka().allBrokersRunning());
 
         // wait for the connector's tasks to have produced records
         connectorHandle.awaitRecords(anotherTopic, recordWriteDurationMs);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -62,9 +62,10 @@ public class RebalanceSourceConnectorsIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(RebalanceSourceConnectorsIntegrationTest.class);
 
     private static final int NUM_TOPIC_PARTITIONS = 3;
-    private static final long CONNECTOR_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(30);
-    private static final long WORKER_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+    private static final long CONNECTOR_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(90);
+    private static final long WORKER_SETUP_DURATION_MS = TimeUnit.SECONDS.toMillis(90);
     private static final int NUM_TASKS = 4;
+    private static final int NUM_WORKERS = 3;
     private static final String CONNECTOR_NAME = "seq-source1";
     private static final String TOPIC_NAME = "sequential-topic";
 
@@ -84,7 +85,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
                 .name("connect-cluster")
-                .numWorkers(3)
+                .numWorkers(NUM_WORKERS)
                 .numBrokers(1)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)
@@ -122,12 +123,14 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
 
         // start a source connector
-        connect.configureConnector("another-source", props);
+        String connectorName2 = "another-source";
+        int numTasks2 = NUM_TASKS;
+        connect.configureConnector(connectorName2, props);
 
         waitForCondition(() -> this.assertConnectorAndTasksRunning(CONNECTOR_NAME, NUM_TASKS).orElse(false),
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
 
-        waitForCondition(() -> this.assertConnectorAndTasksRunning("another-source", 4).orElse(false),
+        waitForCondition(() -> this.assertConnectorAndTasksRunning(connectorName2, numTasks2).orElse(false),
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
     }
 
@@ -157,7 +160,8 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
 
         int numRecordsProduced = 100;
-        long recordTransferDurationMs = TimeUnit.SECONDS.toMillis(30);
+        long recordWriteDurationMs = TimeUnit.SECONDS.toMillis(60);
+        long recordTransferDurationMs = TimeUnit.SECONDS.toMillis(60);
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
         int recordNum = connect.kafka().consume(numRecordsProduced, recordTransferDurationMs, TOPIC_NAME).count();
@@ -167,7 +171,11 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // expect that we're going to restart the connector and its tasks
         StartAndStopLatch restartLatch = connectorHandle.expectedStarts(1);
 
-        // Reconfigure the source connector by changing the Kafka topic used as output
+        // expect that the connector will write the records to a new topic
+        connectorHandle.expectedRecords(anotherTopic, numRecordsProduced);
+
+        // Reconfigure the source connector by changing the Kafka topic used as output,
+        // which will restart the connector and tasks
         props.put(TOPIC_CONFIG, anotherTopic);
         connect.configureConnector(CONNECTOR_NAME, props);
 
@@ -176,9 +184,12 @@ public class RebalanceSourceConnectorsIntegrationTest {
                    + "within " + CONNECTOR_SETUP_DURATION_MS + "ms",
                 restartLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
 
-        // And wait for the Connect to show the connectors and tasks are running
+        // And wait for Connect to show the connectors and tasks are running
         waitForCondition(() -> this.assertConnectorAndTasksRunning(CONNECTOR_NAME, NUM_TASKS).orElse(false),
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
+
+        // wait for the connector's tasks to have produced records
+        connectorHandle.awaitRecords(anotherTopic, recordWriteDurationMs);
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced
         recordNum = connect.kafka().consume(numRecordsProduced, recordTransferDurationMs, anotherTopic).count();
@@ -201,7 +212,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
 
-        waitForCondition(() -> this.assertWorkersUp(3),
+        waitForCondition(() -> this.assertWorkersUp(NUM_WORKERS),
                 WORKER_SETUP_DURATION_MS, "Connect workers did not start in time.");
 
         // start a source connector
@@ -242,7 +253,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
 
-        waitForCondition(() -> this.assertWorkersUp(3),
+        waitForCondition(() -> this.assertWorkersUp(NUM_WORKERS),
                 WORKER_SETUP_DURATION_MS, "Connect workers did not start in time.");
 
         // start a source connector
@@ -259,8 +270,9 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
 
         connect.addWorker();
+        int numWorkers = NUM_WORKERS + 1;
 
-        waitForCondition(() -> this.assertWorkersUp(4),
+        waitForCondition(() -> this.assertWorkersUp(numWorkers),
                 WORKER_SETUP_DURATION_MS, "Connect workers did not start in time.");
 
         waitForCondition(() -> this.assertConnectorAndTasksRunning(CONNECTOR_NAME + 3, NUM_TASKS).orElse(false),
@@ -285,7 +297,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
 
-        waitForCondition(() -> this.assertWorkersUp(3),
+        waitForCondition(() -> this.assertWorkersUp(NUM_WORKERS),
                 WORKER_SETUP_DURATION_MS, "Connect workers did not start in time.");
 
         // start a source connector
@@ -302,8 +314,9 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
 
         connect.removeWorker();
+        int numWorker = NUM_WORKERS - 1;
 
-        waitForCondition(() -> this.assertWorkersUp(2),
+        waitForCondition(() -> this.assertWorkersUp(numWorker),
                 WORKER_SETUP_DURATION_MS, "Connect workers did not start in time.");
 
         waitForCondition(this::assertConnectorAndTasksAreUnique,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RecordLatches.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RecordLatches.java
@@ -226,7 +226,7 @@ public class RecordLatches {
         if (latch != null) {
             latch.countDown(count);
         } else {
-            log.error("Unexpectedly missing latch");
+            log.trace("No latch found due to no expectation");
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RecordLatches.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RecordLatches.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.integration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecordLatches {
+
+    private static final Logger log = LoggerFactory.getLogger(RecordLatches.class);
+
+    private final String name;
+    private final Map<String, Latch> recordsRemainingLatchesByTopic = new ConcurrentHashMap<>();
+    private Latch recordsRemainingLatch;
+    private Latch recordsToCommitLatch;
+
+    public RecordLatches(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Record a message arrival at the task and the connector overall.
+     */
+    public void record() {
+        countDown(recordsRemainingLatch, 1);
+    }
+
+    /**
+     * Record arrival of a batch of messages at the task and the connector overall.
+     *
+     * @param batchSize the number of messages
+     */
+    public void record(int batchSize) {
+        countDown(recordsRemainingLatch, batchSize);
+    }
+
+    /**
+     * Record a message arrival at the task and the connector overall.
+     *
+     * @param topic the name of the topic
+     */
+    public void record(String topic) {
+        countDown(recordsRemainingLatchesByTopic.get(topic), 1);
+        // also record a record for the "all topics" latch
+        record();
+    }
+
+    /**
+     * Record arrival of a batch of messages at the task and the connector overall.
+     *
+     * @param topic     the name of the topic
+     * @param batchSize the number of messages
+     */
+    public void record(String topic, int batchSize) {
+        countDown(recordsRemainingLatchesByTopic.get(topic), batchSize);
+        // also record records for the "all topics" latch
+        record(batchSize);
+    }
+
+    /**
+     * Record a message commit from the task and the connector overall.
+     */
+    public void commit() {
+        countDown(recordsToCommitLatch, 1);
+    }
+
+    /**
+     * Record commit on a batch of messages from the task and the connector overall.
+     *
+     * @param batchSize the number of messages
+     */
+    public void commit(int batchSize) {
+        countDown(recordsToCommitLatch, batchSize);
+    }
+
+    /**
+     * Set the number of expected records for this task across any/all topics.
+     *
+     * @param expected number of records
+     */
+    public void expectedRecords(int expected) {
+        expectedRecords(null, expected);
+    }
+
+    /**
+     * Set the number of expected records for this task.
+     *
+     * @param topic    the name of the topic onto which the records are expected
+     * @param expected number of records
+     */
+    public void expectedRecords(String topic, int expected) {
+        if (topic != null) {
+            recordsRemainingLatchesByTopic.put(topic, new Latch(expected));
+        } else {
+            recordsRemainingLatch = new Latch(expected);
+        }
+    }
+
+    /**
+     * Set the number of expected record commits performed by this task.
+     *
+     * @param expected number of commits
+     */
+    public void expectedCommits(int expected) {
+        recordsToCommitLatch = new Latch(expected);
+    }
+
+    /**
+     * Wait up to the specified number of milliseconds for this task to meet the expected number of
+     * records as defined by {@code expectedRecords}.
+     *
+     * @param timeoutMillis number of milliseconds to wait for records
+     * @throws InterruptedException if another threads interrupts this one while waiting for records
+     */
+    public void awaitRecords(long timeoutMillis) throws InterruptedException {
+        awaitRecords(timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Wait up to the specified timeout for this task to meet the expected number of records as
+     * defined by {@code expectedRecords}.
+     *
+     * @param timeout duration to wait for records
+     * @param unit    the unit of duration; may not be null
+     * @throws InterruptedException if another threads interrupts this one while waiting for records
+     */
+    public void awaitRecords(long timeout, TimeUnit unit) throws InterruptedException {
+        awaitRecords(recordsRemainingLatch, "records", timeout, unit);
+    }
+
+    /**
+     * Wait up to the specified timeout for this task to meet the expected number of records as
+     * defined by {@code expectedRecords}.
+     *
+     * @param topic   the name of the topic; may be null for all topics
+     * @param timeout duration to wait for records
+     * @param unit    the unit of duration; may not be null
+     * @throws InterruptedException if another threads interrupts this one while waiting for records
+     */
+    public void awaitRecords(String topic, long timeout, TimeUnit unit) throws InterruptedException {
+        Latch latch = recordsRemainingLatchesByTopic.get(topic);
+        if (latch != null) {
+            awaitRecords(latch, "records on topic '" + topic + "'", timeout, unit);
+        } else {
+            awaitRecords(recordsRemainingLatch, "records", timeout, unit);
+        }
+    }
+
+    protected void awaitRecords(Latch latch, String type, long timeout, TimeUnit unit) throws InterruptedException {
+        if (latch == null) {
+            throw new IllegalStateException("Illegal state encountered. expectedRecords() was not set for this task?");
+        }
+        if (!latch.await(timeout, unit)) {
+            String msg = String.format(
+                    "Insufficient %s seen by %s in %d millis. Records expected=%d, actual=%d",
+                    type,
+                    name,
+                    unit.toMillis(timeout),
+                    latch.expected(),
+                    latch.count());
+            throw new DataException(msg);
+        }
+        log.debug("{} saw {} {}, expected {} records",
+                name, latch.count(), type, latch.expected());
+    }
+
+    /**
+     * Wait up to the specified timeout in milliseconds for this task to meet the expected number
+     * of commits as defined by {@code expectedCommits}.
+     *
+     * @param timeoutMillis number of milliseconds to wait for commits
+     * @throws InterruptedException if another threads interrupts this one while waiting for commits
+     */
+    public void awaitCommits(long timeoutMillis) throws InterruptedException {
+        awaitCommits(timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Wait up to the specified timeout for this task to meet the expected number of commits as
+     * defined by {@code expectedCommits}.
+     *
+     * @param timeout duration to wait for commits
+     * @param unit    the unit of duration; may not be null
+     * @throws InterruptedException if another threads interrupts this one while waiting for commits
+     */
+    public void awaitCommits(long timeout, TimeUnit unit) throws InterruptedException {
+        if (recordsToCommitLatch == null) {
+            throw new IllegalStateException("Illegal state encountered. expectedRecords() was not set for this task?");
+        }
+        if (!recordsToCommitLatch.await(timeout, unit)) {
+            String msg = String.format(
+                    "Insufficient records seen by %s in %d millis. Records expected=%d, actual=%d",
+                    name,
+                    unit.toMillis(timeout),
+                    recordsToCommitLatch.expected(),
+                    recordsToCommitLatch.count());
+            throw new DataException(msg);
+        }
+        log.debug("{} saw {} records, expected {} records",
+                name, recordsToCommitLatch.count(), recordsRemainingLatch.expected());
+    }
+
+    private void countDown(Latch latch, int count) {
+        if (latch != null) {
+            latch.countDown(count);
+        } else {
+            log.error("Unexpectedly missing latch");
+        }
+    }
+
+    private static class Latch {
+        protected final CountDownLatch latch;
+        protected final int expected;
+
+        public Latch(int expected) {
+            this.latch = new CountDownLatch(expected);
+            this.expected = expected;
+        }
+
+        public int count() {
+            return expected - (int) latch.getCount();
+        }
+
+        public int expected() {
+            return expected;
+        }
+
+        /**
+         * Record a message arrival at the task and the connector overall.
+         */
+        public void countDown() {
+            latch.countDown();
+        }
+
+        /**
+         * Record arrival of a batch of messages at the task and the connector overall.
+         *
+         * @param batchSize the number of messages
+         */
+        public void countDown(int batchSize) {
+            IntStream.range(0, batchSize).forEach(i -> latch.countDown());
+        }
+
+        /**
+         * Wait up to the specified timeout for the current number to reach the expected number.
+         *
+         * @param timeout duration to wait
+         * @param unit    the unit of duration; may not be null
+         * @return true if the count has reached zero, or false otherwise
+         * @throws InterruptedException if another threads interrupts this one while waiting for records
+         */
+        public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.util.clusters;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaConfig$;
 import kafka.server.KafkaServer;
+import kafka.server.RunningAsBroker;
 import kafka.utils.CoreUtils;
 import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
@@ -65,6 +66,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 
 /**
@@ -197,6 +199,18 @@ public class EmbeddedKafkaCluster extends ExternalResource {
         return "127.0.0.1:" + zookeeper.port();
     }
 
+    public boolean allBrokersRunning() {
+        return countBrokersIn(RunningAsBroker.state()) == brokers.length;
+    }
+
+    protected long countBrokersIn(byte expectedState) {
+        return Arrays.stream(brokers)
+                     .map(KafkaServer::brokerState)
+                     .filter(brokerState -> brokerState.currentState() == expectedState)
+                     .count();
+    }
+
+
     /**
      * Create a Kafka topic with 1 partition and a replication factor of 1.
      *
@@ -279,11 +293,13 @@ public class EmbeddedKafkaCluster extends ExternalResource {
      * @return a {@link ConsumerRecords} collection containing at least n records.
      */
     public ConsumerRecords<byte[], byte[]> consume(int n, long maxDuration, String... topics) {
+        log.debug("Consuming from {} for total of {} millis.", Arrays.toString(topics), maxDuration);
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
         int consumedRecords = 0;
-        try (KafkaConsumer<byte[], byte[]> consumer = createConsumerAndSubscribeTo(Collections.emptyMap(), topics)) {
+        Map<String, Object> consumerProps = Collections.singletonMap(MAX_POLL_RECORDS_CONFIG, 10);
+        try (KafkaConsumer<byte[], byte[]> consumer = createConsumerAndSubscribeTo(consumerProps, topics)) {
             final long startMillis = System.currentTimeMillis();
-            long allowedDuration = maxDuration;
+            long allowedDuration = Math.max(10L, maxDuration / 10);
             while (allowedDuration > 0) {
                 log.debug("Consuming from {} for {} millis.", Arrays.toString(topics), allowedDuration);
                 ConsumerRecords<byte[], byte[]> rec = consumer.poll(Duration.ofMillis(allowedDuration));

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -31,5 +31,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 log4j.logger.org.reflections=ERROR
 log4j.logger.kafka=WARN
 log4j.logger.org.apache.kafka.connect=DEBUG
+log4j.logger.org.apache.kafka.connect.runtime=TRACE
 log4j.logger.org.apache.kafka.connect.runtime.distributed=DEBUG
 log4j.logger.org.apache.kafka.connect.integration=DEBUG


### PR DESCRIPTION
Increased the timeout by a substantial amount, though this will only take effect if the test conditions are not met successfully.

Added logic to allow tests to wait for a number of records to have been written to / consumed from a specific topic. This involved extracting the previously-duplicated logic in `ConnectorHandle` and TaskHandle (test framework classes) into a new `RecordLatches` class that can be easily reused by both those handle classes.

These integration tests are passing were occasionally failing for me locally, but now I’ve run them successfully nearly a dozen times in a row. If the Jenkins builds are a bit slower, this might help the tests fail less frequently.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
