### PR TITLE
[WIP] KAFKA-8677: Flaky test testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl

### DIFF
--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -358,6 +358,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     setReadAndWriteAcls(tp)
     consumeRecordsIgnoreOneAuthorizationException(consumer, numRecords, startingOffset = numRecords, topic2)
     sendRecords(producer, numRecords, tp)
+    // ensure consumer has metadata for this partition
+    assertNotNull(consumer.partitionsFor(tp.topic()))
     consumeRecords(consumer, numRecords, topic = topic)
     val describeResults2 = adminClient.describeTopics(Set(topic, topic2).asJava).values
     assertEquals(1, describeResults2.get(topic).get().partitions().size())

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -28,9 +28,12 @@
 #./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl \
 #    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
 #    || { echo 'Test steps failed'; exit 1; }
-./gradlew unitTest integrationTest \
+./gradlew integrationTest \
     --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
     || { echo 'Test steps failed'; exit 1; }
+#./gradlew unitTest integrationTest \
+#    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+#    || { echo 'Test steps failed'; exit 1; }
 
 # Verify that Kafka Streams archetype compiles
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -25,7 +25,9 @@
     || { echo 'Validation steps failed'; exit 1; }
 
 # Run tests
-./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl
+./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl \
+    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+    || { echo 'Test steps failed'; exit 1; }
 #./gradlew unitTest integrationTest \
 #    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
 #    || { echo 'Test steps failed'; exit 1; }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -25,12 +25,12 @@
     || { echo 'Validation steps failed'; exit 1; }
 
 # Run tests
-./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl \
-    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
-    || { echo 'Test steps failed'; exit 1; }
-#./gradlew unitTest integrationTest \
+#./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl \
 #    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
 #    || { echo 'Test steps failed'; exit 1; }
+./gradlew unitTest integrationTest \
+    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+    || { echo 'Test steps failed'; exit 1; }
 
 # Verify that Kafka Streams archetype compiles
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -25,9 +25,10 @@
     || { echo 'Validation steps failed'; exit 1; }
 
 # Run tests
-./gradlew unitTest integrationTest \
-    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
-    || { echo 'Test steps failed'; exit 1; }
+./gradlew core:test --tests GroupEndToEndAuthorizationTest.testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl
+#./gradlew unitTest integrationTest \
+#    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+#    || { echo 'Test steps failed'; exit 1; }
 
 # Verify that Kafka Streams archetype compiles
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then


### PR DESCRIPTION
[KAFKA-8800](https://github.com/apache/kafka/pull/7211) attempted to fix a flaky test, however the tests remained inconsistent even after the fix. Since this test is not reproducible locally, modifying the Jenkins builds and digging through the logs would help debug the cause of this issue.

Potential causes for this test's failure:
1. Client (consumer) did not get metadata for this partition
2. Client's metadata is out-of-date
3. Broker that hosts the leader does not know it is the leader.
4. It takes along time to consume

Findings:
- Adding asserts before consuming records to ensure the client has up-to-date metadata was not the problem.
- When running only the individual test, the test passes all checks.
- When running only integration tests, the test failed failed inconsistently.
- When running all JUnit and integration tests, the test failed inconsistently.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
