### PR TITLE
KAFKA-8868: Generate SubscriptionInfo protocol message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ systest/
 *.swp
 clients/src/generated
 clients/src/generated-test
+streams/src/generated

--- a/build.gradle
+++ b/build.gradle
@@ -1177,6 +1177,31 @@ project(':streams') {
     testRuntime libs.slf4jlog4j
   }
 
+  task processMessages(type:JavaExec) {
+    main = "org.apache.kafka.message.MessageGenerator"
+    classpath = project(':generator').sourceSets.main.runtimeClasspath
+    args = [ "org.apache.kafka.streams.internals.generated",
+             "src/generated/java/org/apache/kafka/streams/internals/generated",
+             "src/main/resources/common/message" ]
+    inputs.dir("src/main/resources/common/message")
+    outputs.dir("src/generated/java/org/apache/kafka/streams/internals/generated")
+  }
+
+  sourceSets {
+    main {
+      java {
+        srcDirs = ["src/generated/java", "src/main/java"]
+      }
+    }
+    test {
+      java {
+        srcDirs = ["src/generated/java", "src/test/java"]
+      }
+    }
+  }
+
+  compileJava.dependsOn 'processMessages'
+
   javadoc {
     include "**/org/apache/kafka/streams/**"
     exclude "**/internals/**"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -184,6 +184,11 @@
     <suppress checks="FinalLocalVariable"
               files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
 
+    <!-- generated code -->
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS)"
+              files="streams[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+
+
     <!-- Streams tests -->
     <suppress checks="ClassFanOutComplexity"
               files="(StreamThreadTest|StreamTaskTest|ProcessorTopologyTestDriver).java"/>

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -561,5 +561,4 @@ public class Struct {
         }
         return true;
     }
-
 }

--- a/generator/src/main/java/org/apache/kafka/message/MessageSpecType.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageSpecType.java
@@ -27,5 +27,8 @@ public enum MessageSpecType {
     RESPONSE,
 
     @JsonProperty("header")
-    HEADER;
+    HEADER,
+
+    @JsonProperty("data")
+    DATA;
 }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -215,7 +215,10 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <Match>
         <!-- Suppress warnings about generated schema arrays. -->
