### PR TITLE
KAFKA-8819 : fix plugin path loader for converter

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -418,10 +418,10 @@ public class Worker {
 
             ClassLoader savedLoader = plugins.currentThreadLoader();
             try {
-                final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
-                String connType = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+                String connType = connProps.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
                 ClassLoader connectorLoader = plugins.delegatingLoader().connectorLoader(connType);
                 savedLoader = Plugins.compareAndSwapLoaders(connectorLoader);
+                final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
                 final TaskConfig taskConfig = new TaskConfig(taskProps);
                 final Class<? extends Task> taskClass = taskConfig.getClass(TaskConfig.TASK_CLASS_CONFIG).asSubclass(Task.class);
                 final Task task = plugins.newTask(taskClass);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -246,7 +246,9 @@ public class Plugins {
                 }
                 catch (ClassNotFoundException e) {
                     throw new ConnectException(
-                        "Failed to find any class that implements Converter and which name matches "
+                        "Failed to find any class that implements Converter for the config "
+                        + classPropertyName + ", available converters are: "
+                        + pluginNames(delegatingLoader.converters())
                     );
                 }
                 break;
@@ -265,7 +267,7 @@ public class Plugins {
                 break;
         }
         if (klass == null) {
-            throw new ConnectException("Unable to instantiate the Converter specified in '" + classPropertyName + "'");
+            throw new ConnectException("Unable to initialize the Converter specified in '" + classPropertyName + "'");
         }
 
         savedLoader = compareAndSwapLoaders(klass.getClassLoader());
@@ -329,7 +331,9 @@ public class Plugins {
                 }
                 catch (ClassNotFoundException e) {
                     throw new ConnectException(
-                        "Failed to find any class that implements Converter and which name matches "
+                        "Failed to find any class that implements HeaderConverter for the config "
+                        + classPropertyName + ", available converters are: "
+                        + pluginNames(delegatingLoader.converters())
                     );
                 }
                 break;
@@ -353,7 +357,7 @@ public class Plugins {
                 }
         }
         if (klass == null) {
-            throw new ConnectException("Unable to instantiate the Converter specified in '" + classPropertyName + "'");
+            throw new ConnectException("Unable to initialize the HeaderConverter specified in '" + classPropertyName + "'");
         }
 
         String configPrefix = classPropertyName + ".";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -80,6 +80,23 @@ public class Plugins {
     }
 
     @SuppressWarnings("unchecked")
+    protected static <U> Class<? extends U> pluginClassFromConfig(
+        AbstractConfig config,
+        String propertyName,
+        Class<U> pluginClass
+    ) throws ClassNotFoundException {
+        Class<?> klass = config.getClass(propertyName);
+        if (pluginClass.isAssignableFrom(klass)) {
+            return (Class<? extends U>) klass;
+        }
+        throw new ClassNotFoundException(
+            "Requested class for property: "
+                + propertyName
+                + " does not extend " + pluginClass.getSimpleName()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
     protected static <U> Class<? extends U> pluginClass(
             DelegatingClassLoader loader,
             String classOrAlias,
@@ -216,17 +233,26 @@ public class Plugins {
             return null;
         }
         Converter plugin = null;
+        ClassLoader savedLoader = null;
+        Class<? extends Converter> klass = null;
         switch (classLoaderUsage) {
             case CURRENT_CLASSLOADER:
                 // Attempt to load first with the current classloader, and plugins as a fallback.
                 // Note: we can't use config.getConfiguredInstance because Converter doesn't implement Configurable, and even if it did
                 // we have to remove the property prefixes before calling config(...) and we still always want to call Converter.config.
-                plugin = getInstance(config, classPropertyName, Converter.class);
+
+                try {
+                    klass = pluginClassFromConfig(config, classPropertyName, Converter.class);
+                }
+                catch (ClassNotFoundException e) {
+                    throw new ConnectException(
+                        "Failed to find any class that implements Converter and which name matches "
+                    );
+                }
                 break;
             case PLUGINS:
                 // Attempt to load with the plugin class loader, which uses the current classloader as a fallback
                 String converterClassOrAlias = config.getClass(classPropertyName).getName();
-                Class<? extends Converter> klass;
                 try {
                     klass = pluginClass(delegatingLoader, converterClassOrAlias, Converter.class);
                 } catch (ClassNotFoundException e) {
@@ -236,36 +262,42 @@ public class Plugins {
                             + pluginNames(delegatingLoader.converters())
                     );
                 }
-                plugin = newPlugin(klass);
                 break;
         }
-        if (plugin == null) {
+        if (klass == null) {
             throw new ConnectException("Unable to instantiate the Converter specified in '" + classPropertyName + "'");
         }
 
-        // Determine whether this is a key or value converter based upon the supplied property name ...
-        @SuppressWarnings("deprecation")
-        final boolean isKeyConverter = WorkerConfig.KEY_CONVERTER_CLASS_CONFIG.equals(classPropertyName)
-                                     || WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG.equals(classPropertyName);
+        savedLoader = compareAndSwapLoaders(klass.getClassLoader());
+        try {
+            plugin = newPlugin(klass);
 
-        // Configure the Converter using only the old configuration mechanism ...
-        String configPrefix = classPropertyName + ".";
-        Map<String, Object> converterConfig = config.originalsWithPrefix(configPrefix);
-        log.debug("Configuring the {} converter with configuration keys:{}{}",
-                  isKeyConverter ? "key" : "value", System.lineSeparator(), converterConfig.keySet());
+            // Determine whether this is a key or value converter based upon the supplied property name ...
+            @SuppressWarnings("deprecation")
+            final boolean isKeyConverter = WorkerConfig.KEY_CONVERTER_CLASS_CONFIG.equals(classPropertyName)
+                                         || WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG.equals(classPropertyName);
 
-        // Have to override schemas.enable from true to false for internal JSON converters
-        // Don't have to warn the user about anything since all deprecation warnings take place in the
-        // WorkerConfig class
-        if (plugin instanceof JsonConverter && isInternalConverter(classPropertyName)) {
-            // If they haven't explicitly specified values for internal.key.converter.schemas.enable
-            // or internal.value.converter.schemas.enable, we can safely default them to false
-            if (!converterConfig.containsKey(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG)) {
-                converterConfig.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
+            // Configure the Converter using only the old configuration mechanism ...
+            String configPrefix = classPropertyName + ".";
+            Map<String, Object> converterConfig = config.originalsWithPrefix(configPrefix);
+            log.debug("Configuring the {} converter with configuration keys:{}{}",
+                      isKeyConverter ? "key" : "value", System.lineSeparator(), converterConfig.keySet());
+
+            // Have to override schemas.enable from true to false for internal JSON converters
+            // Don't have to warn the user about anything since all deprecation warnings take place in the
+            // WorkerConfig class
+            if (plugin instanceof JsonConverter && isInternalConverter(classPropertyName)) {
+                // If they haven't explicitly specified values for internal.key.converter.schemas.enable
+                // or internal.value.converter.schemas.enable, we can safely default them to false
+                if (!converterConfig.containsKey(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG)) {
+                    converterConfig.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
+                }
             }
-        }
 
-        plugin.configure(converterConfig, isKeyConverter);
+            plugin.configure(converterConfig, isKeyConverter);
+        } finally {
+            compareAndSwapLoaders(savedLoader);
+        }
         return plugin;
     }
 
@@ -281,6 +313,8 @@ public class Plugins {
      */
     public HeaderConverter newHeaderConverter(AbstractConfig config, String classPropertyName, ClassLoaderUsage classLoaderUsage) {
         HeaderConverter plugin = null;
+        ClassLoader savedLoader = null;
+        Class<? extends HeaderConverter> klass = null;
         switch (classLoaderUsage) {
             case CURRENT_CLASSLOADER:
                 if (!config.originals().containsKey(classPropertyName)) {
@@ -290,13 +324,19 @@ public class Plugins {
                 // Attempt to load first with the current classloader, and plugins as a fallback.
                 // Note: we can't use config.getConfiguredInstance because we have to remove the property prefixes
                 // before calling config(...)
-                plugin = getInstance(config, classPropertyName, HeaderConverter.class);
+                try {
+                    klass = pluginClassFromConfig(config, classPropertyName, HeaderConverter.class);
+                }
+                catch (ClassNotFoundException e) {
+                    throw new ConnectException(
+                        "Failed to find any class that implements Converter and which name matches "
+                    );
+                }
                 break;
             case PLUGINS:
                 // Attempt to load with the plugin class loader, which uses the current classloader as a fallback.
                 // Note that there will always be at least a default header converter for the worker
                 String converterClassOrAlias = config.getClass(classPropertyName).getName();
-                Class<? extends HeaderConverter> klass;
                 try {
                     klass = pluginClass(
                             delegatingLoader,
@@ -311,9 +351,8 @@ public class Plugins {
                                     + pluginNames(delegatingLoader.headerConverters())
                     );
                 }
-                plugin = newPlugin(klass);
         }
-        if (plugin == null) {
+        if (klass == null) {
             throw new ConnectException("Unable to instantiate the Converter specified in '" + classPropertyName + "'");
         }
 
@@ -321,7 +360,14 @@ public class Plugins {
         Map<String, Object> converterConfig = config.originalsWithPrefix(configPrefix);
         converterConfig.put(ConverterConfig.TYPE_CONFIG, ConverterType.HEADER.getName());
         log.debug("Configuring the header converter with configuration keys:{}{}", System.lineSeparator(), converterConfig.keySet());
-        plugin.configure(converterConfig);
+        savedLoader = compareAndSwapLoaders(klass.getClassLoader());
+        try {
+            plugin = newPlugin(klass);
+            plugin.configure(converterConfig);
+        }
+        finally {
+            compareAndSwapLoaders(savedLoader);
+        }
         return plugin;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -81,9 +81,9 @@ public class Plugins {
 
     @SuppressWarnings("unchecked")
     protected static <U> Class<? extends U> pluginClassFromConfig(
-        AbstractConfig config,
-        String propertyName,
-        Class<U> pluginClass
+            AbstractConfig config,
+            String propertyName,
+            Class<U> pluginClass
     ) throws ClassNotFoundException {
         Class<?> klass = config.getClass(propertyName);
         if (pluginClass.isAssignableFrom(klass)) {
@@ -233,7 +233,6 @@ public class Plugins {
             return null;
         }
         Converter plugin = null;
-        ClassLoader savedLoader = null;
         Class<? extends Converter> klass = null;
         switch (classLoaderUsage) {
             case CURRENT_CLASSLOADER:
@@ -269,7 +268,7 @@ public class Plugins {
             throw new ConnectException("Unable to initialize the Converter specified in '" + classPropertyName + "'");
         }
 
-        savedLoader = compareAndSwapLoaders(klass.getClassLoader());
+        ClassLoader savedLoader = compareAndSwapLoaders(klass.getClassLoader());
         try {
             plugin = newPlugin(klass);
 
@@ -314,7 +313,6 @@ public class Plugins {
      */
     public HeaderConverter newHeaderConverter(AbstractConfig config, String classPropertyName, ClassLoaderUsage classLoaderUsage) {
         HeaderConverter plugin = null;
-        ClassLoader savedLoader = null;
         Class<? extends HeaderConverter> klass = null;
         switch (classLoaderUsage) {
             case CURRENT_CLASSLOADER:
@@ -362,7 +360,7 @@ public class Plugins {
         Map<String, Object> converterConfig = config.originalsWithPrefix(configPrefix);
         converterConfig.put(ConverterConfig.TYPE_CONFIG, ConverterType.HEADER.getName());
         log.debug("Configuring the header converter with configuration keys:{}{}", System.lineSeparator(), converterConfig.keySet());
-        savedLoader = compareAndSwapLoaders(klass.getClassLoader());
+        ClassLoader savedLoader = compareAndSwapLoaders(klass.getClassLoader());
         try {
             plugin = newPlugin(klass);
             plugin.configure(converterConfig);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -243,8 +243,7 @@ public class Plugins {
 
                 try {
                     klass = pluginClassFromConfig(config, classPropertyName, Converter.class);
-                }
-                catch (ClassNotFoundException e) {
+                } catch (ClassNotFoundException e) {
                     throw new ConnectException(
                         "Failed to find any class that implements Converter for the config "
                         + classPropertyName + ", available converters are: "
@@ -328,8 +327,7 @@ public class Plugins {
                 // before calling config(...)
                 try {
                     klass = pluginClassFromConfig(config, classPropertyName, HeaderConverter.class);
-                }
-                catch (ClassNotFoundException e) {
+                } catch (ClassNotFoundException e) {
                     throw new ConnectException(
                         "Failed to find any class that implements HeaderConverter for the config "
                         + classPropertyName + ", available converters are: "
@@ -368,8 +366,7 @@ public class Plugins {
         try {
             plugin = newPlugin(klass);
             plugin.configure(converterConfig);
-        }
-        finally {
+        } finally {
             compareAndSwapLoaders(savedLoader);
         }
         return plugin;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8819 describes the issue and scenario in which it happens in detail.

* Create the Connector config after we set the class loader to be connector's classloader.
* Set the Converter's classloader as the current class loader while instantiating and configuring the connector. ( Maybe we should potentially do this for the actual converter invocation as well )

The changes were manually tested by including the AvroConverter which used the ServiceLoader mechanism internally in 2 different plugin path. When the connectors were created with AvroConverter only one of them would start successfully before the fix and the other one used to fail with some class mismatch issues in the ServiceLoader. After the fix proposed in the PR, we are able to create the connectors successfully.

This PR doesn't change any deployment requirements for Converter. It allows Converters to be included in either the Plugin path of the connector or in its own path. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
