### PR TITLE
MINOR: fix ProduceBenchWorker not to fail on final produce

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -247,7 +247,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     throw e;
                 } finally {
                     if (sendFuture != null) {
-			try {
+                        try {
                             sendFuture.get();
                         } catch (Exception e) {
                             log.error("Exception on final future", e);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -247,7 +247,11 @@ public class ProduceBenchWorker implements TaskWorker {
                     throw e;
                 } finally {
                     if (sendFuture != null) {
-                        sendFuture.get();
+			try {
+                            sendFuture.get();
+                        } catch (Exception e) {
+                            log.error("Exception on final future", e);
+                        }
                     }
                     producer.close();
                 }


### PR DESCRIPTION
When sending bad records, the Trogdor task will fail if
the final record produced is bad.  Instead we should
catch the exception to allow the task to finish since
sending bad records is a valid use case.

