### PR TITLE
MINOR. implement --expose-ports option in ducker-ak

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -73,34 +73,7 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     if --expose-ports is specified then we will expose those ports to random ephemeral ports
     on the host. The argument can be a single port (like 5005), a port range like (5005-5009)
     or a combination of port/port-range separated by comma (like 2181,9092 or 2181,5005-5008).
-    By default no port is exposed.
-
-    The exposed port mapping can be seen by executing `docker ps' command. The PORT column
-    of the output shows the mapping like this (maps port 33891 on host to port 2182 in container):
-
-    0.0.0.0:33891->2182/tcp
-
-    Behind the scene Docker is setting up a DNAT rule for the mapping and it is visible in
-    the DOCKER section of iptables command (`sudo iptables -t nat -L -n'), something like:
-
-    DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:33882 to:172.22.0.2:9092
-
-    The exposed port(s) are useful to attach a remote debugger to the process running
-    in the docker image. For example if port 5005 was exposed and is mapped to an ephemeral
-    port (say 33890), then a debugger attaching to port 33890 on host will be connecting to
-    a debug session started at port 5005 in the docker image. As an example, for above port
-    numbers, run following command in the docker image (say by ssh using `./docker/ducker-ak ssh ducker02'):
-
-    $ export KAFKA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-    $ /opt/kafka-dev/bin/kafka-topics.sh --bootstrap-server ducker03:9095 --topic __consumer_offsets --describe
-
-    This will run the TopicCommand to describe the __consumer-offset topic. The java process
-    will stop and wait for debugger to attach as `suspend=y' option was specified. Now starting
-    a debugger on host with host `localhost' and following command line JVM setting:
-
-    `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=33890'
-
-    will attach it to the TopicCommand process running in the docker image.
+    By default no port is exposed. See README.md for more detail on this option.
 
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -75,6 +75,16 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     or a combination of port/port-range separated by comma (like 2181,9092 or 2181,5005-5008).
     By default no port is exposed.
 
+    The exposed port mapping can be seen by executing `docker ps' command. The PORT column
+    of the output shows the mapping like this (maps port 33891 on host to port 2182 in container):
+
+    0.0.0.0:33891->2182/tcp
+
+    Behind the scene Docker is setting up a DNAT rule for the mapping and it is visible in
+    the DOCKER section of iptables command (`sudo iptables -t nat -L -n'), something like:
+
+    DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:33882 to:172.22.0.2:9092
+
     The exposed port(s) are useful to attach a remote debugger to the process running
     in the docker image. For example if port 5005 was exposed and is mapped to an ephemeral
     port (say 33890), then a debugger attaching to port 33890 on host will be connecting to

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -61,7 +61,7 @@ help|-h|--help
     Display this help message
 
 up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
-        [-C|--custom-ducktape DIR]
+        [-C|--custom-ducktape DIR] [-e|--expose-ports ports]
     Bring up a cluster with the specified amount of nodes (defaults to ${default_num_nodes}).
     The docker image name defaults to ${default_image_name}.  If --force is specified, we will
     attempt to bring up an image even some parameters are not valid.
@@ -69,6 +69,10 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     If --custom-ducktape is specified, we will install the provided custom
     ducktape source code directory before bringing up the nodes.  The provided
     directory should be the ducktape git repo, not the ducktape installed module directory.
+
+    if --expose-ports is specified then we will expose those ports to random ephemeral ports
+    on the host. The argument can be a single port (like 5005) or a port range like (5005-5009).
+    By default no port is exposed.
 
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.
@@ -235,12 +239,17 @@ $((${duration} % 60))s.  See ${build_log} for details."
 docker_run() {
     local node=${1}
     local image_name=${2}
+    local ports_option=${3}
+
+    if [[ -n ${ports_option} ]]; then
+      ports_option="--expose ${ports_option} -P"
+    fi
 
     # Invoke docker-run. We need privileged mode to be able to run iptables
     # and mount FUSE filesystems inside the container.  We also need it to
     # run iptables inside the container.
     must_do -v docker run --privileged \
-        -d -t -h "${node}" --network ducknet \
+        -d -t -h "${node}" --network ducknet "${ports_option}" \
         --memory=${docker_run_memory_limit} --memory-swappiness=1 \
         -v "${kafka_dir}:/opt/kafka-dev" --name "${node}" -- "${image_name}"
 }
@@ -269,6 +278,7 @@ ducker_up() {
             -f|--force) force=1; shift;;
             -n|--num-nodes) set_once num_nodes "${2}" "number of nodes"; shift 2;;
             -j|--jdk) set_once jdk_version "${2}" "the OpenJDK base image"; shift 2;;
