### PR TITLE
KAFKA-8107:Flaky Test kafka.api.ClientIdQuotaTest.testQuotaOverrideDe…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -16,7 +16,8 @@ package kafka.api
 
 import java.util.Properties
 
-import kafka.server.{DynamicConfig, KafkaConfig, KafkaServer}
+import kafka.server.{ConfigType, DynamicConfig, KafkaConfig, KafkaServer}
+import kafka.utils.TestUtils
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.Sanitizer
 import org.junit.Before
@@ -59,6 +60,10 @@ class ClientIdQuotaTest extends BaseQuotaTest {
         val emptyProps = new Properties
         updateQuotaOverride(producerClientId, emptyProps)
         updateQuotaOverride(consumerClientId, emptyProps)
+        TestUtils.waitUntilTrue(
+          () => adminZkClient.fetchEntityConfig(ConfigType.Client, Sanitizer.sanitize(producerClientId)).isEmpty &&
+            adminZkClient.fetchEntityConfig(ConfigType.Client, Sanitizer.sanitize(consumerClientId)).isEmpty,
+          s"Quota for either $producerClientId or $consumerClientId was not removed.")
       }
 
       private def updateQuotaOverride(clientId: String, properties: Properties): Unit = {


### PR DESCRIPTION
…lete

https://issues.apache.org/jira/browse/KAFKA-8107

`removeQuotaOverrides` should await some time to ensure entity cnofig takes effect in ZooKeeper.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
