### PR TITLE
KAFKA-8660: Add connect SMT topic whitelist config

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ApplicableTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ApplicableTransformation.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ApplicableTransformation<R extends ConnectRecord<R>> implements Closeable {
+
+    private final ApplicableTransformationConfig config;
+    protected Transformation<R> transformation;
+
+    <T extends Transformation<R>> ApplicableTransformation(final T transformation,
+                                                           final Map<String, Object> config) {
+        this.transformation = transformation;
+        this.config = new ApplicableTransformationConfig(config);
+    }
+
+    <T extends Transformation<R>> ApplicableTransformation(final T transformation) {
+        this.transformation = transformation;
+        this.config = new ApplicableTransformationConfig(Collections.emptyMap());
+    }
+
+    R apply(final R record) {
+        final List<String> topics = config.getTopics();
+        if (topics.isEmpty() || !topics.contains(record.topic())) {
+            return record;
+        }
+
+        return transformation.apply(record);
+    }
+
+    Transformation<R> getTransformation() {
+        return transformation;
+    }
+
+    @Override
+    public void close() {
+        transformation.close();
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ApplicableTransformationConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ApplicableTransformationConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ApplicableTransformationConfig extends AbstractConfig {
+
+    public static final String TOPICS_CONFIG = "topics";
+    private static final String TOPICS_DOC = "Topic names for which this transformation will be applied.";
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(TOPICS_CONFIG, Type.LIST, Collections.emptyList(), Importance.HIGH, TOPICS_DOC);
+
+    public ApplicableTransformationConfig(Map<String, ?> props) {
+        super(CONFIG_DEF, props, true);
+    }
+
+    public List<String> getTopics() {
+        return this.getList(TOPICS_CONFIG);
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -98,12 +98,12 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String CONFIG_RELOAD_ACTION_CONFIG = "config.action.reload";
     private static final String CONFIG_RELOAD_ACTION_DOC =
             "The action that Connect should take on the connector when changes in external " +
-            "configuration providers result in a change in the connector's configuration properties. " +
-            "A value of 'none' indicates that Connect will do nothing. " +
-            "A value of 'restart' indicates that Connect should restart/reload the connector with the " +
-            "updated configuration properties." +
-            "The restart may actually be scheduled in the future if the external configuration provider " +
-            "indicates that a configuration value will expire in the future.";
+                    "configuration providers result in a change in the connector's configuration properties. " +
+                    "A value of 'none' indicates that Connect will do nothing. " +
+                    "A value of 'restart' indicates that Connect should restart/reload the connector with the " +
+                    "updated configuration properties." +
+                    "The restart may actually be scheduled in the future if the external configuration provider " +
+                    "indicates that a configuration value will expire in the future.";
 
     private static final String CONFIG_RELOAD_ACTION_DISPLAY = "Reload Action";
     public static final String CONFIG_RELOAD_ACTION_NONE = Herder.ConfigReloadAction.NONE.name().toLowerCase(Locale.ROOT);
@@ -146,6 +146,7 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX = "admin.override.";
 
     private final EnrichedConnectorConfig enrichedConfig;
+
     private static class EnrichedConnectorConfig extends AbstractConfig {
         EnrichedConnectorConfig(ConfigDef configDef, Map<String, String> props) {
             super(configDef, props);
@@ -229,7 +230,7 @@ public class ConnectorConfig extends AbstractConfig {
 
     public ToleranceType errorToleranceType() {
         String tolerance = getString(ERRORS_TOLERANCE_CONFIG);
-        for (ToleranceType type: ToleranceType.values()) {
+        for (ToleranceType type : ToleranceType.values()) {
             if (type.name().equalsIgnoreCase(tolerance)) {
                 return type;
             }
@@ -247,19 +248,23 @@ public class ConnectorConfig extends AbstractConfig {
 
     /**
      * Returns the initialized list of {@link Transformation} which are specified in {@link #TRANSFORMS_CONFIG}.
+     *
+     * @return
      */
-    public <R extends ConnectRecord<R>> List<Transformation<R>> transformations() {
+    public <R extends ConnectRecord<R>> List<ApplicableTransformation<R>> transformations() {
         final List<String> transformAliases = getList(TRANSFORMS_CONFIG);
 
-        final List<Transformation<R>> transformations = new ArrayList<>(transformAliases.size());
+        final List<ApplicableTransformation<R>> transformations = new ArrayList<>(transformAliases.size());
         for (String alias : transformAliases) {
             final String prefix = TRANSFORMS_CONFIG + "." + alias + ".";
             try {
-                @SuppressWarnings("unchecked")
-                final Transformation<R> transformation = getClass(prefix + "type").asSubclass(Transformation.class)
+                @SuppressWarnings("unchecked") final Transformation<R> transformation = getClass(prefix + "type").asSubclass(Transformation.class)
                         .getDeclaredConstructor().newInstance();
-                transformation.configure(originalsWithPrefix(prefix));
-                transformations.add(transformation);
+                final Map<String, Object> config = originalsWithPrefix(prefix);
+                transformation.configure(config);
+                final ApplicableTransformation<R> applicableTransformation = new ApplicableTransformation<>(
+                        transformation, config);
+                transformations.add(applicableTransformation);
             } catch (Exception e) {
                 throw new ConnectException(e);
             }
@@ -338,10 +343,10 @@ public class ConnectorConfig extends AbstractConfig {
         ConfigDef configDef = transformation.config();
         if (null == configDef) {
             throw new ConnectException(
-                String.format(
-                    "%s.config() must return a ConfigDef that is not null.",
-                    transformationCls.getName()
-                )
+                    String.format(
+                            "%s.config() must return a ConfigDef that is not null.",
+                            transformationCls.getName()
+                    )
             );
         }
         return configDef;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
 import org.apache.kafka.connect.runtime.errors.Stage;
-import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,10 +29,10 @@ import java.util.StringJoiner;
 public class TransformationChain<R extends ConnectRecord<R>> {
     private static final Logger log = LoggerFactory.getLogger(TransformationChain.class);
 
-    private final List<Transformation<R>> transformations;
+    private final List<ApplicableTransformation<R>> transformations;
     private final RetryWithToleranceOperator retryWithToleranceOperator;
 
-    public TransformationChain(List<Transformation<R>> transformations, RetryWithToleranceOperator retryWithToleranceOperator) {
+    public TransformationChain(List<ApplicableTransformation<R>> transformations, RetryWithToleranceOperator retryWithToleranceOperator) {
         this.transformations = transformations;
         this.retryWithToleranceOperator = retryWithToleranceOperator;
     }
@@ -41,7 +40,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
     public R apply(R record) {
         if (transformations.isEmpty()) return record;
 
-        for (final Transformation<R> transformation : transformations) {
+        for (final ApplicableTransformation<R> transformation : transformations) {
             final R current = record;
 
             log.trace("Applying transformation {} to {}",
@@ -56,7 +55,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
     }
 
     public void close() {
-        for (Transformation<R> transformation : transformations) {
+        for (ApplicableTransformation<R> transformation : transformations) {
             transformation.close();
         }
     }
@@ -76,7 +75,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
 
     public String toString() {
         StringJoiner chain = new StringJoiner(", ", getClass().getName() + "{", "}");
-        for (Transformation<R> transformation : transformations) {
+        for (ApplicableTransformation<R> transformation : transformations) {
             chain.add(transformation.getClass().getName());
         }
         return chain.toString();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ApplicableTransformationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ApplicableTransformationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApplicableTransformationTest {
+
+    private static final UUID ORIGINAL_VALUE = UUID.randomUUID();
+    private static final UUID TRANSFORMED_VALUE = UUID.randomUUID();
+    private static final String INCLUDED_TOPIC_NAME = "includedTopic";
+    private static final String EXCLUDED_TOPIC_NAME = "excludedTopic";
+    private static final SinkRecord INCLUDED_TOPIC_RECORD = new SinkRecord(INCLUDED_TOPIC_NAME, 0, null, null, null, ORIGINAL_VALUE, 0);
+    private static final SinkRecord EXCLUDED_TOPIC_RECORD = new SinkRecord(EXCLUDED_TOPIC_NAME, 0, null, null, null, ORIGINAL_VALUE, 0);
+
+    @Test
+    public void itShouldRunTransformationOnIncludedTopicRecord() {
+        final TestTransformation<SinkRecord> xform = new TestTransformation<>();
+
+        final Map<String, Object> config = buildConfigWithIncludedTopic(INCLUDED_TOPIC_NAME);
+        xform.configure(config);
+        final ApplicableTransformation<SinkRecord> applicableTransformation = new ApplicableTransformation<>(
+                xform, config);
+
+        final SinkRecord transformedRecord = applicableTransformation.apply(INCLUDED_TOPIC_RECORD);
+        assertEquals(TRANSFORMED_VALUE, transformedRecord.value());
+    }
+
+    @Test
+    public void itShouldNotRunTransformationOnExcludedTopicRecord() {
+        final TestTransformation<SinkRecord> xform = new TestTransformation<>();
+
+        final Map<String, Object> config = buildConfigWithIncludedTopic(INCLUDED_TOPIC_NAME);
+        xform.configure(config);
+        final ApplicableTransformation<SinkRecord> applicableTransformation = new ApplicableTransformation<>(
+                xform, config);
+
+        final SinkRecord transformedRecord = applicableTransformation.apply(EXCLUDED_TOPIC_RECORD);
+        assertEquals(ORIGINAL_VALUE, transformedRecord.value());
+    }
+
+    @Test
+    public void itShouldRunAnyTransformationWithWhenTopicsIsNotDefined() {
+        final TestTransformation<SinkRecord> xform = new TestTransformation<>();
+
+        final Map<String, Object> config = buildConfig();
+        xform.configure(config);
+        final ApplicableTransformation<SinkRecord> applicableTransformation = new ApplicableTransformation<>(
+                xform, config);
+
+        assertEquals(ORIGINAL_VALUE, applicableTransformation.apply(INCLUDED_TOPIC_RECORD).value());
+        assertEquals(ORIGINAL_VALUE, applicableTransformation.apply(EXCLUDED_TOPIC_RECORD).value());
+    }
+
+    private static Map<String, Object> buildConfig() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put("value", TRANSFORMED_VALUE);
+        return config;
+    }
+
+    private static Map<String, Object> buildConfigWithIncludedTopic(final String topicsConfig) {
+        final Map<String, Object> config = buildConfig();
+        config.put("topics", topicsConfig);
+        return config;
+    }
+
+    public static class TestTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
+
+        UUID value;
+
+        @Override
+        public R apply(R record) {
+            return record
+                    .newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                            record.valueSchema(), value, record.timestamp());
+        }
+
+        @Override
+        public ConfigDef config() {
+            return new ConfigDef()
+                    .define("value", Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH, "");
+        }
+
+        @Override
+        public void configure(final Map<String, ?> props) {
+            value = (UUID) props.get("value");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -47,7 +47,7 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
     public static abstract class TestConnector extends Connector {
     }
 
-    public static class SimpleTransformation<R extends ConnectRecord<R>> implements Transformation<R>  {
+    public static class SimpleTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
 
         int magicNumber = 0;
 
@@ -143,9 +143,9 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         props.put("transforms.a.type", SimpleTransformation.class.getName());
         props.put("transforms.a.magic.number", "42");
         final ConnectorConfig config = new ConnectorConfig(MOCK_PLUGINS, props);
-        final List<Transformation<R>> transformations = config.transformations();
+        final List<ApplicableTransformation<R>> transformations = config.transformations();
         assertEquals(1, transformations.size());
-        final SimpleTransformation xform = (SimpleTransformation) transformations.get(0);
+        final SimpleTransformation xform = (SimpleTransformation) transformations.get(0).getTransformation();
         assertEquals(42, xform.magicNumber);
     }
 
@@ -171,10 +171,10 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         props.put("transforms.b.type", SimpleTransformation.class.getName());
         props.put("transforms.b.magic.number", "84");
         final ConnectorConfig config = new ConnectorConfig(MOCK_PLUGINS, props);
-        final List<Transformation<R>> transformations = config.transformations();
+        final List<ApplicableTransformation<R>> transformations = config.transformations();
         assertEquals(2, transformations.size());
-        assertEquals(42, ((SimpleTransformation) transformations.get(0)).magicNumber);
-        assertEquals(84, ((SimpleTransformation) transformations.get(1)).magicNumber);
+        assertEquals(42, ((SimpleTransformation) transformations.get(0).getTransformation()).magicNumber);
+        assertEquals(84, ((SimpleTransformation) transformations.get(1).getTransformation()).magicNumber);
     }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -368,7 +368,7 @@ public class ErrorHandlingTaskTest {
         oo.put("schemas.enable", "false");
         converter.configure(oo);
 
-        TransformationChain<SinkRecord> sinkTransforms = new TransformationChain<>(singletonList(new FaultyPassthrough<SinkRecord>()), retryWithToleranceOperator);
+        TransformationChain<SinkRecord> sinkTransforms = new TransformationChain<>(singletonList(new ApplicableTransformation<SinkRecord>(new FaultyPassthrough<SinkRecord>())), retryWithToleranceOperator);
 
         workerSinkTask = new WorkerSinkTask(
             taskId, sinkTask, statusListener, initialState, workerConfig,
@@ -396,7 +396,7 @@ public class ErrorHandlingTaskTest {
     }
 
     private void createSourceTask(TargetState initialState, RetryWithToleranceOperator retryWithToleranceOperator, Converter converter) {
-        TransformationChain<SourceRecord> sourceTransforms = new TransformationChain<>(singletonList(new FaultyPassthrough<SourceRecord>()), retryWithToleranceOperator);
+        TransformationChain<SourceRecord> sourceTransforms = new TransformationChain<>(singletonList(new ApplicableTransformation<SourceRecord>(new FaultyPassthrough<SourceRecord>())), retryWithToleranceOperator);
 
         workerSourceTask = PowerMock.createPartialMock(
                 WorkerSourceTask.class, new String[]{"commitOffsets", "isStopping"},


### PR DESCRIPTION
For source connectors that publish on multiple topics it is essential to be able to configure transforms to be active only for certain topics.

This adds the possibility to define a whitelist of topics each single message transform (SMT) is applied to by adding a comma-separated list of these topics as key `topics` to the transforms configuration.

It solves [KAFKA-8660](https://issues.apache.org/jira/browse/KAFKA-8660) not only for a single but for all SMTs and is an alternative to #7084.

Since this introduces a change breaking backwards compatibility (because anyone could have used `topics` as a configuration key already), this PR is merely a request for comments: would this be something the maintainers of this project would be interested in adding? If yes, a strategy for smooth migration would be needed, and I would add the needed integration tests and documentation.

## Example configuration:

```
transforms: "ValueToKey"
transforms.ValueToKey.type: "org.apache.kafka.connect.transforms.ValueToKey"
transforms.ValueToKey.fields: "userId,city,state"
transforms.ValueToKey.topics: "my-addresses"
```

This makes sure the transform `ValueToKey` is only applied for records published on the `my-addresses` topic.