### PR TITLE
KAFKA-8755: Fix state restore for standby tasks with optimized topology

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -250,7 +250,7 @@ public abstract class AbstractTask implements Task {
         return stateMgr.changelogPartitions();
     }
 
-    protected long getConsumerCommittedOffset(final TopicPartition partition) {
+    long committedOffsetForPartition(final TopicPartition partition) {
         try {
             final OffsetAndMetadata metadata = consumer.committed(partition);
             return metadata != null ? metadata.offset() : 0L;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -171,26 +171,6 @@ public abstract class AbstractTask implements Task {
         return sb.toString();
     }
 
-    protected void updateOffsetLimits() {
-        for (final TopicPartition partition : partitions) {
-            try {
-                final OffsetAndMetadata metadata = consumer.committed(partition); // TODO: batch API?
-                final long offset = metadata != null ? metadata.offset() : 0L;
-                stateMgr.putOffsetLimit(partition, offset);
-
-                if (log.isTraceEnabled()) {
-                    log.trace("Updating store offset limits {} for changelog {}", offset, partition);
-                }
-            } catch (final AuthorizationException e) {
-                throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partition), e);
-            } catch (final WakeupException e) {
-                throw e;
-            } catch (final KafkaException e) {
-                throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partition), e);
-            }
-        }
-    }
-
     /**
      * Flush all state stores owned by this task
      */
@@ -218,9 +198,6 @@ public abstract class AbstractTask implements Task {
                 logPrefix, id));
         }
         log.trace("Initializing state stores");
-
-        // set initial offset limits
-        updateOffsetLimits();
 
         for (final StateStore store : topology.stateStores()) {
             log.trace("Initializing store {}", store.name());
@@ -272,4 +249,18 @@ public abstract class AbstractTask implements Task {
     public Collection<TopicPartition> changelogPartitions() {
         return stateMgr.changelogPartitions();
     }
+
+    protected long getConsumerCommittedOffset(final TopicPartition partition) {
+        try {
+            final OffsetAndMetadata metadata = consumer.committed(partition);
+            return metadata != null ? metadata.offset() : 0L;
+        } catch (final AuthorizationException e) {
+            throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partition), e);
+        } catch (final WakeupException e) {
+            throw e;
+        } catch (final KafkaException e) {
+            throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partition), e);
+        }
+    }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
@@ -24,4 +24,14 @@ class AssignedStandbyTasks extends AssignedTasks<StandbyTask> {
         super(logContext, "standby task");
     }
 
