### PR TITLE
MINOR: fix integer overflow in LRUCacheBenchmark

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/cache/LRUCacheBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/cache/LRUCacheBenchmark.java
@@ -52,7 +52,7 @@ public class LRUCacheBenchmark {
 
     private LRUCache<String, String> lruCache;
 
-    long counter = 0;
+    private long counter = 0;
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -66,7 +66,7 @@ public class LRUCacheBenchmark {
     @Benchmark
     public String testCachePerformance() {
         counter++;
-        int index = (int)(counter % DISTINCT_KEYS);
+        int index = (int) (counter % DISTINCT_KEYS);
         String hashkey = keys[index];
         lruCache.put(hashkey, values[index]);
         return lruCache.get(hashkey);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/cache/LRUCacheBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/cache/LRUCacheBenchmark.java
@@ -52,7 +52,7 @@ public class LRUCacheBenchmark {
 
     private LRUCache<String, String> lruCache;
 
-    int counter;
+    long counter = 0;
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -66,7 +66,7 @@ public class LRUCacheBenchmark {
     @Benchmark
     public String testCachePerformance() {
         counter++;
-        int index = counter % DISTINCT_KEYS;
+        int index = (int)(counter % DISTINCT_KEYS);
         String hashkey = keys[index];
         lruCache.put(hashkey, values[index]);
         return lruCache.get(hashkey);


### PR DESCRIPTION
The jmh LRUCacheBenchmark will exhibit an int overflow when run on a fast machine:

```
java.lang.ArrayIndexOutOfBoundsException: Index -3648 out of bounds for length 10000
	at org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance(LRUCacheBenchmark.java:70)
	at org.apache.kafka.jmh.cache.generated.LRUCacheBenchmark_testCachePerformance_jmhTest.testCachePerformance_thrpt_jmhStub(LRUCacheBenchmark_testCachePerformance_jmhTest.java:119)
	at org.apache.kafka.jmh.cache.generated.LRUCacheBenchmark_testCachePerformance_jmhTest.testCachePerformance_Throughput(LRUCacheBenchmark_testCachePerformance_jmhTest.java:83)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```