-        <Package name="org.apache.kafka.common.message"/>
+        <Or>
+            <Package name="org.apache.kafka.common.message"/>
+            <Package name="org.apache.kafka.streams.internals.generated"/>
+        </Or>
         <Bug pattern="MS_MUTABLE_ARRAY"/>
     </Match>
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -237,6 +237,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             rebalanceProtocol);
         return new SubscriptionInfo(
             usedSubscriptionMetadataVersion,
+            SubscriptionInfo.LATEST_SUPPORTED_VERSION,
             taskManager.processId(),
             activeTasks,
             standbyTasks,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -237,7 +237,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             rebalanceProtocol);
         return new SubscriptionInfo(
             usedSubscriptionMetadataVersion,
-            SubscriptionInfo.LATEST_SUPPORTED_VERSION,
+            LATEST_SUPPORTED_VERSION,
             taskManager.processId(),
             activeTasks,
             standbyTasks,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -16,337 +16,177 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
 import org.apache.kafka.streams.processor.TaskId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
+import java.util.stream.Collectors;
 
 public class SubscriptionInfo {
-    private static final Logger log = LoggerFactory.getLogger(SubscriptionInfo.class);
 
-    private final int usedVersion;
-    private final int latestSupportedVersion;
-    private UUID processId;
-    private Set<TaskId> prevTasks;
-    private Set<TaskId> standbyTasks;
-    private String userEndPoint;
+    public static final int LATEST_SUPPORTED_VERSION = SubscriptionInfoData.SCHEMAS.length - 1;
+    static final int UNKNOWN = -1;
 
-    // used for decoding; don't apply version checks
-    private SubscriptionInfo(final int version,
-                             final int latestSupportedVersion) {
-        this.usedVersion = version;
-        this.latestSupportedVersion = latestSupportedVersion;
-    }
+    private final SubscriptionInfoData data;
+    private Set<TaskId> prevTasksCache = null;
+    private Set<TaskId> standbyTasksCache = null;
 
-    public SubscriptionInfo(final UUID processId,
-                            final Set<TaskId> prevTasks,
-                            final Set<TaskId> standbyTasks,
-                            final String userEndPoint) {
-        this(LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+    private static void validateVersions(final int version, final int latestSupportedVersion) {
+        if (latestSupportedVersion == UNKNOWN && (version < 1 || version > 2)) {
+            throw new IllegalArgumentException(
+                "Only versions 1 and 2 are expected to use an UNKNOWN (-1) latest supported version. " +
+                    "Got " + version + "."
+            );
+        } else if (latestSupportedVersion != UNKNOWN && (version < 1 || version > latestSupportedVersion)) {
+            throw new IllegalArgumentException(
+                "version must be between 1 and " + latestSupportedVersion + "; was: " + version
+            );
+        }
     }
 
     public SubscriptionInfo(final int version,
+                            final int latestSupportedVersion,
                             final UUID processId,
                             final Set<TaskId> prevTasks,
                             final Set<TaskId> standbyTasks,
                             final String userEndPoint) {
-        this(version, LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
-
-        if (version < 1 || version > LATEST_SUPPORTED_VERSION) {
-            throw new IllegalArgumentException("version must be between 1 and " + LATEST_SUPPORTED_VERSION
-                + "; was: " + version);
+        validateVersions(version, latestSupportedVersion);
+        final SubscriptionInfoData data = new SubscriptionInfoData();
+        data.setVersion(version);
+        if (version >= 2) {
+            data.setUserEndPoint(userEndPoint == null
+                                     ? new byte[0]
+                                     : userEndPoint.getBytes(StandardCharsets.UTF_8));
         }
+        if (version >= 3) {
+            data.setLatestSupportedVersion(latestSupportedVersion);
+        }
+        data.setProcessId(processId);
+        data.setPrevTasks(prevTasks.stream().map(t -> {
+            final SubscriptionInfoData.TaskId taskId = new SubscriptionInfoData.TaskId();
+            taskId.setTopicGroupId(t.topicGroupId);
+            taskId.setPartition(t.partition);
+            return taskId;
+        }).collect(Collectors.toList()));
+        data.setStandbyTasks(standbyTasks.stream().map(t -> {
+            final SubscriptionInfoData.TaskId taskId = new SubscriptionInfoData.TaskId();
+            taskId.setTopicGroupId(t.topicGroupId);
+            taskId.setPartition(t.partition);
+            return taskId;
+        }).collect(Collectors.toList()));
+
+        this.data = data;
     }
 
-    // for testing only; don't apply version checks
-    protected SubscriptionInfo(final int version,
-                               final int latestSupportedVersion,
-                               final UUID processId,
-                               final Set<TaskId> prevTasks,
-                               final Set<TaskId> standbyTasks,
-                               final String userEndPoint) {
-        this.usedVersion = version;
-        this.latestSupportedVersion = latestSupportedVersion;
-        this.processId = processId;
-        this.prevTasks = prevTasks;
-        this.standbyTasks = standbyTasks;
-        this.userEndPoint = userEndPoint;
+    private SubscriptionInfo(final SubscriptionInfoData subscriptionInfoData) {
+        validateVersions(subscriptionInfoData.version(), subscriptionInfoData.latestSupportedVersion());
+        this.data = subscriptionInfoData;
     }
 
     public int version() {
-        return usedVersion;
+        return data.version();
     }
 
     public int latestSupportedVersion() {
-        return latestSupportedVersion;
+        return data.latestSupportedVersion();
     }
 
     public UUID processId() {
-        return processId;
+        return data.processId();
     }
 
     public Set<TaskId> prevTasks() {
-        return prevTasks;
+        if (prevTasksCache == null) {
+            prevTasksCache = Collections.unmodifiableSet(
+                data.prevTasks()
+                    .stream()
+                    .map(t -> new TaskId(t.topicGroupId(), t.partition()))
+                    .collect(Collectors.toSet())
+            );
+        }
+        return prevTasksCache;
     }
 
     public Set<TaskId> standbyTasks() {
-        return standbyTasks;
+        if (standbyTasksCache == null) {
+            standbyTasksCache = Collections.unmodifiableSet(
+            data.standbyTasks()
+                .stream()
+                .map(t -> new TaskId(t.topicGroupId(), t.partition()))
+                .collect(Collectors.toSet())
+            );
+        }
+        return standbyTasksCache;
     }
 
     public String userEndPoint() {
-        return userEndPoint;
+        return data.userEndPoint() == null || data.userEndPoint().length == 0
+            ? null
+            : new String(data.userEndPoint(), StandardCharsets.UTF_8);
     }
 
     /**
      * @throws TaskAssignmentException if method fails to encode the data
      */
     public ByteBuffer encode() {
-        final ByteBuffer buf;
-
-        switch (usedVersion) {
-            case 1:
-                buf = encodeVersionOne();
-                break;
-            case 2:
-                buf = encodeVersionTwo();
-                break;
-            case 3:
-                buf = encodeVersionThree();
-                break;
-            case 4:
-                buf = encodeVersionFour();
-                break;
-            case 5:
-                buf = encodeVersionFive();
-                break;
-            default:
-                throw new IllegalStateException("Unknown metadata version: " + usedVersion
-                    + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
-        }
-
-        buf.rewind();
-        return buf;
-    }
-
-    private ByteBuffer encodeVersionOne() {
-        final ByteBuffer buf = ByteBuffer.allocate(getVersionOneByteLength());
-
-        buf.putInt(1); // version
-        encodeClientUUID(buf);
-        encodeTasks(buf, prevTasks);
-        encodeTasks(buf, standbyTasks);
-
-        return buf;
-    }
-
-    private int getVersionOneByteLength() {
-        return 4 + // version
-               16 + // client ID
-               4 + prevTasks.size() * 8 + // length + prev tasks
-               4 + standbyTasks.size() * 8; // length + standby tasks
-    }
-
-    protected void encodeClientUUID(final ByteBuffer buf) {
-        buf.putLong(processId.getMostSignificantBits());
-        buf.putLong(processId.getLeastSignificantBits());
-    }
-
-    protected void encodeTasks(final ByteBuffer buf,
-                               final Collection<TaskId> taskIds) {
-        buf.putInt(taskIds.size());
-        for (final TaskId id : taskIds) {
-            id.writeTo(buf);
-        }
-    }
-
-    protected byte[] prepareUserEndPoint() {
-        if (userEndPoint == null) {
-            return new byte[0];
+        if (data.version() > LATEST_SUPPORTED_VERSION) {
+            // in this special case, we only rely on the version and latest version,
+            final ByteBuffer buffer =
+                ByteBuffer.allocate(8)
+                          .putInt(data.version())
+                          .putInt(data.latestSupportedVersion());
+            buffer.rewind();
+            return buffer;
         } else {
-            return userEndPoint.getBytes(StandardCharsets.UTF_8);
+            final ObjectSerializationCache cache = new ObjectSerializationCache();
+            final ByteBuffer buffer = ByteBuffer.allocate(data.size(cache, (short) data.version()));
+            final ByteBufferAccessor accessor = new ByteBufferAccessor(buffer);
+            data.write(accessor, cache, (short) data.version());
+            buffer.rewind();
+            return buffer;
         }
-    }
-
-    private ByteBuffer encodeVersionTwo() {
-        final byte[] endPointBytes = prepareUserEndPoint();
-
-        final ByteBuffer buf = ByteBuffer.allocate(getVersionTwoByteLength(endPointBytes));
-
-        buf.putInt(2); // version
-        encodeClientUUID(buf);
-        encodeTasks(buf, prevTasks);
-        encodeTasks(buf, standbyTasks);
-        encodeUserEndPoint(buf, endPointBytes);
-
-        return buf;
-    }
-
-    private int getVersionTwoByteLength(final byte[] endPointBytes) {
-        return 4 + // version
-               16 + // client ID
-               4 + prevTasks.size() * 8 + // length + prev tasks
-               4 + standbyTasks.size() * 8 + // length + standby tasks
-               4 + endPointBytes.length; // length + userEndPoint
-    }
-
-    protected void encodeUserEndPoint(final ByteBuffer buf,
-                                      final byte[] endPointBytes) {
-        if (endPointBytes != null) {
-            buf.putInt(endPointBytes.length);
-            buf.put(endPointBytes);
-        }
-    }
-
-    private ByteBuffer encodeVersionThreeFourAndFive(final int usedVersion) {
-        final byte[] endPointBytes = prepareUserEndPoint();
-        final ByteBuffer buf = ByteBuffer.allocate(getVersionThreeFourAndFiveByteLength(endPointBytes));
-
-        buf.putInt(usedVersion); // used version
-        buf.putInt(latestSupportedVersion); // supported version
-        encodeClientUUID(buf);
-        encodeTasks(buf, prevTasks);
-        encodeTasks(buf, standbyTasks);
-        encodeUserEndPoint(buf, endPointBytes);
-
-        return buf;
-    }
-
-    private ByteBuffer encodeVersionThree() {
-        return encodeVersionThreeFourAndFive(3);
-    }
-
-    private ByteBuffer encodeVersionFour() {
-        return encodeVersionThreeFourAndFive(4);
-    }
-
-    private ByteBuffer encodeVersionFive() {
-        return encodeVersionThreeFourAndFive(5);
-    }
-
-    protected int getVersionThreeFourAndFiveByteLength(final byte[] endPointBytes) {
-        return 4 + // used version
-               4 + // latest supported version version
-               16 + // client ID
-               4 + prevTasks.size() * 8 + // length + prev tasks
-               4 + standbyTasks.size() * 8 + // length + standby tasks
-               4 + endPointBytes.length; // length + userEndPoint
     }
 
     /**
      * @throws TaskAssignmentException if method fails to decode the data
      */
     public static SubscriptionInfo decode(final ByteBuffer data) {
-        final SubscriptionInfo subscriptionInfo;
-
-        // ensure we are at the beginning of the ByteBuffer
         data.rewind();
+        final int version = data.getInt();
 
-        final int usedVersion = data.getInt();
-        final int latestSupportedVersion;
-        switch (usedVersion) {
-            case 1:
-                subscriptionInfo = new SubscriptionInfo(usedVersion, UNKNOWN);
-                decodeVersionOneData(subscriptionInfo, data);
-                break;
-            case 2:
-                subscriptionInfo = new SubscriptionInfo(usedVersion, UNKNOWN);
-                decodeVersionTwoData(subscriptionInfo, data);
-                break;
-            case 3:
-            case 4:
-            case 5:
-                latestSupportedVersion = data.getInt();
-                subscriptionInfo = new SubscriptionInfo(usedVersion, latestSupportedVersion);
-                decodeVersionThreeData(subscriptionInfo, data);
-                break;
-            default:
-                latestSupportedVersion = data.getInt();
-                subscriptionInfo = new SubscriptionInfo(usedVersion, latestSupportedVersion);
-                log.info("Unable to decode subscription data: used version: {}; latest supported version: {}", usedVersion, latestSupportedVersion);
+        if (version > LATEST_SUPPORTED_VERSION) {
+            // in this special case, we only rely on the version and latest version,
+            //
+            final int latestSupportedVersion = data.getInt();
+            final SubscriptionInfoData subscriptionInfoData = new SubscriptionInfoData();
+            subscriptionInfoData.setVersion(version);
+            subscriptionInfoData.setLatestSupportedVersion(latestSupportedVersion);
+            return new SubscriptionInfo(subscriptionInfoData);
+        } else {
+            data.rewind();
+            final ByteBufferAccessor accessor = new ByteBufferAccessor(data);
+            final SubscriptionInfoData subscriptionInfoData = new SubscriptionInfoData(accessor, (short) version);
+            return new SubscriptionInfo(subscriptionInfoData);
         }
-
-        return subscriptionInfo;
-    }
-
-    private static void decodeVersionOneData(final SubscriptionInfo subscriptionInfo,
-                                             final ByteBuffer data) {
-        decodeClientUUID(subscriptionInfo, data);
-        decodeTasks(subscriptionInfo, data);
-    }
-
-    private static void decodeClientUUID(final SubscriptionInfo subscriptionInfo,
-                                         final ByteBuffer data) {
-        subscriptionInfo.processId = new UUID(data.getLong(), data.getLong());
-    }
-
-    private static void decodeTasks(final SubscriptionInfo subscriptionInfo,
-                                    final ByteBuffer data) {
-        subscriptionInfo.prevTasks = new HashSet<>();
-        final int numPrevTasks = data.getInt();
-        for (int i = 0; i < numPrevTasks; i++) {
-            subscriptionInfo.prevTasks.add(TaskId.readFrom(data));
-        }
-
-        subscriptionInfo.standbyTasks = new HashSet<>();
-        final int numStandbyTasks = data.getInt();
-        for (int i = 0; i < numStandbyTasks; i++) {
-            subscriptionInfo.standbyTasks.add(TaskId.readFrom(data));
-        }
-    }
-
-    private static void decodeVersionTwoData(final SubscriptionInfo subscriptionInfo,
-                                             final ByteBuffer data) {
-        decodeClientUUID(subscriptionInfo, data);
-        decodeTasks(subscriptionInfo, data);
-        decodeUserEndPoint(subscriptionInfo, data);
-    }
-
-    private static void decodeUserEndPoint(final SubscriptionInfo subscriptionInfo,
-                                           final ByteBuffer data) {
-        final int bytesLength = data.getInt();
-        if (bytesLength != 0) {
-            final byte[] bytes = new byte[bytesLength];
-            data.get(bytes);
-            subscriptionInfo.userEndPoint = new String(bytes, StandardCharsets.UTF_8);
-        }
-    }
-
-    private static void decodeVersionThreeData(final SubscriptionInfo subscriptionInfo,
-                                               final ByteBuffer data) {
-        decodeClientUUID(subscriptionInfo, data);
-        decodeTasks(subscriptionInfo, data);
-        decodeUserEndPoint(subscriptionInfo, data);
     }
 
     @Override
     public int hashCode() {
-        final int hashCode = usedVersion ^ latestSupportedVersion ^ processId.hashCode() ^ prevTasks.hashCode() ^ standbyTasks.hashCode();
-        if (userEndPoint == null) {
-            return hashCode;
-        }
-        return hashCode ^ userEndPoint.hashCode();
+        return data.hashCode();
     }
 
     @Override
     public boolean equals(final Object o) {
         if (o instanceof SubscriptionInfo) {
             final SubscriptionInfo other = (SubscriptionInfo) o;
-            return this.usedVersion == other.usedVersion &&
-                    this.latestSupportedVersion == other.latestSupportedVersion &&
-                    this.processId.equals(other.processId) &&
-                    this.prevTasks.equals(other.prevTasks) &&
-                    this.standbyTasks.equals(other.standbyTasks) &&
-                    this.userEndPoint != null ? this.userEndPoint.equals(other.userEndPoint) : other.userEndPoint == null;
+            return data.equals(other.data);
         } else {
             return false;
         }
@@ -354,11 +194,6 @@ public class SubscriptionInfo {
 
     @Override
     public String toString() {
-        return "[version=" + usedVersion
-            + ", supported version=" + latestSupportedVersion
-            + ", process ID=" + processId
-            + ", prev tasks=" + prevTasks
-            + ", standby tasks=" + standbyTasks
-            + ", user endpoint=" + userEndPoint + "]";
+        return data.toString();
     }
 }

--- a/streams/src/main/resources/common/message/SubscriptionInfo.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfo.json
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "name": "SubscriptionInfo",
+  "validVersions": "1-5",
+  "fields": [
+    {
+      "name": "version",
+      "versions": "1+",
+      "type": "int32"
+    },
+    {
+      "name": "latestSupportedVersion",
+      "versions": "3+",
+      "default": "-1",
+      "type": "int32"
+    },
+    {
+      "name": "processId",
+      "versions": "1+",
+      "type": "uuid"
+    },
+    {
+      "name": "prevTasks",
+      "versions": "1+",
+      "type": "[]TaskId"
+    },
+    {
+      "name": "standbyTasks",
+      "versions": "1+",
+      "type": "[]TaskId"
+    },
+    {
+      "name": "userEndPoint",
+      "versions": "2+",
+      "type": "bytes"
+    }
+  ],
+  "commonStructs": [
+    {
+      "name": "TaskId",
+      "versions": "1+",
+      "fields": [
+        {
+          "name": "topicGroupId",
+          "versions": "1+",
+          "type": "int32"
+        },
+        {
+          "name": "partition",
+          "versions": "1+",
+          "type": "int32"
+        }
+      ]
+    }
+  ],
+  "type": "data"
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -29,6 +29,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -90,6 +91,13 @@ public class StreamsUpgradeTestIntegrationTest {
         assertThat(usedVersion6.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
         assertThat(usedVersion5.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
         assertThat(usedVersion4.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
+
+        kafkaStreams4.close(Duration.ZERO);
+        kafkaStreams5.close(Duration.ZERO);
+        kafkaStreams6.close(Duration.ZERO);
+        kafkaStreams4.close();
+        kafkaStreams5.close();
+        kafkaStreams6.close();
     }
 
     public static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
+import org.apache.kafka.streams.tests.StreamsUpgradeTest;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Category(IntegrationTest.class)
+public class StreamsUpgradeTestIntegrationTest {
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
+
+    @BeforeClass
+    public static void setup() {
+        IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, 1, "data");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        try {
+            CLUSTER.deleteAllTopicsAndWait(IntegrationTestUtils.DEFAULT_TIMEOUT);
+        } catch (final InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testVersionProbingUpgrade() throws InterruptedException {
+        final KafkaStreams kafkaStreams1 = StreamsUpgradeTest.buildStreams(mkProperties(
+            mkMap(
+                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            )
+        ));
+        final KafkaStreams kafkaStreams2 = StreamsUpgradeTest.buildStreams(mkProperties(
+            mkMap(
+                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            )
+        ));
+        final KafkaStreams kafkaStreams3 = StreamsUpgradeTest.buildStreams(mkProperties(
+            mkMap(
+                mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+            )
+        ));
+        startSync(kafkaStreams1, kafkaStreams2, kafkaStreams3);
+
+        // first roll
+        kafkaStreams1.close();
+        final AtomicInteger usedVersion4 = new AtomicInteger();
+        final KafkaStreams kafkaStreams4 = buildFutureStreams(usedVersion4);
+        startSync(kafkaStreams4);
+        assertThat(usedVersion4.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION));
+
+        // second roll
+        kafkaStreams2.close();
+        final AtomicInteger usedVersion5 = new AtomicInteger();
+        final KafkaStreams kafkaStreams5 = buildFutureStreams(usedVersion5);
+        startSync(kafkaStreams5);
+        assertThat(usedVersion5.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION));
+
+        // third roll, upgrade complete
+        kafkaStreams3.close();
+        final AtomicInteger usedVersion6 = new AtomicInteger();
+        final KafkaStreams kafkaStreams6 = buildFutureStreams(usedVersion6);
+        startSync(kafkaStreams6);
+        assertThat(usedVersion6.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
+        assertThat(usedVersion5.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
+        assertThat(usedVersion4.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
+    }
+
+    public static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        properties.put("test.future.metadata", usedVersion4);
+        return StreamsUpgradeTest.buildStreams(properties);
+    }
+
+    public static void startSync(final KafkaStreams... kafkaStreams) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(kafkaStreams.length);
+        for (final KafkaStreams streams : kafkaStreams) {
+            streams.setStateListener((newState, oldState) -> {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    latch.countDown();
+                }
+            });
+        }
+        for (final KafkaStreams streams : kafkaStreams) {
+            streams.start();
+        }
+        latch.await();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
-import org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions;
 import org.apache.kafka.streams.tests.StreamsUpgradeTest;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.BeforeClass;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -20,10 +20,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
-import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
+import org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions;
 import org.apache.kafka.streams.tests.StreamsUpgradeTest;
 import org.apache.kafka.test.IntegrationTest;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -37,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -74,23 +74,23 @@ public class StreamsUpgradeTestIntegrationTest {
         final AtomicInteger usedVersion4 = new AtomicInteger();
         final KafkaStreams kafkaStreams4 = buildFutureStreams(usedVersion4);
         startSync(kafkaStreams4);
-        assertThat(usedVersion4.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION));
+        assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION));
 
         // second roll
         kafkaStreams2.close();
         final AtomicInteger usedVersion5 = new AtomicInteger();
         final KafkaStreams kafkaStreams5 = buildFutureStreams(usedVersion5);
         startSync(kafkaStreams5);
-        assertThat(usedVersion5.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION));
+        assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION));
 
         // third roll, upgrade complete
         kafkaStreams3.close();
         final AtomicInteger usedVersion6 = new AtomicInteger();
         final KafkaStreams kafkaStreams6 = buildFutureStreams(usedVersion6);
         startSync(kafkaStreams6);
-        assertThat(usedVersion6.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion5.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion4.get(), is(SubscriptionInfo.LATEST_SUPPORTED_VERSION + 1));
+        assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1));
+        assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1));
+        assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1));
 
         kafkaStreams4.close(Duration.ZERO);
         kafkaStreams5.close(Duration.ZERO);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -49,15 +49,6 @@ public class StreamsUpgradeTestIntegrationTest {
         IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, 1, "data");
     }
 
-    @AfterClass
-    public static void teardown() {
-        try {
-            CLUSTER.deleteAllTopicsAndWait(IntegrationTestUtils.DEFAULT_TIMEOUT);
-        } catch (final InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     public void testVersionProbingUpgrade() throws InterruptedException {
         final KafkaStreams kafkaStreams1 = StreamsUpgradeTest.buildStreams(mkProperties(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -218,18 +218,18 @@ public class StreamsPartitionAssignorTest {
                                             final Set<TaskId> prevTasks,
                                             final Set<TaskId> standbyTasks,
                                             final String userEndPoint) {
-        return new SubscriptionInfo(version, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+        return new SubscriptionInfo(version, LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
     }
 
     private static SubscriptionInfo getInfo(final UUID processId,
                                             final Set<TaskId> prevTasks,
                                             final Set<TaskId> standbyTasks,
                                             final String userEndPoint) {
-        return new SubscriptionInfo(SubscriptionInfo.LATEST_SUPPORTED_VERSION, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+        return new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
     }
 
     private SubscriptionInfo getInfo(final UUID processId, final Set<TaskId> prevTasks, final Set<TaskId> standbyTasks) {
-        return new SubscriptionInfo(SubscriptionInfo.LATEST_SUPPORTED_VERSION, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+        return new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -213,6 +213,25 @@ public class StreamsPartitionAssignorTest {
         }
     }
 
+    private static SubscriptionInfo getInfo(final int version,
+                                            final UUID processId,
+                                            final Set<TaskId> prevTasks,
+                                            final Set<TaskId> standbyTasks,
+                                            final String userEndPoint) {
+        return new SubscriptionInfo(version, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+    }
+
+    private static SubscriptionInfo getInfo(final UUID processId,
+                                            final Set<TaskId> prevTasks,
+                                            final Set<TaskId> standbyTasks,
+                                            final String userEndPoint) {
+        return new SubscriptionInfo(SubscriptionInfo.LATEST_SUPPORTED_VERSION, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+    }
+
+    private SubscriptionInfo getInfo(final UUID processId, final Set<TaskId> prevTasks, final Set<TaskId> standbyTasks) {
+        return new SubscriptionInfo(SubscriptionInfo.LATEST_SUPPORTED_VERSION, SubscriptionInfo.LATEST_SUPPORTED_VERSION, processId, prevTasks, standbyTasks, userEndPoint);
+    }
+
     @Test
     public void shouldUseEagerRebalancingProtocol() {
         createMockTaskManager();
@@ -415,7 +434,7 @@ public class StreamsPartitionAssignorTest {
 
         // When following the eager protocol, we must encode the previous tasks ourselves since we must revoke
         // everything and thus the "ownedPartitions" field in the subscription will be empty
-        final SubscriptionInfo info = new SubscriptionInfo(processId, prevTasks, standbyTasks, null);
+        final SubscriptionInfo info = getInfo(processId, prevTasks, standbyTasks, null);
         assertEquals(info.encode(), subscription.userData());
     }
 
@@ -449,7 +468,7 @@ public class StreamsPartitionAssignorTest {
 
         // We don't encode the active tasks when following the cooperative protocol, as these are inferred from the
         // ownedPartitions encoded in the subscription
-        final SubscriptionInfo info = new SubscriptionInfo(processId, Collections.emptySet(), standbyTasks, null);
+        final SubscriptionInfo info = getInfo(processId, Collections.emptySet(), standbyTasks, null);
         assertEquals(info.encode(), subscription.userData());
     }
 
@@ -478,20 +497,20 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(
-                    topics,
-                    new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10, userEndPoint).encode(),
-                    Collections.singletonList(t1p0)));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks10, standbyTasks10, userEndPoint).encode()
+                          ));
         subscriptions.put("consumer11",
-                new ConsumerPartitionAssignor.Subscription(
-                    topics,
-                    new SubscriptionInfo(uuid1, prevTasks11, standbyTasks11, userEndPoint).encode(),
-                    Collections.singletonList(t1p1)));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks11, standbyTasks11, userEndPoint).encode()
+                          ));
         subscriptions.put("consumer20",
-                new ConsumerPartitionAssignor.Subscription(
-                    topics,
-                    new SubscriptionInfo(uuid2, prevTasks20, standbyTasks20, userEndPoint).encode(),
-                    Collections.singletonList(t1p2)));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid2, prevTasks20, standbyTasks20, userEndPoint).encode()
+                          ));
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -569,11 +588,15 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer10",
-                          new ConsumerPartitionAssignor.Subscription(topics,
-                                  new SubscriptionInfo(uuid1, new HashSet<>(), new HashSet<>(), userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, new HashSet<>(), new HashSet<>()).encode()
+                          ));
         subscriptions.put("consumer11",
-                          new ConsumerPartitionAssignor.Subscription(topics,
-                                  new SubscriptionInfo(uuid1, new HashSet<>(), new HashSet<>(), userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, new HashSet<>(), new HashSet<>()).encode()
+                          ));
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(localMetadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -616,9 +639,10 @@ public class StreamsPartitionAssignorTest {
 
         // will throw exception if it fails
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode()
-        ));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, emptyTasks, emptyTasks).encode()
+                          ));
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
         // check assignment info
