### PR TITLE
KAFKA-8884: class cast exception improvement

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -123,7 +123,7 @@ public class ProcessorNode<K, V> {
                     + "input types match the deserialized types? Check the Serde setup and change the default Serdes in "
                     + "StreamConfig or provide correct Serdes via method parameters. Make sure the Processor can accept "
                     + "the deserialized input of type key: %s, and value: %s.%n"
-                    + "Note that also although wrong Serdes are a common cause of error, the cast exception might have "
+                    + "Note that although incorrect Serdes are a common cause of error, the cast exception might have "
                     + "another cause (in user code, for example). For example, if a processor wires in a store, but casts "
                     + "the generics incorrectly, a class cast exception could be raised during processing, but the "
                     + "cause would not be wrong Serdes.",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -117,7 +117,15 @@ public class ProcessorNode<K, V> {
         try {
             processor.process(key, value);
         } catch (final ClassCastException e) {
-            throw new StreamsException("ClassCastException in processor node. Are your Serdes correct? Are default Serdes specified?", e);
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            throw new StreamsException(String.format("ClassCastException invoking Processor. Do the Processor's "
+                    + "input types match the deserialized types? Check the Serde setup and change the default Serdes in "
+                    + "StreamConfig or provide correct Serdes via method parameters. Make sure the Processor can accept "
+                    + "the deserialized input of type key: %s, and value: %s",
+                    keyClass,
+                    valueClass),
+                e);
         }
         nodeMetrics.nodeProcessTimeSensor.record(time.nanoseconds() - startNs);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -120,9 +120,13 @@ public class ProcessorNode<K, V> {
             final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             throw new StreamsException(String.format("ClassCastException invoking Processor. Do the Processor's "
-                    + "input types match the deserialized types? Check the Serde setup and change the default Serdes in "
-                    + "StreamConfig or provide correct Serdes via method parameters. Make sure the Processor can accept "
-                    + "the deserialized input of type key: %s, and value: %s",
+                    + "input types match the deserialized types? Check the serde setup and change the default serdes in "
+                    + "StreamConfig or provide correct serdes via method parameters. Make sure the Processor can accept "
+                    + "the deserialized input of type key: %s, and value: %s.\n"
+                    + "Note that also although wrong serdes are a common cause of error, the cast exception might have "
+                    + "another cause (in user code, for example). For example, if a processor wires in a store, but casts "
+                    + "the generics incorrectly, a class cast exception could be raiused during processing, but the "
+                    + "cause would not be wrong serdes.",
                     keyClass,
                     valueClass),
                 e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -120,13 +120,13 @@ public class ProcessorNode<K, V> {
             final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             throw new StreamsException(String.format("ClassCastException invoking Processor. Do the Processor's "
-                    + "input types match the deserialized types? Check the serde setup and change the default serdes in "
-                    + "StreamConfig or provide correct serdes via method parameters. Make sure the Processor can accept "
+                    + "input types match the deserialized types? Check the Serde setup and change the default Serdes in "
+                    + "StreamConfig or provide correct Serdes via method parameters. Make sure the Processor can accept "
                     + "the deserialized input of type key: %s, and value: %s.%n"
-                    + "Note that also although wrong serdes are a common cause of error, the cast exception might have "
+                    + "Note that also although wrong Serdes are a common cause of error, the cast exception might have "
                     + "another cause (in user code, for example). For example, if a processor wires in a store, but casts "
-                    + "the generics incorrectly, a class cast exception could be raiused during processing, but the "
-                    + "cause would not be wrong serdes.",
+                    + "the generics incorrectly, a class cast exception could be raised during processing, but the "
+                    + "cause would not be wrong Serdes.",
                     keyClass,
                     valueClass),
                 e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -114,7 +114,11 @@ public class ProcessorNode<K, V> {
 
     public void process(final K key, final V value) {
         final long startNs = time.nanoseconds();
-        processor.process(key, value);
+        try {
+            processor.process(key, value);
+        } catch (final ClassCastException e) {
+            throw new StreamsException("ClassCastException in processor node. Are your Serdes correct? Are default Serdes specified?", e);
+        }
         nodeMetrics.nodeProcessTimeSensor.record(time.nanoseconds() - startNs);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -122,7 +122,7 @@ public class ProcessorNode<K, V> {
             throw new StreamsException(String.format("ClassCastException invoking Processor. Do the Processor's "
                     + "input types match the deserialized types? Check the serde setup and change the default serdes in "
                     + "StreamConfig or provide correct serdes via method parameters. Make sure the Processor can accept "
-                    + "the deserialized input of type key: %s, and value: %s.\n"
+                    + "the deserialized input of type key: %s, and value: %s.%n"
                     + "Note that also although wrong serdes are a common cause of error, the cast exception might have "
                     + "another cause (in user code, for example). For example, if a processor wires in a store, but casts "
                     + "the generics incorrectly, a class cast exception could be raiused during processing, but the "

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -93,7 +93,7 @@ public class SinkNode<K, V> extends ProcessorNode<K, V> {
             throw new StreamsException(
                     String.format("A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
                                     "(key type: %s / value type: %s). Change the default Serdes in StreamConfig or " +
-                                    "provide correct Serdes via method parameters.",
+                                    "provide correct Serdes via method parameters (for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
                                     keySerializer.getClass().getName(),
                                     valSerializer.getClass().getName(),
                                     keyClass,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -91,7 +91,7 @@ public class SinkNode<K, V> extends ProcessorNode<K, V> {
             final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             throw new StreamsException(
-                    String.format("A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
+                    String.format("ClassCastException while producing data to a sink topic. A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
                                     "(key type: %s / value type: %s). Change the default Serdes in StreamConfig or " +
                                     "provide correct Serdes via method parameters (for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
                                     keySerializer.getClass().getName(),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
@@ -16,16 +16,12 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.Arrays;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
@@ -140,38 +136,4 @@ public class AbstractStreamTest {
             }
         }
     }
-
-    @Test(expected = StreamsException.class)
-    public void testClassCastException() {
-        final Properties props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        builder.<String, String>stream("streams-plaintext-input")
-            .flatMapValues(value -> {
-                return Arrays.asList(value.split("\\W+"));
-            })
-            .to("streams-linesplit-output");
-
-        Topology topology = builder.build();
-
-        final TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
-
-        final ConsumerRecordFactory<String, String> factory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-
-        final ConsumerRecord<byte[], byte[]> consumerRecord = factory.create("streams-plaintext-input", "a-key", "a value");
-
-        try{
-            testDriver.pipeInput(consumerRecord);
-        } catch (StreamsException s) {
-            String msg = s.getMessage();
-            assertTrue("Error about class cast with Serdes", msg.contains("ClassCastException"));
-            assertTrue("Error about class cast with Serdes", msg.contains("Serdes"));
-            throw s;
-        }
-
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -231,6 +231,5 @@ public class ProcessorNodeTest {
             assertThat(e.getMessage(), containsString("input types"));
             throw e;
         }
-
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -166,7 +166,7 @@ public class ProcessorNodeTest {
             .flatMapValues(value -> {
                 return Arrays.asList("");
             });
-        Topology topology = builder.build();
+        final Topology topology = builder.build();
 
         final TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
         final ConsumerRecordFactory<String, String> factory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
@@ -174,8 +174,8 @@ public class ProcessorNodeTest {
 
         try {
             testDriver.pipeInput(consumerRecord);
-        } catch (StreamsException s) {
-            String msg = s.getMessage();
+        } catch (final StreamsException s) {
+            final String msg = s.getMessage();
             assertTrue("Error about class cast with Serdes", msg.contains("ClassCastException"));
             assertTrue("Error about class cast with Serdes", msg.contains("Serdes"));
             throw s;
@@ -196,7 +196,7 @@ public class ProcessorNodeTest {
                 return Arrays.asList("");
             });
 
-        Topology topology = builder.build();
+        final Topology topology = builder.build();
 
         final TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
         final ConsumerRecordFactory<String, String> factory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
@@ -204,17 +204,17 @@ public class ProcessorNodeTest {
 
         try {
             testDriver.pipeInput(consumerRecord);
-        } catch (StreamsException s) {
-            String msg = s.getMessage();
+        } catch (final StreamsException s) {
+            final String msg = s.getMessage();
             assertTrue("Error about class cast with Serdes", msg.contains("ClassCastException"));
             assertTrue("Error about class cast with Serdes", msg.contains("Serdes"));
             throw s;
         }
     }
 
-    private static class ClassCastProcessor extends ExceptionalProcessor{
+    private static class ClassCastProcessor extends ExceptionalProcessor {
         @Override
-        public void process(Object key, Object value) {
+        public void process(final Object key, final Object value) {
             throw new ClassCastException("Incompatible types simulation exception.");
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.util.Arrays;
 import java.util.Properties;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.StringSerializer;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -176,7 +176,7 @@ public class ProcessorNodeTest {
         final StreamsException se = assertThrows(StreamsException.class, () -> testDriver.pipeInput(consumerRecord));
         final String msg = se.getMessage();
         assertTrue("Error about class cast with serdes", msg.contains("ClassCastException"));
-        assertTrue("Error about class cast with serdes", msg.contains("serdes"));
+        assertTrue("Error about class cast with serdes", msg.contains("Serdes"));
     }
 
     private static class ClassCastProcessor extends ExceptionalProcessor {
@@ -191,7 +191,7 @@ public class ProcessorNodeTest {
         final ProcessorNode<Object, Object> node = new ProcessorNode<Object, Object>("name", new ClassCastProcessor(), Collections.<String>emptySet());
         final StreamsException se = assertThrows(StreamsException.class, () -> node.process("aKey", "aValue"));
         assertThat(se.getCause(), instanceOf(ClassCastException.class));
-        assertThat(se.getMessage(), containsString("default serdes"));
+        assertThat(se.getMessage(), containsString("default Serdes"));
         assertThat(se.getMessage(), containsString("input types"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -155,6 +155,7 @@ public class ProcessorNodeTest {
                 groupName, threadId, context.taskId().toString(), node.name())));
     }
 
+    @Test
     public void testTopologyLevelClassCastException() {
         final Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
@@ -185,6 +186,7 @@ public class ProcessorNodeTest {
         }
     }
 
+    @Test
     public void testTopologyLevelClassCastExceptionDirect() {
         final ProcessorNode<Object, Object> node = new ProcessorNode<Object, Object>("name", new ClassCastProcessor(), Collections.<String>emptySet());
         final StreamsException se = assertThrows(StreamsException.class, () -> node.process("aKey", "aValue"));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
@@ -33,7 +34,6 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
@@ -170,10 +170,9 @@ public class ProcessorNodeTest {
         final Topology topology = builder.build();
 
         final TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
-        final ConsumerRecordFactory<String, String> factory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-        final ConsumerRecord<byte[], byte[]> consumerRecord = factory.create("streams-plaintext-input", "a-key", "a value");
+        TestInputTopic<String, String> topic = testDriver.createInputTopic("streams-plaintext-input", new StringSerializer(), new StringSerializer());
 
-        final StreamsException se = assertThrows(StreamsException.class, () -> testDriver.pipeInput(consumerRecord));
+        final StreamsException se = assertThrows(StreamsException.class, () -> topic.pipeInput("a-key", "a value"));
         final String msg = se.getMessage();
         assertTrue("Error about class cast with serdes", msg.contains("ClassCastException"));
         assertTrue("Error about class cast with serdes", msg.contains("Serdes"));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
@@ -66,7 +65,7 @@ public class ProcessorNodeTest {
         node.close();
     }
 
-    private static class ExceptionalProcessor implements Processor {
+    private static class ExceptionalProcessor implements Processor<Object, Object> {
         @Override
         public void init(final ProcessorContext context) {
             throw new RuntimeException();
@@ -186,10 +185,8 @@ public class ProcessorNodeTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    @Test(expected = StreamsException.class)
     public void testTopologyLevelClassCastExceptionDirect() {
-        final ProcessorNode node = new ProcessorNode("name", new ClassCastProcessor(), Collections.emptySet());
+        final ProcessorNode<Object, Object> node = new ProcessorNode<Object, Object>("name", new ClassCastProcessor(), Collections.<String>emptySet());
         final StreamsException se = assertThrows(StreamsException.class, () -> node.process("aKey", "aValue"));
         assertThat(se.getCause(), instanceOf(ClassCastException.class));
         assertThat(se.getMessage(), containsString("default serdes"));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -169,7 +169,7 @@ public class ProcessorNodeTest {
         final Topology topology = builder.build();
 
         final TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
-        TestInputTopic<String, String> topic = testDriver.createInputTopic("streams-plaintext-input", new StringSerializer(), new StringSerializer());
+        final TestInputTopic<String, String> topic = testDriver.createInputTopic("streams-plaintext-input", new StringSerializer(), new StringSerializer());
 
         final StreamsException se = assertThrows(StreamsException.class, () -> topic.pipeInput("a-key", "a value"));
         final String msg = se.getMessage();


### PR DESCRIPTION
If a processor causes a class cast exception, atm you get a bit of a cryptic error if you're not used to them, and without a context sensitive suggestion as to what could be wrong. Often these can be cause by miss-configured Serdes (defaults).

Old error:
```
Caused by: java.lang.ClassCastException: class [B cannot be cast to class java.lang.String ([B and java.lang.String are in module java.base of loader 'bootstrap')
```

An example of the improvement over the case exception:
```
org.apache.kafka.streams.errors.StreamsException: Exception caught in process. taskId=0_0, processor=KSTREAM-SOURCE-0000000000, topic=streams-plaintext-input, partition=0, offset=0, stacktrace=org.apache.kafka.streams.errors.StreamsException: 
ClassCastException invoking Processor. Do the Processor's input types match the deserialized types? Check 
the Serde setup and change the default Serdes in StreamConfig or provide correct Serdes via method 
parameters. Deserialized input types are: key: [B, value: [B
	at org.apache.kafka.streams.processor.internals.ProcessorNode.process(ProcessorNode.java:123)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:201)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:180)
	at org.apache.kafka.streams.processor.internals.ProcessorContextImpl.forward(ProcessorContextImpl.java:133)
	at org.apache.kafka.streams.processor.internals.SourceNode.process(SourceNode.java:87)
	at org.apache.kafka.streams.processor.internals.StreamTask.process(StreamTask.java:366)
	at org.apache.kafka.streams.TopologyTestDriver.pipeInput(TopologyTestDriver.java:419)
	at org.apache.kafka.streams.processor.internals.ProcessorNodeTest.testTopologyLevelClassCastException(ProcessorNodeTest.java:176)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:305)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:365)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:330)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:78)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:328)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:65)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:292)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:305)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:412)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassCastException: class [B cannot be cast to class java.lang.String ([B and java.lang.String are in module java.base of loader 'bootstrap')
	at org.apache.kafka.streams.kstream.internals.AbstractStream.lambda$withKey$1(AbstractStream.java:103)
	at org.apache.kafka.streams.kstream.internals.KStreamFlatMapValues$KStreamFlatMapValuesProcessor.process(KStreamFlatMapValues.java:40)
	at org.apache.kafka.streams.processor.internals.ProcessorNode.process(ProcessorNode.java:119)
	... 32 more
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