+            -e|--expose-ports) set_once expose_ports "${2}" "the ports to expose"; shift 2;;
             *) set_once image_name "${1}" "docker image name"; shift;;
         esac
     done
@@ -322,7 +332,7 @@ attempting to start new ones."
     fi
     for n in $(seq -f %02g 1 ${num_nodes}); do
         local node="ducker${n}"
-        docker_run "${node}" "${image_name}"
+        docker_run "${node}" "${image_name}" "${expose_ports}"
     done
     mkdir -p "${ducker_dir}/build"
     exec 3<> "${ducker_dir}/build/node_hosts"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -71,8 +71,26 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     directory should be the ducktape git repo, not the ducktape installed module directory.
 
     if --expose-ports is specified then we will expose those ports to random ephemeral ports
-    on the host. The argument can be a single port (like 5005) or a port range like (5005-5009).
+    on the host. The argument can be a single port (like 5005), a port range like (5005-5009)
+    or a combination of port/port-range separated by comma (like 2181,9092 or 2181,5005-5008).
     By default no port is exposed.
+
+    The exposed port(s) are useful to attach a remote debugger to the process running
+    in the docker image. For example if port 5005 was exposed and is mapped to an ephemeral
+    port (say 33890), then a debugger attaching to port 33890 on host will be connecting to
+    a debug session started at port 5005 in the docker image. As an example, for above port
+    numbers, run following command in the docker image (say by ssh using `./docker/ducker-ak ssh ducker02'):
+
+    $ export KAFKA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+    $ /opt/kafka-dev/bin/kafka-topics.sh --bootstrap-server ducker03:9095 --topic __consumer_offsets --describe
+
+    This will run the TopicCommand to describe the __consumer-offset topic. The java process
+    will stop and wait for debugger to attach as `suspend=y' option was specified. Now starting
+    a debugger on host with host `localhost' and following command line JVM setting:
+
+    `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=33890'
+
+    will attach it to the TopicCommand process running in the docker image.
 
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.
@@ -241,15 +259,19 @@ docker_run() {
     local image_name=${2}
     local ports_option=${3}
 
+    local expose_ports=""
     if [[ -n ${ports_option} ]]; then
-      ports_option="--expose ${ports_option} -P"
+        expose_ports="-P"
+        for expose_port in ${ports_option//,/ }; do
+            expose_ports="${expose_ports} --expose ${expose_port}"
+        done
     fi
 
     # Invoke docker-run. We need privileged mode to be able to run iptables
     # and mount FUSE filesystems inside the container.  We also need it to
     # run iptables inside the container.
     must_do -v docker run --privileged \
-        -d -t -h "${node}" --network ducknet "${ports_option}" \
+        -d -t -h "${node}" --network ducknet "${expose_ports}" \
         --memory=${docker_run_memory_limit} --memory-swappiness=1 \
         -v "${kafka_dir}:/opt/kafka-dev" --name "${node}" -- "${image_name}"
 }


### PR DESCRIPTION
This change adds a command line option to the `ducker-ak up` command to
enable exposing ports from docker containers. The exposed ports will be
mapped to the ephemeral ports on the host. The option is called
`expose-ports` and can take either a single value (like 5005) or a range
(like 5005-5009). This port will then exposed from each docker container
that ducker-ak sets up.

Here is one command line example:

> ./docker/ducker-ak up --expose-ports 5005

After doing this, docker will report mapped ports. Here is example
output of `docker ps` command:

CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS                PORTS                     NAMES
d470b708391d        ducker-ak-openjdk-8               "/bin/sh -c 'sudo se…"   16 minutes ago      Up 16 minutes         0.0.0.0:32845->5005/tcp   ducker14
4a25ae952f28        ducker-ak-openjdk-8               "/bin/sh -c 'sudo se…"   16 minutes ago      Up 16 minutes         0.0.0.0:32844->5005/tcp   ducker13
d7b8dad9259d        ducker-ak-openjdk-8               "/bin/sh -c 'sudo se…"   16 minutes ago      Up 16 minutes         0.0.0.0:32843->5005/tcp   ducker12
...

Tested by launching a bin/kafka-topics.sh command and then verifying
that I can attach the debugger successfully to the launched binary.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
