### PR TITLE
KAFKA-8876:KafkaBasedLog does not throw exception when some partition…

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -149,9 +149,8 @@ public class KafkaBasedLogTest {
     @Test(expected = ConnectException.class)
     public void testStartFailedWhenSomePartitionOffline() throws Exception {
         KafkaBasedLog store = PowerMock.createPartialMock(KafkaBasedLog.class, new String[]{"createConsumer", "createProducer"},
-                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, Time.SYSTEM, initializer);
+                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, Time.SYSTEM, initializer, 1000L);
 
-        store.setTopicMetadataTimeoutMs(1000L);
         PartitionInfo tpWithNoLeader = new PartitionInfo(TOPIC, 2, null, new Node[]{REPLICA}, new Node[0], new Node[]{REPLICA});
         consumer.updatePartitions(TOPIC, Arrays.asList(TPINFO0, TPINFO1, tpWithNoLeader));
         try {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -143,6 +144,34 @@ public class KafkaBasedLogTest {
         beginningOffsets.put(TP0, 0L);
         beginningOffsets.put(TP1, 0L);
         consumer.updateBeginningOffsets(beginningOffsets);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testStartFailedWhenSomePartitionOffline() throws Exception {
+        KafkaBasedLog store = PowerMock.createPartialMock(KafkaBasedLog.class, new String[]{"createConsumer", "createProducer"},
+                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, Time.SYSTEM, initializer);
+
+        store.setTopicMetadataTimeoutMs(1000L);
+        PartitionInfo tpWithNoLeader = new PartitionInfo(TOPIC, 2, null, new Node[]{REPLICA}, new Node[0], new Node[]{REPLICA});
+        consumer.updatePartitions(TOPIC, Arrays.asList(TPINFO0, TPINFO1, tpWithNoLeader));
+        try {
+            // Expectation
+            initializer.run();
+            EasyMock.expectLastCall().times(1);
+
+            PowerMock.expectPrivate(store, "createProducer")
+                    .andReturn(producer);
+            PowerMock.expectPrivate(store, "createConsumer")
+                    .andReturn(consumer);
+            EasyMock.expectLastCall().times(1);
+
+            PowerMock.replayAll();
+
+            store.start();
+        } finally {
+            // Recover consumer subscription
+            consumer.updatePartitions(TOPIC, Arrays.asList(TPINFO0, TPINFO1));
+        }
     }
 
     @Test


### PR DESCRIPTION
…s of the topic is offline

https://issues.apache.org/jira/browse/KAFKA-8876

When starting up, KafkaBasedLog should throw ConnectException if any of the subscribed partitions has no leader.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
