### PR TITLE
MINOR: improve the Kafka RPC code generator

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -118,6 +118,7 @@
     <subpackage name="protocol">
       <allow pkg="org.apache.kafka.common.errors" />
       <allow pkg="org.apache.kafka.common.message" />
+      <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
       <allow pkg="org.apache.kafka.common.record" />
       <allow pkg="org.apache.kafka.common.requests" />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -8,6 +8,14 @@
 
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
+    <!-- Generator -->
+    <suppress checks="CyclomaticComplexity|BooleanExpressionComplexity"
+              files="(SchemaGenerator|MessageDataGenerator).java"/>
+    <suppress checks="NPathComplexity"
+              files="(FieldSpec).java"/>
+    <suppress checks="JavaNCSS"
+              files="(ApiMessageType).java"/>
+
     <!-- Clients -->
     <suppress checks="ClassFanOutComplexity"
               files="(Fetcher|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin).java"/>
@@ -49,7 +57,7 @@
               files="(Utils|Topic|KafkaLZ4BlockOutputStream|AclData|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|SchemaGenerator|AbstractCoordinator).java"/>
+              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator).java"/>
 
     <suppress checks="JavaNCSS"
               files="AbstractRequest.java|KerberosLogin.java|WorkerSinkTaskTest.java|TransactionManagerTest.java|SenderTest.java|KafkaAdminClient.java"/>
@@ -59,6 +67,12 @@
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>
+
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|MethodLength|JavaNCSS)"
+            files="clients[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+
+    <suppress checks="NPathComplexity"
+            files="MessageTest.java"/>
 
     <!-- clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
@@ -232,12 +246,5 @@
               files="KafkaLog4jAppender.java"/>
     <suppress checks="JavaNCSS"
               files="RequestResponseTest.java"/>
-
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling)"
-            files="clients[\\/]src[\\/]generated[\\/].+.java$"/>
-    <suppress checks="NPathComplexity"
-            files="MessageTest.java"/>
-
-    <suppress checks="CyclomaticComplexity" files="MessageDataGenerator.java"/>
 
 </suppressions>

