### PR TITLE
KAFKA-8580: Compute RocksDB metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -59,6 +60,7 @@ import org.apache.kafka.streams.state.internals.GlobalStateStoreProvider;
 import org.apache.kafka.streams.state.internals.QueryableStoreProvider;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.StreamThreadStateStoreProvider;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -80,6 +82,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.utils.Utils.getHost;
 import static org.apache.kafka.common.utils.Utils.getPort;
+import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
 import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 
 /**
@@ -138,12 +141,15 @@ public class KafkaStreams implements AutoCloseable {
     private final StateDirectory stateDirectory;
     private final StreamsMetadataState streamsMetadataState;
     private final ScheduledExecutorService stateDirCleaner;
+    private final ScheduledExecutorService rocksDBMetricsRecordingTriggerThread;
     private final QueryableStoreProvider queryableStoreProvider;
     private final Admin adminClient;
 
     private GlobalStreamThread globalStreamThread;
     private KafkaStreams.StateListener stateListener;
     private StateRestoreListener globalStateRestoreListener;
+
+    private final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger = new RocksDBMetricsRecordingTrigger();
 
     // container states
     /**
@@ -665,6 +671,7 @@ public class KafkaStreams implements AutoCloseable {
         reporters.add(new JmxReporter(JMX_PREFIX));
         metrics = new Metrics(metricConfig, reporters, time);
 
+
         // re-write the physical topology according to the config
         internalTopologyBuilder.rewriteTopology(config);
 
@@ -698,15 +705,18 @@ public class KafkaStreams implements AutoCloseable {
         GlobalStreamThread.State globalThreadState = null;
         if (globalTaskTopology != null) {
             final String globalThreadId = clientId + "-GlobalStreamThread";
-            globalStreamThread = new GlobalStreamThread(globalTaskTopology,
-                                                        config,
-                                                        clientSupplier.getGlobalConsumer(config.getGlobalConsumerConfigs(clientId)),
-                                                        stateDirectory,
-                                                        cacheSizePerThread,
-                                                        metrics,
-                                                        time,
-                                                        globalThreadId,
-                                                        delegatingStateRestoreListener);
+            globalStreamThread = new GlobalStreamThread(
+                globalTaskTopology,
+                config,
+                clientSupplier.getGlobalConsumer(config.getGlobalConsumerConfigs(clientId)),
+                stateDirectory,
+                cacheSizePerThread,
+                metrics,
+                time,
+                globalThreadId,
+                delegatingStateRestoreListener,
+                rocksDBMetricsRecordingTrigger
+            );
             globalThreadState = globalStreamThread.state();
         }
 
@@ -716,19 +726,21 @@ public class KafkaStreams implements AutoCloseable {
         final Map<Long, StreamThread.State> threadState = new HashMap<>(threads.length);
         final ArrayList<StateStoreProvider> storeProviders = new ArrayList<>();
         for (int i = 0; i < threads.length; i++) {
-            threads[i] = StreamThread.create(internalTopologyBuilder,
-                                             config,
-                                             clientSupplier,
-                                             adminClient,
-                                             processId,
-                                             clientId,
-                                             metrics,
-                                             time,
-                                             streamsMetadataState,
-                                             cacheSizePerThread,
-                                             stateDirectory,
-                                             delegatingStateRestoreListener,
-                                             i + 1);
+            threads[i] = StreamThread.create(
+                internalTopologyBuilder,
+                config,
+                clientSupplier,
+                adminClient,
+                processId,
+                clientId,
+                metrics,
+                time,
+                streamsMetadataState,
+                cacheSizePerThread,
+                stateDirectory,
+                delegatingStateRestoreListener,
+                i + 1);
+            threads[i].setRocksDBMetricsRecordingTrigger(rocksDBMetricsRecordingTrigger);
             threadState.put(threads[i].getId(), threads[i].state());
             storeProviders.add(new StreamThreadStateStoreProvider(threads[i]));
         }
@@ -746,6 +758,12 @@ public class KafkaStreams implements AutoCloseable {
 
         stateDirCleaner = Executors.newSingleThreadScheduledExecutor(r -> {
             final Thread thread = new Thread(r, clientId + "-CleanupThread");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        rocksDBMetricsRecordingTriggerThread = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread thread = new Thread(r, clientId + "-RocksDBMetricsRecordingTrigger");
             thread.setDaemon(true);
             return thread;
         });
@@ -803,6 +821,15 @@ public class KafkaStreams implements AutoCloseable {
                     stateDirectory.cleanRemovedTasks(cleanupDelay);
                 }
             }, cleanupDelay, cleanupDelay, TimeUnit.MILLISECONDS);
+
+            if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
+                rocksDBMetricsRecordingTriggerThread.scheduleAtFixedRate(
+                    rocksDBMetricsRecordingTrigger,
+                    Duration.ZERO.toMinutes(),
+                    Duration.ofMinutes(1).toMinutes(),
+                    TimeUnit.MINUTES
+                );
+            }
         } else {
             throw new IllegalStateException("The client is either already started or already stopped, cannot re-start");
         }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -671,7 +671,6 @@ public class KafkaStreams implements AutoCloseable {
         reporters.add(new JmxReporter(JMX_PREFIX));
         metrics = new Metrics(metricConfig, reporters, time);
 
-
         // re-write the physical topology according to the config
         internalTopologyBuilder.rewriteTopology(config);
 
@@ -822,11 +821,13 @@ public class KafkaStreams implements AutoCloseable {
                 }
             }, cleanupDelay, cleanupDelay, TimeUnit.MILLISECONDS);
 
+            final long recordingDelay = 0;
+            final long recordingInterval = 1;
             if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
                 rocksDBMetricsRecordingTriggerThread.scheduleAtFixedRate(
                     rocksDBMetricsRecordingTrigger,
-                    Duration.ZERO.toMinutes(),
-                    Duration.ofMinutes(1).toMinutes(),
+                    recordingDelay,
+                    recordingInterval,
                     TimeUnit.MINUTES
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -182,18 +183,20 @@ public class GlobalStreamThread extends Thread {
                               final Metrics metrics,
                               final Time time,
                               final String threadClientId,
-                              final StateRestoreListener stateRestoreListener) {
+                              final StateRestoreListener stateRestoreListener,
+                              final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger) {
         super(threadClientId);
         this.time = time;
         this.config = config;
         this.topology = topology;
         this.globalConsumer = globalConsumer;
         this.stateDirectory = stateDirectory;
-        this.streamsMetrics = new StreamsMetricsImpl(
+        streamsMetrics = new StreamsMetricsImpl(
             metrics,
             threadClientId,
             config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
         );
+        streamsMetrics.setRocksDBMetricsRecordingTrigger(rocksDBMetricsRecordingTrigger);
         this.logPrefix = String.format("global-stream-thread [%s] ", threadClientId);
         this.logContext = new LogContext(logPrefix);
         this.log = logContext.logger(getClass());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -46,6 +46,7 @@ import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -746,6 +747,10 @@ public class StreamThread extends Thread {
     // currently admin client is shared among all threads
     public static String getSharedAdminClientId(final String clientId) {
         return clientId + "-admin";
+    }
+
+    public void setRocksDBMetricsRecordingTrigger(final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger) {
+        streamsMetrics.setRocksDBMetricsRecordingTrigger(rocksDBMetricsRecordingTrigger);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,6 +61,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     private final Map<String, Deque<String>> nodeLevelSensors = new HashMap<>();
     private final Map<String, Deque<String>> cacheLevelSensors = new HashMap<>();
     private final Map<String, Deque<String>> storeLevelSensors = new HashMap<>();
+
+    private RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger;
 
     private static final String SENSOR_PREFIX_DELIMITER = ".";
     private static final String SENSOR_NAME_DELIMITER = ".s.";
@@ -120,6 +123,14 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public Version version() {
         return version;
+    }
+
+    public void setRocksDBMetricsRecordingTrigger(final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger) {
+        this.rocksDBMetricsRecordingTrigger = rocksDBMetricsRecordingTrigger;
+    }
+
+    public RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger() {
+        return rocksDBMetricsRecordingTrigger;
     }
 
     public final Sensor threadLevelSensor(final String sensorName,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -597,7 +597,24 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                             final Map<String, String> tags,
                                             final String operation,
                                             final String description) {
-        sensor.add(new MetricName(operation + TOTAL_SUFFIX, group, description, tags), new CumulativeSum());
+        addSumMetricToSensor(sensor, group, tags, operation, true, description);
+    }
+
+    public static void addSumMetricToSensor(final Sensor sensor,
+                                            final String group,
+                                            final Map<String, String> tags,
+                                            final String operation,
+                                            final boolean withSuffix,
+                                            final String description) {
+        sensor.add(
+            new MetricName(
+                withSuffix ? operation + TOTAL_SUFFIX : operation,
+                group,
+                description,
+                tags
+            ),
+            new CumulativeSum()
+        );
     }
 
     public static void addValueMetricToSensor(final Sensor sensor,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
  */
 class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
 
