### PR TITLE
KAFKA-8875:CreateTopic API should check topic existence before replic…

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.clients.admin.AlterConfigOp
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.common.config.ConfigDef.ConfigKey
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigException, ConfigResource, LogLevelConfig}
-import org.apache.kafka.common.errors.{ApiException, InvalidConfigurationException, InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidRequestException, ReassignmentInProgressException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{ApiException, InvalidConfigurationException, InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidRequestException, ReassignmentInProgressException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic
 import org.apache.kafka.common.metrics.Metrics
@@ -88,7 +88,9 @@ class AdminManager(val config: KafkaConfig,
     val brokers = metadataCache.getAliveBrokers.map { b => kafka.admin.BrokerMetadata(b.id, b.rack) }
     val metadata = toCreate.values.map(topic =>
       try {
-        adminZkClient.validateTopicExists(topic.name)
+        if (metadataCache.contains(topic.name))
+          throw new TopicExistsException(s"Topic '${topic.name}' already exists.")
+
         val configs = new Properties()
         topic.configs.asScala.foreach { entry =>
           configs.setProperty(entry.name, entry.value)

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -88,6 +88,7 @@ class AdminManager(val config: KafkaConfig,
     val brokers = metadataCache.getAliveBrokers.map { b => kafka.admin.BrokerMetadata(b.id, b.rack) }
     val metadata = toCreate.values.map(topic =>
       try {
+        adminZkClient.validateTopicExists(topic.name)
         val configs = new Properties()
         topic.configs.asScala.foreach { entry =>
           configs.setProperty(entry.name, entry.value)

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -95,7 +95,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
     writeTopicPartitionAssignment(topic, partitionReplicaAssignment, isUpdate = false)
   }
 
-  def validateTopicExists(topic: String) {
+  def validateTopicExists(topic: String): Unit = {
     if (zkClient.topicExists(topic))
       throw new TopicExistsException(s"Topic '$topic' already exists.")
   }

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -95,6 +95,11 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
     writeTopicPartitionAssignment(topic, partitionReplicaAssignment, isUpdate = false)
   }
 
+  def validateTopicExists(topic: String) {
+    if (zkClient.topicExists(topic))
+      throw new TopicExistsException(s"Topic '$topic' already exists.")
+  }
+
   /**
    * Validate topic creation parameters
    */
@@ -103,9 +108,8 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                           config: Properties): Unit = {
     Topic.validate(topic)
 
-    if (zkClient.topicExists(topic))
-      throw new TopicExistsException(s"Topic '$topic' already exists.")
-    else if (Topic.hasCollisionChars(topic)) {
+    validateTopicExists(topic)
+    if (Topic.hasCollisionChars(topic)) {
       val allTopics = zkClient.getAllTopicsInCluster
       // check again in case the topic was created in the meantime, otherwise the
       // topic could potentially collide with itself

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -95,11 +95,6 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
     writeTopicPartitionAssignment(topic, partitionReplicaAssignment, isUpdate = false)
   }
 
-  def validateTopicExists(topic: String): Unit = {
-    if (zkClient.topicExists(topic))
-      throw new TopicExistsException(s"Topic '$topic' already exists.")
-  }
-
   /**
    * Validate topic creation parameters
    */
@@ -108,8 +103,9 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                           config: Properties): Unit = {
     Topic.validate(topic)
 
-    validateTopicExists(topic)
-    if (Topic.hasCollisionChars(topic)) {
+    if (zkClient.topicExists(topic))
+      throw new TopicExistsException(s"Topic '$topic' already exists.")
+    else if (Topic.hasCollisionChars(topic)) {
       val allTopics = zkClient.getAllTopicsInCluster
       // check again in case the topic was created in the meantime, otherwise the
       // topic could potentially collide with itself

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -226,6 +226,32 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
   }
 
   @Test
+  def testCreateExistedTopicsThrowTopicExistsException(): Unit = {
+    client = AdminClient.create(createConfig())
+    val topic = "mytopic"
+    val topics = Seq(topic)
+    val newTopics = Seq(
+      new NewTopic(topic, 1, 1.toShort),
+    )
+    client.createTopics(newTopics.asJava, new CreateTopicsOptions().validateOnly(true)).all.get()
+    waitForTopics(client, List(), topics)
+
+    client.createTopics(newTopics.asJava).all.get()
+    waitForTopics(client, topics, List())
+
+    val newTopicsWithInvalidRF = Seq(
+      new NewTopic(topic, 1, (servers.size + 1).toShort),
+    )
+    try {
+      client.createTopics(newTopicsWithInvalidRF.asJava, new CreateTopicsOptions().validateOnly(true)).all.get()
+      waitForTopics(client, topics, List())
+    } catch {
+      case e: ExecutionException =>
+        assertTrue(e.getCause.isInstanceOf[TopicExistsException])
+    }
+  }
+
+  @Test
   def testMetadataRefresh(): Unit = {
     client = AdminClient.create(createConfig())
     val topics = Seq("mytopic")

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -230,16 +230,12 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     client = AdminClient.create(createConfig())
     val topic = "mytopic"
     val topics = Seq(topic)
-    val newTopics = Seq(
-      new NewTopic(topic, 1, 1.toShort),
-    )
+    val newTopics = Seq(new NewTopic(topic, 1, 1.toShort))
 
     client.createTopics(newTopics.asJava).all.get()
     waitForTopics(client, topics, List())
 
-    val newTopicsWithInvalidRF = Seq(
-      new NewTopic(topic, 1, (servers.size + 1).toShort),
-    )
+    val newTopicsWithInvalidRF = Seq(new NewTopic(topic, 1, (servers.size + 1).toShort))
     val e = intercept[ExecutionException] {
       client.createTopics(newTopicsWithInvalidRF.asJava, new CreateTopicsOptions().validateOnly(true)).all.get()
     }

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -242,13 +242,10 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     val newTopicsWithInvalidRF = Seq(
       new NewTopic(topic, 1, (servers.size + 1).toShort),
     )
-    try {
+    val e = intercept[ExecutionException] {
       client.createTopics(newTopicsWithInvalidRF.asJava, new CreateTopicsOptions().validateOnly(true)).all.get()
-      waitForTopics(client, topics, List())
-    } catch {
-      case e: ExecutionException =>
-        assertTrue(e.getCause.isInstanceOf[TopicExistsException])
     }
+    assertTrue(e.getCause.isInstanceOf[TopicExistsException])
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -226,15 +226,13 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
   }
 
   @Test
-  def testCreateExistedTopicsThrowTopicExistsException(): Unit = {
+  def testCreateExistingTopicsThrowTopicExistsException(): Unit = {
     client = AdminClient.create(createConfig())
     val topic = "mytopic"
     val topics = Seq(topic)
     val newTopics = Seq(
       new NewTopic(topic, 1, 1.toShort),
     )
-    client.createTopics(newTopics.asJava, new CreateTopicsOptions().validateOnly(true)).all.get()
-    waitForTopics(client, List(), topics)
 
     client.createTopics(newTopics.asJava).all.get()
     waitForTopics(client, topics, List())


### PR DESCRIPTION
…ation factor

https://issues.apache.org/jira/browse/KAFKA-8875

If the topic already exists, `handleCreateTopicsRequest` should return TopicExistsException even given an invalid config (replication factor for instance).

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