+    @Override
+    int commit() {
+        final int committed = super.commit();
+        // TODO: this contortion would not be necessary if we got rid of the two-step
+        // task.commitNeeded and task.commit and instead just had task.commitIfNeeded. Currently
+        // we only call commit if commitNeeded is true, which means that we need a way to indicate
+        // that we are eligible for updating the offset limit outside of commit.
+        running.forEach((id, task) -> task.allowUpdateOfOffsetLimit());
+        return committed;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -16,6 +16,14 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -25,20 +33,14 @@ import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * A StandbyTask
  */
 public class StandbyTask extends AbstractTask {
-
     private Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
     private final Sensor closeTaskSensor;
+    private final Map<TopicPartition, Long> offsetLimits = new HashMap<>();
+    private final Set<TopicPartition> updateableOffsetLimits = new HashSet<>();
 
     /**
      * Create {@link StandbyTask} with its assigned partitions
@@ -63,6 +65,14 @@ public class StandbyTask extends AbstractTask {
 
         closeTaskSensor = metrics.threadLevelSensor("task-closed", Sensor.RecordingLevel.INFO);
         processorContext = new StandbyContextImpl(id, config, stateMgr, metrics);
+
+        final Set<String> changelogTopicNames = new HashSet<>(topology.storeToChangelogTopic().values());
+        partitions.stream()
+            .filter(tp -> changelogTopicNames.contains(tp.topic()))
+            .forEach(tp -> {
+                offsetLimits.put(tp, 0L);
+                updateableOffsetLimits.add(tp);
+            });
     }
 
     @Override
@@ -88,7 +98,7 @@ public class StandbyTask extends AbstractTask {
     @Override
     public void resume() {
         log.debug("Resuming");
-        updateOffsetLimits();
+        allowUpdateOfOffsetLimit();
     }
 
     /**
@@ -102,9 +112,7 @@ public class StandbyTask extends AbstractTask {
     public void commit() {
         log.trace("Committing");
         flushAndCheckpointState();
-        // reinitialize offset limits
-        updateOffsetLimits();
-
+        allowUpdateOfOffsetLimit();
         commitNeeded = false;
     }
 
@@ -166,11 +174,21 @@ public class StandbyTask extends AbstractTask {
     public List<ConsumerRecord<byte[], byte[]>> update(final TopicPartition partition,
                                                        final List<ConsumerRecord<byte[], byte[]>> records) {
         log.trace("Updating standby replicas of its state store for partition [{}]", partition);
-        final long limit = stateMgr.offsetLimit(partition);
+        long limit = offsetLimits.getOrDefault(partition, Long.MAX_VALUE);
 
         long lastOffset = -1L;
         final List<ConsumerRecord<byte[], byte[]>> restoreRecords = new ArrayList<>(records.size());
         final List<ConsumerRecord<byte[], byte[]>> remainingRecords = new ArrayList<>();
+
+        // Check if we are unable to process one or more records due to an offset limit (e.g. when
+        // our partition is both a source and changelog). If we are limited then try to refresh
+        // the offset limit if possible.
+        if (!records.isEmpty() &&
+            records.get(records.size() - 1).offset() >= limit &&
+            updateableOffsetLimits.remove(partition)) {
+
+            limit = updateOffsetLimits(partition);
+        }
 
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             if (record.offset() < limit) {
@@ -181,9 +199,8 @@ public class StandbyTask extends AbstractTask {
             }
         }
 
-        stateMgr.updateStandbyStates(partition, restoreRecords, lastOffset);
-
         if (!restoreRecords.isEmpty()) {
+            stateMgr.updateStandbyStates(partition, restoreRecords, lastOffset);
             commitNeeded = true;
         }
 
@@ -194,4 +211,21 @@ public class StandbyTask extends AbstractTask {
         return checkpointedOffsets;
     }
 
+    private long updateOffsetLimits(final TopicPartition partition) {
+        if (!offsetLimits.containsKey(partition)) {
+            throw new IllegalArgumentException("Topic is not both a source and a changelog: " + partition);
+        }
+
+        final long newLimit = getConsumerCommittedOffset(partition);
+        final long previousLimit = offsetLimits.put(partition, newLimit);
+        if (previousLimit > newLimit) {
+            throw new IllegalStateException("Offset limit should monotonically increase, but was reduced. " +
+                "New limit: " + newLimit + ". Previous limit: " + previousLimit);
+        }
+        return newLimit;
+    }
+
+    void allowUpdateOfOffsetLimit() {
+        updateableOffsetLimits.addAll(offsetLimits.keySet());
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -189,7 +189,6 @@ public class StandbyTask extends AbstractTask {
             // partition is both a source and a changelog). If we're limited then try to refresh
             // the offset limit if possible.
             if (record.offset() >= limit && updateableOffsetLimits.contains(partition)) {
-                updateableOffsetLimits.remove(partition);
                 limit = updateOffsetLimits(partition);
             }
 
@@ -217,6 +216,8 @@ public class StandbyTask extends AbstractTask {
         if (!offsetLimits.containsKey(partition)) {
             throw new IllegalArgumentException("Topic is not both a source and a changelog: " + partition);
         }
+
+        updateableOffsetLimits.remove(partition);
 
         final long newLimit = committedOffsetForPartition(partition);
         final long previousLimit = offsetLimits.put(partition, newLimit);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -151,10 +151,7 @@ public class StoreChangelogReader implements ChangelogReader {
             return;
         }
 
-        for (final Entry<TopicPartition, Long> endOffsetEntry : endOffsets.entrySet()) {
-            final Long endOffset = endOffsetEntry.getValue();
-            final TopicPartition partition = endOffsetEntry.getKey();
-
+        endOffsets.forEach((partition, endOffset) -> {
             if (endOffset != null) {
                 final StateRestorer restorer = stateRestorers.get(partition);
                 final long offsetLimit = restorer.offsetLimit();
@@ -163,7 +160,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 log.info("End offset cannot be found form the returned metadata; removing this partition from the current run loop");
                 initializable.remove(partition);
             }
-        }
+        });
 
         final Iterator<TopicPartition> iter = initializable.iterator();
         while (iter.hasNext()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -16,6 +16,19 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static org.apache.kafka.streams.kstream.internals.metrics.Sensors.recordLatenessSensor;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -47,18 +60,6 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.format;
-import static java.util.Collections.singleton;
-import static org.apache.kafka.streams.kstream.internals.metrics.Sensors.recordLatenessSensor;
 
 /**
  * A StreamTask is associated with a {@link PartitionGroup}, and is assigned to a StreamThread for processing.
@@ -236,6 +237,22 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     @Override
     public boolean initializeStateStores() {
         log.trace("Initializing state stores");
+
+        // Currently there is no easy way to tell the ProcessorStateManager to only restore up to
+        // a specific offset. In most cases this is fine. However, in optimized topologies we can
+        // have a source topic that also serves as a changelog, and in this case we want our active
+        // stream task to only play records up to the last consumer committed offset. Here we find
+        // partitions of topics that are both sources and changelogs and set the consumer committed
+        // offset via stateMgr as there is not a more direct route.
+        final Set<String> changelogTopicNames = new HashSet<>(topology.storeToChangelogTopic().values());
+        partitions.stream()
+            .filter(tp -> changelogTopicNames.contains(tp.topic()))
+            .forEach(tp -> {
+                final long offset = getConsumerCommittedOffset(tp);
+                stateMgr.putOffsetLimit(tp, offset);
+                log.trace("Updating store offset limits {} for changelog {}", offset, tp);
+            });
+
         registerStateStores();
 
         return changelogPartitions().isEmpty();
@@ -460,7 +477,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             final TopicPartition partition = entry.getKey();
             final long offset = entry.getValue() + 1;
             consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
-            stateMgr.putOffsetLimit(partition, offset);
         }
 
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -248,7 +248,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         partitions.stream()
             .filter(tp -> changelogTopicNames.contains(tp.topic()))
             .forEach(tp -> {
-                final long offset = getConsumerCommittedOffset(tp);
+                final long offset = committedOffsetForPartition(tp);
                 stateMgr.putOffsetLimit(tp, offset);
                 log.trace("Updating store offset limits {} for changelog {}", offset, tp);
             });

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(IntegrationTest.class)
+public class OptimizedKTableIntegrationTest {
+    private static final int NUM_BROKERS = 1;
+
+    private static final String INPUT_TOPIC_NAME = "input-topic";
+    private static final String TABLE_NAME = "source-table";
+
+    @Rule
+    public final EmbeddedKafkaCluster cluster = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    private final Map<KafkaStreams, State> clientStates = new HashMap<>();
+    private final Lock clientStatesLock = new ReentrantLock();
+    private final Condition clientStateUpdate = clientStatesLock.newCondition();
+    private final MockTime mockTime = cluster.time;
+
+    @Before
+    public void before() throws InterruptedException {
+        cluster.createTopic(INPUT_TOPIC_NAME, 2, 1);
+    }
+
+    @After
+    public void after() {
+        for (final KafkaStreams client : clientStates.keySet()) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void standbyShouldNotPerformRestoreAtStartup() throws InterruptedException, ExecutionException {
+        final int numMessages = 10;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                    .withCachingDisabled())
+            .toStream()
+            .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams client1 = createClient(builder, streamsConfiguration());
+        final KafkaStreams client2 = createClient(builder, streamsConfiguration());
+        final List<KafkaStreams> clients = Arrays.asList(client1, client2);
+
+        final AtomicLong restoreStartOffset = new AtomicLong(-1);
+        clients.forEach(client -> {
+            client.setGlobalStateRestoreListener(createTrackingRestoreListener(restoreStartOffset));
+            client.start();
+        });
+        waitForClientsToEnterRunningState(clients, 60, TimeUnit.SECONDS);
+
+        produceValueRange(key, 0, 10);
+
+        assertThat("all messages in the first batch were processed in a timely manner",
+            semaphore.tryAcquire(numMessages, 60, TimeUnit.SECONDS));
+
+        assertThat("no restore has occurred", restoreStartOffset.get(), is(equalTo(-1L)));
+    }
+
+    @Test
+    public void shouldApplyUpdatesToStandbyStore() throws InterruptedException, ExecutionException {
+        final int batch1NumMessages = 100;
+        final int batch2NumMessages = 100;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                    .withCachingDisabled())
+            .toStream()
+            .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams client1 = createClient(builder, streamsConfiguration());
+        final KafkaStreams client2 = createClient(builder, streamsConfiguration());
+        final List<KafkaStreams> clients = Arrays.asList(client1, client2);
+
+        final AtomicLong restoreStartOffset = new AtomicLong(-1L);
+        clients.forEach(client -> {
+            client.setGlobalStateRestoreListener(createTrackingRestoreListener(restoreStartOffset));
+            client.start();
+        });
+        waitForClientsToEnterRunningState(clients, 60, TimeUnit.SECONDS);
+
+        produceValueRange(key, 0, batch1NumMessages);
+
+        assertThat("all messages in the first batch were processed in a timely manner",
+            semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store1 = client1
+            .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store2 = client2
+            .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
+
+        final boolean client1WasFirstActive;
+        if (store1.get(key) != null) {
+            client1WasFirstActive = true;
+        } else {
+            assertThat("data from the job was sent to the store", store2.get(key) != null);
+            client1WasFirstActive = false;
+        }
+
+        assertThat("no restore has occurred", restoreStartOffset.get(), is(equalTo(-1L)));
+        assertThat("current value in store should reflect all messages being processed",
+            client1WasFirstActive ? store1.get(key) : store2.get(key), is(equalTo(batch1NumMessages - 1)));
+
+        if (client1WasFirstActive) {
+            client1.close();
+        } else {
+            client2.close();
+        }
+
+        final int totalNumMessages = batch1NumMessages + batch2NumMessages;
+
+        produceValueRange(key, batch1NumMessages, totalNumMessages);
+
+        assertThat("all messages in the second batch were processed in a timely manner",
+            semaphore.tryAcquire(batch2NumMessages, 60, TimeUnit.SECONDS));
+
+        assertThat("either restore was unnecessary or we restored from an offset later than 0",
+            restoreStartOffset.get(), is(anyOf(greaterThan(0L), equalTo(-1L))));
+
+        assertThat("current value in store should reflect all messages being processed",
+            client1WasFirstActive ? store2.get(key) : store1.get(key), is(equalTo(totalNumMessages - 1)));
+    }
+
+    private void produceValueRange(final int key, final int start, final int endExclusive) throws ExecutionException, InterruptedException {
+        final Properties producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            INPUT_TOPIC_NAME,
+            IntStream.range(start, endExclusive)
+                .mapToObj(i -> KeyValue.pair(key, i))
+                .collect(Collectors.toList()),
+            producerProps,
+            mockTime);
+    }
+
+    private void waitForClientsToEnterRunningState(final Collection<KafkaStreams> clients,
+                                                   final long time,
+                                                   final TimeUnit timeUnit) throws InterruptedException {
+
+        final long expectedEnd = System.currentTimeMillis() + timeUnit.toMillis(time);
+
+        clientStatesLock.lock();
+        try {
+            while (!clients.stream().allMatch(client -> clientStates.get(client) == State.RUNNING)) {
+                if (expectedEnd <= System.currentTimeMillis()) {
+                    assertThat("requested clients entered " + State.RUNNING + " in a timely manner", false);
+                }
+                final long millisRemaining = Math.max(1, expectedEnd - System.currentTimeMillis());
+                clientStateUpdate.await(millisRemaining, TimeUnit.MILLISECONDS);
+            }
+        } finally {
+            clientStatesLock.unlock();
+        }
+    }
+
+    private KafkaStreams createClient(final StreamsBuilder builder, final Properties config) {
+        final KafkaStreams client = new KafkaStreams(builder.build(config), config);
+        clientStatesLock.lock();
+        try {
+            clientStates.put(client, client.state());
+        } finally {
+            clientStatesLock.unlock();
+        }
+
+        client.setStateListener((newState, oldState) -> {
+            clientStatesLock.lock();
+            try {
+                clientStates.put(client, newState);
+                if (newState == State.RUNNING) {
+                    if (clientStates.values().stream().allMatch(state -> state == State.RUNNING)) {
+                        clientStateUpdate.signalAll();
+                    }
+                }
+            } finally {
+                clientStatesLock.unlock();
+            }
+        });
+        return client;
+    }
+
+    private StateRestoreListener createTrackingRestoreListener(final AtomicLong restoreStartOffset) {
+        return new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(final TopicPartition topicPartition, final String storeName,
+                final long startingOffset, final long endingOffset) {
+                restoreStartOffset.set(startingOffset);
+            }
+
+            @Override
+            public void onBatchRestored(final TopicPartition topicPartition, final String storeName,
+                final long batchEndOffset, final long numRestored) {
+
+            }
+
+            @Override
+            public void onRestoreEnd(final TopicPartition topicPartition, final String storeName,
+                final long totalRestored) {
+
+            }
+        };
+    }
+
+    private Properties streamsConfiguration() {
+        final String applicationId = "streamsApp";
+        final Properties config = new Properties();
+        config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(applicationId).getPath());
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        config.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
+        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        return config;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -16,29 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
-import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.AuthorizationException;
-import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.LockException;
-import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.test.InternalMockProcessorContext;
-import org.apache.kafka.test.MockRestoreCallback;
-import org.apache.kafka.test.MockStateRestoreListener;
-import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import static org.apache.kafka.streams.processor.internals.ProcessorTopologyFactories.withLocalStores;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,12 +31,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import static org.apache.kafka.streams.processor.internals.ProcessorTopologyFactories.withLocalStores;
-import static org.easymock.EasyMock.expect;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockRestoreCallback;
+import org.apache.kafka.test.MockStateRestoreListener;
+import org.apache.kafka.test.TestUtils;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 
 public class AbstractTaskTest {
 
@@ -70,27 +62,6 @@ public class AbstractTaskTest {
     @Before
     public void before() {
         expect(stateDirectory.directoryForTask(id)).andReturn(TestUtils.tempDirectory());
-    }
-
-    @Test(expected = ProcessorStateException.class)
-    public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenAuthorizationException() {
-        final Consumer consumer = mockConsumer(new AuthorizationException("blah"));
-        final AbstractTask task = createTask(consumer, Collections.<StateStore, String>emptyMap());
-        task.updateOffsetLimits();
-    }
-
-    @Test(expected = ProcessorStateException.class)
-    public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenKafkaException() {
-        final Consumer consumer = mockConsumer(new KafkaException("blah"));
-        final AbstractTask task = createTask(consumer, Collections.<StateStore, String>emptyMap());
-        task.updateOffsetLimits();
-    }
-
-    @Test(expected = WakeupException.class)
-    public void shouldThrowWakeupExceptionOnInitializeOffsetsWhenWakeupException() {
-        final Consumer consumer = mockConsumer(new WakeupException());
-        final AbstractTask task = createTask(consumer, Collections.<StateStore, String>emptyMap());
-        task.updateOffsetLimits();
     }
 
     @Test
@@ -270,14 +241,4 @@ public class AbstractTaskTest {
             public void initializeTopology() {}
         };
     }
-
-    private Consumer mockConsumer(final RuntimeException toThrow) {
-        return new MockConsumer(OffsetResetStrategy.EARLIEST) {
-            @Override
-            public OffsetAndMetadata committed(final TopicPartition partition) {
-                throw toThrow;
-            }
-        };
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -552,6 +554,94 @@ public class StandbyTaskTest {
             integerSerializer.serialize(null, key),
             integerSerializer.serialize(null, 100)
         );
+    }
+
+    @Test
+    public void shouldNotGetConsumerCommittedOffsetIfThereAreNoRecordUpdates() throws IOException {
+        final AtomicInteger committedCallCount = new AtomicInteger();
+
+        final Consumer<byte[], byte[]> consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized OffsetAndMetadata committed(final TopicPartition partition) {
+                committedCallCount.getAndIncrement();
+                return super.committed(partition);
+            }
+        };
+
+        consumer.assign(Collections.singletonList(globalTopicPartition));
+        consumer.commitSync(mkMap(mkEntry(globalTopicPartition, new OffsetAndMetadata(0L))));
+
+        task = new StandbyTask(
+            taskId,
+            ktablePartitions,
+            ktableTopology,
+            consumer,
+            changelogReader,
+            createConfig(baseDir),
+            streamsMetrics,
+            stateDirectory
+        );
+        task.initializeStateStores();
+        assertThat(committedCallCount.get(), equalTo(0));
+
+        task.update(globalTopicPartition, Collections.emptyList());
+        // We should not make a consumer.committed() call because there are no new records.
+        assertThat(committedCallCount.get(), equalTo(0));
+    }
+
+    @Test
+    public void shouldGetConsumerCommittedOffsetsOncePerCommit() throws IOException {
+        final AtomicInteger committedCallCount = new AtomicInteger();
+
+        final Consumer<byte[], byte[]> consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized OffsetAndMetadata committed(final TopicPartition partition) {
+                committedCallCount.getAndIncrement();
+                return super.committed(partition);
+            }
+        };
+
+        consumer.assign(Collections.singletonList(globalTopicPartition));
+        consumer.commitSync(mkMap(mkEntry(globalTopicPartition, new OffsetAndMetadata(0L))));
+
+        task = new StandbyTask(
+            taskId,
+            ktablePartitions,
+            ktableTopology,
+            consumer,
+            changelogReader,
+            createConfig(baseDir),
+            streamsMetrics,
+            stateDirectory
+        );
+        task.initializeStateStores();
+
+        task.update(
+            globalTopicPartition,
+            Collections.singletonList(
+                makeConsumerRecord(globalTopicPartition, 1, 1)
+            )
+        );
+        assertThat(committedCallCount.get(), equalTo(1));
+
+        task.update(
+            globalTopicPartition,
+            Collections.singletonList(
+                makeConsumerRecord(globalTopicPartition, 1, 1)
+            )
+        );
+        // We should not make another consumer.committed() call until we commit
+        assertThat(committedCallCount.get(), equalTo(1));
+
+        task.commit();
+        task.update(
+            globalTopicPartition,
+            Collections.singletonList(
+                makeConsumerRecord(globalTopicPartition, 1, 1)
+            )
+        );
+        // We committed so we're allowed to make another consumer.committed() call
+        assertThat(committedCallCount.get(), equalTo(2));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -750,6 +750,64 @@ public class StoreChangelogReaderTest {
         assertThat(callback.restored.size(), equalTo(10));
     }
 
+    @Test
+    public void shouldRestoreUpToOffsetLimit() {
+        setupConsumer(10, topicPartition);
+        changelogReader.register(new StateRestorer(
+            topicPartition,
+            restoreListener,
+            2L,
+            5,
+            true,
+            "storeName1",
+            identity()));
+        expect(active.restoringTaskFor(topicPartition)).andStubReturn(task);
+        replay(active, task);
+        changelogReader.restore(active);
+
+        assertThat(callback.restored.size(), equalTo(3));
+        assertAllCallbackStatesExecuted(callback, "storeName1");
+        assertCorrectOffsetsReportedByListener(callback, 2L, 4L, 3L);
+    }
+
+    @Test
+    public void shouldNotRestoreIfCheckpointIsEqualToOffsetLimit() {
+        setupConsumer(10, topicPartition);
+        changelogReader.register(new StateRestorer(
+            topicPartition,
+            restoreListener,
+            5L,
+            5,
+            true,
+            "storeName1",
+            identity()));
+        expect(active.restoringTaskFor(topicPartition)).andStubReturn(task);
+        replay(active, task);
+        changelogReader.restore(active);
+
+        assertThat(callback.storeNameCalledStates.size(), equalTo(0));
+        assertThat(callback.restored.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotRestoreIfCheckpointIsGreaterThanOffsetLimit() {
+        setupConsumer(10, topicPartition);
+        changelogReader.register(new StateRestorer(
+            topicPartition,
+            restoreListener,
+            10L,
+            5,
+            true,
+            "storeName1",
+            identity()));
+        expect(active.restoringTaskFor(topicPartition)).andStubReturn(task);
+        replay(active, task);
+        changelogReader.restore(active);
+
+        assertThat(callback.storeNameCalledStates.size(), equalTo(0));
+        assertThat(callback.restored.size(), equalTo(0));
+    }
+
     private void setupConsumer(final long messages,
                                final TopicPartition topicPartition) {
         assignPartition(messages, topicPartition);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -317,10 +317,7 @@ public class StreamThreadStateStoreProviderTest {
             stateDirectory,
             null,
             new MockTime(),
-            () -> clientSupplier.getProducer(new HashMap<>())) {
-            @Override
-            protected void updateOffsetLimits() {}
-        };
+            () -> clientSupplier.getProducer(new HashMap<>()));
     }
 
     private void mockThread(final boolean initialized) {


### PR DESCRIPTION
Key changes include:

1. Moves general offset limit updates down to StandbyTask.
2. Updates offsets for StandbyTask at most once per commit and only when
we need and updated offset limit to make progress.
3. Avoids writing an 0 checkpoint when StandbyTask.update is called but
we cannot apply any of the records.
4. Avoids going into a restoring state in the case that the last
checkpoint is greater or equal to the offset limit (consumer committed
offset). This needs special attention please. Code is in
StoreChangelogReader.
5. Does update offset limits initially for StreamTask because it
provides a way to prevent playing to many records from the changelog
(also the input topic with optimized topology).

NOTE: this PR depends on KAFKA-8816, which is under review separately. Fortunately the changes involved are few. You can focus just on the KAFKA-8755 commit if you prefer.

@guozhangwang @mjsax @cadonna 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
