### PR TITLE
MINOR: Fix a wrong path in tests/docker/Dockerfile

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-1.1.1-test.jar" -o /opt/kafka-1.1.1/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.0.1-test.jar" -o /opt/kafka-2.0.1/libs/kafka-streams-2.0.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.1.1-test.jar" -o /opt/kafka-2.1.1/libs/kafka-streams-2.1.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.2.1-test.jar" -o /opt/kafka-2.2.1/libs/kafka-streams-2.2.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.3.0-test.jar" -o /opt/kafka-2.2.0/libs/kafka-streams-2.3.0-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.3.0-test.jar" -o /opt/kafka-2.3.0/libs/kafka-streams-2.3.0-test.jar
 
 # The version of Kibosh to use for testing.
 # If you update this, also update vagrant/base.sy


### PR DESCRIPTION
I tried to build a Docker image with tests/docker/Dockerfile, but it failed with the following error. This PR fixes a wrong path in it.

```
$ docker build tests/docker

(snip)

Step 37/43 : RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.3.0-test.jar" -o /opt/kafka-2.2.0/libs/kafka-streams-2.3.0-test.jar
 ---> Running in 73353b7f1850
The command '/bin/sh -c curl -s "$KAFKA_MIRROR/kafka-streams-2.3.0-test.jar" -o /opt/kafka-2.2.0/libs/kafka-streams-2.3.0-test.jar' returned a non-zero code:
23
```

As a manual test, I ran the same command with this fix and confirmed that the image was successfully built.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
