### PR TITLE
KAFKA-8842: Reading/Writing confused in Connect QuickStart Guide

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -211,7 +211,7 @@ my test message 2
 
 <h4><a id="quickstart_kafkaconnect" href="#quickstart_kafkaconnect">Step 7: Use Kafka Connect to import/export data</a></h4>
 
-<p>Writing data from the console and writing it back to the console is a convenient place to start, but you'll probably want
+<p>Reading data from the console and writing it back to the console is a convenient place to start, but you'll probably want
 to use data from other sources or export data from Kafka to other systems. For many systems, instead of writing custom
 integration code you can use Kafka Connect to import or export data.</p>
 


### PR DESCRIPTION
In step 7 of the QuickStart guide, "**Writing** data from the console and writing it back to the console" should be "**Reading** data from the console and writing it back to the console".

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
