### PR TITLE
Increased Warnings for Production Deployment

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -226,6 +226,7 @@
     <h3><a id="connect_insecure_by_default" href="#connect_insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
     <p> Kafka Connect does not come with TLS client authenticatsion enabled by default. This allows unauthenticated clients to create/modify/delete connectors. This can be used in default configurations to read arbitrary data from the filesystem.</p>
     <p>For any production deployment, it is strongly urged that TLS client authentication be enabled, or Connect endpoints should be bound to loopback interfaces.</p>
+    <p>For more information, refer to <a href="#insecure_by_default">Kafka Security</a></p>
 
     <p>The following are the currently supported REST API endpoints:</p>
 

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -223,6 +223,10 @@
     can be used to change the URI which will be used by the follower nodes to connect with the leader. When using both HTTP and HTTPS listeners, the <code>rest.advertised.listener</code> option can be also used to define which listener
         will be used for the cross-cluster communication. When using HTTPS for communication between nodes, the same <code>ssl.*</code> or <code>listeners.https</code> options will be used to configure the HTTPS client.</p>
 
+    <h3><a id="insecure_by_default" href="#insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
+    <p> Kafka Connect does not come with TLS client authenticatsion enabled by default. This allows unauthenticated clients to create/modify/delete connectors. This can be used in default configurations to read arbitrary data from the filesystem.</p>
+    <p>For any production deployment, it is strongly urged that TLS client authentication be enabled, or Connect endpoints should be bound to loopback interfaces.</p>
+
     <p>The following are the currently supported REST API endpoints:</p>
 
     <ul>

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -223,7 +223,7 @@
     can be used to change the URI which will be used by the follower nodes to connect with the leader. When using both HTTP and HTTPS listeners, the <code>rest.advertised.listener</code> option can be also used to define which listener
         will be used for the cross-cluster communication. When using HTTPS for communication between nodes, the same <code>ssl.*</code> or <code>listeners.https</code> options will be used to configure the HTTPS client.</p>
 
-    <h3><a id="insecure_by_default" href="#insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
+    <h3><a id="connect_insecure_by_default" href="#connect_insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
     <p> Kafka Connect does not come with TLS client authenticatsion enabled by default. This allows unauthenticated clients to create/modify/delete connectors. This can be used in default configurations to read arbitrary data from the filesystem.</p>
     <p>For any production deployment, it is strongly urged that TLS client authentication be enabled, or Connect endpoints should be bound to loopback interfaces.</p>
 

--- a/docs/security.html
+++ b/docs/security.html
@@ -43,7 +43,7 @@
         <li>Ability to reconfigure instances (NOTE: this can result in denial of service or remote code execution)</li>
         <li>Ability to create arbitrary Connect configurations, resulting in arbitrary file disclosure</li>
     </ul>
-    For any production deployment, it is strongly urged that RBAC be enabled at a minimum to avoid cluster compromise. There is no method of mitigation
+    For any production deployment, it is strongly urged that RBAC be enabled at a minimum to avoid cluster compromise. There is no alternative mitigation other than restricting access via network firewall rules.
     </p>
 
 

--- a/docs/security.html
+++ b/docs/security.html
@@ -1836,6 +1836,9 @@
 
     The metadata stored in ZooKeeper for the Kafka cluster is world-readable, but can only be modified by the brokers. The rationale behind this decision is that the data stored in ZooKeeper is not sensitive, but inappropriate manipulation of that data can cause cluster disruption. We also recommend limiting the access to ZooKeeper via network segmentation (only brokers and some admin tools need access to ZooKeeper).
 
+   <h3><a id="zookeeper_insecure_by_default" href="#zookeeper_insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
+    <p> ZooKeeper does not have any security mechanisms enabled by default and will bind to all interfaces. Prior to any network deployment, this should be restricted.
+    
     <h4><a id="zk_authz_migration" href="#zk_authz_migration">7.6.2 Migrating clusters</a></h4>
     If you are running a version of Kafka that does not support security or simply with security disabled, and you want to make the cluster secure, then you need to execute the following steps to enable ZooKeeper authentication with minimal disruption to your operations:
     <ol>

--- a/docs/security.html
+++ b/docs/security.html
@@ -34,6 +34,19 @@
 
     It's worth noting that security is optional - non-secured clusters are supported, as well as a mix of authenticated, unauthenticated, encrypted and non-encrypted clients.
 
+    <h3><a id="insecure_by_default" href="#insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
+    <p> While security it optional, Kafka/Kafka Connect do not come with any security enabled by default. This means that Kafka/Kafka Connect instances can be read/written/configured by unauthenticated clients.
+    This can result in serious security implications, such as:
+    <ul>
+        <li>Ability to read arbitrary data from topics</li>
+        <li>Ability to write arbitrary data from topics</li>
+        <li>Ability to reconfigure instances (NOTE: this can result in denial of service or remote code execution)</li>
+        <li>Ability to create arbitrary Connect configurations, resulting in arbitrary file disclosure</li>
+    </ul>
+    For any production deployment, it is strongly urged that RBAC be enabled at a minimum to avoid cluster compromise. There is no method of mitigation
+    </p>
+
+
     The guides below explain how to configure and use the security features in both clients and brokers.
 
     <h3><a id="security_ssl" href="#security_ssl">7.2 Encryption and Authentication using SSL</a></h3>

--- a/docs/security.html
+++ b/docs/security.html
@@ -35,16 +35,15 @@
     It's worth noting that security is optional - non-secured clusters are supported, as well as a mix of authenticated, unauthenticated, encrypted and non-encrypted clients.
 
     <h3><a id="insecure_by_default" href="#insecure_by_default"> &#9888; WARNING: Insecure By Default</a></h3>
-    <p> While security it optional, Kafka/Kafka Connect do not come with any security enabled by default. This means that Kafka/Kafka Connect instances can be read/written/configured by unauthenticated clients.
-    This can result in serious security implications, such as:
+    <p> While security it optional, Kafka does not come with any security enabled by default. This means that Kafka instances can be read/written/configured by unauthenticated clients.</p>
+    <p>This can result in serious security implications, such as:</p>
     <ul>
         <li>Ability to read arbitrary data from topics</li>
         <li>Ability to write arbitrary data from topics</li>
-        <li>Ability to reconfigure instances (NOTE: this can result in denial of service or remote code execution)</li>
+        <li>Ability to reconfigure instances, possibly resulting in denial of service or remote code execution</li>
         <li>Ability to create arbitrary Connect configurations, resulting in arbitrary file disclosure</li>
     </ul>
-    For any production deployment, it is strongly urged that RBAC be enabled at a minimum to avoid cluster compromise. There is no alternative mitigation other than restricting access via network firewall rules.
-    </p>
+    <p>For any production deployment, it is strongly urged that RBAC be enabled at a minimum to avoid cluster compromise. There is no alternative mitigation other than restricting access via network firewall rules.</p>
 
 
     The guides below explain how to configure and use the security features in both clients and brokers.


### PR DESCRIPTION
Kafka is insecure by default and must be securely configured prior to any network deployment.
The documentation didn't clearly call this out, so some slight updates we're made with linkable id's.