### PR TITLE
MINOR: Update dependencies for Kafka 2.4 (part 2)

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.12.9
+  SCALA_VERSION=2.12.10
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.12.9
+  set SCALA_VERSION=2.12.10
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.4.0-SNAPSHOT
-scalaVersion=2.12.9
+scalaVersion=2.12.10
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
 // Add Scala version
 def defaultScala211Version = '2.11.12'
 def defaultScala212Version = '2.12.10'
-def defaultScala213Version = '2.13.0'
+def defaultScala213Version = '2.13.1'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
     versions["scala"] = defaultScala211Version

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
 // Add Scala version
 def defaultScala211Version = '2.11.12'
-def defaultScala212Version = '2.12.9'
+def defaultScala212Version = '2.12.10'
 def defaultScala213Version = '2.13.0'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
@@ -63,10 +63,10 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.62",
+  bcpkix: "1.63",
   checkstyle: "8.20",
   commonsCli: "1.4",
-  gradle: "5.4.1",
+  gradle: "5.6.2",
   gradleVersionsPlugin: "0.21.0",
   grgit: "3.1.1",
   httpclient: "4.5.9",
@@ -74,7 +74,7 @@ versions += [
   jackson: "2.9.9",
   jacksonDatabind: "2.9.9.3",
   jacoco: "0.8.3",
-  jetty: "9.4.19.v20190610",
+  jetty: "9.4.20.v20190813",
   jersey: "2.28",
   jmh: "1.21",
   hamcrest: "2.1",
@@ -110,13 +110,13 @@ versions += [
   scoverage: "1.4.0",
   scoveragePlugin: "2.5.0",
   shadowPlugin: "4.0.4",
-  slf4j: "1.7.27",
+  slf4j: "1.7.28",
   snappy: "1.1.7.3",
   spotbugs: "3.1.12",
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.1",
   zookeeper: "3.5.5",
-  zstd: "1.4.2-1"
+  zstd: "1.4.3-1"
 ]
 
 libs += [


### PR DESCRIPTION
Upgrade to Gradle 5.6.2 as a step towards Gradle 6.0 (necessary
for Java 13 support).

https://docs.gradle.org/5.5.1/release-notes.html
https://docs.gradle.org/5.6.2/release-notes.html

The other updates are mostly bug fixes:

* Scala 2.13.1: https://github.com/scala/scala/releases/tag/v2.13.1
* Scala 2.12.10: https://github.com/scala/scala/releases/tag/v2.12.10
* Jetty 9.4.20: https://www.eclipse.org/lists/jetty-announce/msg00133.html
* SLF4J 1.7.28: adds Automatic-Module-Name in MANIFEST.MF
* Bouncy castle 1.63: https://www.bouncycastle.org/releasenotes.html
* zstd 1.4.3: https://github.com/facebook/zstd/releases/tag/v1.4.3

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
