### PR TITLE
KAFKA-8908; Use ApiVersion request for inter-broker requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.protocol;
 
+import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
@@ -53,8 +55,6 @@ import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
-import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
-import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.MetadataRequestData;
@@ -75,10 +75,10 @@ import org.apache.kafka.common.message.StopReplicaRequestData;
 import org.apache.kafka.common.message.StopReplicaResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
-import org.apache.kafka.common.message.UpdateMetadataRequestData;
-import org.apache.kafka.common.message.UpdateMetadataResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
+import org.apache.kafka.common.message.UpdateMetadataRequestData;
+import org.apache.kafka.common.message.UpdateMetadataResponseData;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
@@ -28,8 +28,11 @@ public abstract class AbstractControlRequest extends AbstractRequest {
         protected final int controllerEpoch;
         protected final long brokerEpoch;
 
-        protected Builder(ApiKeys api, short version, int controllerId, int controllerEpoch, long brokerEpoch) {
-            super(api, version);
+        protected Builder(ApiKeys api,
+                          int controllerId,
+                          int controllerEpoch,
+                          long brokerEpoch) {
+            super(api);
             this.controllerId = controllerId;
             this.controllerEpoch = controllerEpoch;
             this.brokerEpoch = brokerEpoch;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -30,8 +30,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
 
     public static abstract class Builder<T extends AbstractRequest> {
         private final ApiKeys apiKey;
-        private final short oldestAllowedVersion;
-        private final short latestAllowedVersion;
+        private short oldestAllowedVersion;
+        private short latestAllowedVersion;
 
         /**
          * Construct a new builder which allows any supported version
@@ -56,6 +56,11 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
             this.latestAllowedVersion = latestAllowedVersion;
         }
 
+        public void requireVersion(short version) {
+            this.oldestAllowedVersion = version;
+            this.latestAllowedVersion = version;
+        }
+
         public ApiKeys apiKey() {
             return apiKey;
         }
@@ -66,6 +71,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
 
         public short latestAllowedVersion() {
             return latestAllowedVersion;
+        }
+
+        protected void ensureSupportedVersion(short version) {
+            if (version < oldestAllowedVersion || version > latestAllowedVersion)
+                throw new UnsupportedVersionException("Version " + version + " is not in the supported " +
+                        "version range [" + oldestAllowedVersion + ", " + latestAllowedVersion + "]");
         }
 
         public T build() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownRequest.java
@@ -30,13 +30,14 @@ public class ControlledShutdownRequest extends AbstractRequest {
 
         private final ControlledShutdownRequestData data;
 
-        public Builder(ControlledShutdownRequestData data, short desiredVersion) {
-            super(ApiKeys.CONTROLLED_SHUTDOWN, desiredVersion);
+        public Builder(ControlledShutdownRequestData data) {
+            super(ApiKeys.CONTROLLED_SHUTDOWN);
             this.data = data;
         }
 
         @Override
         public ControlledShutdownRequest build(short version) {
+            ensureSupportedVersion(version);
             return new ControlledShutdownRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -313,9 +313,12 @@ public class FetchRequest extends AbstractRequest {
                 CONSUMER_REPLICA_ID, maxWait, minBytes, fetchData);
         }
 
-        public static Builder forReplica(short allowedVersion, int replicaId, int maxWait, int minBytes,
+        public static Builder forReplica(int replicaId,
+                                         int maxWait,
+                                         int minBytes,
                                          Map<TopicPartition, PartitionData> fetchData) {
-            return new Builder(allowedVersion, allowedVersion, replicaId, maxWait, minBytes, fetchData);
+            return new Builder(ApiKeys.FETCH.oldestVersion(), ApiKeys.FETCH.latestVersion(),
+                    replicaId, maxWait, minBytes, fetchData);
         }
 
         public Builder(short minVersion, short maxVersion, int replicaId, int maxWait, int minBytes,
@@ -362,6 +365,8 @@ public class FetchRequest extends AbstractRequest {
 
         @Override
         public FetchRequest build(short version) {
+            ensureSupportedVersion(version);
+
             if (version < 3) {
                 maxBytes = DEFAULT_RESPONSE_MAX_BYTES;
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -19,8 +19,8 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrLiveLeader;
-import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrTopicState;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrTopicState;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrPartitionError;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -45,9 +45,12 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
         private final List<LeaderAndIsrPartitionState> partitionStates;
         private final Collection<Node> liveLeaders;
 
-        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch,
-                       List<LeaderAndIsrPartitionState> partitionStates, Collection<Node> liveLeaders) {
-            super(ApiKeys.LEADER_AND_ISR, version, controllerId, controllerEpoch, brokerEpoch);
+        public Builder(int controllerId,
+                       int controllerEpoch,
+                       long brokerEpoch,
+                       List<LeaderAndIsrPartitionState> partitionStates,
+                       Collection<Node> liveLeaders) {
+            super(ApiKeys.LEADER_AND_ISR, controllerId, controllerEpoch, brokerEpoch);
             this.partitionStates = partitionStates;
             this.liveLeaders = liveLeaders;
         }
@@ -73,6 +76,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 data.setUngroupedPartitionStates(partitionStates);
             }
 
+                ensureSupportedVersion(version);
             return new LeaderAndIsrRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -57,6 +57,8 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
 
         @Override
         public LeaderAndIsrRequest build(short version) {
+            ensureSupportedVersion(version);
+
             List<LeaderAndIsrLiveLeader> leaders = liveLeaders.stream().map(n -> new LeaderAndIsrLiveLeader()
                 .setBrokerId(n.id())
                 .setHostName(n.host())
@@ -76,7 +78,6 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 data.setUngroupedPartitionStates(partitionStates);
             }
 
-                ensureSupportedVersion(version);
             return new LeaderAndIsrRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
@@ -137,8 +137,9 @@ public class ListOffsetRequest extends AbstractRequest {
         private final IsolationLevel isolationLevel;
         private Map<TopicPartition, PartitionData> partitionTimestamps = new HashMap<>();
 
-        public static Builder forReplica(short allowedVersion, int replicaId) {
-            return new Builder((short) 0, allowedVersion, replicaId, IsolationLevel.READ_UNCOMMITTED);
+        public static Builder forReplica(int replicaId) {
+            return new Builder(ApiKeys.LIST_OFFSETS.oldestVersion(), ApiKeys.LIST_OFFSETS.latestVersion(),
+                    replicaId, IsolationLevel.READ_UNCOMMITTED);
         }
 
         public static Builder forConsumer(boolean requireTimestamp, IsolationLevel isolationLevel) {
@@ -166,6 +167,7 @@ public class ListOffsetRequest extends AbstractRequest {
 
         @Override
         public ListOffsetRequest build(short version) {
+            ensureSupportedVersion(version);
             return new ListOffsetRequest(replicaId, partitionTimestamps, isolationLevel, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Field;
@@ -122,14 +121,14 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
                     epochsByPartition, CONSUMER_REPLICA_ID);
         }
 
-        public static Builder forFollower(short version, Map<TopicPartition, PartitionData> epochsByPartition, int replicaId) {
-            return new Builder(version, version, epochsByPartition, replicaId);
+        public static Builder forReplica(Map<TopicPartition, PartitionData> epochsByPartition, int replicaId) {
+            return new Builder(ApiKeys.OFFSET_FOR_LEADER_EPOCH.oldestVersion(),
+                    ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion(), epochsByPartition, replicaId);
         }
 
         @Override
         public OffsetsForLeaderEpochRequest build(short version) {
-            if (version < oldestAllowedVersion() || version > latestAllowedVersion())
-                throw new UnsupportedVersionException("Cannot build " + this + " with version " + version);
+            ensureSupportedVersion(version);
             return new OffsetsForLeaderEpochRequest(epochsByPartition, replicaId, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
@@ -43,9 +43,12 @@ public class StopReplicaRequest extends AbstractControlRequest {
         private final boolean deletePartitions;
         private final Collection<TopicPartition> partitions;
 
-        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch, boolean deletePartitions,
+        public Builder(int controllerId,
+                       int controllerEpoch,
+                       long brokerEpoch,
+                       boolean deletePartitions,
                        Collection<TopicPartition> partitions) {
-            super(ApiKeys.STOP_REPLICA, version, controllerId, controllerEpoch, brokerEpoch);
+            super(ApiKeys.STOP_REPLICA, controllerId, controllerEpoch, brokerEpoch);
             this.deletePartitions = deletePartitions;
             this.partitions = partitions;
         }
@@ -74,6 +77,7 @@ public class StopReplicaRequest extends AbstractControlRequest {
                 data.setUngroupedPartitions(requestPartitions);
             }
 
+            ensureSupportedVersion(version);
             return new StopReplicaRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
@@ -54,6 +54,8 @@ public class StopReplicaRequest extends AbstractControlRequest {
         }
 
         public StopReplicaRequest build(short version) {
+            ensureSupportedVersion(version);
+
             StopReplicaRequestData data = new StopReplicaRequestData()
                 .setControllerId(controllerId)
                 .setControllerEpoch(controllerEpoch)
@@ -77,7 +79,6 @@ public class StopReplicaRequest extends AbstractControlRequest {
                 data.setUngroupedPartitions(requestPartitions);
             }
 
-            ensureSupportedVersion(version);
             return new StopReplicaRequest(data, version);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -45,15 +45,20 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         private final List<UpdateMetadataPartitionState> partitionStates;
         private final List<UpdateMetadataBroker> liveBrokers;
 
-        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch,
-                       List<UpdateMetadataPartitionState> partitionStates, List<UpdateMetadataBroker> liveBrokers) {
-            super(ApiKeys.UPDATE_METADATA, version, controllerId, controllerEpoch, brokerEpoch);
+        public Builder(int controllerId,
+                       int controllerEpoch,
+                       long brokerEpoch,
+                       List<UpdateMetadataPartitionState> partitionStates,
+                       List<UpdateMetadataBroker> liveBrokers) {
+            super(ApiKeys.UPDATE_METADATA, controllerId, controllerEpoch, brokerEpoch);
             this.partitionStates = partitionStates;
             this.liveBrokers = liveBrokers;
         }
 
         @Override
         public UpdateMetadataRequest build(short version) {
+            ensureSupportedVersion(version);
+
             if (version < 3) {
                 for (UpdateMetadataBroker broker : liveBrokers) {
                     if (version == 0) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
@@ -146,6 +146,7 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
 
         @Override
         public WriteTxnMarkersRequest build(short version) {
+            ensureSupportedVersion(version);
             return new WriteTxnMarkersRequest(version, markers);
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -44,12 +44,7 @@ import java.util.stream.Collectors;
  * A mock network client for use testing code
  */
 public class MockClient implements KafkaClient {
-    public static final RequestMatcher ALWAYS_TRUE = new RequestMatcher() {
-        @Override
-        public boolean matches(AbstractRequest body) {
-            return true;
-        }
-    };
+    public static final RequestMatcher ALWAYS_TRUE = request -> true;
 
     private static class FutureResponse {
         private final Node node;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ControlledShutdownRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ControlledShutdownRequestTest.java
@@ -31,17 +31,16 @@ public class ControlledShutdownRequestTest {
     @Test
     public void testUnsupportedVersion() {
         ControlledShutdownRequest.Builder builder = new ControlledShutdownRequest.Builder(
-                new ControlledShutdownRequestData().setBrokerId(1),
-                (short) (CONTROLLED_SHUTDOWN.latestVersion() + 1));
-        assertThrows(UnsupportedVersionException.class, builder::build);
+                new ControlledShutdownRequestData().setBrokerId(1));
+        assertThrows(UnsupportedVersionException.class, () -> builder.build((short) (CONTROLLED_SHUTDOWN.latestVersion() + 1)));
     }
 
     @Test
     public void testGetErrorResponse() {
         for (short version = CONTROLLED_SHUTDOWN.oldestVersion(); version < CONTROLLED_SHUTDOWN.latestVersion(); version++) {
             ControlledShutdownRequest.Builder builder = new ControlledShutdownRequest.Builder(
-                    new ControlledShutdownRequestData().setBrokerId(1), version);
-            ControlledShutdownRequest request = builder.build();
+                    new ControlledShutdownRequestData().setBrokerId(1));
+            ControlledShutdownRequest request = builder.build(version);
             ControlledShutdownResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
             assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED, response.error());

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
@@ -49,18 +49,17 @@ public class LeaderAndIsrRequestTest {
 
     @Test
     public void testUnsupportedVersion() {
-        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(
-                (short) (LEADER_AND_ISR.latestVersion() + 1), 0, 0, 0,
+        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(0, 0, 0,
                 Collections.emptyList(), Collections.emptySet());
-        assertThrows(UnsupportedVersionException.class, builder::build);
+        assertThrows(UnsupportedVersionException.class, () -> builder.build((short) (LEADER_AND_ISR.latestVersion() + 1)));
     }
 
     @Test
     public void testGetErrorResponse() {
         for (short version = LEADER_AND_ISR.oldestVersion(); version < LEADER_AND_ISR.latestVersion(); version++) {
-            LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(version, 0, 0, 0,
+            LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(0, 0, 0,
                     Collections.emptyList(), Collections.emptySet());
-            LeaderAndIsrRequest request = builder.build();
+            LeaderAndIsrRequest request = builder.build(version);
             LeaderAndIsrResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
             assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED, response.error());
@@ -116,8 +115,8 @@ public class LeaderAndIsrRequestTest {
                 new Node(0, "host0", 9090),
                 new Node(1, "host1", 9091)
             );
-            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(version, 1, 2, 3, partitionStates,
-                liveNodes).build();
+            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(1, 2, 3, partitionStates,
+                liveNodes).build(version);
 
             List<LeaderAndIsrLiveLeader> liveLeaders = liveNodes.stream().map(n -> new LeaderAndIsrLiveLeader()
                 .setBrokerId(n.id())
@@ -158,7 +157,7 @@ public class LeaderAndIsrRequestTest {
                 .setTopicName(tp.topic())
                 .setPartitionIndex(tp.partition()));
         }
-        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder((short) 2, 0, 0, 0,
+        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(0, 0, 0,
             partitionStates, Collections.emptySet());
 
         LeaderAndIsrRequest v2 = builder.build((short) 2);

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrPartitionError;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.junit.Test;
 
@@ -57,8 +56,8 @@ public class LeaderAndIsrResponseTest {
             .setZkVersion(20)
             .setReplicas(Collections.singletonList(10))
             .setIsNew(false));
-        LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion(),
-                15, 20, 0, partitionStates, Collections.emptySet()).build();
+        LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(15, 20, 0,
+                partitionStates, Collections.emptySet()).build();
         LeaderAndIsrResponse response = request.getErrorResponse(0, Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
         assertEquals(Collections.singletonMap(Errors.CLUSTER_AUTHORIZATION_FAILED, 2), response.errorCounts());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
@@ -45,9 +45,9 @@ public class OffsetsForLeaderEpochRequestTest {
     public void testDefaultReplicaId() {
         for (short version = 0; version < ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion(); version++) {
             int replicaId = 1;
-            OffsetsForLeaderEpochRequest.Builder builder = OffsetsForLeaderEpochRequest.Builder.forFollower(
-                    version, Collections.emptyMap(), replicaId);
-            OffsetsForLeaderEpochRequest request = builder.build();
+            OffsetsForLeaderEpochRequest.Builder builder = OffsetsForLeaderEpochRequest.Builder.forReplica(
+                    Collections.emptyMap(), replicaId);
+            OffsetsForLeaderEpochRequest request = builder.build(version);
             OffsetsForLeaderEpochRequest parsed = (OffsetsForLeaderEpochRequest) AbstractRequest.parseRequest(
                     ApiKeys.OFFSET_FOR_LEADER_EPOCH, version, request.toStruct());
             if (version < 3)

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1244,7 +1244,8 @@ public class RequestResponseTest {
 
     private StopReplicaRequest createStopReplicaRequest(int version, boolean deletePartitions) {
         Set<TopicPartition> partitions = Utils.mkSet(new TopicPartition("test", 0));
-        return new StopReplicaRequest.Builder((short) version, 0, 1, 0, deletePartitions, partitions).build();
+        return new StopReplicaRequest.Builder(0, 1, 0, deletePartitions, partitions)
+                .build((short) version);
     }
 
     private StopReplicaResponse createStopReplicaResponse() {
@@ -1262,18 +1263,14 @@ public class RequestResponseTest {
         ControlledShutdownRequestData data = new ControlledShutdownRequestData()
                 .setBrokerId(10)
                 .setBrokerEpoch(0L);
-        return new ControlledShutdownRequest.Builder(
-                data,
-                ApiKeys.CONTROLLED_SHUTDOWN.latestVersion()).build();
+        return new ControlledShutdownRequest.Builder(data).build();
     }
 
     private ControlledShutdownRequest createControlledShutdownRequest(int version) {
         ControlledShutdownRequestData data = new ControlledShutdownRequestData()
                 .setBrokerId(10)
                 .setBrokerEpoch(0L);
-        return new ControlledShutdownRequest.Builder(
-                data,
-                ApiKeys.CONTROLLED_SHUTDOWN.latestVersion()).build((short) version);
+        return new ControlledShutdownRequest.Builder(data).build((short) version);
     }
 
     private ControlledShutdownResponse createControlledShutdownResponse() {
@@ -1331,7 +1328,8 @@ public class RequestResponseTest {
                 new Node(0, "test0", 1223),
                 new Node(1, "test1", 1223)
         );
-        return new LeaderAndIsrRequest.Builder((short) version, 1, 10, 0, partitionStates, leaders).build();
+        return new LeaderAndIsrRequest.Builder(1, 10, 0, partitionStates, leaders)
+                .build((short) version);
     }
 
     private LeaderAndIsrResponse createLeaderAndIsrResponse() {
@@ -1420,8 +1418,8 @@ public class RequestResponseTest {
                 .setEndpoints(endpoints2)
                 .setRack(rack)
         );
-        return new UpdateMetadataRequest.Builder((short) version, 1, 10, 0, partitionStates,
-            liveBrokers).build();
+        return new UpdateMetadataRequest.Builder(1, 10, 0, partitionStates,
+            liveBrokers).build((short) version);
     }
 
     private UpdateMetadataResponse createUpdateMetadataResponse() {
@@ -1560,7 +1558,7 @@ public class RequestResponseTest {
 
     private OffsetsForLeaderEpochRequest createLeaderEpochRequestForReplica(int version, int replicaId) {
         Map<TopicPartition, OffsetsForLeaderEpochRequest.PartitionData> epochs = createOffsetForLeaderEpochPartitionData();
-        return OffsetsForLeaderEpochRequest.Builder.forFollower((short) version, epochs, replicaId).build();
+        return OffsetsForLeaderEpochRequest.Builder.forReplica(epochs, replicaId).build((short) version);
     }
 
     private OffsetsForLeaderEpochResponse createLeaderEpochResponse() {

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
@@ -36,18 +36,17 @@ public class StopReplicaRequestTest {
 
     @Test
     public void testUnsupportedVersion() {
-        StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(
-                (short) (STOP_REPLICA.latestVersion() + 1),
-                0, 0, 0L, false, Collections.emptyList());
-        assertThrows(UnsupportedVersionException.class, builder::build);
+        StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(0, 0, 0L,
+                false, Collections.emptyList());
+        assertThrows(UnsupportedVersionException.class, () -> builder.build((short) (STOP_REPLICA.latestVersion() + 1)));
     }
 
     @Test
     public void testGetErrorResponse() {
         for (short version = STOP_REPLICA.oldestVersion(); version < STOP_REPLICA.latestVersion(); version++) {
-            StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(version,
-                    0, 0, 0L, false, Collections.emptyList());
-            StopReplicaRequest request = builder.build();
+            StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(0, 0, 0L,
+                    false, Collections.emptyList());
+            StopReplicaRequest request = builder.build(version);
             StopReplicaResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
             assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED, response.error());
@@ -57,7 +56,7 @@ public class StopReplicaRequestTest {
     @Test
     public void testStopReplicaRequestNormalization() {
         Set<TopicPartition> tps = TestUtils.generateRandomTopicPartitions(10, 10);
-        StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder((short) 5, 0, 0, 0, false, tps);
+        StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(0, 0, 0, false, tps);
         assertTrue(MessageTestUtil.messageSize(builder.build((short) 1).data(), (short) 1) <
             MessageTestUtil.messageSize(builder.build((short) 0).data(), (short) 0));
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.StopReplicaResponseData;
 import org.apache.kafka.common.message.StopReplicaResponseData.StopReplicaPartitionError;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class StopReplicaResponseTest {
 
     @Test
     public void testErrorCountsFromGetErrorResponse() {
-        StopReplicaRequest request = new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion(), 15, 20, 0, false,
+        StopReplicaRequest request = new StopReplicaRequest.Builder(15, 20, 0, false,
                 Utils.mkSet(new TopicPartition("foo", 0), new TopicPartition("foo", 1))).build();
         StopReplicaResponse response = request.getErrorResponse(0, Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
         assertEquals(Collections.singletonMap(Errors.CLUSTER_AUTHORIZATION_FAILED, 2), response.errorCounts());

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
@@ -51,18 +51,17 @@ public class UpdateMetadataRequestTest {
 
     @Test
     public void testUnsupportedVersion() {
-        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(
-                (short) (UPDATE_METADATA.latestVersion() + 1), 0, 0, 0,
+        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(0, 0, 0,
                 Collections.emptyList(), Collections.emptyList());
-        assertThrows(UnsupportedVersionException.class, builder::build);
+        assertThrows(UnsupportedVersionException.class, () -> builder.build((short) (UPDATE_METADATA.latestVersion() + 1)));
     }
 
     @Test
     public void testGetErrorResponse() {
         for (short version = UPDATE_METADATA.oldestVersion(); version < UPDATE_METADATA.latestVersion(); version++) {
             UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(
-                    version, 0, 0, 0, Collections.emptyList(), Collections.emptyList());
-            UpdateMetadataRequest request = builder.build();
+                    0, 0, 0, Collections.emptyList(), Collections.emptyList());
+            UpdateMetadataRequest request = builder.build(version);
             UpdateMetadataResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
             assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED, response.error());
@@ -148,8 +147,8 @@ public class UpdateMetadataRequestTest {
                     ))
             );
 
-            UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(version, 1, 2, 3,
-                partitionStates, liveBrokers).build();
+            UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(1, 2, 3,
+                partitionStates, liveBrokers).build(version);
 
             assertEquals(new HashSet<>(partitionStates), iterableToSet(request.partitionStates()));
             assertEquals(liveBrokers, request.liveBrokers());
@@ -200,7 +199,7 @@ public class UpdateMetadataRequestTest {
                 .setTopicName(tp.topic())
                 .setPartitionIndex(tp.partition()));
         }
-        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder((short) 5, 0, 0, 0,
+        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(0, 0, 0,
                 partitionStates, Collections.emptyList());
 
         assertTrue(MessageTestUtil.messageSize(builder.build((short) 5).data(), (short) 5) <

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -129,7 +129,7 @@ object ApiVersion {
   /**
    * Get the minimum inter broker version which supports the ApiVersion API.
    */
-  def minVersionForApiDiscovery: ApiVersion = KAFKA_0_10_0_IV0
+  def minVersionForApiDiscovery: ApiVersion = KAFKA_0_10_0_IV1
 
 }
 

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -125,6 +125,12 @@ object ApiVersion {
       case _ => throw new IllegalArgumentException(s"Invalid message format version $recordVersion")
     }
   }
+
+  /**
+   * Get the minimum inter broker version which supports the ApiVersion API.
+   */
+  def minVersionForApiDiscovery: ApiVersion = KAFKA_0_10_0_IV0
+
 }
 
 sealed trait ApiVersion extends Ordered[ApiVersion] {

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -138,7 +138,8 @@ abstract class InterBrokerSendThread(name: String,
   def wakeup(): Unit = networkClient.wakeup()
 }
 
-case class RequestAndCompletionHandler(destination: Node, request: AbstractRequest.Builder[_ <: AbstractRequest],
+case class RequestAndCompletionHandler(destination: Node,
+                                       request: AbstractRequest.Builder[_ <: AbstractRequest],
                                        handler: RequestCompletionHandler)
 
 private class UnsentRequests {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -34,6 +34,8 @@ import com.yammer.metrics.core.Gauge
 import java.util
 import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue}
 
+import kafka.api.ApiVersion
+
 import collection.JavaConverters._
 import scala.collection.{concurrent, immutable}
 
@@ -81,7 +83,7 @@ object TransactionMarkerChannelManager {
       config.requestTimeoutMs,
       ClientDnsLookup.DEFAULT,
       time,
-      false,
+      config.interBrokerProtocolVersion >= ApiVersion.minVersionForApiDiscovery,
       new ApiVersions,
       logContext
     )

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -28,7 +28,7 @@ import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.server.QuotaFactory.UnboundedQuota
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.requests.EpochEndOffset._
 import org.apache.kafka.common.requests.FetchResponse.PartitionData
@@ -243,7 +243,7 @@ class ReplicaAlterLogDirsThread(name: String,
     } else {
       // Set maxWait and minBytes to 0 because the response should return immediately if
       // the future log has caught up with the current log of the partition
-      val requestBuilder = FetchRequest.Builder.forReplica(ApiKeys.FETCH.latestVersion, replicaId, 0, 0, requestMap).setMaxBytes(maxBytes)
+      val requestBuilder = FetchRequest.Builder.forReplica(replicaId, 0, 0, requestMap).setMaxBytes(maxBytes)
       Some(ReplicaFetch(requestMap, requestBuilder))
     }
 

--- a/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
@@ -18,16 +18,16 @@ package kafka.server
 
 import java.net.SocketTimeoutException
 
+import kafka.api.KAFKA_0_10_0_IV0
 import kafka.cluster.BrokerEndPoint
-import org.apache.kafka.clients._
+import org.apache.kafka.clients.{ApiVersions, ClientResponse, ManualMetadataUpdater, NetworkClient, _}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network._
 import org.apache.kafka.common.requests.AbstractRequest
+import org.apache.kafka.common.requests.AbstractRequest.Builder
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.{LogContext, Time}
-import org.apache.kafka.clients.{ApiVersions, ClientResponse, ManualMetadataUpdater, NetworkClient}
 import org.apache.kafka.common.{Node, Reconfigurable}
-import org.apache.kafka.common.requests.AbstractRequest.Builder
 
 import scala.collection.JavaConverters._
 
@@ -78,6 +78,9 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
       channelBuilder,
       logContext
     )
+
+    val useApiVersionDiscovery = brokerConfig.interBrokerProtocolVersion >= KAFKA_0_10_0_IV0
+
     val networkClient = new NetworkClient(
       selector,
       new ManualMetadataUpdater(),
@@ -90,7 +93,7 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
       brokerConfig.requestTimeoutMs,
       ClientDnsLookup.DEFAULT,
       time,
-      false,
+      useApiVersionDiscovery,
       new ApiVersions,
       logContext
     )

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -27,14 +27,13 @@ import java.util.{Date, Optional, Properties}
 
 import joptsimple.OptionParser
 import kafka.api._
-import kafka.utils.Whitelist
-import kafka.utils._
+import kafka.utils.{Whitelist, _}
 import org.apache.kafka.clients._
 import org.apache.kafka.clients.admin.{Admin, ListTopicsOptions, TopicDescription}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{NetworkReceive, Selectable, Selector}
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.MemoryRecords
 import org.apache.kafka.common.requests.AbstractRequest.Builder
 import org.apache.kafka.common.requests.{AbstractRequest, FetchResponse, ListOffsetRequest, FetchRequest => JFetchRequest}
@@ -401,7 +400,7 @@ private class ReplicaFetcher(name: String, sourceBroker: Node, topicPartitions: 
         0L, fetchSize, Optional.empty()))
 
     val fetchRequestBuilder = JFetchRequest.Builder.
-      forReplica(ApiKeys.FETCH.latestVersion, Request.DebuggingConsumerId, maxWait, minBytes, requestMap)
+      forReplica(Request.DebuggingConsumerId, maxWait, minBytes, requestMap)
 
     debug("Issuing fetch request ")
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -272,8 +272,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   private def createFetchFollowerRequest = {
     val partitionMap = new util.LinkedHashMap[TopicPartition, requests.FetchRequest.PartitionData]
     partitionMap.put(tp, new requests.FetchRequest.PartitionData(0, 0, 100, Optional.of(27)))
-    val version = ApiKeys.FETCH.latestVersion
-    requests.FetchRequest.Builder.forReplica(version, 5000, 100, Int.MaxValue, partitionMap).build()
+    requests.FetchRequest.Builder.forReplica(5000, 100, Int.MaxValue, partitionMap).build()
   }
 
   private def createListOffsetsRequest = {
@@ -317,7 +316,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
         .setSecurityProtocol(securityProtocol.id)
         .setListener(ListenerName.forSecurityProtocol(securityProtocol).value)).asJava)).asJava
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    new requests.UpdateMetadataRequest.Builder(version, brokerId, Int.MaxValue, Long.MaxValue, partitionStates, brokers).build()
+    new requests.UpdateMetadataRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue, partitionStates, brokers)
+      .build(version)
   }
 
   private def createJoinGroupRequest = {
@@ -398,7 +398,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   ).build()
 
   private def leaderAndIsrRequest = {
-    new requests.LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,
+    new requests.LeaderAndIsrRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp.topic)
         .setPartitionIndex(tp.partition)
@@ -409,16 +409,16 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
         .setZkVersion(2)
         .setReplicas(Seq(brokerId).asJava)
         .setIsNew(false)).asJava,
-      Set(new Node(brokerId, "localhost", 0)).asJava).build()
+     Set(new Node(brokerId, "localhost", 0)).asJava)
+      .build()
   }
 
-  private def stopReplicaRequest = new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion, brokerId, Int.MaxValue, Long.MaxValue, true, Set(tp).asJava).build()
+  private def stopReplicaRequest = new StopReplicaRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue, true, Set(tp).asJava).build()
 
   private def controlledShutdownRequest = new ControlledShutdownRequest.Builder(
       new ControlledShutdownRequestData()
         .setBrokerId(brokerId)
-        .setBrokerEpoch(Long.MaxValue),
-      ApiKeys.CONTROLLED_SHUTDOWN.latestVersion).build()
+        .setBrokerEpoch(Long.MaxValue)).build()
 
   private def createTopicsRequest =
     new CreateTopicsRequest.Builder(new CreateTopicsRequestData().setTopics(

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -18,14 +18,14 @@ package kafka.controller
 
 import java.util.Properties
 
-import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_10_2_IV0, KAFKA_0_9_0, KAFKA_1_0_IV0, KAFKA_2_2_IV0, KAFKA_2_4_IV0, KAFKA_2_4_IV1, LeaderAndIsr}
+import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_9_0, LeaderAndIsr}
 import kafka.cluster.{Broker, EndPoint}
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.message.{LeaderAndIsrResponseData, StopReplicaResponseData, UpdateMetadataResponseData}
 import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrPartitionError
 import org.apache.kafka.common.message.StopReplicaResponseData.StopReplicaPartitionError
+import org.apache.kafka.common.message.{LeaderAndIsrResponseData, StopReplicaResponseData, UpdateMetadataResponseData}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{AbstractControlRequest, AbstractResponse, LeaderAndIsrRequest, LeaderAndIsrResponse, StopReplicaRequest, StopReplicaResponse, UpdateMetadataRequest, UpdateMetadataResponse}
@@ -70,7 +70,7 @@ class ControllerChannelManagerTest {
     assertEquals(1, leaderAndIsrRequests.size)
     assertEquals(1, updateMetadataRequests.size)
 
-    val leaderAndIsrRequest = leaderAndIsrRequests.head
+    val leaderAndIsrRequest = leaderAndIsrRequests.head.build()
     assertEquals(controllerId, leaderAndIsrRequest.controllerId)
     assertEquals(controllerEpoch, leaderAndIsrRequest.controllerEpoch)
     assertEquals(partitions.keySet,
@@ -110,7 +110,7 @@ class ControllerChannelManagerTest {
     assertEquals(1, leaderAndIsrRequests.size)
     assertEquals(1, updateMetadataRequests.size)
 
-    val leaderAndIsrRequest = leaderAndIsrRequests.head
+    val leaderAndIsrRequest = leaderAndIsrRequests.head.build()
     val partitionStates = leaderAndIsrRequest.partitionStates.asScala
     assertEquals(Seq(partition), partitionStates.map(p => new TopicPartition(p.topicName, p.partitionIndex)))
     val partitionState = partitionStates.find(p => p.topicName == partition.topic && p.partitionIndex == partition.partition)
@@ -145,29 +145,24 @@ class ControllerChannelManagerTest {
       val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(brokerId)
       assertEquals(1, leaderAndIsrRequests.size)
       assertEquals(1, updateMetadataRequests.size)
-      val leaderAndIsrRequest = leaderAndIsrRequests.head
+      val leaderAndIsrRequest = leaderAndIsrRequests.head.build()
       assertEquals(Seq(partition), leaderAndIsrRequest.partitionStates.asScala.map(p => new TopicPartition(p.topicName, p.partitionIndex)))
     }
   }
 
   @Test
   def testLeaderAndIsrInterBrokerProtocolVersion(): Unit = {
-    testLeaderAndIsrRequestFollowsInterBrokerProtocolVersion(ApiVersion.latestVersion, ApiKeys.LEADER_AND_ISR.latestVersion)
-
     for (apiVersion <- ApiVersion.allVersions) {
-      val leaderAndIsrRequestVersion: Short =
-        if (apiVersion >= KAFKA_2_4_IV1) 4
-        else if (apiVersion >= KAFKA_2_4_IV0) 3
-        else if (apiVersion >= KAFKA_2_2_IV0) 2
-        else if (apiVersion >= KAFKA_1_0_IV0) 1
-        else 0
+      val leaderAndIsrRequestVersion: Option[Short] =
+        if (apiVersion >= KAFKA_0_10_0_IV1) None
+        else Some(0)
 
       testLeaderAndIsrRequestFollowsInterBrokerProtocolVersion(apiVersion, leaderAndIsrRequestVersion)
     }
   }
 
   private def testLeaderAndIsrRequestFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                                       expectedLeaderAndIsrVersion: Short): Unit = {
+                                                                       expectedVersion: Option[Short]): Unit = {
     val context = initContext(Seq(1, 2, 3), Set("foo", "bar"), 2, 3)
     val config = createConfig(interBrokerProtocolVersion)
     val batch = new MockControllerBrokerRequestBatch(context, config)
@@ -182,10 +177,12 @@ class ControllerChannelManagerTest {
     batch.addLeaderAndIsrRequestForBrokers(Seq(2), partition, leaderIsrAndControllerEpoch, replicaAssignment(Seq(1, 2, 3)), isNew = false)
     batch.sendRequestsToBrokers(controllerEpoch)
 
-    val leaderAndIsrRequests = batch.collectLeaderAndIsrRequestsFor(2)
-    assertEquals(1, leaderAndIsrRequests.size)
-    assertEquals(s"IBP $interBrokerProtocolVersion should use version $expectedLeaderAndIsrVersion",
-      expectedLeaderAndIsrVersion, leaderAndIsrRequests.head.version)
+    val requests = batch.collectLeaderAndIsrRequestsFor(2)
+    assertEquals(1, requests.size)
+
+    requests.foreach { req =>
+      assertExpectedVersions(req, ApiKeys.LEADER_AND_ISR, interBrokerProtocolVersion, expectedVersion)
+    }
   }
 
   @Test
@@ -207,7 +204,7 @@ class ControllerChannelManagerTest {
     batch.addUpdateMetadataRequestForBrokers(Seq(2), partitions.keySet)
     batch.sendRequestsToBrokers(controllerEpoch)
 
-    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2)
+    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2).map(_.build())
     assertEquals(1, updateMetadataRequests.size)
 
     val updateMetadataRequest = updateMetadataRequests.head
@@ -250,7 +247,7 @@ class ControllerChannelManagerTest {
     assertEquals(1, batch.sentRequests.size)
     assertTrue(batch.sentRequests.contains(2))
 
-    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2)
+    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2).map(_.build())
     assertEquals(1, updateMetadataRequests.size)
 
     val updateMetadataRequest = updateMetadataRequests.head
@@ -280,7 +277,7 @@ class ControllerChannelManagerTest {
     batch.addUpdateMetadataRequestForBrokers(Seq(2), partitions.keySet)
     batch.sendRequestsToBrokers(controllerEpoch)
 
-    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2)
+    val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(2).map(_.build())
     assertEquals(1, updateMetadataRequests.size)
 
     val updateMetadataRequest = updateMetadataRequests.head
@@ -317,7 +314,7 @@ class ControllerChannelManagerTest {
     assertEquals(Set(1, 2), batch.sentRequests.keySet)
 
     for (brokerId <- Set(1, 2)) {
-      val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(brokerId)
+      val updateMetadataRequests = batch.collectUpdateMetadataRequestsFor(brokerId).map(_.build())
       assertEquals(1, updateMetadataRequests.size)
 
       val updateMetadataRequest = updateMetadataRequests.head
@@ -329,24 +326,18 @@ class ControllerChannelManagerTest {
 
   @Test
   def testUpdateMetadataInterBrokerProtocolVersion(): Unit = {
-    testUpdateMetadataFollowsInterBrokerProtocolVersion(ApiVersion.latestVersion, ApiKeys.UPDATE_METADATA.latestVersion)
-
     for (apiVersion <- ApiVersion.allVersions) {
-      val updateMetadataRequestVersion: Short =
-        if (apiVersion >= KAFKA_2_4_IV1) 6
-        else if (apiVersion >= KAFKA_2_2_IV0) 5
-        else if (apiVersion >= KAFKA_1_0_IV0) 4
-        else if (apiVersion >= KAFKA_0_10_2_IV0) 3
-        else if (apiVersion >= KAFKA_0_10_0_IV1) 2
-        else if (apiVersion >= KAFKA_0_9_0) 1
-        else 0
+      val updateMetadataRequestVersion: Option[Short] =
+        if (apiVersion >= KAFKA_0_10_0_IV1) None
+        else if (apiVersion >= KAFKA_0_9_0) Some(1)
+        else Some(0)
 
       testUpdateMetadataFollowsInterBrokerProtocolVersion(apiVersion, updateMetadataRequestVersion)
     }
   }
 
   private def testUpdateMetadataFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                          expectedUpdateMetadataVersion: Short): Unit = {
+                                                                  expectedVersion: Option[Short]): Unit = {
     val context = initContext(Seq(1, 2, 3), Set("foo", "bar"), 2, 3)
     val config = createConfig(interBrokerProtocolVersion)
     val batch = new MockControllerBrokerRequestBatch(context, config)
@@ -360,10 +351,11 @@ class ControllerChannelManagerTest {
     assertTrue(batch.sentRequests.contains(2))
 
     val requests = batch.collectUpdateMetadataRequestsFor(2)
-    val allVersions = requests.map(_.version)
-    assertTrue(s"IBP $interBrokerProtocolVersion should use version $expectedUpdateMetadataVersion, " +
-      s"but found versions $allVersions",
-      allVersions.forall(_ == expectedUpdateMetadataVersion))
+    assertEquals(1, requests.size)
+
+    requests.foreach { req =>
+      assertExpectedVersions(req, ApiKeys.UPDATE_METADATA, interBrokerProtocolVersion, expectedVersion)
+    }
   }
 
   @Test
@@ -393,7 +385,7 @@ class ControllerChannelManagerTest {
     val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2)
     assertEquals(1, sentStopReplicaRequests.size)
 
-    val stopReplicaRequest = sentStopReplicaRequests.head
+    val stopReplicaRequest = sentStopReplicaRequests.head.build()
     assertFalse(stopReplicaRequest.deletePartitions())
     assertEquals(partitions, stopReplicaRequest.partitions.asScala.toSet)
 
@@ -428,7 +420,7 @@ class ControllerChannelManagerTest {
     val sentRequests = batch.sentRequests(2)
     assertEquals(1, sentRequests.size)
 
-    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2)
+    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2).map(_.build())
     assertEquals(1, sentStopReplicaRequests.size)
     assertEquals(partitions, sentStopReplicaRequests.flatMap(_.partitions.asScala).toSet)
     assertTrue(sentStopReplicaRequests.forall(_.deletePartitions))
@@ -465,7 +457,7 @@ class ControllerChannelManagerTest {
     val sentRequests = batch.sentRequests(2)
     assertEquals(1, sentRequests.size)
 
-    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2)
+    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2).map(_.build())
     assertEquals(1, sentStopReplicaRequests.size)
     assertEquals(partitions, sentStopReplicaRequests.flatMap(_.partitions.asScala).toSet)
     assertTrue(sentStopReplicaRequests.forall(_.deletePartitions()))
@@ -514,7 +506,7 @@ class ControllerChannelManagerTest {
     val sentRequests = batch.sentRequests(2)
     assertEquals(2, sentRequests.size)
 
-    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2)
+    val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2).map(_.build())
     assertEquals(2, sentStopReplicaRequests.size)
 
     val (deleteRequests, nonDeleteRequests) = sentStopReplicaRequests.partition(_.deletePartitions())
@@ -550,7 +542,7 @@ class ControllerChannelManagerTest {
     assertEquals(1, sentRequests.size)
 
     for (brokerId <- Set(2, 3)) {
-      val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(brokerId)
+      val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(brokerId).map(_.build())
       assertEquals(1, sentStopReplicaRequests.size)
 
       val stopReplicaRequest = sentStopReplicaRequests.head
@@ -593,27 +585,23 @@ class ControllerChannelManagerTest {
     val sentStopReplicaRequests = batch.collectStopReplicaRequestsFor(2)
     assertEquals(1, sentStopReplicaRequests.size)
 
-    val stopReplicaRequest = sentStopReplicaRequests.head
+    val stopReplicaRequest = sentStopReplicaRequests.head.build()
     assertFalse(stopReplicaRequest.deletePartitions())
     assertEquals(partitions, stopReplicaRequest.partitions.asScala.toSet)
   }
 
   @Test
   def testStopReplicaInterBrokerProtocolVersion(): Unit = {
-    testStopReplicaFollowsInterBrokerProtocolVersion(ApiVersion.latestVersion, ApiKeys.STOP_REPLICA.latestVersion)
-
     for (apiVersion <- ApiVersion.allVersions) {
-      if (apiVersion < KAFKA_2_2_IV0)
-        testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 0.toShort)
-      else if (apiVersion < KAFKA_2_4_IV1)
-        testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 1.toShort)
-      else
-        testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 2.toShort)
+      val expectedVersion: Option[Short] =
+        if (apiVersion >= KAFKA_0_10_0_IV1) None
+        else Some(0)
+      testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, expectedVersion)
     }
   }
 
   private def testStopReplicaFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                               expectedStopReplicaRequestVersion: Short): Unit = {
+                                                               expectedVersion: Option[Short]): Unit = {
     val context = initContext(Seq(1, 2, 3), Set("foo"), 2, 3)
     val config = createConfig(interBrokerProtocolVersion)
     val batch = new MockControllerBrokerRequestBatch(context, config)
@@ -629,10 +617,11 @@ class ControllerChannelManagerTest {
     assertTrue(batch.sentRequests.contains(2))
 
     val requests = batch.collectStopReplicaRequestsFor(2)
-    val allVersions = requests.map(_.version)
-    assertTrue(s"IBP $interBrokerProtocolVersion should use version $expectedStopReplicaRequestVersion, " +
-      s"but found versions $allVersions",
-      allVersions.forall(_ == expectedStopReplicaRequestVersion))
+    assertEquals(1, requests.size)
+
+    requests.foreach { req =>
+      assertExpectedVersions(req, ApiKeys.STOP_REPLICA, interBrokerProtocolVersion, expectedVersion)
+    }
   }
 
   private def applyStopReplicaResponseCallbacks(error: Errors, sentRequests: List[SentRequest]): Unit = {
@@ -715,6 +704,20 @@ class ControllerChannelManagerTest {
     context
   }
 
+  private def assertExpectedVersions(req: ControlRequest,
+                                     apiKey: ApiKeys,
+                                     interBrokerProtocolVersion: ApiVersion,
+                                     expectedUpdateMetadataVersion: Option[Short]): Unit = {
+    val (expectedMinVersion, expectedLatestVersion) = expectedUpdateMetadataVersion match {
+      case Some(version) => (version, version)
+      case None => (apiKey.oldestVersion, apiKey.latestVersion)
+    }
+    assertEquals(s"Unexpected oldest version for $interBrokerProtocolVersion",
+      expectedMinVersion, req.oldestAllowedVersion)
+    assertEquals(s"Unexpected latest version for $interBrokerProtocolVersion",
+      expectedLatestVersion, req.latestAllowedVersion)
+  }
+
   private case class SentRequest(request: ControlRequest, responseCallback: AbstractResponse => Unit)
 
   private class MockControllerBrokerRequestBatch(context: ControllerContext, config: KafkaConfig = config)
@@ -731,30 +734,30 @@ class ControllerChannelManagerTest {
       sentRequests(brokerId).append(SentRequest(request, callback))
     }
 
-    def collectStopReplicaRequestsFor(brokerId: Int): List[StopReplicaRequest] = {
+    def collectStopReplicaRequestsFor(brokerId: Int): List[StopReplicaRequest.Builder] = {
       sentRequests.get(brokerId) match {
         case Some(requests) => requests
           .filter(_.request.apiKey == ApiKeys.STOP_REPLICA)
-          .map(_.request.build().asInstanceOf[StopReplicaRequest]).toList
-        case None => List.empty[StopReplicaRequest]
+          .map(_.request.asInstanceOf[StopReplicaRequest.Builder]).toList
+        case None => List.empty[StopReplicaRequest.Builder]
       }
     }
 
-    def collectUpdateMetadataRequestsFor(brokerId: Int): List[UpdateMetadataRequest] = {
+    def collectUpdateMetadataRequestsFor(brokerId: Int): List[UpdateMetadataRequest.Builder] = {
       sentRequests.get(brokerId) match {
         case Some(requests) => requests
           .filter(_.request.apiKey == ApiKeys.UPDATE_METADATA)
-          .map(_.request.build().asInstanceOf[UpdateMetadataRequest]).toList
-        case None => List.empty[UpdateMetadataRequest]
+          .map(_.request.asInstanceOf[UpdateMetadataRequest.Builder]).toList
+        case None => List.empty[UpdateMetadataRequest.Builder]
       }
     }
 
-    def collectLeaderAndIsrRequestsFor(brokerId: Int): List[LeaderAndIsrRequest] = {
+    def collectLeaderAndIsrRequestsFor(brokerId: Int): List[LeaderAndIsrRequest.Builder] = {
       sentRequests.get(brokerId) match {
         case Some(requests) => requests
           .filter(_.request.apiKey == ApiKeys.LEADER_AND_ISR)
-          .map(_.request.build().asInstanceOf[LeaderAndIsrRequest]).toList
-        case None => List.empty[LeaderAndIsrRequest]
+          .map(_.request.asInstanceOf[LeaderAndIsrRequest.Builder]).toList
+        case None => List.empty[LeaderAndIsrRequest.Builder]
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -104,14 +104,18 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
         dataPlaneMetricMap.put(kafkaMetric.metricName().name(), kafkaMetric)
       }
     }
-    assertEquals(1e-0, controlPlaneMetricMap("response-total").metricValue().asInstanceOf[Double], 0)
-    assertEquals(0e-0, dataPlaneMetricMap("response-total").metricValue().asInstanceOf[Double], 0)
-    assertEquals(1e-0, controlPlaneMetricMap("request-total").metricValue().asInstanceOf[Double], 0)
-    assertEquals(0e-0, dataPlaneMetricMap("request-total").metricValue().asInstanceOf[Double], 0)
+
+    // On the control plane listener, we expect to receive the initial ApiVersions and UpdateMetadata
+    assertEquals(2.0, controlPlaneMetricMap("response-total").metricValue().asInstanceOf[Double], 0)
+    assertEquals(2.0, controlPlaneMetricMap("request-total").metricValue().asInstanceOf[Double], 0)
     assertTrue(controlPlaneMetricMap("incoming-byte-total").metricValue().asInstanceOf[Double] > 1.0)
-    assertTrue(dataPlaneMetricMap("incoming-byte-total").metricValue().asInstanceOf[Double] == 0.0)
-    assertTrue(controlPlaneMetricMap("network-io-total").metricValue().asInstanceOf[Double] == 2.0)
-    assertTrue(dataPlaneMetricMap("network-io-total").metricValue().asInstanceOf[Double] == 0.0)
+    assertEquals(4.0, controlPlaneMetricMap("network-io-total").metricValue().asInstanceOf[Double], 0)
+
+    // On the data plane listener, we do not expect any requests
+    assertEquals(0.0, dataPlaneMetricMap("response-total").metricValue().asInstanceOf[Double], 0)
+    assertEquals(0.0, dataPlaneMetricMap("request-total").metricValue().asInstanceOf[Double], 0)
+    assertEquals(0.0, dataPlaneMetricMap("incoming-byte-total").metricValue().asInstanceOf[Double], 0)
+    assertEquals(0.0, dataPlaneMetricMap("network-io-total").metricValue().asInstanceOf[Double], 0)
   }
 
   // This test case is used to ensure that there will be no correctness issue after we avoid sending out full

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -71,7 +71,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     waitUntilControllerEpoch(firstControllerEpoch, "broker failed to set controller epoch")
     servers.head.shutdown()
     servers.head.awaitShutdown()
-    TestUtils.waitUntilTrue(() => !zkClient.getControllerId.isDefined, "failed to kill controller")
+    TestUtils.waitUntilTrue(() => zkClient.getControllerId.isEmpty, "failed to kill controller")
     waitUntilControllerEpoch(firstControllerEpoch, "controller epoch was not persisted after broker failure")
   }
 
@@ -122,7 +122,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilBrokerMetadataIsPropagated(servers)
     val controllerId = TestUtils.waitUntilControllerElected(zkClient)
     // Need to make sure the broker we shutdown and startup are not the controller. Otherwise we will send out
-    // full UpdateMetadataReuqest to all brokers during controller failover.
+    // full UpdateMetadataRequest to all brokers during controller failover.
     val testBroker = servers.filter(e => e.config.brokerId != controllerId).head
     val remainingBrokers = servers.filter(_.config.brokerId != testBroker.config.brokerId)
     val topic = "topic1"

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -31,7 +31,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{FencedLeaderEpochException, UnknownLeaderEpochException}
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.{EpochEndOffset, FetchRequest}
 import org.apache.kafka.common.utils.Time
@@ -916,7 +916,7 @@ class AbstractFetcherThreadTest {
             1024 * 1024, Optional.of[Integer](state.currentLeaderEpoch)))
         }
       }
-      val fetchRequest = FetchRequest.Builder.forReplica(ApiKeys.FETCH.latestVersion, replicaId, 0, 1, fetchData.asJava)
+      val fetchRequest = FetchRequest.Builder.forReplica(replicaId, 0, 1, fetchData.asJava)
       ResultWithPartitions(Some(ReplicaFetch(fetchData.asJava, fetchRequest)), Set.empty)
     }
 

--- a/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrParti
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Time
@@ -145,9 +145,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
             .setReplicas(Seq(0, 1).map(Integer.valueOf).asJava)
             .setIsNew(false)
         )
-        val requestBuilder = new LeaderAndIsrRequest.Builder(
-          ApiKeys.LEADER_AND_ISR.latestVersion, controllerId, controllerEpoch,
-          epochInRequest,
+        val requestBuilder = new LeaderAndIsrRequest.Builder(controllerId, controllerEpoch, epochInRequest,
           partitionStates.asJava, nodes.toSet.asJava)
 
         if (isEpochInRequestStale) {
@@ -186,7 +184,8 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
             .setRack(broker.rack.orNull)
         }.toBuffer
         val requestBuilder = new UpdateMetadataRequest.Builder(
-          ApiKeys.UPDATE_METADATA.latestVersion, controllerId, controllerEpoch,
+          controllerId,
+          controllerEpoch,
           epochInRequest,
           partitionStates.asJava, liveBrokers.asJava)
 
@@ -203,8 +202,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
 
       // Send StopReplica request with correct broker epoch
       {
-        val requestBuilder = new StopReplicaRequest.Builder(
-          ApiKeys.STOP_REPLICA.latestVersion, controllerId, controllerEpoch,
+        val requestBuilder = new StopReplicaRequest.Builder(controllerId, controllerEpoch,
           epochInRequest, // Correct broker epoch
           true, Set(tp).asJava)
 

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -155,8 +155,8 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
     val leaderId = conversionDisabledTopicsMap.head._2
 
     allTopicPartitions.foreach(tp => producer.send(new ProducerRecord(tp.topic(), "key", "value")).get())
-    val fetchRequest = FetchRequest.Builder.forReplica(1, 1, Int.MaxValue, 0,
-      createPartitionMap(1024, allTopicPartitions)).build()
+    val fetchRequest = FetchRequest.Builder.forReplica(1, Int.MaxValue, 0,
+      createPartitionMap(1024, allTopicPartitions)).build(1)
     val fetchResponse = sendFetchRequest(leaderId, fetchRequest)
 
     allTopicPartitions.foreach(tp => assertEquals(Errors.NONE, fetchResponse.responseData().get(tp).error))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -948,8 +948,8 @@ class KafkaApisTest {
             .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
             .setListener(plaintextListener.value)).asJava)
     )
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
-      0, 0, Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava).build()
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(0, 0, 0,
+      Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava).build()
     metadataCache.updateMetadata(correlationId = 0, updateMetadataRequest)
     (plaintextListener, anotherListener)
   }
@@ -1064,7 +1064,7 @@ class KafkaApisTest {
         .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
         .setListener(plaintextListener.value)).asJava)
     val partitionStates = (0 until numPartitions).map(createPartitionState)
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(0,
       0, 0, partitionStates.asJava, Seq(broker).asJava).build()
     metadataCache.updateMetadata(correlationId = 0, updateMetadataRequest)
   }

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -17,24 +17,24 @@
 
 package kafka.server
 
-import org.apache.kafka.common.TopicPartition
-
-import scala.collection.JavaConverters._
 import kafka.api.LeaderAndIsr
-import org.apache.kafka.common.requests._
-import org.junit.Assert._
-import kafka.utils.TestUtils
 import kafka.cluster.Broker
 import kafka.controller.{ControllerChannelManager, ControllerContext, StateChangeLogger}
+import kafka.utils.TestUtils
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Time
+import org.junit.Assert._
 import org.junit.{After, Before, Test}
+
+import scala.collection.JavaConverters._
 
 class LeaderElectionTest extends ZooKeeperTestHarness {
   val brokerId1 = 0
@@ -153,8 +153,7 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
           .setReplicas(Seq(0, 1).map(Integer.valueOf).asJava)
           .setIsNew(false)
       )
-      val requestBuilder = new LeaderAndIsrRequest.Builder(
-        ApiKeys.LEADER_AND_ISR.latestVersion, controllerId, staleControllerEpoch,
+      val requestBuilder = new LeaderAndIsrRequest.Builder(controllerId, staleControllerEpoch,
         servers(brokerId2).kafkaController.brokerEpoch, partitionStates.asJava, nodes.toSet.asJava)
 
       controllerChannelManager.sendRequest(brokerId2, requestBuilder, staleControllerEpochCallback)

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -42,12 +42,12 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       .build()
 
     val replicaRequest = ListOffsetRequest.Builder
-      .forReplica(ApiKeys.LIST_OFFSETS.latestVersion, servers.head.config.brokerId)
+      .forReplica(servers.head.config.brokerId)
       .setTargetTimes(targetTimes)
       .build()
 
     val debugReplicaRequest = ListOffsetRequest.Builder
-      .forReplica(ApiKeys.LIST_OFFSETS.latestVersion, ListOffsetRequest.DEBUGGING_REPLICA_ID)
+      .forReplica(ListOffsetRequest.DEBUGGING_REPLICA_ID)
       .setTargetTimes(targetTimes)
       .build()
 

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -86,9 +86,10 @@ class LogOffsetTest extends BaseRequestTest {
 
     TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, server),
       "Leader should be elected")
-    val request = ListOffsetRequest.Builder.forReplica(0, 0)
+    val request = ListOffsetRequest.Builder.forReplica(0)
       .setTargetTimes(Map(topicPartition ->
-        new ListOffsetRequest.PartitionData(ListOffsetRequest.LATEST_TIMESTAMP, 15)).asJava).build()
+        new ListOffsetRequest.PartitionData(ListOffsetRequest.LATEST_TIMESTAMP, 15)).asJava)
+      .build(0)
     val consumerOffsets = sendListOffsetsRequest(request).responseData.get(topicPartition).offsets.asScala
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 3L), consumerOffsets)
   }
@@ -114,9 +115,10 @@ class LogOffsetTest extends BaseRequestTest {
 
     TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, server),
       "Leader should be elected")
