### PR TITLE
MINOR: Add support for bootstrap-server in create_topic

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -491,7 +491,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def perform_leader_election(self, topic, partition, election_type, node=None):
         """
-        Perform leader election for the partition of the topic passed in as argument.
+        Perform leader election for the partition of the topic passed in as argument
+        and waits until leadership changes replica.
         """
         if node is None:
             node = self.nodes[0]

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -766,15 +766,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def connect_setting(self, node):
         """
-        Checks if --bootstrap-server config is supported, if yes then returns a string with
-        bootstrap server, otherwise returns zookeeper connection string.
+        Returns bootstrap server connection string.
         """
-        if node.version.supports_bootstrap_server():
-            connection_setting = "--bootstrap-server %s" % self.bootstrap_servers(self.security_protocol)
-        else:
-            connection_setting = "--zookeeper %s" % self.zk_connect_setting()
-
-        return connection_setting
+        return "--bootstrap-server %s" % self.bootstrap_servers(self.security_protocol)
 
     def __bootstrap_servers(self, port, validate=True, offline_nodes=[]):
         if validate and not port.open:

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -52,6 +52,8 @@ class KafkaVersion(LooseVersion):
     def supports_named_listeners(self):
         return self >= V_0_10_2_0
 
+    def supports_bootstrap_server(self):
+        return self > LATEST_2_2
 
 def get_version(node=None):
     """Return the version attached to the given node.

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -52,8 +52,6 @@ class KafkaVersion(LooseVersion):
     def supports_named_listeners(self):
         return self >= V_0_10_2_0
 
-    def supports_bootstrap_server(self):
-        return self > LATEST_2_2
 
 def get_version(node=None):
     """Return the version attached to the given node.


### PR DESCRIPTION
create_topic method uses --zookeeper option to create a new topic. This
change adds support for it to switch to --bootstrap-server config if it
is supported.

As "--zookeeper" option is deprecated and "--bootstrap-server" is
preferred, this change allows us to move away from the deprecated
option.

Tested by launching tests and confirming they pass and use the new
--bootstrap-server option.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
