### PR TITLE
HOTFIX: fix compile error in 2.2 branch

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -170,7 +170,7 @@ public class RecordCollectorTest {
         try {
             offsets.put(new TopicPartition(topic, 0), 50L);
             fail("Should have thrown UnsupportedOperationException");
-        } catch (final UnsupportedOperationException expected) {}
+        } catch (final UnsupportedOperationException expected) { }
 
         assertThat(collector.offsets().get(topicPartition), equalTo(2L));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -53,7 +53,6 @@ import java.util.concurrent.Future;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -168,7 +167,10 @@ public class RecordCollectorTest {
         final Map<TopicPartition, Long> offsets = collector.offsets();
 
         assertThat(offsets.get(topicPartition), equalTo(2L));
-        assertThrows(UnsupportedOperationException.class, () -> offsets.put(new TopicPartition(topic, 0), 50L));
+        try {
+            offsets.put(new TopicPartition(topic, 0), 50L);
+            fail("Should have thrown UnsupportedOperationException");
+        } catch (final UnsupportedOperationException expected) {}
 
         assertThat(collector.offsets().get(topicPartition), equalTo(2L));
     }


### PR DESCRIPTION
Backport of #7223 broke 2.2 branch -- `assertThrows` is not available in `2.2`. I assume 2.1 and 2.0 are affected, too. Verifying now.

Call for review @rhauch @guozhangwang 