-    val request = ListOffsetRequest.Builder.forReplica(0, 0)
+    val request = ListOffsetRequest.Builder.forReplica(0)
       .setTargetTimes(Map(topicPartition ->
-        new ListOffsetRequest.PartitionData(ListOffsetRequest.LATEST_TIMESTAMP, 15)).asJava).build()
+        new ListOffsetRequest.PartitionData(ListOffsetRequest.LATEST_TIMESTAMP, 15)).asJava)
+      .build(0)
     val consumerOffsets = sendListOffsetsRequest(request).responseData.get(topicPartition).offsets.asScala
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), consumerOffsets)
 
@@ -142,9 +144,10 @@ class LogOffsetTest extends BaseRequestTest {
     var offsetChanged = false
     for (_ <- 1 to 14) {
       val topicPartition = new TopicPartition(topic, 0)
-      val request = ListOffsetRequest.Builder.forReplica(0, 0)
+      val request = ListOffsetRequest.Builder.forReplica(0)
         .setTargetTimes(Map(topicPartition ->
-          new ListOffsetRequest.PartitionData(ListOffsetRequest.EARLIEST_TIMESTAMP, 1)).asJava).build()
+          new ListOffsetRequest.PartitionData(ListOffsetRequest.EARLIEST_TIMESTAMP, 1)).asJava)
+        .build(0)
       val consumerOffsets = sendListOffsetsRequest(request).responseData.get(topicPartition).offsets.asScala
       if (consumerOffsets.head == 1)
         offsetChanged = true