-    final private RocksDBMetricsRecorder metricsRecorder;
+    private final RocksDBMetricsRecorder metricsRecorder;
 
     KeyValueSegments(final String name,
                      final String metricsScope,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -54,7 +54,7 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
 
     @Override
     public void close() {
-        metricsRecorder.close();
         super.close();
+        metricsRecorder.close();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -51,10 +51,4 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
             return newSegment;
         }
     }
-
-    @Override
-    public void close() {
-        super.close();
-        metricsRecorder.close();
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -104,7 +104,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
     private RocksDBConfigSetter configSetter;
 
     private final RocksDBMetricsRecorder metricsRecorder;
-    private boolean isRecordingLevelDebug = false;
+    private boolean isStatisticsRegistered = false;
 
     private volatile boolean prepareForBulkload = false;
     ProcessorContext internalProcessorContext;
@@ -198,7 +198,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
         if (userSpecifiedOptions.statistics() == null &&
             RecordingLevel.forName((String) configs.get(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
 
-            isRecordingLevelDebug = true;
+            isStatisticsRegistered = true;
             // metrics recorder will clean up statistics object
             final Statistics statistics = new Statistics();
             userSpecifiedOptions.setStatistics(statistics);
@@ -449,9 +449,9 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
     }
 
     private void maybeRemoveStatisticsFromMetricsRecorder() {
-        if (isRecordingLevelDebug) {
+        if (isStatisticsRegistered) {
             metricsRecorder.removeStatistics(name);
-            isRecordingLevelDebug = false;
+            isStatisticsRegistered = false;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -54,7 +54,7 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
 
     @Override
     public void close() {
-        metricsRecorder.close();
         super.close();
+        metricsRecorder.close();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -51,10 +51,4 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
             return newSegment;
         }
     }
-
-    @Override
-    public void close() {
-        super.close();
-        metricsRecorder.close();
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
@@ -30,7 +30,6 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndSumMetricsToSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
 public class RocksDBMetrics {
@@ -380,7 +379,7 @@ public class RocksDBMetrics {
     public static Sensor numberOfFileErrorsSensor(final StreamsMetricsImpl streamsMetrics,
                                                   final RocksDBMetricContext metricContext) {
         final Sensor sensor = createSensor(streamsMetrics, metricContext, NUMBER_OF_FILE_ERRORS);
-        addSumMetricToSensor(
+        addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
             streamsMetrics

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
@@ -30,6 +30,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndSumMetricsToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
 public class RocksDBMetrics {
@@ -365,12 +366,13 @@ public class RocksDBMetrics {
     public static Sensor numberOfOpenFilesSensor(final StreamsMetricsImpl streamsMetrics,
                                                  final RocksDBMetricContext metricContext) {
         final Sensor sensor = createSensor(streamsMetrics, metricContext, NUMBER_OF_OPEN_FILES);
-        addValueMetricToSensor(
+        addSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
             streamsMetrics
                 .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
             NUMBER_OF_OPEN_FILES,
+            false,
             NUMBER_OF_OPEN_FILES_DESCRIPTION
         );
         return sensor;
@@ -379,7 +381,7 @@ public class RocksDBMetrics {
     public static Sensor numberOfFileErrorsSensor(final StreamsMetricsImpl streamsMetrics,
                                                   final RocksDBMetricContext metricContext) {
         final Sensor sensor = createSensor(streamsMetrics, metricContext, NUMBER_OF_FILE_ERRORS);
-        addValueMetricToSensor(
+        addSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
             streamsMetrics

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -198,9 +198,9 @@ public class RocksDBMetricsRecorder {
         long numberOfOpenFiles = 0;
         long numberOfFileErrors = 0;
         for (final Statistics statistics : statisticsToRecord.values()) {
-            bytesWrittenToDatabase += statistics.getTickerCount(TickerType.BYTES_WRITTEN);
-            bytesReadFromDatabase += statistics.getTickerCount(TickerType.BYTES_READ);
-            memtableBytesFlushed += statistics.getTickerCount(TickerType.FLUSH_WRITE_BYTES);
+            bytesWrittenToDatabase += statistics.getAndResetTickerCount(TickerType.BYTES_WRITTEN);
+            bytesReadFromDatabase += statistics.getAndResetTickerCount(TickerType.BYTES_READ);
+            memtableBytesFlushed += statistics.getAndResetTickerCount(TickerType.FLUSH_WRITE_BYTES);
             memtableHits += statistics.getAndResetTickerCount(TickerType.MEMTABLE_HIT);
             memtableMisses += statistics.getAndResetTickerCount(TickerType.MEMTABLE_MISS);
             blockCacheDataHits += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_HIT);
@@ -209,9 +209,9 @@ public class RocksDBMetricsRecorder {
             blockCacheIndexMisses += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_MISS);
             blockCacheFilterHits += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_HIT);
             blockCacheFilterMisses += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_MISS);
-            writeStallDuration += statistics.getTickerCount(TickerType.STALL_MICROS);
-            bytesWrittenDuringCompaction += statistics.getTickerCount(TickerType.COMPACT_WRITE_BYTES);
-            bytesReadDuringCompaction += statistics.getTickerCount(TickerType.COMPACT_READ_BYTES);
+            writeStallDuration += statistics.getAndResetTickerCount(TickerType.STALL_MICROS);
+            bytesWrittenDuringCompaction += statistics.getAndResetTickerCount(TickerType.COMPACT_WRITE_BYTES);
+            bytesReadDuringCompaction += statistics.getAndResetTickerCount(TickerType.COMPACT_READ_BYTES);
             numberOfOpenFiles += statistics.getTickerCount(TickerType.NO_FILE_OPENS)
                 - statistics.getTickerCount(TickerType.NO_FILE_CLOSES);
             numberOfFileErrors += statistics.getTickerCount(TickerType.NO_FILE_ERRORS);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -17,64 +17,65 @@
 package org.apache.kafka.streams.state.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.RocksDBMetricContext;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
+import org.rocksdb.TickerType;
+import org.slf4j.Logger;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
 public class RocksDBMetricsRecorder {
 
+    private Logger log;
+
     private Sensor bytesWrittenToDatabaseSensor;
-    private Sensor bytesReadToDatabaseSensor;
+    private Sensor bytesReadFromDatabaseSensor;
     private Sensor memtableBytesFlushedSensor;
     private Sensor memtableHitRatioSensor;
-    private Sensor memtableAvgFlushTimeSensor;
-    private Sensor memtableMinFlushTimeSensor;
-    private Sensor memtableMaxFlushTimeSensor;
     private Sensor writeStallDurationSensor;
     private Sensor blockCacheDataHitRatioSensor;
     private Sensor blockCacheIndexHitRatioSensor;
     private Sensor blockCacheFilterHitRatioSensor;
     private Sensor bytesReadDuringCompactionSensor;
     private Sensor bytesWrittenDuringCompactionSensor;
-    private Sensor compactionTimeAvgSensor;
-    private Sensor compactionTimeMinSensor;
-    private Sensor compactionTimeMaxSensor;
     private Sensor numberOfOpenFilesSensor;
     private Sensor numberOfFileErrorsSensor;
 
-    final private Map<String, Statistics> statisticsToRecord = new HashMap<>();
-    final private String metricsScope;
-    final private String storeName;
+    private final Map<String, Statistics> statisticsToRecord = new HashMap<>();
+    private final String metricsScope;
+    private final String storeName;
+
+    private Duration recordingInterval = Duration.ZERO;
+    private volatile boolean stopRecording = false;
+    private boolean recordingAlreadyStarted = false;
 
     public RocksDBMetricsRecorder(final String metricsScope, final String storeName) {
         this.metricsScope = metricsScope;
         this.storeName = storeName;
+        final String logPrefix = String.format("[RocksDB Metrics Recorder for %s] ", storeName);
+        final LogContext logContext = new LogContext(logPrefix);
+        this.log = logContext.logger(RocksDBMetricsRecorder.class);
     }
 
     private void init(final StreamsMetricsImpl streamsMetrics, final TaskId taskId) {
         final RocksDBMetricContext metricContext = new RocksDBMetricContext(taskId.toString(), metricsScope, storeName);
         bytesWrittenToDatabaseSensor = RocksDBMetrics.bytesWrittenToDatabaseSensor(streamsMetrics, metricContext);
-        bytesReadToDatabaseSensor = RocksDBMetrics.bytesReadFromDatabaseSensor(streamsMetrics, metricContext);
+        bytesReadFromDatabaseSensor = RocksDBMetrics.bytesReadFromDatabaseSensor(streamsMetrics, metricContext);
         memtableBytesFlushedSensor = RocksDBMetrics.memtableBytesFlushedSensor(streamsMetrics, metricContext);
         memtableHitRatioSensor = RocksDBMetrics.memtableHitRatioSensor(streamsMetrics, metricContext);
-        memtableAvgFlushTimeSensor = RocksDBMetrics.memtableAvgFlushTimeSensor(streamsMetrics, metricContext);
-        memtableMinFlushTimeSensor = RocksDBMetrics.memtableMinFlushTimeSensor(streamsMetrics, metricContext);
-        memtableMaxFlushTimeSensor = RocksDBMetrics.memtableMaxFlushTimeSensor(streamsMetrics, metricContext);
         writeStallDurationSensor = RocksDBMetrics.writeStallDurationSensor(streamsMetrics, metricContext);
         blockCacheDataHitRatioSensor = RocksDBMetrics.blockCacheDataHitRatioSensor(streamsMetrics, metricContext);
         blockCacheIndexHitRatioSensor = RocksDBMetrics.blockCacheIndexHitRatioSensor(streamsMetrics, metricContext);
         blockCacheFilterHitRatioSensor = RocksDBMetrics.blockCacheFilterHitRatioSensor(streamsMetrics, metricContext);
-        bytesReadDuringCompactionSensor = RocksDBMetrics.bytesReadDuringCompactionSensor(streamsMetrics, metricContext);
         bytesWrittenDuringCompactionSensor =
             RocksDBMetrics.bytesWrittenDuringCompactionSensor(streamsMetrics, metricContext);
-        compactionTimeAvgSensor = RocksDBMetrics.compactionTimeAvgSensor(streamsMetrics, metricContext);
-        compactionTimeMinSensor = RocksDBMetrics.compactionTimeMinSensor(streamsMetrics, metricContext);
-        compactionTimeMaxSensor = RocksDBMetrics.compactionTimeMaxSensor(streamsMetrics, metricContext);
+        bytesReadDuringCompactionSensor = RocksDBMetrics.bytesReadDuringCompactionSensor(streamsMetrics, metricContext);
         numberOfOpenFilesSensor = RocksDBMetrics.numberOfOpenFilesSensor(streamsMetrics, metricContext);
         numberOfFileErrorsSensor = RocksDBMetrics.numberOfFileErrorsSensor(streamsMetrics, metricContext);
     }
@@ -87,47 +88,113 @@ public class RocksDBMetricsRecorder {
             init(streamsMetrics, taskId);
         }
         if (statisticsToRecord.containsKey(storeName)) {
-            throw new IllegalStateException("A statistics for store " + storeName + "has been already registered. "
+            throw new IllegalStateException("A statistics for store \"" + storeName + "\" has been already added. "
                 + "This is a bug in Kafka Streams.");
         }
         statistics.setStatsLevel(StatsLevel.EXCEPT_DETAILED_TIMERS);
         statisticsToRecord.put(storeName, statistics);
+        log.debug("Added Statistics for store segment {}", storeName);
     }
 
     public void removeStatistics(final String storeName) {
         final Statistics removedStatistics = statisticsToRecord.remove(storeName);
         if (removedStatistics != null) {
             removedStatistics.close();
+        } else {
+            throw new IllegalStateException("No statistics for store \"" + storeName
+                + "\" found. This is a bug in Kafka Streams.");
+        }
+        log.debug("Removed Statistics for store segment {}", storeName);
+    }
+
+    public void startRecording(final Duration recordingInterval) {
+        this.recordingInterval = recordingInterval;
+        if (!recordingAlreadyStarted) {
+            final Thread thread = new Thread(this::recordLoop);
+            thread.setName(storeName.replace(" ", "-") + "-RocksDB-metrics-recorder");
+            thread.start();
+            recordingAlreadyStarted = true;
         }
     }
 
-    public void record() {
-        // TODO: this block of record calls merely avoids compiler warnings.
-        //       The actual computations of the metrics will be implemented in the next PR
-        bytesWrittenToDatabaseSensor.record(0);
-        bytesReadToDatabaseSensor.record(0);
-        memtableBytesFlushedSensor.record(0);
-        memtableHitRatioSensor.record(0);
-        memtableAvgFlushTimeSensor.record(0);
-        memtableMinFlushTimeSensor.record(0);
-        memtableMaxFlushTimeSensor.record(0);
-        writeStallDurationSensor.record(0);
-        blockCacheDataHitRatioSensor.record(0);
-        blockCacheIndexHitRatioSensor.record(0);
-        blockCacheFilterHitRatioSensor.record(0);
-        bytesReadDuringCompactionSensor.record(0);
-        bytesWrittenDuringCompactionSensor.record(0);
-        compactionTimeAvgSensor.record(0);
-        compactionTimeMinSensor.record(0);
-        compactionTimeMaxSensor.record(0);
-        numberOfOpenFilesSensor.record(0);
-        numberOfFileErrorsSensor.record(0);
+    private void recordLoop() {
+        log.info("Started with recording interval {}", recordingInterval.toString());
+        while (!stopRecording) {
+            recordOnce();
+            try {
+                Thread.sleep(recordingInterval.toMillis());
+            } catch (final InterruptedException exception) {
+                // do nothing and wait until next iteration
+            }
+        }
+        log.info("Stopped", storeName);
+    }
+
+    public void recordOnce() {
+        long bytesWrittenToDatabase = 0;
+        long bytesReadFromDatabase = 0;
+        long memtableBytesFlushed = 0;
+        long memtableHits = 0;
+        long memtableMisses = 0;
+        long blockCacheDataHits = 0;
+        long blockCacheDataMisses = 0;
+        long blockCacheIndexHits = 0;
+        long blockCacheIndexMisses = 0;
+        long blockCacheFilterHits = 0;
+        long blockCacheFilterMisses = 0;
+        long writeStallDuration = 0;
+        long bytesWrittenDuringCompaction = 0;
+        long bytesReadDuringCompaction = 0;
+        long numberOfOpenFiles = 0;
+        long numberOfFileErrors = 0;
+        synchronized (statisticsToRecord) {
+            for (final Statistics statistics : statisticsToRecord.values()) {
+                bytesWrittenToDatabase += statistics.getTickerCount(TickerType.BYTES_WRITTEN);
+                bytesReadFromDatabase += statistics.getTickerCount(TickerType.BYTES_READ);
+                memtableBytesFlushed += statistics.getTickerCount(TickerType.FLUSH_WRITE_BYTES);
+                memtableHits += statistics.getAndResetTickerCount(TickerType.MEMTABLE_HIT);
+                memtableMisses += statistics.getAndResetTickerCount(TickerType.MEMTABLE_MISS);
+                blockCacheDataHits += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_HIT);
+                blockCacheDataMisses += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_MISS);
+                blockCacheIndexHits += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_HIT);
+                blockCacheIndexMisses += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_MISS);
+                blockCacheFilterHits += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_HIT);
+                blockCacheFilterMisses += statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_MISS);
+                writeStallDuration += statistics.getTickerCount(TickerType.STALL_MICROS);
+                bytesWrittenDuringCompaction += statistics.getTickerCount(TickerType.COMPACT_WRITE_BYTES);
+                bytesReadDuringCompaction += statistics.getTickerCount(TickerType.COMPACT_READ_BYTES);
+                numberOfOpenFiles += statistics.getTickerCount(TickerType.NO_FILE_OPENS)
+                    - statistics.getTickerCount(TickerType.NO_FILE_CLOSES);
+                numberOfFileErrors += statistics.getTickerCount(TickerType.NO_FILE_ERRORS);
+            }
+        }
+        bytesWrittenToDatabaseSensor.record(bytesWrittenToDatabase);
+        bytesReadFromDatabaseSensor.record(bytesReadFromDatabase);
+        memtableBytesFlushedSensor.record(memtableBytesFlushed);
+        memtableHitRatioSensor.record(computeHitRatio(memtableHits, memtableMisses));
+        blockCacheDataHitRatioSensor.record(computeHitRatio(blockCacheDataHits, blockCacheDataMisses));
+        blockCacheIndexHitRatioSensor.record(computeHitRatio(blockCacheIndexHits, blockCacheIndexMisses));
+        blockCacheFilterHitRatioSensor.record(computeHitRatio(blockCacheFilterHits, blockCacheFilterMisses));
+        writeStallDurationSensor.record(writeStallDuration);
+        bytesWrittenDuringCompactionSensor.record(bytesWrittenDuringCompaction);
+        bytesReadDuringCompactionSensor.record(bytesReadDuringCompaction);
+        numberOfOpenFilesSensor.record(numberOfOpenFiles);
+        numberOfFileErrorsSensor.record(numberOfFileErrors);
+    }
+
+    private double computeHitRatio(final long hits, final long misses) {
+        if (hits == 0) {
+            return 0;
+        }
+        return (double) hits / (hits + misses);
     }
 
     public void close() {
+        stopRecording = true;
         for (final Statistics statistics : statisticsToRecord.values()) {
             statistics.close();
         }
         statisticsToRecord.clear();
+        log.debug("Closed", storeName);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals.metrics;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RocksDBMetricsRecordingTrigger implements Runnable {
+
+    private final Map<String, RocksDBMetricsRecorder> metricsRecordersToTrigger = new ConcurrentHashMap<>();
+
+    public void addMetricsRecorder(final RocksDBMetricsRecorder metricsRecorder) {
+        final String metricsRecorderName = metricsRecorderName(metricsRecorder);
+        if (metricsRecordersToTrigger.containsKey(metricsRecorderName)) {
+            throw new IllegalStateException("RocksDB metrics recorder for store \"" + metricsRecorder.storeName() +
+                "\" of task " + metricsRecorder.taskId().toString() + " has already been added. "
+                + "This is a bug in Kafka Streams.");
+        }
+        metricsRecordersToTrigger.put(metricsRecorderName, metricsRecorder);
+    }
+
+    public void removeMetricsRecorder(final RocksDBMetricsRecorder metricsRecorder) {
+        final RocksDBMetricsRecorder removedMetricsRecorder =
+            metricsRecordersToTrigger.remove(metricsRecorderName(metricsRecorder));
+        if (removedMetricsRecorder == null) {
+            throw new IllegalStateException("No RocksDB metrics recorder for store "
+                + "\"" + metricsRecorder.storeName() + "\" of task " + metricsRecorder.taskId() + " could be found. "
+                + "This is a bug in Kafka Streams.");
+        }
+    }
+
+    private String metricsRecorderName(final RocksDBMetricsRecorder metricsRecorder) {
+        return metricsRecorder.taskId().toString() + "-" + metricsRecorder.storeName();
+    }
+
+    @Override
+    public void run() {
+        for (final RocksDBMetricsRecorder metricsRecorder : metricsRecordersToTrigger.values()) {
+            metricsRecorder.record();
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -180,7 +180,7 @@ public class MetricsIntegrationTest {
     private static final String COMPACTION_TIME_MIN = "compaction-time-min";
     private static final String COMPACTION_TIME_MAX = "compaction-time-max";
     private static final String NUMBER_OF_OPEN_FILES = "number-open-files";
-    private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors";
+    private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors-total";
 
     // stores name
     private static final String TIME_WINDOWED_AGGREGATED_STREAM_STORE = "time-windowed-aggregated-stream-store";

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -475,9 +475,6 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricStore, MEMTABLE_BYTES_FLUSHED_RATE, 1);
         checkMetricByName(listMetricStore, MEMTABLE_BYTES_FLUSHED_TOTAL, 1);
         checkMetricByName(listMetricStore, MEMTABLE_HIT_RATIO, 1);
-        checkMetricByName(listMetricStore, MEMTABLE_FLUSH_TIME_AVG, 1);
-        checkMetricByName(listMetricStore, MEMTABLE_FLUSH_TIME_MIN, 1);
-        checkMetricByName(listMetricStore, MEMTABLE_FLUSH_TIME_MAX, 1);
         checkMetricByName(listMetricStore, WRITE_STALL_DURATION_AVG, 1);
         checkMetricByName(listMetricStore, WRITE_STALL_DURATION_TOTAL, 1);
         checkMetricByName(listMetricStore, BLOCK_CACHE_DATA_HIT_RATIO, 1);
@@ -485,9 +482,6 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricStore, BLOCK_CACHE_FILTER_HIT_RATIO, 1);
         checkMetricByName(listMetricStore, BYTES_READ_DURING_COMPACTION_RATE, 1);
         checkMetricByName(listMetricStore, BYTES_WRITTEN_DURING_COMPACTION_RATE, 1);
-        checkMetricByName(listMetricStore, COMPACTION_TIME_AVG, 1);
-        checkMetricByName(listMetricStore, COMPACTION_TIME_MIN, 1);
-        checkMetricByName(listMetricStore, COMPACTION_TIME_MAX, 1);
         checkMetricByName(listMetricStore, NUMBER_OF_OPEN_FILES, 1);
         checkMetricByName(listMetricStore, NUMBER_OF_FILE_ERRORS, 1);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -180,7 +180,7 @@ public class MetricsIntegrationTest {
     private static final String COMPACTION_TIME_MIN = "compaction-time-min";
     private static final String COMPACTION_TIME_MAX = "compaction-time-max";
     private static final String NUMBER_OF_OPEN_FILES = "number-open-files";
-    private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors-total";
+    private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors";
 
     // stores name
     private static final String TIME_WINDOWED_AGGREGATED_STREAM_STORE = "time-windowed-aggregated-stream-store";
@@ -641,7 +641,7 @@ public class MetricsIntegrationTest {
         final List<Metric> metrics = listMetric.stream()
             .filter(m -> m.metricName().name().equals(metricName))
             .collect(Collectors.toList());
-        Assert.assertEquals("Size of metrics of type:'" + metricName + "' must be equal to:" + numMetric + " but it's equal to " + metrics.size(), numMetric, metrics.size());
+        Assert.assertEquals("Size of metrics of type:'" + metricName + "' must be equal to " + numMetric + " but it's equal to " + metrics.size(), numMetric, metrics.size());
         for (final Metric m : metrics) {
             Assert.assertNotNull("Metric:'" + m.metricName() + "' must be not null", m.metricValue());
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -101,15 +101,18 @@ public class GlobalStreamThreadTest {
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "blah");
         properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         config = new StreamsConfig(properties);
-        globalStreamThread = new GlobalStreamThread(builder.rewriteTopology(config).buildGlobalStateTopology(),
-                                                    config,
-                                                    mockConsumer,
-                                                    new StateDirectory(config, time, true),
-                                                    0,
-                                                    new Metrics(),
-                                                    new MockTime(),
-                                                    "clientId",
-                                                     stateRestoreListener);
+        globalStreamThread = new GlobalStreamThread(
+            builder.rewriteTopology(config).buildGlobalStateTopology(),
+            config,
+            mockConsumer,
+            new StateDirectory(config, time, true),
+            0,
+            new Metrics(),
+            new MockTime(),
+            "clientId",
+            stateRestoreListener,
+            null
+        );
     }
 
     @Test
@@ -134,15 +137,18 @@ public class GlobalStreamThreadTest {
                 throw new RuntimeException("KABOOM!");
             }
         };
-        globalStreamThread = new GlobalStreamThread(builder.buildGlobalStateTopology(),
-                                                    config,
-                                                    mockConsumer,
-                                                    new StateDirectory(config, time, true),
-                                                    0,
-                                                    new Metrics(),
-                                                    new MockTime(),
-                                                    "clientId",
-                                                    stateRestoreListener);
+        globalStreamThread = new GlobalStreamThread(
+            builder.buildGlobalStateTopology(),
+            config,
+            mockConsumer,
+            new StateDirectory(config, time, true),
+            0,
+            new Metrics(),
+            new MockTime(),
+            "clientId",
+            stateRestoreListener,
+            null
+        );
 
         try {
             globalStreamThread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -255,7 +255,8 @@ public class StreamThreadTest {
             0,
             stateDirectory,
             new MockStateRestoreListener(),
-            threadIdx);
+            threadIdx
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
@@ -27,14 +28,12 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreListener;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
@@ -62,11 +61,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
-import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
-import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -90,6 +86,8 @@ public class RocksDBStoreTest {
     private final Serializer<String> stringSerializer = new StringSerializer();
     private final Deserializer<String> stringDeserializer = new StringDeserializer();
 
+    private final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
+
     InternalMockProcessorContext context;
     RocksDBStore rocksDBStore;
 
@@ -103,10 +101,38 @@ public class RocksDBStoreTest {
             Serdes.String(),
             Serdes.String(),
             new StreamsConfig(props));
+        context.metrics().setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
     }
 
     RocksDBStore getRocksDBStore() {
         return new RocksDBStore(DB_NAME, METRICS_SCOPE);
+    }
+
+    private RocksDBStore getRocksDBStoreWithRocksDBMetricsRecorder() {
+        return new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
+    }
+
+    private InternalMockProcessorContext getProcessorContext(final Properties streamsProps) {
+        return new InternalMockProcessorContext(
+            TestUtils.tempDirectory(),
+            new StreamsConfig(streamsProps)
+        );
+    }
+
+    private InternalMockProcessorContext getProcessorContext(
+        final RecordingLevel recordingLevel,
+        final Class<? extends RocksDBConfigSetter> rocksDBConfigSetterClass) {
+
+        final Properties streamsProps = StreamsTestUtils.getStreamsConfig();
+        streamsProps.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel.name());
+        streamsProps.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, rocksDBConfigSetterClass);
+        return getProcessorContext(streamsProps);
+    }
+
+    private InternalMockProcessorContext getProcessorContext(final RecordingLevel recordingLevel) {
+        final Properties streamsProps = StreamsTestUtils.getStreamsConfig();
+        streamsProps.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, recordingLevel.name());
+        return getProcessorContext(streamsProps);
     }
 
     @After
@@ -115,20 +141,41 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldRemoveStatisticsFromAndNotCloseInjectedMetricsRecorderOnClose() {
-        final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
-        final RocksDBStore store = new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
-        final ProcessorContext mockContext = mock(ProcessorContext.class);
-        expect(mockContext.appConfigs()).andReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "DEBUG")));
-        final String directoryPath = TestUtils.tempDirectory().getAbsolutePath();
-        final File directory = new File(directoryPath);
-        expect(mockContext.stateDir()).andReturn(directory);
-        expect(mockContext.metrics()).andReturn(mock(StreamsMetricsImpl.class));
-        expect(mockContext.taskId()).andReturn(new TaskId(0, 0));
-        replay(mockContext);
+    public void shouldAddStatisticsToInjectedMetricsRecorderWhenRecordingLevelIsDebug() {
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext = getProcessorContext(RecordingLevel.DEBUG);
+        reset(metricsRecorder);
+        metricsRecorder.addStatistics(
+            eq(DB_NAME),
+            anyObject(Statistics.class),
+            eq(mockContext.metrics()),
+            eq(mockContext.taskId())
+        );
+        replay(metricsRecorder);
+
+        store.openDB(mockContext);
+
+        verify(metricsRecorder);
+    }
+
+    @Test
+    public void shouldNotAddStatisticsToInjectedMetricsRecorderWhenRecordingLevelIsInfo() {
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext = getProcessorContext(RecordingLevel.INFO);
+        reset(metricsRecorder);
+        replay(metricsRecorder);
+
+        store.openDB(mockContext);
+
+        verify(metricsRecorder);
+    }
+
+    @Test
+    public void shouldRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenRecordingLevelIsDebug() {
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext = getProcessorContext(RecordingLevel.DEBUG);
         store.openDB(mockContext);
         reset(metricsRecorder);
-        expect(metricsRecorder.isRunning()).andReturn(true);
         metricsRecorder.removeStatistics(DB_NAME);
         replay(metricsRecorder);
 
@@ -139,17 +186,11 @@ public class RocksDBStoreTest {
 
     @Test
     public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenRecordingLevelIsInfo() {
-        final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
-        expect(metricsRecorder.isRunning()).andReturn(false);
-        replay(metricsRecorder);
-        final RocksDBStore store = new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
-        final ProcessorContext mockContext = mock(ProcessorContext.class);
-        expect(mockContext.appConfigs()).andReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
-        final String directoryPath = TestUtils.tempDirectory().getAbsolutePath();
-        final File directory = new File(directoryPath);
-        expect(mockContext.stateDir()).andReturn(directory);
-        replay(mockContext);
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext = getProcessorContext(RecordingLevel.INFO);
         store.openDB(mockContext);
+        reset(metricsRecorder);
+        replay(metricsRecorder);
 
         store.close();
 
@@ -169,20 +210,24 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenUserProvidesStatistics() {
-        final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
-        expect(metricsRecorder.isRunning()).andReturn(false);
+    public void shouldNotAddStatisticsToInjectedMetricsRecorderWhenUserProvidesStatistics() {
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext =
+            getProcessorContext(RecordingLevel.DEBUG, RocksDBConfigSetterWithUserProvidedStatistics.class);
         replay(metricsRecorder);
-        final RocksDBStore store = new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
-        final ProcessorContext mockContext = mock(ProcessorContext.class);
-        expect(mockContext.appConfigs()).andReturn(mkMap(
-            mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "DEBUG"),
-            mkEntry(ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, RocksDBConfigSetterWithUserProvidedStatistics.class)));
-        final String directoryPath = TestUtils.tempDirectory().getAbsolutePath();
-        final File directory = new File(directoryPath);
-        expect(mockContext.stateDir()).andReturn(directory);
-        replay(mockContext);
+
         store.openDB(mockContext);
+        verify(metricsRecorder);
+    }
+
+    @Test
+    public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenUserProvidesStatistics() {
+        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        final InternalMockProcessorContext mockContext =
+            getProcessorContext(RecordingLevel.DEBUG, RocksDBConfigSetterWithUserProvidedStatistics.class);
+        store.openDB(mockContext);
+        reset(metricsRecorder);
+        replay(metricsRecorder);
 
         store.close();
 
@@ -536,6 +581,7 @@ public class RocksDBStoreTest {
             Serdes.String(),
             Serdes.String(),
             new StreamsConfig(props));
+        context.metrics().setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
 
         enableBloomFilters = false;
         rocksDBStore.init(context, rocksDBStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
@@ -32,6 +33,7 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -39,6 +41,9 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.Filter;
@@ -63,9 +68,7 @@ import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CON
 import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -73,7 +76,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({RocksDBMetrics.class, Sensor.class})
 public class RocksDBStoreTest {
     private static boolean enableBloomFilters = false;
     final static String DB_NAME = "db-name";
@@ -108,7 +115,7 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldRemoveStatisticsFromInjectedMetricsRecorderOnClose() {
+    public void shouldRemoveStatisticsFromAndNotCloseInjectedMetricsRecorderOnClose() {
         final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
         final RocksDBStore store = new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);
         final ProcessorContext mockContext = mock(ProcessorContext.class);
@@ -160,7 +167,7 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenUserProvidsStatistics() {
+    public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenUserProvidesStatistics() {
         final RocksDBMetricsRecorder metricsRecorder = mock(RocksDBMetricsRecorder.class);
         replay(metricsRecorder);
         final RocksDBStore store = new RocksDBStore(DB_NAME, METRICS_SCOPE, metricsRecorder);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -41,10 +41,11 @@ import static org.junit.Assert.assertTrue;
 
 public class SegmentIteratorTest {
 
+    private final RocksDBMetricsRecorder rocksDBMetricsRecorder = new RocksDBMetricsRecorder("metrics-scope", "store-name");
     private final KeyValueSegment segmentOne =
-        new KeyValueSegment("one", "one", 0, new RocksDBMetricsRecorder("metrics-scope", "store-name"));
+        new KeyValueSegment("one", "one", 0, rocksDBMetricsRecorder);
     private final KeyValueSegment segmentTwo =
-        new KeyValueSegment("two", "window", 1, new RocksDBMetricsRecorder("metrics-scope", "store-name"));
+        new KeyValueSegment("two", "window", 1, rocksDBMetricsRecorder);
     private final HasNextCondition hasNextCondition = Iterator::hasNext;
 
     private SegmentIterator<KeyValueSegment> iterator = null;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -278,15 +278,15 @@ public class RocksDBMetricsRecorderTest {
         bytesReadDuringCompactionSensor.record(5 + 6);
         replay(bytesReadDuringCompactionSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.NO_FILE_OPENS)).andReturn(5L);
-        expect(statisticsToAdd1.getTickerCount(TickerType.NO_FILE_CLOSES)).andReturn(3L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.NO_FILE_OPENS)).andReturn(7L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.NO_FILE_CLOSES)).andReturn(4L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.NO_FILE_OPENS)).andReturn(5L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.NO_FILE_CLOSES)).andReturn(3L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.NO_FILE_OPENS)).andReturn(7L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.NO_FILE_CLOSES)).andReturn(4L);
         numberOfOpenFilesSensor.record((5 + 7) - (3 + 4));
         replay(numberOfOpenFilesSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.NO_FILE_ERRORS)).andReturn(34L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.NO_FILE_ERRORS)).andReturn(11L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.NO_FILE_ERRORS)).andReturn(34L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.NO_FILE_ERRORS)).andReturn(11L);
         numberOfFileErrorsSensor.record(11 + 34);
         replay(numberOfFileErrorsSensor);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -191,18 +191,18 @@ public class RocksDBMetricsRecorderTest {
         reset(statisticsToAdd1);
         reset(statisticsToAdd2);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.BYTES_WRITTEN)).andReturn(1L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.BYTES_WRITTEN)).andReturn(2L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.BYTES_WRITTEN)).andReturn(1L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.BYTES_WRITTEN)).andReturn(2L);
         bytesWrittenToDatabaseSensor.record(1 + 2);
         replay(bytesWrittenToDatabaseSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.BYTES_READ)).andReturn(2L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.BYTES_READ)).andReturn(3L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.BYTES_READ)).andReturn(2L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.BYTES_READ)).andReturn(3L);
         bytesReadFromDatabaseSensor.record(2 + 3);
         replay(bytesReadFromDatabaseSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.FLUSH_WRITE_BYTES)).andReturn(3L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.FLUSH_WRITE_BYTES)).andReturn(4L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.FLUSH_WRITE_BYTES)).andReturn(3L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.FLUSH_WRITE_BYTES)).andReturn(4L);
         memtableBytesFlushedSensor.record(3 + 4);
         replay(memtableBytesFlushedSensor);
 
