### PR TITLE
MINOR: Move the resetting from revoked to the thread loop

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -321,11 +321,7 @@ public class StreamThread extends Thread {
                 final long start = time.milliseconds();
                 try {
                     // suspend active tasks
-                    if (streamThread.assignmentErrorCode.get() == StreamsPartitionAssignor.Error.VERSION_PROBING.code()) {
-                        streamThread.assignmentErrorCode.set(StreamsPartitionAssignor.Error.NONE.code());
-                    } else {
-                        taskManager.suspendTasksAndState();
-                    }
+                    taskManager.suspendTasksAndState();
                 } catch (final Throwable t) {
                     log.error(
                         "Error caught during partition revocation, " +
@@ -796,6 +792,7 @@ public class StreamThread extends Thread {
                 runOnce();
                 if (assignmentErrorCode.get() == StreamsPartitionAssignor.Error.VERSION_PROBING.code()) {
                     log.info("Version probing detected. Triggering new rebalance.");
+                    assignmentErrorCode.set(StreamsPartitionAssignor.Error.NONE.code());
                     enforceRebalance();
                 }
             } catch (final TaskMigratedException ignoreAndRejoinGroup) {


### PR DESCRIPTION
Move the error code resetting logic from the onPartitionsRevoked callback into the streamthread directly after we've decided to rejoin the group, since onPartitionsRevoked are not guaranteed to be triggered.

Ran system tests on the originally failed tests 10 times: http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2019-08-23--001.1566527172--guozhangwang--KMinor-upgrade-system-test--de48dd4/report.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