@@ -175,9 +178,10 @@ class LogOffsetTest extends BaseRequestTest {
 
     TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, server),
       "Leader should be elected")
-    val request = ListOffsetRequest.Builder.forReplica(0, 0)
+    val request = ListOffsetRequest.Builder.forReplica(0)
       .setTargetTimes(Map(topicPartition ->
-        new ListOffsetRequest.PartitionData(now, 15)).asJava).build()
+        new ListOffsetRequest.PartitionData(now, 15)).asJava)
+      .build(0)
     val consumerOffsets = sendListOffsetsRequest(request).responseData.get(topicPartition).offsets.asScala
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), consumerOffsets)
   }
@@ -203,9 +207,10 @@ class LogOffsetTest extends BaseRequestTest {
 
     TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, server),
       "Leader should be elected")
-    val request = ListOffsetRequest.Builder.forReplica(0, 0)
+    val request = ListOffsetRequest.Builder.forReplica(0)
       .setTargetTimes(Map(topicPartition ->
-        new ListOffsetRequest.PartitionData(ListOffsetRequest.EARLIEST_TIMESTAMP, 10)).asJava).build()
+        new ListOffsetRequest.PartitionData(ListOffsetRequest.EARLIEST_TIMESTAMP, 10)).asJava)
+      .build(0)
     val consumerOffsets = sendListOffsetsRequest(request).responseData.get(topicPartition).offsets.asScala
     assertEquals(Seq(0L), consumerOffsets)
   }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -22,7 +22,7 @@ import util.Arrays.asList
 
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.UpdateMetadataRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Test
@@ -105,8 +105,7 @@ class MetadataCacheTest {
         .setZkVersion(zkVersion)
         .setReplicas(asList(2, 1, 3)))
 