@@ -651,16 +675,18 @@ public class StreamsPartitionAssignorTest {
         configurePartitionAssignor(Collections.emptyMap());
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10, userEndPoint).encode()
-                ));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks10, standbyTasks10).encode()
+                          ));
 
         // initially metadata is empty
-        Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(emptyMetadata, new GroupSubscription(subscriptions)).groupAssignment();
+        Map<String, ConsumerPartitionAssignor.Assignment> assignments =
+            partitionAssignor.assign(emptyMetadata, new GroupSubscription(subscriptions)).groupAssignment();
 
         // check assigned partitions
         assertEquals(Collections.emptySet(),
-            new HashSet<>(assignments.get("consumer10").partitions()));
+                     new HashSet<>(assignments.get("consumer10").partitions()));
 
         // check assignment info
         AssignmentInfo info10 = checkAssignment(Collections.emptySet(), assignments.get("consumer10"));
@@ -672,7 +698,7 @@ public class StreamsPartitionAssignorTest {
         assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
         // check assigned partitions
         assertEquals(Utils.mkSet(Utils.mkSet(t1p0, t2p0, t1p0, t2p0, t1p1, t2p1, t1p2, t2p2)),
-            Utils.mkSet(new HashSet<>(assignments.get("consumer10").partitions())));
+                     Utils.mkSet(new HashSet<>(assignments.get("consumer10").partitions())));
 
         // the first consumer
         info10 = checkAssignment(allTopics, assignments.get("consumer10"));
