### PR TITLE
KAFKA-7931 : [Proposal] Fix metadata fetch for ephemeral brokers behind a Virtual IP

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -59,6 +59,11 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
+    public List<Node> fetchBootStrapNodes() {
+        return new ArrayList<>(0);
+    }
+
+    @Override
     public boolean isUpdateDue(long now) {
         return false;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -38,6 +38,11 @@ public interface MetadataUpdater extends Closeable {
     List<Node> fetchNodes();
 
     /**
+     * Gets the initial set of nodes used for bootstrap.
+     */
+    List<Node> fetchBootStrapNodes();
+
+    /**
      * Returns true if an update to the cluster metadata info is due.
      */
     boolean isUpdateDue(long now);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -87,6 +88,11 @@ public class AdminMetadataManager {
         @Override
         public List<Node> fetchNodes() {
             return cluster.nodes();
+        }
+
+        @Override
+        public List<Node> fetchBootStrapNodes() {
+            return new ArrayList<>(0);
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -110,6 +110,10 @@ public class TestUtils {
         return new Cluster("kafka-cluster", asList(ns), parts, Collections.emptySet(), Collections.emptySet());
     }
 
+    public static Node getRandomNode() {
+        return new Node(RANDOM.nextInt(), "localhost", 2000);
+    }
+
     public static MetadataResponse metadataUpdateWith(final int numNodes,
                                                       final Map<String, Integer> topicPartitionCounts) {
         return metadataUpdateWith("kafka-cluster", numNodes, topicPartitionCounts);


### PR DESCRIPTION
If we have ephemeral brokers sitting behind a Virtual IP and when all the brokers go down, the client won't be able to reconnect as mentioned in: https://issues.apache.org/jira/browse/KAFKA-7931. This is because we take the bootstrap nodes and completely forget about it once the first metadata response comes in (and then we create a new metadata cache and a new cluster). Now when all the brokers go down before the metadata is updated, then the client will be stuck unless it is rebooted. 

This patch simply stores the bootstrap brokers list. Instead of simply giving up when a 'leastLoadedNode' is not found, we simply use one of the bootstrap nodes to get the metadata. Also we can make sure to use the bootstrap nodes only when the bootstrap node is not part of the set of nodes on the cluster.

Testing
--------
* Manual Testing - Setup ephemeral brokers behind a VIP. Recreate all the ephemeral brokers (so that they change their IPs)
* NetworkClient Unit Test - Test metadata with bootstrap - being the same as the node on the cluster and also different than the node on the cluster.

Note: This doesn't change any existing system behavior and this code path will be hit only if we are unable to find any `leastLoadedNode`