@@ -213,8 +213,8 @@ public class RocksDBMetricsRecorderTest {
         memtableHitRatioSensor.record((double) 4 / (4 + 6));
         replay(memtableHitRatioSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.STALL_MICROS)).andReturn(4L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.STALL_MICROS)).andReturn(5L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.STALL_MICROS)).andReturn(4L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.STALL_MICROS)).andReturn(5L);
         writeStallDurationSensor.record(4 + 5);
         replay(writeStallDurationSensor);
 
@@ -239,13 +239,13 @@ public class RocksDBMetricsRecorderTest {
         blockCacheFilterHitRatioSensor.record((double) 5 / (5 + 9));
         replay(blockCacheFilterHitRatioSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.COMPACT_WRITE_BYTES)).andReturn(2L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.COMPACT_WRITE_BYTES)).andReturn(4L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.COMPACT_WRITE_BYTES)).andReturn(2L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.COMPACT_WRITE_BYTES)).andReturn(4L);
         bytesWrittenDuringCompactionSensor.record(2 + 4);
         replay(bytesWrittenDuringCompactionSensor);
 
-        expect(statisticsToAdd1.getTickerCount(TickerType.COMPACT_READ_BYTES)).andReturn(5L);
-        expect(statisticsToAdd2.getTickerCount(TickerType.COMPACT_READ_BYTES)).andReturn(6L);
+        expect(statisticsToAdd1.getAndResetTickerCount(TickerType.COMPACT_READ_BYTES)).andReturn(5L);
+        expect(statisticsToAdd2.getAndResetTickerCount(TickerType.COMPACT_READ_BYTES)).andReturn(6L);
         bytesReadDuringCompactionSensor.record(5 + 6);
         replay(bytesReadDuringCompactionSensor);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -39,6 +39,8 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.resetToNice;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -307,14 +309,12 @@ public class RocksDBMetricsRecorderTest {
 
         Thread.sleep(20);
         LogCaptureAppender.unregister(appender);
-        final List<String> logMessages = appender.getMessages().stream()
-            .filter(m ->
-                m.contains("[RocksDB Metrics Recorder for " + STORE_NAME + "] Started with recording interval PT0.01S")
-                || m.contains("[RocksDB Metrics Recorder for " + STORE_NAME + "] Stopped"))
-            .collect(Collectors.toList());
-        assertThat(logMessages.size(), is(2));
-        assertThat(logMessages.get(0), containsString("Started"));
-        assertThat(logMessages.get(1), containsString("Stopped"));
+        final List<String> logMessages = appender.getMessages();
+        assertThat(
+            logMessages,
+            hasItem("[RocksDB Metrics Recorder for " + STORE_NAME + "] Started with recording interval PT0.01S")
+        );
+        assertThat(logMessages, hasItem("[RocksDB Metrics Recorder for " + STORE_NAME + "] Stopped"));
     }
 
     private void setUpMetricsMockforInitializationOfRecorder() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -31,17 +31,13 @@ import org.rocksdb.TickerType;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.resetToNice;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.powermock.api.easymock.PowerMock.reset;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTriggerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTriggerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals.metrics;