@@ -708,14 +734,17 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, prevTasks10, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks10, emptyTasks).encode()));
         subscriptions.put("consumer11",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, prevTasks11, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks11, emptyTasks).encode()));
         subscriptions.put("consumer20",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid2, prevTasks20, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid2, prevTasks20, emptyTasks).encode()));
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -771,14 +800,14 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(topics,
+                                                                     getInfo(uuid1, emptyTasks, emptyTasks).encode()));
         subscriptions.put("consumer11",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(topics,
+                                                                     getInfo(uuid1, emptyTasks, emptyTasks).encode()));
         subscriptions.put("consumer20",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid2, emptyTasks, emptyTasks, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(topics,
+                                                                     getInfo(uuid2, emptyTasks, emptyTasks).encode()));
 
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -860,16 +889,20 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, prevTasks00, standbyTasks01, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks00, standbyTasks01).encode()));
         subscriptions.put("consumer11",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, prevTasks01, standbyTasks02, userEndPoint).encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, prevTasks01, standbyTasks02).encode()));
         subscriptions.put("consumer20",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid2, prevTasks02, standbyTasks00, "any:9097").encode()));
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid2, prevTasks02, standbyTasks00, "any:9097").encode()));
 
-        final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
+        final Map<String, ConsumerPartitionAssignor.Assignment> assignments =
+            partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
         // the first consumer
         final AssignmentInfo info10 = checkAssignment(allTopics, assignments.get("consumer10"));