--- a/generator/src/main/java/org/apache/kafka/message/ClauseGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/ClauseGenerator.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+/**
+ * Generates a clause.
+ */
+public interface ClauseGenerator {
+    void generate(Versions versions);
+}

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -42,11 +42,6 @@ public interface FieldType {
         private static final String NAME = "int8";
 
         @Override
-        public boolean isInteger() {
-            return true;
-        }
-
-        @Override
         public Optional<Integer> fixedLength() {
             return Optional.of(1);
         }
@@ -60,11 +55,6 @@ public interface FieldType {
     final class Int16FieldType implements FieldType {
         static final Int16FieldType INSTANCE = new Int16FieldType();
         private static final String NAME = "int16";
-
-        @Override
-        public boolean isInteger() {
-            return true;
-        }
 
         @Override
         public Optional<Integer> fixedLength() {
@@ -82,11 +72,6 @@ public interface FieldType {
         private static final String NAME = "int32";
 
         @Override
-        public boolean isInteger() {
-            return true;
-        }
-
-        @Override
         public Optional<Integer> fixedLength() {
             return Optional.of(4);
         }
@@ -100,11 +85,6 @@ public interface FieldType {
     final class Int64FieldType implements FieldType {
         static final Int64FieldType INSTANCE = new Int64FieldType();
         private static final String NAME = "int64";
-
-        @Override
-        public boolean isInteger() {
-            return true;
-        }
 
         @Override
         public Optional<Integer> fixedLength() {
@@ -137,6 +117,11 @@ public interface FieldType {
         private static final String NAME = "string";
 
         @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
         public boolean isString() {
             return true;
         }
@@ -155,6 +140,11 @@ public interface FieldType {
     final class BytesFieldType implements FieldType {
         static final BytesFieldType INSTANCE = new BytesFieldType();
         private static final String NAME = "bytes";
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
 
         @Override
         public boolean isBytes() {
@@ -180,6 +170,11 @@ public interface FieldType {
         }
 
         @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
         public boolean isStruct() {
             return true;
         }
@@ -195,6 +190,11 @@ public interface FieldType {
 
         ArrayType(FieldType elementType) {
             this.elementType = elementType;
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
         }
 
         @Override
@@ -266,10 +266,6 @@ public interface FieldType {
         }
     }
 
-    default boolean isInteger() {
-        return false;
-    }
-
     /**
      * Returns true if this is an array type.
      */
@@ -281,6 +277,13 @@ public interface FieldType {
      * Returns true if this is an array of structures.
      */
     default boolean isStructArray() {
+        return false;
+    }
+
+    /**
+     * Returns true if the serialization of this type is different in flexible versions.
+     */
+    default boolean serializationIsDifferentInFlexibleVersions() {
         return false;
     }
 
@@ -317,6 +320,10 @@ public interface FieldType {
      */
     default Optional<Integer> fixedLength() {
         return Optional.empty();
+    }
+
+    default boolean isVariableLength() {
+        return !fixedLength().isPresent();
     }
 
     /**

--- a/generator/src/main/java/org/apache/kafka/message/HeaderGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/HeaderGenerator.java
@@ -52,14 +52,21 @@ public final class HeaderGenerator {
     private final TreeSet<String> imports;
     private final String packageName;
 
+    private final TreeSet<String> staticImports;
+
     public HeaderGenerator(String packageName) {
         this.buffer = new CodeBuffer();
         this.imports = new TreeSet<>();
         this.packageName = packageName;
+        this.staticImports = new TreeSet<>();
     }
 
     public void addImport(String newImport) {
         this.imports.add(newImport);
+    }
+
+    public void addStaticImport(String newImport) {
+        this.staticImports.add(newImport);
     }
 
     public void generate() {
@@ -73,6 +80,12 @@ public final class HeaderGenerator {
             buffer.printf("import %s;%n", newImport);
         }
         buffer.printf("%n");
+        if (!staticImports.isEmpty()) {
+            for (String newImport : staticImports) {
+                buffer.printf("import static %s;%n", newImport);
+            }
+            buffer.printf("%n");
+        }
     }
 
     public CodeBuffer buffer() {

--- a/generator/src/main/java/org/apache/kafka/message/IsNullConditional.java
+++ b/generator/src/main/java/org/apache/kafka/message/IsNullConditional.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+/**
+ * Creates an if statement based on whether or not a particular field is null.
+ */
+public final class IsNullConditional {
+    static IsNullConditional forField(String name) {
+        return new IsNullConditional(name);
+    }
+
+    static IsNullConditional forField(FieldSpec field) {
+        IsNullConditional cond = new IsNullConditional(field.camelCaseName());
+        cond.nullableVersions(field.nullableVersions());
+        return cond;
+    }
+
+    private final String name;
+    private Versions nullableVersions = Versions.ALL;
+    private Versions possibleVersions = Versions.ALL;
+    private Runnable ifNull = null;
+    private Runnable ifNotNull = null;
+    private boolean alwaysEmitBlockScope = false;
+
+    private IsNullConditional(String name) {
+        this.name = name;
+    }
+
+    IsNullConditional nullableVersions(Versions nullableVersions) {
+        this.nullableVersions = nullableVersions;
+        return this;
+    }
+
+    IsNullConditional possibleVersions(Versions possibleVersions) {
+        this.possibleVersions = possibleVersions;
+        return this;
+    }
+
+    IsNullConditional ifNull(Runnable ifNull) {
+        this.ifNull = ifNull;
+        return this;
+    }
+
+    IsNullConditional ifNotNull(Runnable ifNotNull) {
+        this.ifNotNull = ifNotNull;
+        return this;
+    }
+
+    IsNullConditional alwaysEmitBlockScope(boolean alwaysEmitBlockScope) {
+        this.alwaysEmitBlockScope = alwaysEmitBlockScope;
+        return this;
+    }
+
+    void generate(CodeBuffer buffer) {
+        if (nullableVersions.intersect(possibleVersions).empty()) {
+            if (ifNotNull != null) {
+                if (alwaysEmitBlockScope) {
+                    buffer.printf("{%n");
+                    buffer.incrementIndent();
+                }
+                ifNotNull.run();
+                if (alwaysEmitBlockScope) {
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
+                }
+            }
+        } else {
+            if (ifNull != null) {
+                buffer.printf("if (%s == null) {%n", name);
+                buffer.incrementIndent();
+                ifNull.run();
+                buffer.decrementIndent();
+                if (ifNotNull != null) {
+                    buffer.printf("} else {%n");
+                    buffer.incrementIndent();
+                    ifNotNull.run();
+                    buffer.decrementIndent();
+                }
+                buffer.printf("}%n");
+            } else if (ifNotNull != null) {
+                buffer.printf("if (%s != null) {%n", name);
+                buffer.incrementIndent();
+                ifNotNull.run();
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+}

--- a/generator/src/main/java/org/apache/kafka/message/IsNullConditional.java
+++ b/generator/src/main/java/org/apache/kafka/message/IsNullConditional.java
@@ -21,7 +21,7 @@ package org.apache.kafka.message;
  * Creates an if statement based on whether or not a particular field is null.
  */
 public final class IsNullConditional {
-    static IsNullConditional forField(String name) {
+    static IsNullConditional forName(String name) {
         return new IsNullConditional(name);
     }
 

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -757,7 +757,10 @@ public final class MessageDataGenerator {
                 " cannot be nullable.");
         }
         if ((field.type() instanceof FieldType.BoolFieldType) ||
-                (field.type().isInteger()) ||
+                (field.type() instanceof FieldType.Int8FieldType) ||
+                (field.type() instanceof FieldType.Int16FieldType) ||
+                (field.type() instanceof FieldType.Int32FieldType) ||
+                (field.type() instanceof FieldType.Int64FieldType) ||
                 (field.type() instanceof FieldType.UUIDFieldType) ||
                 (field.type() instanceof FieldType.StringFieldType)) {
             boolean maybeAbsent =

--- a/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
+++ b/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
@@ -56,11 +56,26 @@ public final class VersionConditional {
         return this;
     }
 
+    /**
+     * If this is set, we will always create a new block scope, even if there
+     * are no 'if' statements.  This is useful for cases where we want to
+     * declare variables in the clauses without worrying if they conflict with
+     * other variables of the same name.
+     */
     VersionConditional alwaysEmitBlockScope(boolean alwaysEmitBlockScope) {
         this.alwaysEmitBlockScope = alwaysEmitBlockScope;
         return this;
     }
 
+    /**
+     * If this is set, VersionConditional#generate will throw an exception if
+     * the 'ifMember' clause is never used.  This is useful as a sanity check
+     * in some cases where it doesn't make sense for the condition to always be
+     * false.  For example, when generating a Message#write function, 
+     * we might check that the version we're writing is supported.  It wouldn't
+     * make sense for this check to always be false, since that would mean that
+     * no versions at all were supported.
+     */
     VersionConditional allowMembershipCheckAlwaysFalse(boolean allowMembershipCheckAlwaysFalse) {
         this.allowMembershipCheckAlwaysFalse = allowMembershipCheckAlwaysFalse;
         return this;

--- a/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
+++ b/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+/**
+ * Creates an if statement based on whether or not the current version
+ * falls within a given range.
+ */
+public final class VersionConditional {
+    /**
+     * Create a version conditional.
+     *
+     * @param containingVersions    The versions for which the conditional is true.
+     * @param possibleVersions      The range of possible versions.
+     * @return                      The version conditional.
+     */
+    static VersionConditional forVersions(Versions containingVersions,
+                                          Versions possibleVersions) {
+        return new VersionConditional(containingVersions, possibleVersions);
+    }
+
+    private final Versions containingVersions;
+    private final Versions possibleVersions;
+    private ClauseGenerator ifMember = null;
+    private ClauseGenerator ifNotMember = null;
+    private boolean alwaysEmitBlockScope = false;
+    private boolean allowMembershipCheckAlwaysFalse = true;
+
+    private VersionConditional(Versions containingVersions, Versions possibleVersions) {
+        this.containingVersions = containingVersions;
+        this.possibleVersions = possibleVersions;
+    }
+
+    VersionConditional ifMember(ClauseGenerator ifMember) {
+        this.ifMember = ifMember;
+        return this;
+    }
+
+    VersionConditional ifNotMember(ClauseGenerator ifNotMember) {
+        this.ifNotMember = ifNotMember;
+        return this;
+    }
+
+    VersionConditional alwaysEmitBlockScope(boolean alwaysEmitBlockScope) {
+        this.alwaysEmitBlockScope = alwaysEmitBlockScope;
+        return this;
+    }
+
+    VersionConditional allowMembershipCheckAlwaysFalse(boolean allowMembershipCheckAlwaysFalse) {
+        this.allowMembershipCheckAlwaysFalse = allowMembershipCheckAlwaysFalse;
+        return this;
+    }
+
+    private void generateFullRangeCheck(Versions ifVersions,
+                                        Versions ifNotVersions,
+                                        CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if ((version >= %d) && (version <= %d)) {%n",
+                    containingVersions.lowest(), containingVersions.highest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            } else {
+                buffer.printf("}%n");
+            }
+        } else if (ifNotMember != null) {
+            buffer.printf("if ((version < %d) || (version > %d)) {%n",
+                    containingVersions.lowest(), containingVersions.highest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateLowerRangeCheck(Versions ifVersions,
+                                         Versions ifNotVersions,
+                                         CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if (version >= %d) {%n", containingVersions.lowest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            } else {
+                buffer.printf("}%n");
+            }
+        } else if (ifNotMember != null) {
+            buffer.printf("if (version < %d) {%n", containingVersions.lowest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateUpperRangeCheck(Versions ifVersions,
+                                         Versions ifNotVersions,
+                                         CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if (version <= %d) {%n", containingVersions.highest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            } else {
+                buffer.printf("}%n");
+            }
+        } else if (ifNotMember != null) {
+            buffer.printf("if (version > %d) {%n", containingVersions.highest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateAlwaysTrueCheck(Versions ifVersions, CodeBuffer buffer) {
+        if (ifMember != null) {
+            if (alwaysEmitBlockScope) {
+                buffer.printf("{%n");
+                buffer.incrementIndent();
+            }
+            ifMember.generate(ifVersions);
+            if (alwaysEmitBlockScope) {
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+
+    private void generateAlwaysFalseCheck(Versions ifNotVersions, CodeBuffer buffer) {
+        if (!allowMembershipCheckAlwaysFalse) {
+            throw new RuntimeException("Version ranges " + containingVersions +
+                " and " + possibleVersions + " have no versions in common.");
+        }
+        if (ifNotMember != null) {
+            if (alwaysEmitBlockScope) {
+                buffer.printf("{%n");
+                buffer.incrementIndent();
+            }
+            ifNotMember.generate(ifNotVersions);
+            if (alwaysEmitBlockScope) {
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+
+    void generate(CodeBuffer buffer) {
+        Versions ifVersions = possibleVersions.intersect(containingVersions);
+        Versions ifNotVersions = possibleVersions.subtract(containingVersions);
+        // In the case where ifNotVersions would be two ranges rather than one,
+        // we just pass in the original possibleVersions instead.
+        // This is slightly less optimal, but allows us to avoid dealing with
+        // multiple ranges.
+        if (ifNotVersions == null) {
+            ifNotVersions = possibleVersions;
+        }
+
+        if (possibleVersions.lowest() < containingVersions.lowest()) {
+            if (possibleVersions.highest() > containingVersions.highest()) {
+                generateFullRangeCheck(ifVersions, ifNotVersions, buffer);
+            } else if (possibleVersions.highest() >= containingVersions.lowest()) {
+                generateLowerRangeCheck(ifVersions, ifNotVersions, buffer);
+            } else {
+                generateAlwaysFalseCheck(ifNotVersions, buffer);
+            }
+        } else if (possibleVersions.highest() >= containingVersions.lowest() &&
+                    (possibleVersions.lowest() <= containingVersions.highest())) {
+            if (possibleVersions.highest() > containingVersions.highest()) {
+                generateUpperRangeCheck(ifVersions, ifNotVersions, buffer);
+            } else {
+                generateAlwaysTrueCheck(ifVersions, buffer);
+            }
+        } else {
+            generateAlwaysFalseCheck(ifNotVersions, buffer);
+        }
+    }
+}

--- a/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
+++ b/generator/src/main/java/org/apache/kafka/message/VersionConditional.java
@@ -80,10 +80,8 @@ public final class VersionConditional {
                 buffer.incrementIndent();
                 ifNotMember.generate(ifNotVersions);
                 buffer.decrementIndent();
-                buffer.printf("}%n");
-            } else {
-                buffer.printf("}%n");
             }
+            buffer.printf("}%n");
         } else if (ifNotMember != null) {
             buffer.printf("if ((version < %d) || (version > %d)) {%n",
                     containingVersions.lowest(), containingVersions.highest());
@@ -107,10 +105,8 @@ public final class VersionConditional {
                 buffer.incrementIndent();
                 ifNotMember.generate(ifNotVersions);
                 buffer.decrementIndent();
-                buffer.printf("}%n");
-            } else {
-                buffer.printf("}%n");
             }
+            buffer.printf("}%n");
         } else if (ifNotMember != null) {
             buffer.printf("if (version < %d) {%n", containingVersions.lowest());
             buffer.incrementIndent();
@@ -133,10 +129,8 @@ public final class VersionConditional {
                 buffer.incrementIndent();
                 ifNotMember.generate(ifNotVersions);
                 buffer.decrementIndent();
-                buffer.printf("}%n");
-            } else {
-                buffer.printf("}%n");
             }
+            buffer.printf("}%n");
         } else if (ifNotMember != null) {
             buffer.printf("if (version > %d) {%n", containingVersions.highest());
             buffer.incrementIndent();

--- a/generator/src/main/java/org/apache/kafka/message/Versions.java
+++ b/generator/src/main/java/org/apache/kafka/message/Versions.java
@@ -109,6 +109,12 @@ public final class Versions {
         }
     }
 
+    /**
+     * Return the intersection of two version ranges.
+     *
+     * @param other     The other version range.
+     * @return          A new version range.
+     */
     public Versions intersect(Versions other) {
         short newLowest = lowest > other.lowest ? lowest : other.lowest;
         short newHighest = highest < other.highest ? highest : other.highest;
@@ -116,6 +122,56 @@ public final class Versions {
             return Versions.NONE;
         }
         return new Versions(newLowest, newHighest);
+    }
+
+    /**
+     * Return a new version range that trims some versions from this range, if possible.
+     * We can't trim any versions if the resulting range would be disjoint.
+     *
+     * Some examples:
+     * 1-4.trim(1-2) = 3-4
+     * 3+.trim(4+) = 3
+     * 4+.trim(3+) = none
+     * 1-5.trim(2-4) = null
+     *
+     * This is similar to subtracting the other version range, except that if two
+     * version ranges would be
+     *
+     * @param other                 The other version range.
+     * @return                      A new version range.
+     */
+    public Versions subtract(Versions other) {
+        if (other.lowest() <= lowest) {
+            if (other.highest >= highest) {
+                // Case 1: other is a superset of this.  Trim everything.
+                return Versions.NONE;
+            } else if (other.highest < lowest) {
+                // Case 2: other is a disjoint version range that is lower than this.  Trim nothing.
+                return this;
+            } else {
+                // Case 3: trim some values from the beginning of this range.
+                //
+                // Note: it is safe to assume that other.highest() + 1 will not overflow.
+                // The reason is because if other.highest() were Short.MAX_VALUE,
+                // other.highest() < highest could not be true.
+                return new Versions((short) (other.highest() + 1), highest);
+            }
+        } else if (other.highest >= highest) {
+            int newHighest = other.lowest - 1;
+            if (newHighest < 0) {
+                // Case 4: other was NONE.  Trim nothing.
+                return this;
+            } else if (newHighest < highest) {
+                // Case 5: trim some values from the end of this range.
+                return new Versions(lowest, (short) newHighest);
+            } else {
+                // Case 6: other is a disjoint range that is higher than this.  Trim nothing.
+                return this;
+            }
+        } else {
+            // Case 7: the difference between this and other would be two ranges, not one.
+            return null;
+        }
     }
 
     public boolean contains(short version) {

--- a/generator/src/main/java/org/apache/kafka/message/Versions.java
+++ b/generator/src/main/java/org/apache/kafka/message/Versions.java
@@ -134,9 +134,6 @@ public final class Versions {
      * 4+.trim(3+) = none
      * 1-5.trim(2-4) = null
      *
-     * This is similar to subtracting the other version range, except that if two
-     * version ranges would be
-     *
      * @param other                 The other version range.
      * @return                      A new version range.
      */

--- a/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.StringWriter;
+
+public class CodeBufferTest {
+    @Rule
+    final public Timeout globalTimeout = Timeout.millis(120000);
+
+    @Test
+    public void testWrite() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        buffer.printf("public static void main(String[] args) throws Exception {%n");
+        buffer.incrementIndent();
+        buffer.printf("System.out.println(\"%s\");%n", "hello world");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        StringWriter stringWriter = new StringWriter();
+        buffer.write(stringWriter);
+        Assert.assertEquals(
+            String.format("public static void main(String[] args) throws Exception {%n") +
+            String.format("    System.out.println(\"hello world\");%n") +
+            String.format("}%n"),
+            stringWriter.toString());
+    }
+
+    @Test
+    public void testEquals() {
+        CodeBuffer buffer1 = new CodeBuffer();
+        CodeBuffer buffer2 = new CodeBuffer();
+        Assert.assertEquals(buffer1, buffer2);
+        buffer1.printf("hello world");
+        Assert.assertNotEquals(buffer1, buffer2);
+        buffer2.printf("hello world");
+        Assert.assertEquals(buffer1, buffer2);
+        buffer1.printf("foo, bar, and baz");
+        buffer2.printf("foo, bar, and baz");
+        Assert.assertEquals(buffer1, buffer2);
+    }
+
+    @Test
+    public void testIndentMustBeNonNegative() {
+        CodeBuffer buffer = new CodeBuffer();
+        buffer.incrementIndent();
+        buffer.decrementIndent();
+        try {
+            buffer.decrementIndent();
+        } catch (RuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("Indent < 0"));
+        }
+    }
+}

--- a/generator/src/test/java/org/apache/kafka/message/IsNullConditionalTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/IsNullConditionalTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class IsNullConditionalTest {
+    @Rule
+    final public Timeout globalTimeout = Timeout.millis(120000);
+
+    @Test
+    public void testNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.
+            forField("foobar").
+            nullableVersions(Versions.parse("2+", null)).
+            possibleVersions(Versions.parse("0+", null)).
+            ifNull(() -> {
+                buffer.printf("System.out.println(\"null\");%n");
+            }).
+            generate(buffer);
+        VersionConditionalTest.assertEquals(buffer,
+            "if (foobar == null) {%n",
+            "    System.out.println(\"null\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testAnotherNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.
+            forField("foobar").
+            nullableVersions(Versions.parse("0+", null)).
+            possibleVersions(Versions.parse("2+", null)).
+            ifNull(() -> {
+                buffer.printf("System.out.println(\"null\");%n");
+            }).
+            ifNotNull(() -> {
+                buffer.printf("System.out.println(\"not null\");%n");
+            }).
+            generate(buffer);
+        VersionConditionalTest.assertEquals(buffer,
+            "if (foobar == null) {%n",
+            "    System.out.println(\"null\");%n",
+            "} else {%n",
+            "    System.out.println(\"not null\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testNotNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.
+            forField("foobar").
+            nullableVersions(Versions.parse("0+", null)).
+            possibleVersions(Versions.parse("2+", null)).
+            ifNotNull(() -> {
+                buffer.printf("System.out.println(\"not null\");%n");
+            }).
+            generate(buffer);
+        VersionConditionalTest.assertEquals(buffer,
+            "if (foobar != null) {%n",
+            "    System.out.println(\"not null\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testNeverNull() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.
+            forField("baz").
+            nullableVersions(Versions.parse("0-2", null)).
+            possibleVersions(Versions.parse("3+", null)).
+            ifNull(() -> {
+                buffer.printf("System.out.println(\"null\");%n");
+            }).
+            ifNotNull(() -> {
+                buffer.printf("System.out.println(\"not null\");%n");
+            }).
+            generate(buffer);
+        VersionConditionalTest.assertEquals(buffer,
+            "System.out.println(\"not null\");%n");
+    }
+
+    @Test
+    public void testNeverNullWithBlockScope() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.
+            forField("baz").
+            nullableVersions(Versions.parse("0-2", null)).
+            possibleVersions(Versions.parse("3+", null)).
+            ifNull(() -> {
+                buffer.printf("System.out.println(\"null\");%n");
+            }).
+            ifNotNull(() -> {
+                buffer.printf("System.out.println(\"not null\");%n");
+            }).
+            alwaysEmitBlockScope(true).
+            generate(buffer);
+        VersionConditionalTest.assertEquals(buffer,
+            "{%n",
+            "    System.out.println(\"not null\");%n",
+            "}%n");
+    }
+}

--- a/generator/src/test/java/org/apache/kafka/message/IsNullConditionalTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/IsNullConditionalTest.java
@@ -29,7 +29,7 @@ public class IsNullConditionalTest {
     public void testNullCheck() throws Exception {
         CodeBuffer buffer = new CodeBuffer();
         IsNullConditional.
-            forField("foobar").
+            forName("foobar").
             nullableVersions(Versions.parse("2+", null)).
             possibleVersions(Versions.parse("0+", null)).
             ifNull(() -> {
@@ -46,7 +46,7 @@ public class IsNullConditionalTest {
     public void testAnotherNullCheck() throws Exception {
         CodeBuffer buffer = new CodeBuffer();
         IsNullConditional.
-            forField("foobar").
+            forName("foobar").
             nullableVersions(Versions.parse("0+", null)).
             possibleVersions(Versions.parse("2+", null)).
             ifNull(() -> {
@@ -68,7 +68,7 @@ public class IsNullConditionalTest {
     public void testNotNullCheck() throws Exception {
         CodeBuffer buffer = new CodeBuffer();
         IsNullConditional.
-            forField("foobar").
+            forName("foobar").
             nullableVersions(Versions.parse("0+", null)).
             possibleVersions(Versions.parse("2+", null)).
             ifNotNull(() -> {
@@ -85,7 +85,7 @@ public class IsNullConditionalTest {
     public void testNeverNull() throws Exception {
         CodeBuffer buffer = new CodeBuffer();
         IsNullConditional.
-            forField("baz").
+            forName("baz").
             nullableVersions(Versions.parse("0-2", null)).
             possibleVersions(Versions.parse("3+", null)).
             ifNull(() -> {
@@ -103,7 +103,7 @@ public class IsNullConditionalTest {
     public void testNeverNullWithBlockScope() throws Exception {
         CodeBuffer buffer = new CodeBuffer();
         IsNullConditional.
-            forField("baz").
+            forName("baz").
             nullableVersions(Versions.parse("0-2", null)).
             possibleVersions(Versions.parse("3+", null)).
             ifNull(() -> {

--- a/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertTrue;
+
+public class VersionConditionalTest {
+    @Rule
+    final public Timeout globalTimeout = Timeout.millis(120000);
+
+    static void assertEquals(CodeBuffer buffer, String... lines) throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        buffer.write(stringWriter);
+        StringBuilder expectedStringBuilder = new StringBuilder();
+        for (String line : lines) {
+            expectedStringBuilder.append(String.format(line));
+        }
+        Assert.assertEquals(expectedStringBuilder.toString(), stringWriter.toString());
+    }
+
+    @Test
+    public void testAlwaysFalseConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1-2", null), Versions.parse("3+", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "System.out.println(\"foobar\");%n");
+    }
+
+    @Test
+    public void testAnotherAlwaysFalseConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("3+", null), Versions.parse("1-2", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "System.out.println(\"foobar\");%n");
+    }
+
+    @Test
+    public void testAllowMembershipCheckAlwaysFalseFails() throws Exception {
+        try {
+            CodeBuffer buffer = new CodeBuffer();
+            VersionConditional.
+                forVersions(Versions.parse("1-2", null), Versions.parse("3+", null)).
+                ifMember(__ -> {
+                    buffer.printf("System.out.println(\"hello world\");%n");
+                }).
+                ifNotMember(__ -> {
+                    buffer.printf("System.out.println(\"foobar\");%n");
+                }).
+                allowMembershipCheckAlwaysFalse(false).
+                generate(buffer);
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("no versions in common"));
+        }
+    }
+
+    @Test
+    public void testAlwaysTrueConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1-5", null), Versions.parse("2-4", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            allowMembershipCheckAlwaysFalse(false).
+            generate(buffer);
+        assertEquals(buffer,
+            "System.out.println(\"hello world\");%n");
+    }
+
+    @Test
+    public void testAlwaysTrueConditionalWithAlwaysEmitBlockScope() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1-5", null), Versions.parse("2-4", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            alwaysEmitBlockScope(true).
+            generate(buffer);
+        assertEquals(buffer,
+            "{%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithElse() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version >= 1) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "} else {%n",
+            "    System.out.println(\"foobar\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithIfMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version >= 1) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithIfNotMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version < 1) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithElse() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("0-10", null), Versions.parse("4+", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"foobar\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version <= 10) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "} else {%n",
+            "    System.out.println(\"foobar\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithIfMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("0-10", null), Versions.parse("4+", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version <= 10) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithIfNotMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).
+            ifNotMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            generate(buffer);
+        assertEquals(buffer,
+            "if (version < 1) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+
+    @Test
+    public void testFullRangeCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.
+            forVersions(Versions.parse("5-10", null), Versions.parse("1+", null)).
+            ifMember(__ -> {
+                buffer.printf("System.out.println(\"hello world\");%n");
+            }).
+            allowMembershipCheckAlwaysFalse(false).
+            generate(buffer);
+        assertEquals(buffer,
+            "if ((version >= 5) && (version <= 10)) {%n",
+            "    System.out.println(\"hello world\");%n",
+            "}%n");
+    }
+}

--- a/generator/src/test/java/org/apache/kafka/message/VersionsTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/VersionsTest.java
@@ -72,6 +72,8 @@ public class VersionsTest {
         assertEquals(Versions.NONE,
             newVersions(9, Short.MAX_VALUE).intersect(
                 newVersions(2, 8)));
+        assertEquals(Versions.NONE,
+            Versions.NONE.intersect(Versions.NONE));
     }
 
     @Test
@@ -86,5 +88,27 @@ public class VersionsTest {
         assertFalse(newVersions(2, 3).contains(newVersions(2, 4)));
         assertTrue(newVersions(2, 3).contains(Versions.NONE));
         assertTrue(Versions.ALL.contains(newVersions(1, 2)));
+    }
+
+    @Test
+    public void testSubtract() {
+        assertEquals(Versions.NONE,
+            Versions.NONE.subtract(Versions.NONE));
+        assertEquals(newVersions(0, 0),
+            newVersions(0, 0).subtract(Versions.NONE));
+        assertEquals(newVersions(1, 1),
+            newVersions(1, 2).subtract(newVersions(2, 2)));
+        assertEquals(newVersions(2, 2),
+            newVersions(1, 2).subtract(newVersions(1, 1)));
+        assertEquals(null,
+            newVersions(0, Short.MAX_VALUE).subtract(newVersions(1, 100)));
+        assertEquals(newVersions(10, 10),
+            newVersions(1, 10).subtract(newVersions(1, 9)));
+        assertEquals(newVersions(1, 1),
+            newVersions(1, 10).subtract(newVersions(2, 10)));
+        assertEquals(newVersions(2, 4),
+            newVersions(2, Short.MAX_VALUE).subtract(newVersions(5, Short.MAX_VALUE)));
+        assertEquals(newVersions(5, Short.MAX_VALUE),
+            newVersions(0, Short.MAX_VALUE).subtract(newVersions(0, 4)));
     }
 }


### PR DESCRIPTION
Move the generator checkstyle suppressions to a special section, rather than mixing them in with the other sections.  For generated code, do not complain about variable names or cyclic complexity.

Remove FieldType#isInteger.  This way, we don't have to decide whether a UUID is an integer or not (there are arguments for both choices).  Add FieldType#serializationIsDifferentInFlexibleVersions and FieldType#isVariableLength.

HeaderGenerator: add the ability to generate static imports.  Add
IsNullConditional, VersionConditional, and ClauseGenerator as easier ways of
generating "if" statements.

Add Versions#subtract, and a unit test for it.

Add CodeBufferTest to test the existing CodeBuffer class.