### PR TITLE
MINOR: A bugfix for GlobalKTable with different source topics.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -235,7 +235,7 @@ public class GlobalStreamThread extends Thread {
             final Set<String> unusedTopics = new HashSet<>();
             final Iterator<Entry<TopicPartition, Long>> tps = partitionOffsets.entrySet().iterator();
             while (tps.hasNext()) {
-                Entry<TopicPartition, Long> tp = tps.next();
+                final Entry<TopicPartition, Long> tp = tps.next();
                 if (!this.sourceTopics.contains(tp.getKey().topic())) {
                     unusedTopics.add(tp.getKey().topic());
                     tps.remove();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.types.Field.Array;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -241,7 +242,9 @@ public class GlobalStreamThread extends Thread {
                 }
             }
             if (!unusedTopics.isEmpty()) {
-                log.warn("Checkpoint contains unused topic(s): {}, skipped them now, need to clean them.", Arrays.toString(unusedTopics.toArray()));
+                log.warn("Checkpoint contains unused topic(s): {}, skipped them now, need to clean them, current source topic(s): ",
+                    Arrays.toString(unusedTopics.toArray()),
+                    Arrays.toString(this.topology.sourceTopics().toArray()));
             }
             globalConsumer.assign(partitionOffsets.keySet());
             for (final Map.Entry<TopicPartition, Long> entry : partitionOffsets.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -231,7 +232,7 @@ public class GlobalStreamThread extends Thread {
          * @throws StreamsException      if the store's change log does not contain the partition
          */
         void initialize() {
-            final Map<TopicPartition, Long> partitionOffsets = stateMaintainer.initialize();
+            final Map<TopicPartition, Long> partitionOffsets = new HashMap<>(stateMaintainer.initialize());
             Set<String> unusedTopics = new HashSet<>();
             Iterator<Entry<TopicPartition, Long>> tps = partitionOffsets.entrySet().iterator();
             while (tps.hasNext()) {
@@ -242,7 +243,7 @@ public class GlobalStreamThread extends Thread {
                 }
             }
             if (!unusedTopics.isEmpty()) {
-                log.warn("Checkpoint contains unused topic(s): {}, skipped them now, need to clean them, current source topic(s): ",
+                log.warn("Checkpoint contains unused topic(s): {}, skipped them now, need to clean them, current source topic(s): {}",
                     Arrays.toString(unusedTopics.toArray()),
                     Arrays.toString(this.topology.sourceTopics().toArray()));
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -88,6 +88,14 @@ public class GlobalStreamThreadTest {
         );
     }
 
+    private HashMap<String, Object> getDefaultProperties() {
+        final HashMap<String, Object> properties = new HashMap<>();
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "blah");
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "blah");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+        return properties;
+    }
+
     @SuppressWarnings("unchecked")
     @Before
     public void before() {
@@ -104,11 +112,7 @@ public class GlobalStreamThreadTest {
             "processorName",
             new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME));
 
-        final HashMap<String, Object> properties = new HashMap<>();
-        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "blah");
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "blah");
-        properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-        config = new StreamsConfig(properties);
+        config = new StreamsConfig(getDefaultProperties());
         globalStreamThread = new GlobalStreamThread(builder.rewriteTopology(config).buildGlobalStateTopology(),
                                                     config,
                                                     mockConsumer,
@@ -288,11 +292,7 @@ public class GlobalStreamThreadTest {
             GLOBAL_STORE_TOPIC_NAME,
             "processorName",
             new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME));
-        final HashMap<String, Object> properties = new HashMap<>();
-        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "blah");
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "blah");
-        properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-        config = new StreamsConfig(properties);
+        config = new StreamsConfig(getDefaultProperties());
         globalStreamThread = new GlobalStreamThread(tmpBuilder.rewriteTopology(config).buildGlobalStateTopology(),
             config,
             tmpMockConsumer1,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -234,7 +234,6 @@ public class GlobalStreamThreadTest {
     public void shouldDieOnInvalidOffsetException() throws Exception {
         initializeConsumer();
         globalStreamThread.start();
-        initializeConsumer();
         TestUtils.waitForCondition(
             () -> globalStreamThread.state() == RUNNING,
             10 * 1000,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -264,16 +264,18 @@ public class GlobalStreamThreadTest {
         final MockConsumer<byte[], byte[]> tmpMockConsumer1 = new MockConsumer<>(OffsetResetStrategy.NONE);
         tmpMockConsumer1.updatePartitions(
             GLOBAL_STORE_TOPIC_NAME,
-            Collections.singletonList(new PartitionInfo(
-                GLOBAL_STORE_TOPIC_NAME,
-                0,
-                null,
-                new Node[0],
-                new Node[0])));
+            Collections.singletonList(
+                new PartitionInfo(
+                    GLOBAL_STORE_TOPIC_NAME,
+                    0,
+                    null,
+                    new Node[0],
+                    new Node[0])
+            )
+        );
         tmpMockConsumer1.updateBeginningOffsets(Collections.singletonMap(topicPartition, 0L));
         tmpMockConsumer1.updateEndOffsets(Collections.singletonMap(topicPartition, 0L));
         tmpMockConsumer1.assign(Collections.singleton(topicPartition));
-
         final MaterializedInternal<Object, Object, KeyValueStore<Bytes, byte[]>> materialized =
             getDefaultMaterialized();
         InternalTopologyBuilder tmpBuilder = new InternalTopologyBuilder();
@@ -289,8 +291,7 @@ public class GlobalStreamThreadTest {
         final HashMap<String, Object> properties = new HashMap<>();
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "blah");
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "blah");
-        final String tempDir = TestUtils.tempDirectory().getAbsolutePath();
-        properties.put(StreamsConfig.STATE_DIR_CONFIG, tempDir);
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         config = new StreamsConfig(properties);
         globalStreamThread = new GlobalStreamThread(tmpBuilder.rewriteTopology(config).buildGlobalStateTopology(),
             config,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -71,24 +71,28 @@ public class GlobalStreamThreadTest {
     private final TopicPartition topicPartition = new TopicPartition(GLOBAL_STORE_TOPIC_NAME, 0);
     private final TopicPartition secondTopicPartition = new TopicPartition(SECOND_TOPIC, 0);
 
+    private MaterializedInternal<Object, Object, KeyValueStore<Bytes, byte[]>> getDefaultMaterialized() {
+        return new MaterializedInternal<>(Materialized.with(null, null),
+            new InternalNameProvider() {
+                @Override
+                public String newProcessorName(final String prefix) {
+                    return "processorName";
+                }
+
+                @Override
+                public String newStoreName(final String prefix) {
+                    return GLOBAL_STORE_NAME;
+                }
+            },
+            "store-"
+        );
+    }
+
     @SuppressWarnings("unchecked")
     @Before
     public void before() {
         final MaterializedInternal<Object, Object, KeyValueStore<Bytes, byte[]>> materialized =
-            new MaterializedInternal<>(Materialized.with(null, null),
-                new InternalNameProvider() {
-                    @Override
-                    public String newProcessorName(final String prefix) {
-                        return "processorName";
-                    }
-
-                    @Override
-                    public String newStoreName(final String prefix) {
-                        return GLOBAL_STORE_NAME;
-                    }
-                },
-                "store-"
-            );
+            getDefaultMaterialized();
 
         builder.addGlobalStore(
             new TimestampedKeyValueStoreMaterializer<>(materialized).materialize().withLoggingDisabled(),
@@ -271,20 +275,7 @@ public class GlobalStreamThreadTest {
         tmpMockConsumer1.assign(Collections.singleton(topicPartition));
 
         final MaterializedInternal<Object, Object, KeyValueStore<Bytes, byte[]>> materialized =
-            new MaterializedInternal<>(Materialized.with(null, null),
-                new InternalNameProvider() {
-                    @Override
-                    public String newProcessorName(final String prefix) {
-                        return "processorName";
-                    }
-
-                    @Override
-                    public String newStoreName(final String prefix) {
-                        return GLOBAL_STORE_NAME;
-                    }
-                },
-                "store-"
-            );
+            getDefaultMaterialized();
         InternalTopologyBuilder tmpBuilder = new InternalTopologyBuilder();
         tmpBuilder.addGlobalStore(
             new TimestampedKeyValueStoreMaterializer<>(materialized).materialize().withLoggingDisabled(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.HashSet;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -45,6 +46,7 @@ public class StateConsumerTest {
     private final MockTime time = new MockTime();
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final Map<TopicPartition, Long> partitionOffsets = new HashMap<>();
+    private final Set<String> sourceTopics = new HashSet<>();
     private final LogContext logContext = new LogContext("test ");
     private GlobalStreamThread.StateConsumer stateConsumer;
     private StateMaintainerStub stateMaintainer;
@@ -54,7 +56,9 @@ public class StateConsumerTest {
         partitionOffsets.put(topicOne, 20L);
         partitionOffsets.put(topicTwo, 30L);
         stateMaintainer = new StateMaintainerStub(partitionOffsets);
-        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, new HashSet<>(), consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
+        sourceTopics.add(topicOne.topic());
+        sourceTopics.add(topicTwo.topic());
+        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, sourceTopics, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.HashSet;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -53,7 +54,7 @@ public class StateConsumerTest {
         partitionOffsets.put(topicOne, 20L);
         partitionOffsets.put(topicTwo, 30L);
         stateMaintainer = new StateMaintainerStub(partitionOffsets);
-        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
+        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, new HashSet<>(), consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.HashSet;
-import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -46,7 +44,6 @@ public class StateConsumerTest {
     private final MockTime time = new MockTime();
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final Map<TopicPartition, Long> partitionOffsets = new HashMap<>();
-    private final Set<String> sourceTopics = new HashSet<>();
     private final LogContext logContext = new LogContext("test ");
     private GlobalStreamThread.StateConsumer stateConsumer;
     private StateMaintainerStub stateMaintainer;
@@ -56,9 +53,7 @@ public class StateConsumerTest {
         partitionOffsets.put(topicOne, 20L);
         partitionOffsets.put(topicTwo, 30L);
         stateMaintainer = new StateMaintainerStub(partitionOffsets);
-        sourceTopics.add(topicOne.topic());
-        sourceTopics.add(topicTwo.topic());
-        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, sourceTopics, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
+        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
     }
 
     @Test
@@ -72,13 +67,6 @@ public class StateConsumerTest {
         stateConsumer.initialize();
         assertEquals(20L, consumer.position(topicOne));
         assertEquals(30L, consumer.position(topicTwo));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldSeekToInitialOffsetsWithMissingTopic() {
-        sourceTopics.remove(topicOne.topic());
-        stateConsumer.initialize();
-        assertEquals(20L, consumer.position(topicOne));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -74,6 +74,13 @@ public class StateConsumerTest {
         assertEquals(30L, consumer.position(topicTwo));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldSeekToInitialOffsetsWithMissingTopic() {
+        sourceTopics.remove(topicOne.topic());
+        stateConsumer.initialize();
+        assertEquals(20L, consumer.position(topicOne));
+    }
+
     @Test
     public void shouldUpdateStateWithReceivedRecordsForPartition() {
         stateConsumer.initialize();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -44,6 +47,7 @@ public class StateConsumerTest {
     private final MockTime time = new MockTime();
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final Map<TopicPartition, Long> partitionOffsets = new HashMap<>();
+    private final Set<String> sourceTopics = new HashSet<>();
     private final LogContext logContext = new LogContext("test ");
     private GlobalStreamThread.StateConsumer stateConsumer;
     private StateMaintainerStub stateMaintainer;
@@ -53,7 +57,9 @@ public class StateConsumerTest {
         partitionOffsets.put(topicOne, 20L);
         partitionOffsets.put(topicTwo, 30L);
         stateMaintainer = new StateMaintainerStub(partitionOffsets);
-        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
+        sourceTopics.add(topicOne.topic());
+        sourceTopics.add(topicTwo.topic());
+        stateConsumer = new GlobalStreamThread.StateConsumer(logContext, sourceTopics, consumer, stateMaintainer, time, Duration.ofMillis(10L), FLUSH_INTERVAL);
     }
 
     @Test


### PR DESCRIPTION
Description of changes:
When we use `GlobalKtable`, we found that if the source topic(s) of the `GlobalKtable` changed, then the `checkpoint` still keeps the old topic(s) and offsets and try to continue to consume messages from the topic(s). This issue caused kafka global stream thread was in `ERROR`.
The exception:
```
java.lang.NullPointerException: null
>---at org.apache.kafka.streams.processor.internals.GlobalStateUpdateTask.update(GlobalStateUpdateTask.java:77) ~[kafka-streams-1.1.0.jar!/:na]
>---at org.apache.kafka.streams.processor.internals.GlobalStreamThread$StateConsumer.pollAndUpdate(GlobalStreamThread.java:241) ~[kafka-streams-1.1.0.jar!/:na]
>---at org.apache.kafka.streams.processor.internals.GlobalStreamThread.run(GlobalStreamThread.java:289) ~[kafka-streams-1.1.0.jar!/:na]
``` 

There is no functionality changed

### Committer Checklist (excluded from commit message)
- [x ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