@@ -958,8 +991,9 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(internalTopicManager);
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, emptyTasks, emptyTasks).encode())
         );
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -989,12 +1023,14 @@ public class StreamsPartitionAssignorTest {
         EasyMock.replay(taskManager);
 
         configurePartitionAssignor(Collections.emptyMap());
-        final MockInternalTopicManager internalTopicManager = new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer);
+        final MockInternalTopicManager internalTopicManager =
+            new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer);
         partitionAssignor.setInternalTopicManager(internalTopicManager);
 
         subscriptions.put("consumer10",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, emptyTasks, emptyTasks).encode())
         );
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -1042,9 +1078,9 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
 
         subscriptions.put(client,
-                new ConsumerPartitionAssignor.Subscription(
-                        asList("topic1", "topic3"),
-                        new SubscriptionInfo(uuid, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              asList("topic1", "topic3"),
+                              getInfo(uuid, emptyTasks, emptyTasks).encode())
         );
         final Map<String, ConsumerPartitionAssignor.Assignment> assignment =
             partitionAssignor.assign(metadata, new GroupSubscription(subscriptions))
@@ -1116,8 +1152,9 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer1",
-                new ConsumerPartitionAssignor.Subscription(topics,
-                        new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              topics,
+                              getInfo(uuid1, emptyTasks, emptyTasks).encode())
         );
         final Map<String, ConsumerPartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
         final ConsumerPartitionAssignor.Assignment consumerAssignment = assignments.get("consumer1");
@@ -1212,9 +1249,9 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
 
         subscriptions.put(client,
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("unknownTopic"),
-                        new SubscriptionInfo(uuid, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("unknownTopic"),
+                              getInfo(uuid, emptyTasks, emptyTasks).encode())
         );
         final Map<String, ConsumerPartitionAssignor.Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
@@ -1264,14 +1301,14 @@ public class StreamsPartitionAssignorTest {
             mockClientSupplier.restoreConsumer));
 
         subscriptions.put("consumer1",
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("topic1"),
-                        new SubscriptionInfo(uuid, emptyTasks, emptyTasks, userEndPoint).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("topic1"),
+                              getInfo(uuid, emptyTasks, emptyTasks).encode())
         );
         subscriptions.put("consumer2",
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("topic1"),
-                        new SubscriptionInfo(UUID.randomUUID(), emptyTasks, emptyTasks, "other:9090").encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("topic1"),
+                              getInfo(UUID.randomUUID(), emptyTasks, emptyTasks, "other:9090").encode())
         );
         final Set<TopicPartition> allPartitions = Utils.mkSet(t1p0, t1p1, t1p2);
         final Map<String, ConsumerPartitionAssignor.Assignment> assign = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