+
+import org.apache.kafka.streams.processor.TaskId;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.resetToDefault;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertThrows;
+
+public class RocksDBMetricsRecordingTriggerTest {
+
+    private final static String STORE_NAME1 = "store-name1";
+    private final static String STORE_NAME2 = "store-name2";
+    private final static TaskId TASK_ID1 = new TaskId(1, 2);
+    private final static TaskId TASK_ID2 = new TaskId(2, 4);
+    private final RocksDBMetricsRecorder recorder1 = niceMock(RocksDBMetricsRecorder.class);
+    private final RocksDBMetricsRecorder recorder2 = niceMock(RocksDBMetricsRecorder.class);
+
+    private final RocksDBMetricsRecordingTrigger recordingTrigger = new RocksDBMetricsRecordingTrigger();
+
+    @Before
+    public void setUp() {
+        expect(recorder1.storeName()).andStubReturn(STORE_NAME1);
+        expect(recorder1.taskId()).andStubReturn(TASK_ID1);
+        replay(recorder1);
+        expect(recorder2.storeName()).andStubReturn(STORE_NAME2);
+        expect(recorder2.taskId()).andStubReturn(TASK_ID2);
+        replay(recorder2);
+    }
+
+    @Test
+    public void shouldTriggerAddedMetricsRecorders() {
+        recordingTrigger.addMetricsRecorder(recorder1);
+        recordingTrigger.addMetricsRecorder(recorder2);
+
+        resetToDefault(recorder1);
+        recorder1.record();
+        replay(recorder1);
+        resetToDefault(recorder2);
+        recorder2.record();
+        replay(recorder2);
+
+        recordingTrigger.run();
+
+        verify(recorder1);
+        verify(recorder2);
+    }
+
+    @Test
+    public void shouldThrowIfRecorderToAddHasBeenAlreadyAdded() {
+        recordingTrigger.addMetricsRecorder(recorder1);
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> recordingTrigger.addMetricsRecorder(recorder1)
+        );
+    }
+
+    @Test
+    public void shouldThrowIfRecorderToRemoveCouldNotBeFound() {
+        recordingTrigger.addMetricsRecorder(recorder1);
+        assertThrows(
+            IllegalStateException.class,
+            () -> recordingTrigger.removeMetricsRecorder(recorder2)
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -204,17 +204,14 @@ public class RocksDBMetricsTest {
     public void shouldGetNumberOfOpenFilesSensor() {
         final String metricNamePrefix = "number-open-files";
         final String description = "Number of currently open files";
-        verifyValueSensor(metricNamePrefix, description, RocksDBMetrics::numberOfOpenFilesSensor);
+        verifySumSensor(metricNamePrefix, false, description, RocksDBMetrics::numberOfOpenFilesSensor);
     }
 
     @Test
     public void shouldGetNumberOfFilesErrors() {
         final String metricNamePrefix = "number-file-errors";
         final String description = "Total number of file errors occurred";
-        setupStreamsMetricsMock(metricNamePrefix);
-        StreamsMetricsImpl.addValueMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, description);
-
-        replayCallAndVerify(RocksDBMetrics::numberOfFileErrorsSensor);
+        verifySumSensor(metricNamePrefix, true, description, RocksDBMetrics::numberOfFileErrorsSensor);
     }
 
     private void verifyRateAndTotalSensor(final String metricNamePrefix,
@@ -248,6 +245,21 @@ public class RocksDBMetricsTest {
                                    final SensorCreator sensorCreator) {
         setupStreamsMetricsMock(metricNamePrefix);
         StreamsMetricsImpl.addValueMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, description);
+
+        replayCallAndVerify(sensorCreator);
+    }
+
+    private void verifySumSensor(final String metricNamePrefix,
+                                 final boolean withSuffix,
+                                 final String description,
+                                 final SensorCreator sensorCreator) {
+        setupStreamsMetricsMock(metricNamePrefix);
+        if (withSuffix) {
+            StreamsMetricsImpl.addSumMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, description);
+        } else {
+            StreamsMetricsImpl
+                .addSumMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, withSuffix, description);
+        }
 
         replayCallAndVerify(sensorCreator);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -212,7 +212,7 @@ public class RocksDBMetricsTest {
         final String metricNamePrefix = "number-file-errors";
         final String description = "Total number of file errors occurred";
         setupStreamsMetricsMock(metricNamePrefix);
-        StreamsMetricsImpl.addSumMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, description);
+        StreamsMetricsImpl.addValueMetricToSensor(sensor, STATE_LEVEL_GROUP, tags, metricNamePrefix, description);
 
         replayCallAndVerify(RocksDBMetrics::numberOfFileErrorsSensor);
     }

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.internals.ToInternal;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 
 import java.io.File;
 import java.time.Duration;
@@ -155,6 +156,7 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
         this.keySerde = keySerde;
         this.valSerde = valSerde;
         this.recordCollectorSupplier = collectorSupplier;
+        this.metrics().setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
     }
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -74,6 +74,7 @@ import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.streams.test.OutputVerifier;
 import org.slf4j.Logger;
@@ -285,6 +286,7 @@ public class TopologyTestDriver implements Closeable {
             threadName,
             StreamsConfig.METRICS_LATEST
         );
+        streamsMetrics.setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
         final Sensor skippedRecordsSensor = streamsMetrics.threadLevelSensor("skipped-records", Sensor.RecordingLevel.INFO);
         final String threadLevelGroup = "stream-metrics";
         skippedRecordsSensor.add(new MetricName("skipped-records-rate",


### PR DESCRIPTION
A metric recorder runs in it own thread and regularly records RocksDB metrics from
RocksDB's statistics. For segmented state stores the metrics are aggregated over the
segments.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
