### PR TITLE
MINOR: Fix capitalization inconsistency in ConfigCommand.scala

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -154,7 +154,7 @@ object ConfigCommand extends Config {
 
     adminZkClient.changeConfigs(entityType, entityName, configs)
 
-    println(s"Completed Updating config for entity: $entity.")
+    println(s"Completed updating config for entity: $entity.")
   }
 
   private def preProcessScramCredentials(configsToBeAdded: Properties): Unit = {


### PR DESCRIPTION
- Fix a minor capitalization inconsistency in `ConfigCommand.scala`

https://github.com/apache/kafka/blob/fcfee618ee440cb78e422963ba7db1fa03620b33/core/src/main/scala/kafka/admin/ConfigCommand.scala#L157

Example output: `Completed Updating config for entity: topic 'test'.`

Other similar output lines:
https://github.com/apache/kafka/blob/fcfee618ee440cb78e422963ba7db1fa03620b33/core/src/main/scala/kafka/admin/ConfigCommand.scala#L335-L339

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