@@ -1360,15 +1397,15 @@ public class StreamsPartitionAssignorTest {
     private void shouldReturnLowestAssignmentVersionForDifferentSubscriptionVersions(final int smallestVersion,
                                                                                      final int otherVersion) {
         subscriptions.put("consumer1",
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("topic1"),
-                        new SubscriptionInfo(smallestVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("topic1"),
+                              getInfo(smallestVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode())
         );
         subscriptions.put("consumer2",
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("topic1"),
-                        new SubscriptionInfo(otherVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode()
-                )
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("topic1"),
+                              getInfo(otherVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode()
+                          )
         );
 
         createMockTaskManager(emptyTasks, emptyTasks, UUID.randomUUID(), builder);
@@ -1438,13 +1475,13 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put(c1,
             new ConsumerPartitionAssignor.Subscription(
                 Collections.singletonList("topic1"),
-                new SubscriptionInfo(UUID.randomUUID(), allTasks, Collections.emptySet(), null).encode(),
+                getInfo(UUID.randomUUID(), allTasks, Collections.emptySet(), null).encode(),
                 Arrays.asList(t1p0, t1p1, t1p2))
         );
         subscriptions.put(c2,
             new ConsumerPartitionAssignor.Subscription(
                 Collections.singletonList("topic1"),
-                new SubscriptionInfo(UUID.randomUUID(), Collections.emptySet(), Collections.emptySet(), null).encode(),
+                getInfo(UUID.randomUUID(), Collections.emptySet(), Collections.emptySet(), null).encode(),
                 Collections.emptyList())
         );
 
@@ -1499,7 +1536,7 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer1",
                 new ConsumerPartitionAssignor.Subscription(
                         Collections.singletonList("topic1"),
-                        new SubscriptionInfo(UUID.randomUUID(), activeTasks, standbyTasks, null).encode(),
+                        getInfo(UUID.randomUUID(), activeTasks, standbyTasks, null).encode(),
                         Arrays.asList(t1p0, t1p1))
         );
         subscriptions.put("future-consumer",
@@ -1606,9 +1643,9 @@ public class StreamsPartitionAssignorTest {
 
     private void shouldThrowIfPreVersionProbingSubscriptionAndFutureSubscriptionIsMixed(final int oldVersion) {
         subscriptions.put("consumer1",
-                new ConsumerPartitionAssignor.Subscription(
-                        Collections.singletonList("topic1"),
-                        new SubscriptionInfo(oldVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode())
+                          new ConsumerPartitionAssignor.Subscription(
+                              Collections.singletonList("topic1"),
+                              getInfo(oldVersion, UUID.randomUUID(), emptyTasks, emptyTasks, null).encode())
         );
         subscriptions.put("future-consumer",
                 new ConsumerPartitionAssignor.Subscription(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.assignment;
+
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class LegacySubscriptionInfoSerde {
+
+    private static final Logger log = LoggerFactory.getLogger(LegacySubscriptionInfoSerde.class);
+
+    public static final int LATEST_SUPPORTED_VERSION = 5;
+    static final int UNKNOWN = -1;
+
+    private final int usedVersion;
+    private final int latestSupportedVersion;
+    private final UUID processId;
+    private final Set<TaskId> prevTasks;
+    private final Set<TaskId> standbyTasks;
+    private final String userEndPoint;
+
+    public LegacySubscriptionInfoSerde(final int version,
+                                       final int latestSupportedVersion,
+                                       final UUID processId,
+                                       final Set<TaskId> prevTasks,
+                                       final Set<TaskId> standbyTasks,
+                                       final String userEndPoint) {
+        if (latestSupportedVersion == UNKNOWN && (version < 1 || version > 2)) {
+            throw new IllegalArgumentException(
+                "Only versions 1 and 2 are expected to use an UNKNOWN (-1) latest supported version. " +
+                    "Got " + version + "."
+            );
+        } else if (latestSupportedVersion != UNKNOWN && (version < 1 || version > latestSupportedVersion)) {
+            throw new IllegalArgumentException(
+                "version must be between 1 and " + latestSupportedVersion + "; was: " + version
+            );
+        }
+        usedVersion = version;
+        this.latestSupportedVersion = latestSupportedVersion;
+        this.processId = processId;
+        this.prevTasks = prevTasks;
+        this.standbyTasks = standbyTasks;
+        // Coerce empty string to null. This was the effect of the serialization logic, anyway.
+        this.userEndPoint = userEndPoint == null || userEndPoint.isEmpty() ? null : userEndPoint;
+    }
+
+    public int version() {
+        return usedVersion;
+    }
+
+    public int latestSupportedVersion() {
+        return latestSupportedVersion;
+    }
+
+    public UUID processId() {
+        return processId;
+    }
+
+    public Set<TaskId> prevTasks() {
+        return prevTasks;
+    }
+
+    public Set<TaskId> standbyTasks() {
+        return standbyTasks;
+    }
+
+    public String userEndPoint() {
+        return userEndPoint;
+    }
+
+    /**
+     * @throws TaskAssignmentException if method fails to encode the data
+     */
+    public ByteBuffer encode() {
+        if (usedVersion == 3 || usedVersion == 4 || usedVersion == 5) {
+            final byte[] endPointBytes = prepareUserEndPoint(this.userEndPoint);
+
+            final ByteBuffer buf = ByteBuffer.allocate(
+                4 + // used version
+                    4 + // latest supported version version
+                    16 + // client ID
+                    4 + prevTasks.size() * 8 + // length + prev tasks
+                    4 + standbyTasks.size() * 8 + // length + standby tasks
+                    4 + endPointBytes.length
+            );
+
+            buf.putInt(usedVersion); // used version
+            buf.putInt(LATEST_SUPPORTED_VERSION); // supported version
+            encodeClientUUID(buf, processId());
+            encodeTasks(buf, prevTasks);
+            encodeTasks(buf, standbyTasks);
+            encodeUserEndPoint(buf, endPointBytes);
+
+            buf.rewind();
+
+            return buf;
+        } else if (usedVersion == 2) {
+            final byte[] endPointBytes = prepareUserEndPoint(this.userEndPoint);
+
+            final ByteBuffer buf = ByteBuffer.allocate(
+                4 + // version
+                    16 + // client ID
+                    4 + prevTasks.size() * 8 + // length + prev tasks
+                    4 + standbyTasks.size() * 8 + // length + standby tasks
+                    4 + endPointBytes.length
+            );
+
+            buf.putInt(2); // version
+            encodeClientUUID(buf, processId());
+            encodeTasks(buf, prevTasks);
+            encodeTasks(buf, standbyTasks);
+            encodeUserEndPoint(buf, endPointBytes);
+
+            buf.rewind();
+
+            return buf;
+        } else if (usedVersion == 1) {
+            final ByteBuffer buf1 = ByteBuffer.allocate(
+                4 + // version
+                    16 + // client ID
+                    4 + prevTasks.size() * 8 + // length + prev tasks
+                    4 + standbyTasks.size() * 8
+            );
+
+            buf1.putInt(1); // version
+            encodeClientUUID(buf1, processId());
+            encodeTasks(buf1, prevTasks);
+            encodeTasks(buf1, standbyTasks);
+            buf1.rewind();
+            return buf1;
+        } else {
+            throw new IllegalStateException("Unknown metadata version: " + usedVersion
+                                                + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
+        }
+    }
+
+    public static void encodeClientUUID(final ByteBuffer buf, final UUID processId) {
+        buf.putLong(processId.getMostSignificantBits());
+        buf.putLong(processId.getLeastSignificantBits());
+    }
+
+    public static void encodeTasks(final ByteBuffer buf,
+                                   final Collection<TaskId> taskIds) {
+        buf.putInt(taskIds.size());
+        for (final TaskId id : taskIds) {
+            id.writeTo(buf);
+        }
+    }
+
+    public static void encodeUserEndPoint(final ByteBuffer buf,
+                                             final byte[] endPointBytes) {
+        if (endPointBytes != null) {
+            buf.putInt(endPointBytes.length);
+            buf.put(endPointBytes);
+        }
+    }
+
+    public static byte[] prepareUserEndPoint(final String userEndPoint) {
+        if (userEndPoint == null) {
+            return new byte[0];
+        } else {
+            return userEndPoint.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * @throws TaskAssignmentException if method fails to decode the data
+     */
+    public static LegacySubscriptionInfoSerde decode(final ByteBuffer data) {
+
+        // ensure we are at the beginning of the ByteBuffer
+        data.rewind();
+
+        final int usedVersion = data.getInt();
+        if (usedVersion == 4 || usedVersion == 3) {
+            final int latestSupportedVersion = data.getInt();
+            final UUID processId = decodeProcessId(data);
+            final Set<TaskId> prevTasks = decodeTasks(data);
+            final Set<TaskId> standbyTasks = decodeTasks(data);
+            final String userEndPoint = decodeUserEndpoint(data);
+            return new LegacySubscriptionInfoSerde(usedVersion, latestSupportedVersion, processId, prevTasks, standbyTasks, userEndPoint);
+        } else if (usedVersion == 2) {
+            final UUID processId = decodeProcessId(data);
+            final Set<TaskId> prevTasks = decodeTasks(data);
+            final Set<TaskId> standbyTasks = decodeTasks(data);
+            final String userEndPoint = decodeUserEndpoint(data);
+            return new LegacySubscriptionInfoSerde(2, UNKNOWN, processId, prevTasks, standbyTasks, userEndPoint);
+        } else if (usedVersion == 1) {
+            final UUID processId = decodeProcessId(data);
+            final Set<TaskId> prevTasks = decodeTasks(data);
+            final Set<TaskId> standbyTasks = decodeTasks(data);
+            return new LegacySubscriptionInfoSerde(1, UNKNOWN, processId, prevTasks, standbyTasks, null);
+        } else {
+            final int latestSupportedVersion = data.getInt();
+            log.info("Unable to decode subscription data: used version: {}; latest supported version: {}", usedVersion, LATEST_SUPPORTED_VERSION);
+            return new LegacySubscriptionInfoSerde(usedVersion, latestSupportedVersion, null, null, null, null);
+        }
+    }
+
+    private static String decodeUserEndpoint(final ByteBuffer data) {
+        final int userEndpointBytesLength = data.getInt();
+        final byte[] userEndpointBytes = new byte[userEndpointBytesLength];
+        data.get(userEndpointBytes);
+        return new String(userEndpointBytes, StandardCharsets.UTF_8);
+    }
+
+    private static Set<TaskId> decodeTasks(final ByteBuffer data) {
+        final Set<TaskId> prevTasks = new HashSet<>();
+        final int numPrevTasks = data.getInt();
+        for (int i = 0; i < numPrevTasks; i++) {
+            prevTasks.add(TaskId.readFrom(data));
+        }
+        return prevTasks;
+    }
+
+    private static UUID decodeProcessId(final ByteBuffer data) {
+        return new UUID(data.getLong(), data.getLong());
+    }
+
+    @Override
+    public int hashCode() {
+        final int hashCode = usedVersion ^ latestSupportedVersion ^ processId.hashCode() ^ prevTasks.hashCode() ^ standbyTasks.hashCode();
+        if (userEndPoint == null) {
+            return hashCode;
+        }
+        return hashCode ^ userEndPoint.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof LegacySubscriptionInfoSerde) {
+            final LegacySubscriptionInfoSerde other = (LegacySubscriptionInfoSerde) o;
+            return usedVersion == other.usedVersion &&
+                latestSupportedVersion == other.latestSupportedVersion &&
+                processId.equals(other.processId) &&
+                prevTasks.equals(other.prevTasks) &&
+                standbyTasks.equals(other.standbyTasks) &&
+                userEndPoint != null ? userEndPoint.equals(other.userEndPoint) : other.userEndPoint == null;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "[version=" + usedVersion
+            + ", supported version=" + latestSupportedVersion
+            + ", process ID=" + processId
+            + ", prev tasks=" + prevTasks
+            + ", standby tasks=" + standbyTasks
+            + ", user endpoint=" + userEndPoint + "]";
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -25,9 +25,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
+import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.LATEST_SUPPORTED_VERSION;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class SubscriptionInfoTest {
     private final UUID processId = UUID.randomUUID();
@@ -43,53 +43,236 @@ public class SubscriptionInfoTest {
 
     @Test
     public void shouldUseLatestSupportedVersionByDefault() {
-        final SubscriptionInfo info = new SubscriptionInfo(processId, activeTasks, standbyTasks, "localhost:80");
+        final SubscriptionInfo info = new SubscriptionInfo(
+            LATEST_SUPPORTED_VERSION,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
         assertEquals(LATEST_SUPPORTED_VERSION, info.version());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
-        new SubscriptionInfo(0, processId, activeTasks, standbyTasks, "localhost:80");
+        new SubscriptionInfo(
+            0,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion2() {
-        new SubscriptionInfo(LATEST_SUPPORTED_VERSION + 1, processId, activeTasks, standbyTasks, "localhost:80");
+        new SubscriptionInfo(
+            LATEST_SUPPORTED_VERSION + 1,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion1() {
-        final SubscriptionInfo info = new SubscriptionInfo(1, processId, activeTasks, standbyTasks, IGNORED_USER_ENDPOINT);
-        final SubscriptionInfo expectedInfo = new SubscriptionInfo(1, UNKNOWN, processId, activeTasks, standbyTasks, null);
-        assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
+        final SubscriptionInfo info = new SubscriptionInfo(
+            1,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            IGNORED_USER_ENDPOINT
+        );
+        final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
+        assertEquals(1, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertNull(decoded.userEndPoint());
+    }
+
+    @Test
+    public void generatedVersion1ShouldBeDecodableByLegacyLogic() {
+        final SubscriptionInfo info = new SubscriptionInfo(
+            1,
+            1234,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "ignoreme"
+        );
+        final ByteBuffer buffer = info.encode();
+
+        final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
+        assertEquals(1, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertNull(decoded.userEndPoint());
+    }
+
+
+    @Test
+    public void generatedVersion1ShouldDecodeLegacyFormat() {
+        final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
+            1,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
+        final ByteBuffer buffer = info.encode();
+        buffer.rewind();
+        final SubscriptionInfo decoded = SubscriptionInfo.decode(buffer);
+        assertEquals(1, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertNull(decoded.userEndPoint());
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion2() {
-        final SubscriptionInfo info = new SubscriptionInfo(2, processId, activeTasks, standbyTasks, "localhost:80");
-        final SubscriptionInfo expectedInfo = new SubscriptionInfo(2, UNKNOWN, processId, activeTasks, standbyTasks, "localhost:80");
-        assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
+        final SubscriptionInfo info = new SubscriptionInfo(
+            2,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
+        final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
+        assertEquals(2, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertEquals("localhost:80", decoded.userEndPoint());
     }
 
     @Test
-    public void shouldEncodeAndDecodeVersion3() {
-        final SubscriptionInfo info = new SubscriptionInfo(3, processId, activeTasks, standbyTasks, "localhost:80");
-        final SubscriptionInfo expectedInfo = new SubscriptionInfo(3, LATEST_SUPPORTED_VERSION, processId, activeTasks, standbyTasks, "localhost:80");
-        assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
+    public void generatedVersion2ShouldBeDecodableByLegacyLogic() {
+        final SubscriptionInfo info = new SubscriptionInfo(
+            2,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
+        final ByteBuffer buffer = info.encode();
+
+        final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
+        assertEquals(2, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertEquals("localhost:80", decoded.userEndPoint());
     }
 
     @Test
-    public void shouldEncodeAndDecodeVersion4() {
-        final SubscriptionInfo info = new SubscriptionInfo(4, processId, activeTasks, standbyTasks, "localhost:80");
-        final SubscriptionInfo expectedInfo = new SubscriptionInfo(4, LATEST_SUPPORTED_VERSION, processId, activeTasks, standbyTasks, "localhost:80");
-        assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
+    public void generatedVersion2ShouldDecodeLegacyFormat() {
+        final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
+            2,
+            LATEST_SUPPORTED_VERSION,
+            processId,
+            activeTasks,
+            standbyTasks,
+            "localhost:80"
+        );
+        final ByteBuffer buffer = info.encode();
+        buffer.rewind();
+        final SubscriptionInfo decoded = SubscriptionInfo.decode(buffer);
+        assertEquals(2, decoded.version());
+        assertEquals(SubscriptionInfo.UNKNOWN, decoded.latestSupportedVersion());
+        assertEquals(processId, decoded.processId());
+        assertEquals(activeTasks, decoded.prevTasks());
+        assertEquals(standbyTasks, decoded.standbyTasks());
+        assertEquals("localhost:80", decoded.userEndPoint());
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeVersion3And4() {
+        for (int version = 3; version <= 4; version++) {
+            final SubscriptionInfo info = new SubscriptionInfo(
+                version,
+                LATEST_SUPPORTED_VERSION,
+                processId,
+                activeTasks,
+                standbyTasks,
+                "localhost:80"
+            );
+            final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
+            assertEquals(version, decoded.version());
+            assertEquals(LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
+            assertEquals(processId, decoded.processId());
+            assertEquals(activeTasks, decoded.prevTasks());
+            assertEquals(standbyTasks, decoded.standbyTasks());
+            assertEquals("localhost:80", decoded.userEndPoint());
+        }
+    }
+
+    @Test
+    public void generatedVersion3And4ShouldBeDecodableByLegacyLogic() {
+        for (int version = 3; version <= 4; version++) {
+            final SubscriptionInfo info = new SubscriptionInfo(
+                version,
+                LATEST_SUPPORTED_VERSION,
+                processId,
+                activeTasks,
+                standbyTasks,
+                "localhost:80"
+            );
+            final ByteBuffer buffer = info.encode();
+
+            final LegacySubscriptionInfoSerde decoded = LegacySubscriptionInfoSerde.decode(buffer);
+            assertEquals(version, decoded.version());
+            assertEquals(LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
+            assertEquals(processId, decoded.processId());
+            assertEquals(activeTasks, decoded.prevTasks());
+            assertEquals(standbyTasks, decoded.standbyTasks());
+            assertEquals("localhost:80", decoded.userEndPoint());
+        }
+    }
+
+    @Test
+    public void generatedVersion3And4ShouldDecodeLegacyFormat() {
+        for (int version = 3; version <= 5; version++) {
+            final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
+                version,
+                LATEST_SUPPORTED_VERSION,
+                processId,
+                activeTasks,
+                standbyTasks,
+                "localhost:80"
+            );
+            final ByteBuffer buffer = info.encode();
+            buffer.rewind();
+            final SubscriptionInfo decoded = SubscriptionInfo.decode(buffer);
+            final String message = "for version: " + version;
+            assertEquals(message, version, decoded.version());
+            assertEquals(message, LATEST_SUPPORTED_VERSION, decoded.latestSupportedVersion());
+            assertEquals(message, processId, decoded.processId());
+            assertEquals(message, activeTasks, decoded.prevTasks());
+            assertEquals(message, standbyTasks, decoded.standbyTasks());
+            assertEquals(message, "localhost:80", decoded.userEndPoint());
+        }
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion5() {
-        final SubscriptionInfo info = new SubscriptionInfo(5, processId, activeTasks, standbyTasks, "localhost:80");
-        final SubscriptionInfo expectedInfo = new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION, processId, activeTasks, standbyTasks, "localhost:80");
-        assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
+        final SubscriptionInfo info = new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION, processId, activeTasks, standbyTasks, "localhost:80");
+        assertEquals(info, SubscriptionInfo.decode(info.encode()));
     }
 
     @Test
@@ -109,11 +292,12 @@ public class SubscriptionInfoTest {
         assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
     }
 
-    private ByteBuffer encodeFutureVersion() {
+    private static ByteBuffer encodeFutureVersion() {
         final ByteBuffer buf = ByteBuffer.allocate(4 /* used version */
-                                                   + 4 /* supported version */);
+                                                       + 4 /* supported version */);
         buf.putInt(LATEST_SUPPORTED_VERSION + 1);
         buf.putInt(LATEST_SUPPORTED_VERSION + 1);
+        buf.rewind();
         return buf;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.LATEST_SUPPORTED_VERSION;
+import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.apache.kafka.streams.processor.internals.TaskManager;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
+import org.apache.kafka.streams.processor.internals.assignment.LegacySubscriptionInfoSerde;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
 import org.apache.kafka.streams.state.HostInfo;
 
@@ -57,6 +58,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 
@@ -76,25 +78,7 @@ public class StreamsUpgradeTest {
         System.out.println("StreamsTest instance started (StreamsUpgradeTest trunk)");
         System.out.println("props=" + streamsProperties);
 
-        final StreamsBuilder builder = new StreamsBuilder();
-        final KStream dataStream = builder.stream("data");
-        dataStream.process(SmokeTestUtil.printProcessorSupplier("data"));
-        dataStream.to("echo");
-
-        final Properties config = new Properties();
-        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "StreamsUpgradeTest");
-        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
-
-        final KafkaClientSupplier kafkaClientSupplier;
-        if (streamsProperties.containsKey("test.future.metadata")) {
-            streamsProperties.remove("test.future.metadata");
-            kafkaClientSupplier = new FutureKafkaClientSupplier();
-        } else {
-            kafkaClientSupplier = new DefaultKafkaClientSupplier();
-        }
-        config.putAll(streamsProperties);
-
-        final KafkaStreams streams = new KafkaStreams(builder.build(), config, kafkaClientSupplier);
+        final KafkaStreams streams = buildStreams(streamsProperties);
         streams.start();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -104,6 +88,27 @@ public class StreamsUpgradeTest {
             System.out.println("UPGRADE-TEST-CLIENT-CLOSED");
             System.out.flush();
         }));
+    }
+
+    public static KafkaStreams buildStreams(final Properties streamsProperties) {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Void, Void> dataStream = builder.stream("data");
+        dataStream.process(SmokeTestUtil.printProcessorSupplier("data"));
+        dataStream.to("echo");
+
+        final Properties config = new Properties();
+        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "StreamsUpgradeTest");
+        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
+
+        final KafkaClientSupplier kafkaClientSupplier;
+        if (streamsProperties.containsKey("test.future.metadata")) {
+            kafkaClientSupplier = new FutureKafkaClientSupplier();
+        } else {
+            kafkaClientSupplier = new DefaultKafkaClientSupplier();
+        }
+        config.putAll(streamsProperties);
+
+        return new KafkaStreams(builder.build(), config, kafkaClientSupplier);
     }
 
     private static class FutureKafkaClientSupplier extends DefaultKafkaClientSupplier {
@@ -116,8 +121,20 @@ public class StreamsUpgradeTest {
 
     public static class FutureStreamsPartitionAssignor extends StreamsPartitionAssignor {
 
+        private AtomicInteger usedSubscriptionMetadataVersionPeek;
+
         public FutureStreamsPartitionAssignor() {
             usedSubscriptionMetadataVersion = LATEST_SUPPORTED_VERSION + 1;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs) {
+            final Object o = configs.get("test.future.metadata");
+            if (o instanceof AtomicInteger) {
+                usedSubscriptionMetadataVersionPeek = (AtomicInteger) o;
+            }
+            configs.remove("test.future.metadata");
+            super.configure(configs);
         }
 
         @Override
@@ -148,6 +165,7 @@ public class StreamsUpgradeTest {
                                  final ConsumerGroupMetadata metadata) {
             try {
                 super.onAssignment(assignment, metadata);
+                usedSubscriptionMetadataVersionPeek.set(usedSubscriptionMetadataVersion);
                 return;
             } catch (final TaskAssignmentException cannotProcessFutureVersion) {
                 // continue
@@ -171,8 +189,9 @@ public class StreamsUpgradeTest {
             final AssignmentInfo info = AssignmentInfo.decode(
                 assignment.userData().putInt(0, LATEST_SUPPORTED_VERSION));
 
-            if (super.maybeUpdateSubscriptionVersion(usedVersion, info.commonlySupportedVersion())) {
+            if (maybeUpdateSubscriptionVersion(usedVersion, info.commonlySupportedVersion())) {
                 setAssignmentErrorCode(AssignorError.VERSION_PROBING.code());
+                usedSubscriptionMetadataVersionPeek.set(usedSubscriptionMetadataVersion);
                 return;
             }
 
@@ -197,6 +216,7 @@ public class StreamsUpgradeTest {
             taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
             taskManager.updateSubscriptionsFromAssignment(partitions);
             taskManager.setRebalanceInProgress(false);
+            usedSubscriptionMetadataVersionPeek.set(usedSubscriptionMetadataVersion);
         }
 
         @Override
@@ -228,14 +248,16 @@ public class StreamsUpgradeTest {
                     final Subscription subscription = entry.getValue();
 
                     final SubscriptionInfo info = SubscriptionInfo.decode(subscription.userData()
-                        .putInt(0, LATEST_SUPPORTED_VERSION)
-                        .putInt(4, LATEST_SUPPORTED_VERSION));
+                                                                                      .putInt(0, LATEST_SUPPORTED_VERSION)
+                                                                                      .putInt(4, LATEST_SUPPORTED_VERSION));
 
                     downgradedSubscriptions.put(
                         entry.getKey(),
                         new Subscription(
                             subscription.topics(),
                             new SubscriptionInfo(
+                                SubscriptionInfo.LATEST_SUPPORTED_VERSION,
+                                SubscriptionInfo.LATEST_SUPPORTED_VERSION,
                                 info.processId(),
                                 info.prevTasks(),
                                 info.standbyTasks(),
@@ -293,20 +315,28 @@ public class StreamsUpgradeTest {
         }
 
         private ByteBuffer encodeFutureVersion() {
-            final byte[] endPointBytes = prepareUserEndPoint();
+            final byte[] endPointBytes = LegacySubscriptionInfoSerde.prepareUserEndPoint(userEndPoint());
 
-            final ByteBuffer buf = ByteBuffer.allocate(getVersionThreeFourAndFiveByteLength(endPointBytes));
+            final ByteBuffer buf = ByteBuffer.allocate(
+                4 + // used version
+                    4 + // latest supported version version
+                    16 + // client ID
+                    4 + prevTasks().size() * 8 + // length + prev tasks
+                    4 + standbyTasks().size() * 8 + // length + standby tasks
+                    4 + endPointBytes.length
+            );
 
             buf.putInt(LATEST_SUPPORTED_VERSION + 1); // used version
             buf.putInt(LATEST_SUPPORTED_VERSION + 1); // supported version
-            encodeClientUUID(buf);
-            encodeTasks(buf, prevTasks());
-            encodeTasks(buf, standbyTasks());
-            encodeUserEndPoint(buf, endPointBytes);
+            LegacySubscriptionInfoSerde.encodeClientUUID(buf, processId());
+            LegacySubscriptionInfoSerde.encodeTasks(buf, prevTasks());
+            LegacySubscriptionInfoSerde.encodeTasks(buf, standbyTasks());
+            LegacySubscriptionInfoSerde.encodeUserEndPoint(buf, endPointBytes);
+
+            buf.rewind();
 
             return buf;
         }
-
     }
 
     private static class FutureAssignmentInfo extends AssignmentInfo {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.streams.processor.internals.TaskManager;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.LegacySubscriptionInfoSerde;
-import org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
 import org.apache.kafka.streams.state.HostInfo;
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -132,6 +132,9 @@ public class StreamsUpgradeTest {
             final Object o = configs.get("test.future.metadata");
             if (o instanceof AtomicInteger) {
                 usedSubscriptionMetadataVersionPeek = (AtomicInteger) o;
+            } else {
+                // will not be used, just adding a dummy container for simpler code paths
+                usedSubscriptionMetadataVersionPeek = new AtomicInteger();
             }
             configs.remove("test.future.metadata");
             super.configure(configs);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.internals.TaskManager;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.LegacySubscriptionInfoSerde;
+import org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
 import org.apache.kafka.streams.state.HostInfo;
 
@@ -259,8 +260,8 @@ public class StreamsUpgradeTest {
                         new Subscription(
                             subscription.topics(),
                             new SubscriptionInfo(
-                                SubscriptionInfo.LATEST_SUPPORTED_VERSION,
-                                SubscriptionInfo.LATEST_SUPPORTED_VERSION,
+                                LATEST_SUPPORTED_VERSION,
+                                LATEST_SUPPORTED_VERSION,
                                 info.processId(),
                                 info.prevTasks(),
                                 info.standbyTasks(),


### PR DESCRIPTION
Rather than maintain hand coded protocol serialization code, Streams could use the same code-generation framework as Clients/Core.

There isn't a perfect match, since the code generation framework includes an assumption that you're generating "protocol messages", rather than just arbitrary blobs, but I think it's close enough to justify using it, and improving it over time.

Using the code generation allows us to drop a lot of detail-oriented, brittle, and hard-to-maintain serialization logic in favor of a schema spec.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
