### PR TITLE
Improve connect exception reporting

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -333,7 +333,8 @@ public class ConnectorConfig extends AbstractConfig {
         try {
             transformation = transformationCls.asSubclass(Transformation.class).newInstance();
         } catch (Exception e) {
-            throw new ConfigException(key, String.valueOf(transformationCls), "Error getting config definition from Transformation: " + e.getMessage());
+            String exDetail = e.getMessage() == null ? e.toString() : e.getMessage();
+            throw new ConfigException(key, String.valueOf(transformationCls), "Error getting config definition from Transformation: " + exDetail);
         }
         ConfigDef configDef = transformation.config();
         if (null == configDef) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -334,7 +334,11 @@ public class ConnectorConfig extends AbstractConfig {
             transformation = transformationCls.asSubclass(Transformation.class).newInstance();
         } catch (Exception e) {
             String exDetail = e.getMessage() == null ? e.toString() : e.getMessage();
-            throw new ConfigException(key, String.valueOf(transformationCls), "Error getting config definition from Transformation: " + exDetail);
+            throw new ConfigException(
+                key, 
+                String.valueOf(transformationCls), 
+                "Error getting config definition from Transformation: " + exDetail
+            );
         }
         ConfigDef configDef = transformation.config();
         if (null == configDef) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -334,6 +334,7 @@ public class ConnectorConfig extends AbstractConfig {
             transformation = transformationCls.asSubclass(Transformation.class).newInstance();
         } catch (Exception e) {
             String exDetail = e.getMessage() == null ? e.toString() : e.getMessage();
+            
             throw new ConfigException(
                 key, 
                 String.valueOf(transformationCls), 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -334,7 +334,6 @@ public class ConnectorConfig extends AbstractConfig {
             transformation = transformationCls.asSubclass(Transformation.class).newInstance();
         } catch (Exception e) {
             String exDetail = e.getMessage() == null ? e.toString() : e.getMessage();
-            
             throw new ConfigException(
                 key, 
                 String.valueOf(transformationCls), 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/errors/ConnectExceptionMapper.java
@@ -36,7 +36,7 @@ public class ConnectExceptionMapper implements ExceptionMapper<Exception> {
 
     @Override
     public Response toResponse(Exception exception) {
-        log.debug("Uncaught exception in REST call to /{}", uriInfo.getPath(), exception);
+        log.error("Uncaught exception in REST call to /{}", uriInfo.getPath(), exception);
 
         if (exception instanceof ConnectRestException) {
             ConnectRestException restException = (ConnectRestException) exception;
@@ -55,10 +55,6 @@ public class ConnectExceptionMapper implements ExceptionMapper<Exception> {
             return Response.status(Response.Status.CONFLICT)
                     .entity(new ErrorMessage(Response.Status.CONFLICT.getStatusCode(), exception.getMessage()))
                     .build();
-        }
-
-        if (!log.isDebugEnabled()) {
-            log.error("Uncaught exception in REST call to /{}", uriInfo.getPath(), exception);
         }
 
         final int statusCode;


### PR DESCRIPTION
1. Avoid the "null" reason in the dreaded Connect error message "Error getting config definition from Transformation: null"

2. Always log the exception in the Connect server. In my scenario, a java.lang.InstantiationException would result in no logging in Connect.