### PR TITLE
KAFKA-8886; Make Authorizer create/delete methods asynchronous

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
@@ -20,7 +20,8 @@ package org.apache.kafka.server.authorizer;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.acl.AclBinding;
@@ -47,7 +48,18 @@ import org.apache.kafka.common.annotation.InterfaceStability;
  * Authorizer implementation class may optionally implement @{@link org.apache.kafka.common.Reconfigurable}
  * to enable dynamic reconfiguration without restarting the broker.
  * <p>
- * <b>Thread safety:</b> All authorizer operations including authorization and ACL updates must be thread-safe.
+ * <b>Threading model:</b>
+ * <ul>
+ *   <li>All authorizer operations including authorization and ACL updates must be thread-safe.</li>
+ *   <li>ACL update methods are asynchronous. Implementations with low update latency may return a
+ *       completed future using {@link java.util.concurrent.CompletableFuture#completedFuture(Object)}.
+ *       This ensures that the request will be handled synchronously by the caller without using a
+ *       purgatory to wait for the result. If ACL updates require remote communication which may block,
+ *       return a future that is completed asynchronously when the remote operation completes. This enables
+ *       the caller to process other requests on the request threads without blocking.</li>
+ *   <li>Any threads or thread pools used for processing remote operations asynchronously can be started during
+ *       {@link #start(AuthorizerServerInfo)}. These threads must be shutdown during {@link Authorizer#close()}.</li>
+ * </ul>
  * </p>
  */
 @InterfaceStability.Evolving
@@ -60,14 +72,18 @@ public interface Authorizer extends Configurable, Closeable {
      * requests on that listener.
      *
      * @param serverInfo Metadata for the broker including broker id and listener endpoints
-     * @return CompletableFutures for each endpoint that completes when authorizer is ready to
+     * @return CompletionStage for each endpoint that completes when authorizer is ready to
      *         start authorizing requests on that listener.
      */
-    Map<Endpoint, CompletableFuture<Void>> start(AuthorizerServerInfo serverInfo);
+    Map<Endpoint, ? extends CompletionStage<Void>> start(AuthorizerServerInfo serverInfo);
 
     /**
      * Authorizes the specified action. Additional metadata for the action is specified
      * in `requestContext`.
+     * <p>
+     * This is a synchronous API designed for use with locally cached ACLs. Since this method is invoked on the
+     * request thread while processing each request, implementations of this method should avoid time-consuming
+     * remote communication that may block request threads.
      *
      * @param requestContext Request context including request type, security protocol and listener name
      * @param actions Actions being authorized including resource and operation for each action
@@ -77,18 +93,27 @@ public interface Authorizer extends Configurable, Closeable {
 
     /**
      * Creates new ACL bindings.
+     * <p>
+     * This is an asynchronous API that enables the caller to avoid blocking during the update. Implementations of this
+     * API can return completed futures using {@link java.util.concurrent.CompletableFuture#completedFuture(Object)}
+     * to process the update synchronously on the request thread.
      *
      * @param requestContext Request context if the ACL is being created by a broker to handle
      *        a client request to create ACLs. This may be null if ACLs are created directly in ZooKeeper
      *        using AclCommand.
      * @param aclBindings ACL bindings to create
      *
-     * @return Create result for each ACL binding in the same order as in the input list
+     * @return Create result for each ACL binding in the same order as in the input list. Each result
+     *         is returned as a CompletionStage that completes when the result is available.
      */
-    List<AclCreateResult> createAcls(AuthorizableRequestContext requestContext, List<AclBinding> aclBindings);
+    List<? extends CompletionStage<AclCreateResult>> createAcls(AuthorizableRequestContext requestContext, List<AclBinding> aclBindings);
 
     /**
      * Deletes all ACL bindings that match the provided filters.
+     * <p>
+     * This is an asynchronous API that enables the caller to avoid blocking during the update. Implementations of this
+     * API can return completed futures using {@link java.util.concurrent.CompletableFuture#completedFuture(Object)}
+     * to process the update synchronously on the request thread.
      *
      * @param requestContext Request context if the ACL is being deleted by a broker to handle
      *        a client request to delete ACLs. This may be null if ACLs are deleted directly in ZooKeeper
@@ -97,12 +122,17 @@ public interface Authorizer extends Configurable, Closeable {
      *
      * @return Delete result for each filter in the same order as in the input list.
      *         Each result indicates which ACL bindings were actually deleted as well as any
-     *         bindings that matched but could not be deleted.
+     *         bindings that matched but could not be deleted. Each result is returned as a
+     *         CompletionStage that completes when the result is available.
      */
-    List<AclDeleteResult> deleteAcls(AuthorizableRequestContext requestContext, List<AclBindingFilter> aclBindingFilters);
+    List<? extends CompletionStage<AclDeleteResult>> deleteAcls(AuthorizableRequestContext requestContext, List<AclBindingFilter> aclBindingFilters);
 
     /**
      * Returns ACL bindings which match the provided filter.
+     * <p>
+     * This is a synchronous API designed for use with locally cached ACLs. This method is invoked on the request
+     * thread while processing DescribeAcls requests and should avoid time-consuming remote communication that may
+     * block request threads.
      *
      * @return Iterator for ACL bindings, which may be populated lazily.
      */

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -315,7 +315,7 @@ object AclCommand extends Logging {
         for ((resource, acls) <- resourceToAcl) {
           println(s"Adding ACLs for resource `$resource`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
           val aclBindings = acls.map(acl => new AclBinding(resource, acl))
-          authorizer.createAcls(null, aclBindings.toList.asJava).asScala.foreach { result =>
+          authorizer.createAcls(null,aclBindings.toList.asJava).asScala.map(_.toCompletableFuture.get).foreach { result =>
             result.exception.asScala.foreach { exception =>
               println(s"Error while adding ACLs: ${exception.getMessage}")
               println(Utils.stackTrace(exception))
@@ -374,7 +374,7 @@ object AclCommand extends Logging {
         val aclBindingFilters = acls.map(acl => new AclBindingFilter(filter, acl.toFilter)).toList.asJava
         authorizer.deleteAcls(null, aclBindingFilters)
       }
-      result.asScala.foreach { result =>
+      result.asScala.map(_.toCompletableFuture.get).foreach { result =>
         result.exception.asScala.foreach { exception =>
           println(s"Error while removing ACLs: ${exception.getMessage}")
           println(Utils.stackTrace(exception))

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -23,6 +23,7 @@ import kafka.security.authorizer.{AclAuthorizer, AuthorizerUtils}
 import kafka.utils._
 import kafka.zk.ZkVersion
 import org.apache.kafka.common.acl.{AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
+import org.apache.kafka.common.errors.ApiException
 import org.apache.kafka.common.resource.{PatternType, ResourcePatternFilter}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
@@ -125,14 +126,14 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
 
   private def createAcls(bindings: Set[AclBinding]): Unit = {
     aclAuthorizer.maxUpdateRetries = maxUpdateRetries
-    val results = aclAuthorizer.createAcls(null, bindings.toList.asJava).asScala
-    results.foreach { result => result.exception.asScala.foreach(e => throw e) }
+    val results = aclAuthorizer.createAcls(null, bindings.toList.asJava).asScala.map(_.toCompletableFuture.get)
+    results.foreach { result => result.exception.asScala.foreach(throwException) }
   }
 
   private def deleteAcls(filters: Set[AclBindingFilter]): Boolean = {
     aclAuthorizer.maxUpdateRetries = maxUpdateRetries
-    val results = aclAuthorizer.deleteAcls(null, filters.toList.asJava).asScala
-    results.foreach { result => result.exception.asScala.foreach(e => throw e) }
+    val results = aclAuthorizer.deleteAcls(null, filters.toList.asJava).asScala.map(_.toCompletableFuture.get)
+    results.foreach { result => result.exception.asScala.foreach(throwException) }
     results.flatMap(_.aclBindingDeleteResults.asScala).foreach { result => result.exception.asScala.foreach(e => throw e) }
     results.exists(r => r.aclBindingDeleteResults.asScala.exists(d => !d.exception.isPresent))
   }
@@ -145,6 +146,15 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
       result.getOrElseUpdate(resource, mutable.Set()).add(acl)
     }
     result.mapValues(_.toSet).toMap
+  }
+
+  // To retain the same exceptions as in previous versions, throw the underlying exception when the exception
+  // was wrapped by AclAuthorizer in an ApiException
+  private def throwException(e: ApiException): Unit = {
+    if (e.getCause != null)
+      throw e.getCause
+    else
+      throw e
   }
 
   class BaseAuthorizer extends AclAuthorizer {

--- a/core/src/main/scala/kafka/security/authorizer/AuthorizerWrapper.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AuthorizerWrapper.scala
@@ -17,7 +17,7 @@
 
 package kafka.security.authorizer
 
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 import java.{lang, util}
 
 import kafka.network.RequestChannel.Session
@@ -40,7 +40,7 @@ class AuthorizerWrapper(private[kafka] val baseAuthorizer: kafka.security.auth.A
     baseAuthorizer.configure(configs)
   }
 
-  override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, CompletableFuture[Void]] = {
+  override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = {
     serverInfo.endpoints.asScala.map { endpoint =>
       endpoint -> CompletableFuture.completedFuture[Void](null) }.toMap.asJava
   }
@@ -57,7 +57,7 @@ class AuthorizerWrapper(private[kafka] val baseAuthorizer: kafka.security.auth.A
   }
 
   override def createAcls(requestContext: AuthorizableRequestContext,
-                          aclBindings: util.List[AclBinding]): util.List[AclCreateResult] = {
+                          aclBindings: util.List[AclBinding]): util.List[_ <: CompletionStage[AclCreateResult]] = {
     aclBindings.asScala
       .map { aclBinding =>
         AuthorizerUtils.convertToResourceAndAcl(aclBinding.toFilter) match {
@@ -71,11 +71,11 @@ class AuthorizerWrapper(private[kafka] val baseAuthorizer: kafka.security.auth.A
               case e: Throwable => new AclCreateResult(new InvalidRequestException("Failed to create ACL", e))
             }
         }
-      }.toList.asJava
+      }.toList.map(CompletableFuture.completedFuture[AclCreateResult]).asJava
   }
 
   override def deleteAcls(requestContext: AuthorizableRequestContext,
-                          aclBindingFilters: util.List[AclBindingFilter]): util.List[AclDeleteResult] = {
+                          aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = {
     val filters = aclBindingFilters.asScala
     val results = mutable.Map[Int, AclDeleteResult]()
     val toDelete = mutable.Map[Int, ArrayBuffer[(Resource, Acl)]]()
@@ -121,7 +121,7 @@ class AuthorizerWrapper(private[kafka] val baseAuthorizer: kafka.security.auth.A
 
     filters.indices.map { i =>
       results.getOrElse(i, new AclDeleteResult(Seq.empty[AclBindingDeleteResult].asJava))
-    }.asJava
+    }.map(CompletableFuture.completedFuture[AclDeleteResult]).asJava
   }
 
   override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2201,7 +2201,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         val createResults = auth.createAcls(request.context, validBindings.asJava)
 
         val aclCreationResults = aclBindings.map { acl =>
-          val result = errorResults.getOrElse(acl, createResults.get(validBindings.indexOf(acl)))
+          val result = errorResults.getOrElse(acl, createResults.get(validBindings.indexOf(acl)).toCompletableFuture.get)
           new AclCreationResponse(result.exception.asScala.map(ApiError.fromThrowable).getOrElse(ApiError.NONE))
         }
 
@@ -2224,7 +2224,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         def toErrorCode(exception: Optional[ApiException]): ApiError = {
           exception.asScala.map(ApiError.fromThrowable).getOrElse(ApiError.NONE)
         }
-        val filterResponses = results.asScala.map { result =>
+        val filterResponses = results.asScala.map(_.toCompletableFuture.get).map { result =>
           val deletions = result.aclBindingDeleteResults().asScala.toList.map { deletionResult =>
             new AclDeletionResult(toErrorCode(deletionResult.exception), deletionResult.aclBinding)
           }.asJava

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -297,7 +297,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         authorizer.foreach(_.configure(config.originals))
         val authorizerFutures: Map[Endpoint, CompletableFuture[Void]] = authorizer match {
           case Some(authZ) =>
-            authZ.start(brokerInfo.broker.toServerInfo(clusterId, config)).asScala
+            authZ.start(brokerInfo.broker.toServerInfo(clusterId, config)).asScala.mapValues(_.toCompletableFuture).toMap
           case None =>
             brokerInfo.broker.endPoints.map{ ep => (ep.asInstanceOf[Endpoint], CompletableFuture.completedFuture[Void](null)) }.toMap
         }

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -1636,7 +1636,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def removeAllAcls(): Unit = {
     val authorizer = servers.head.dataPlaneRequestProcessor.authorizer.get
     val aclFilter = AclBindingFilter.ANY
-    authorizer.deleteAcls(null, List(aclFilter).asJava).asScala.flatMap { deletion =>
+    authorizer.deleteAcls(null, List(aclFilter).asJava).asScala.map(_.toCompletableFuture.get).flatMap { deletion =>
       deletion.aclBindingDeleteResults().asScala.map(_.aclBinding.pattern).toSet
     }.foreach { resource =>
       TestUtils.waitAndVerifyAcls(Set.empty[AccessControlEntry], authorizer, resource)
@@ -1695,7 +1695,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   private def addAndVerifyAcls(acls: Set[AccessControlEntry], resource: ResourcePattern): Unit = {
     val aclBindings = acls.map { acl => new AclBinding(resource, acl) }
     servers.head.dataPlaneRequestProcessor.authorizer.get
-      .createAcls(null, aclBindings.toList.asJava).asScala.foreach {result =>
+      .createAcls(null, aclBindings.toList.asJava).asScala.map(_.toCompletableFuture.get).foreach {result =>
         result.exception.asScala.foreach { e => throw e }
       }
     val aclFilter = new AclBindingFilter(resource.toFilter, AccessControlEntryFilter.ANY)

--- a/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
@@ -60,7 +60,7 @@ class DescribeAuthorizedOperationsTest extends IntegrationTestHarness with SaslS
         new AclBinding(clusterResource, accessControlEntry(JaasTestUtils.KafkaServerPrincipalUnqualifiedName.toString, ALLOW, CLUSTER_ACTION)),
         new AclBinding(clusterResource, accessControlEntry(JaasTestUtils.KafkaClientPrincipalUnqualifiedName2.toString, ALLOW, ALTER)),
         new AclBinding(topicResource, accessControlEntry(JaasTestUtils.KafkaClientPrincipalUnqualifiedName2.toString, ALLOW, DESCRIBE))).asJava)
-      result.asScala.foreach { result => assertFalse(result.exception.isPresent) }
+      result.asScala.map(_.toCompletableFuture.get).foreach { result => assertFalse(result.exception.isPresent) }
 
     } finally {
       authorizer.close()

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -281,7 +281,7 @@ class DelegationTokenManagerTest extends ZooKeeperTestHarness  {
     assert(tokens.size == 2)
 
     def createAcl(aclBinding: AclBinding): Unit = {
-      val result = aclAuthorizer.createAcls(null, List(aclBinding).asJava).get(0)
+      val result = aclAuthorizer.createAcls(null, List(aclBinding).asJava).get(0).toCompletableFuture.get
       result.exception.asScala.foreach { e => throw e }
     }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -19,7 +19,7 @@ package kafka.server
 
 import java.{lang, util}
 import java.util.Properties
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 import kafka.utils.TestUtils
 import kafka.zk.KafkaZkClient
@@ -332,13 +332,13 @@ class DynamicBrokerConfigTest {
 
     class TestAuthorizer extends Authorizer with Reconfigurable {
       @volatile var superUsers = ""
-      override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = null
-      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, CompletableFuture[Void]] = Map.empty.asJava
-      override def deleteAcls(requestContext: AuthorizableRequestContext, aclBindingFilters: util.List[AclBindingFilter]): util.List[AclDeleteResult] = null
-      override def createAcls(requestContext: AuthorizableRequestContext, aclBindings: util.List[AclBinding]): util.List[AclCreateResult] = null
+      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = Map.empty.asJava
       override def authorize(requestContext: AuthorizableRequestContext, actions: util.List[Action]): util.List[AuthorizationResult] = null
-      override def configure(configs: util.Map[String, _]): Unit = {}
+      override def createAcls(requestContext: AuthorizableRequestContext, aclBindings: util.List[AclBinding]): util.List[_ <: CompletionStage[AclCreateResult]] = null
+      override def deleteAcls(requestContext: AuthorizableRequestContext, aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = null
+      override def acls(filter: AclBindingFilter): lang.Iterable[AclBinding] = null
       override def close(): Unit = {}
+      override def configure(configs: util.Map[String, _]): Unit = {}
       override def reconfigurableConfigs(): util.Set[String] = Set("super.users").asJava
       override def validateReconfiguration(configs: util.Map[String, _]): Unit = {}
       override def reconfigure(configs: util.Map[String, _]): Unit = {


### PR DESCRIPTION
As discussed on the KIP-504 mailing list, createAcls and deleteAcls methods in the new Authorizer API have been made asynchronous. Will submit a separate PR under https://issues.apache.org/jira/browse/KAFKA-8887 to handle these requests asynchronously in KafkaApis using a purgatory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