-    val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(controllerId, controllerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava).build()
     cache.updateMetadata(15, updateMetadataRequest)
 
@@ -250,8 +249,7 @@ class MetadataCacheTest {
       .setZkVersion(zkVersion)
       .setReplicas(asList(0)))
 
-    val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(controllerId, controllerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava).build()
     cache.updateMetadata(15, updateMetadataRequest)
 
@@ -308,8 +306,7 @@ class MetadataCacheTest {
         .setZkVersion(zkVersion)
         .setReplicas(replicas))
 
-    val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(controllerId, controllerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava).build()
     cache.updateMetadata(15, updateMetadataRequest)
 
@@ -382,8 +379,7 @@ class MetadataCacheTest {
       .setZkVersion(zkVersion)
       .setReplicas(replicas))
 
-    val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(controllerId, controllerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava).build()
     cache.updateMetadata(15, updateMetadataRequest)
 
@@ -447,8 +443,7 @@ class MetadataCacheTest {
       .setIsr(isr)
       .setZkVersion(3)
       .setReplicas(replicas))
-    val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(2, controllerEpoch, brokerEpoch, partitionStates.asJava,
       brokers.asJava).build()
     cache.updateMetadata(15, updateMetadataRequest)
 
@@ -489,8 +484,7 @@ class MetadataCacheTest {
         .setIsr(isr)
         .setZkVersion(3)
         .setReplicas(replicas))
-      val version = ApiKeys.UPDATE_METADATA.latestVersion
-      val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+      val updateMetadataRequest = new UpdateMetadataRequest.Builder(2, controllerEpoch, brokerEpoch, partitionStates.asJava,
         brokers.asJava).build()
       cache.updateMetadata(15, updateMetadataRequest)
     }

--- a/core/src/test/scala/unit/kafka/server/OffsetsForLeaderEpochRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetsForLeaderEpochRequestTest.scala
@@ -35,8 +35,7 @@ class OffsetsForLeaderEpochRequestTest extends BaseRequestTest {
     val partition = new TopicPartition(topic, 0)
 
     val epochs = Map(partition -> new OffsetsForLeaderEpochRequest.PartitionData(Optional.empty[Integer], 0)).asJava
-    val request = OffsetsForLeaderEpochRequest.Builder.forFollower(
-      ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion, epochs, 1).build()
+    val request = OffsetsForLeaderEpochRequest.Builder.forReplica(epochs, 1).build()
 
     // Unknown topic
     val randomBrokerId = servers.head.config.brokerId
@@ -62,8 +61,7 @@ class OffsetsForLeaderEpochRequestTest extends BaseRequestTest {
     def assertResponseErrorForEpoch(error: Errors, brokerId: Int, currentLeaderEpoch: Optional[Integer]): Unit = {
       val epochs = Map(topicPartition -> new OffsetsForLeaderEpochRequest.PartitionData(
         currentLeaderEpoch, 0)).asJava
-      val request = OffsetsForLeaderEpochRequest.Builder.forFollower(
-        ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion, epochs, 1).build()
+      val request = OffsetsForLeaderEpochRequest.Builder.forReplica(epochs, 1).build()
       assertResponseError(error, brokerId, request)
     }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -35,7 +35,7 @@ import kafka.utils.{MockScheduler, MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
@@ -167,7 +167,7 @@ class ReplicaManagerTest {
       partition.createLogIfNotExists(0, isNew = false, isFutureReplica = false,
         new LazyOffsetCheckpoints(rm.highWatermarkCheckpoints))
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -189,7 +189,7 @@ class ReplicaManagerTest {
       }
 
       // Make this replica the follower
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -222,7 +222,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints))
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -282,7 +282,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints))
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -387,7 +387,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints))
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -462,7 +462,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(rm.highWatermarkCheckpoints))
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -525,7 +525,7 @@ class ReplicaManagerTest {
         .setZkVersion(0)
         .setReplicas(replicas)
         .setIsNew(true)
-      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(leaderAndIsrPartitionState).asJava,
         Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava).build()
       val leaderAndIsrResponse = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest, (_, _) => ())
@@ -618,7 +618,7 @@ class ReplicaManagerTest {
       replicaManager.createPartition(tp1).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val partition1Replicas = Seq[Integer](0, 2).asJava
-      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -736,8 +736,7 @@ class ReplicaManagerTest {
     // Make local partition a follower - because epoch increased by more than 1, truncation should
     // trigger even though leader does not change
     leaderEpoch += leaderEpochIncrement
-    val leaderAndIsrRequest0 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-      controllerId, controllerEpoch, brokerEpoch,
+    val leaderAndIsrRequest0 = new LeaderAndIsrRequest.Builder(, controllerId, controllerEpoch, brokerEpoch,
       Seq(leaderAndIsrPartitionState(tp, leaderEpoch, leaderBrokerId, aliveBrokerIds)).asJava,
       Set(new Node(followerBrokerId, "host1", 0),
         new Node(leaderBrokerId, "host2", 1)).asJava).build()
@@ -809,7 +808,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(new TopicPartition(topic, 0))
 
     // Make this replica the follower
-    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(topic)
         .setPartitionIndex(0)
@@ -858,7 +857,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(new TopicPartition(topic, 0))
 
     // Make this replica the follower
-    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(topic)
         .setPartitionIndex(0)
@@ -925,7 +924,7 @@ class ReplicaManagerTest {
     val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
-    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -965,7 +964,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -985,7 +984,7 @@ class ReplicaManagerTest {
     assertNull(fetchResult.get)
 
     // Become a follower and ensure that the delayed fetch returns immediately
-    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1013,7 +1012,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1034,7 +1033,7 @@ class ReplicaManagerTest {
     assertNull(fetchResult.get)
 
     // Become a follower and ensure that the delayed fetch returns immediately
-    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1061,7 +1060,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1103,7 +1102,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1142,7 +1141,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(0, isNew = false, isFutureReplica = false, offsetCheckpoints)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(0, 0, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1517,8 +1516,7 @@ class ReplicaManagerTest {
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val partition1Replicas = Seq[Integer](1, 0).asJava
 
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(controllerId, 0, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -1547,7 +1545,7 @@ class ReplicaManagerTest {
       rm1.becomeLeaderOrFollower(correlationId, leaderAndIsrRequest1, (_, _) => ())
 
       // make broker 0 the leader of partition 1 so broker 1 loses its leadership position
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, controllerId,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(controllerId,
         controllerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
@@ -1606,8 +1604,7 @@ class ReplicaManagerTest {
       val partition0Replicas = Seq[Integer](1, 0).asJava
       val partition1Replicas = Seq[Integer](1, 0).asJava
 
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(controllerId, 0, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -1636,7 +1633,7 @@ class ReplicaManagerTest {
       rm1.becomeLeaderOrFollower(correlationId, leaderAndIsrRequest1, (_, _) => ())
 
       // make broker 0 the leader of partition 1 so broker 1 loses its leadership position
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, controllerId,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(controllerId,
         controllerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -736,7 +736,7 @@ class ReplicaManagerTest {
     // Make local partition a follower - because epoch increased by more than 1, truncation should
     // trigger even though leader does not change
     leaderEpoch += leaderEpochIncrement
-    val leaderAndIsrRequest0 = new LeaderAndIsrRequest.Builder(, controllerId, controllerEpoch, brokerEpoch,
+    val leaderAndIsrRequest0 = new LeaderAndIsrRequest.Builder(controllerId, controllerEpoch, brokerEpoch,
       Seq(leaderAndIsrPartitionState(tp, leaderEpoch, leaderBrokerId, aliveBrokerIds)).asJava,
       Set(new Node(followerBrokerId, "host1", 0),
         new Node(leaderBrokerId, "host2", 1)).asJava).build()

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -225,7 +225,7 @@ class RequestQuotaTest extends BaseRequestTest {
               0L, Optional.of[Integer](15))).asJava)
 
         case ApiKeys.LEADER_AND_ISR =>
-          new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,
+          new LeaderAndIsrRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue,
             Seq(new LeaderAndIsrPartitionState()
               .setTopicName(tp.topic)
               .setPartitionIndex(tp.partition)
@@ -239,7 +239,7 @@ class RequestQuotaTest extends BaseRequestTest {
             Set(new Node(brokerId, "localhost", 0)).asJava)
 
         case ApiKeys.STOP_REPLICA =>
-          new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion, brokerId, Int.MaxValue, Long.MaxValue, true, Set(tp).asJava)
+          new StopReplicaRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue, true, Set(tp).asJava)
 
         case ApiKeys.UPDATE_METADATA =>
           val partitionState = Seq(new UpdateMetadataPartitionState()
@@ -259,14 +259,13 @@ class RequestQuotaTest extends BaseRequestTest {
               .setPort(0)
               .setSecurityProtocol(securityProtocol.id)
               .setListener(ListenerName.forSecurityProtocol(securityProtocol).value)).asJava)).asJava
-          new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, brokerId, Int.MaxValue, Long.MaxValue, partitionState, brokers)
+          new UpdateMetadataRequest.Builder(brokerId, Int.MaxValue, Long.MaxValue, partitionState, brokers)
 
         case ApiKeys.CONTROLLED_SHUTDOWN =>
           new ControlledShutdownRequest.Builder(
               new ControlledShutdownRequestData()
                 .setBrokerId(brokerId)
-                .setBrokerEpoch(Long.MaxValue),
-              ApiKeys.CONTROLLED_SHUTDOWN.latestVersion)
+                .setBrokerEpoch(Long.MaxValue))
 
         case ApiKeys.OFFSET_COMMIT =>
           new OffsetCommitRequest.Builder(

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.LeaderAndIsrRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
@@ -232,8 +231,8 @@ class ServerShutdownTest extends ZooKeeperTestHarness {
       controllerChannelManager.startup()
 
       // Initiate a sendRequest and wait until connection is established and one byte is received by the peer
-      val requestBuilder = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 1, 0L, Seq.empty.asJava, brokerAndEpochs.keys.map(_.node(listenerName)).toSet.asJava)
+      val requestBuilder = new LeaderAndIsrRequest.Builder(controllerId, 1, 0L,
+        Seq.empty.asJava, brokerAndEpochs.keys.map(_.node(listenerName)).toSet.asJava)
       controllerChannelManager.sendRequest(1, requestBuilder)
       receiveFuture.get(10, TimeUnit.SECONDS)
 

--- a/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
@@ -45,9 +45,9 @@ class StopReplicaRequestTest extends BaseRequestTest {
     server.replicaManager.handleLogDirFailure(offlineDir, sendZkNotification = false)
 
     for (_ <- 1 to 2) {
-      val request1 = new StopReplicaRequest.Builder(1,
+      val request1 = new StopReplicaRequest.Builder(
         server.config.brokerId, server.replicaManager.controllerEpoch, server.kafkaController.brokerEpoch,
-        true, Set(tp0, tp1).asJava).build()
+        true, Set(tp0, tp1).asJava).build(1)
       val response1 = connectAndReceive[StopReplicaResponse](request1, destination = controllerSocketServer)
       val partitionErrors1 = response1.partitionErrors.asScala
       assertEquals(Some(Errors.NONE.code),

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -24,16 +24,15 @@ import kafka.utils.TestUtils._
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors._
 import org.apache.kafka.common.requests.EpochEndOffset._
+import org.apache.kafka.common.requests.{EpochEndOffset, OffsetsForLeaderEpochRequest, OffsetsForLeaderEpochResponse}
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.{LogContext, SystemTime}
-import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.protocol.ApiKeys
 import org.junit.Assert._
 import org.junit.{After, Test}
-import org.apache.kafka.common.requests.{EpochEndOffset, OffsetsForLeaderEpochRequest, OffsetsForLeaderEpochResponse}
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -277,8 +276,7 @@ class LeaderEpochIntegrationTest extends ZooKeeperTestHarness with Logging {
       val partitionData = partitions.mapValues(
         new OffsetsForLeaderEpochRequest.PartitionData(Optional.empty(), _)).toMap
 
-      val request = OffsetsForLeaderEpochRequest.Builder.forFollower(
-        ApiKeys.OFFSET_FOR_LEADER_EPOCH.latestVersion, partitionData.asJava, 1)
+      val request = OffsetsForLeaderEpochRequest.Builder.forReplica(partitionData.asJava, 1)
       val response = sender.sendRequest(request)
       response.responseBody.asInstanceOf[OffsetsForLeaderEpochResponse].responses.asScala
     }


### PR DESCRIPTION
This patch enables the usage of version discovery for inter-broker requests using the ApiVersions API. This is only used when `inter.broker.protocol.version` is high enough to support this. Otherwise, we use the existing static version determination based on `inter.broker.protocol.version`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
