### PR TITLE
MINOR: Improve the org.apache.kafka.common.protocol code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -38,6 +38,10 @@ public final class MessageUtil {
         return (short) count;
     }
 
+    /**
+     * Copy a byte buffer into an array.  This will not affect the buffer's
+     * position or mark.
+     */
     public static byte[] byteBufferToArray(ByteBuffer buf) {
         byte[] arr = new byte[buf.remaining()];
         int prevPosition = buf.position();

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -41,8 +41,11 @@ public final class MessageUtil {
     public static byte[] byteBufferToArray(ByteBuffer buf) {
         byte[] arr = new byte[buf.remaining()];
         int prevPosition = buf.position();
-        buf.get(arr);
-        buf.position(prevPosition);
+        try {
+            buf.get(arr);
+        } finally {
+            buf.position(prevPosition);
+        }
         return arr;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.utils.Utils;
 
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -35,6 +36,14 @@ public final class MessageUtil {
             throw new RuntimeException("String " + input + " is too long to serialize.");
         }
         return (short) count;
+    }
+
+    public static byte[] byteBufferToArray(ByteBuffer buf) {
+        byte[] arr = new byte[buf.remaining()];
+        int prevPosition = buf.position();
+        buf.get(arr);
+        buf.position(prevPosition);
+        return arr;
     }
 
     public static String deepToString(Iterator<?> iter) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -81,7 +81,7 @@ public class Protocol {
     private static void populateSchemaFields(Schema schema, Set<BoundField> fields) {
         for (BoundField field: schema.fields()) {
             fields.add(field);
-            if (field.def.type.arrayElementType().isPresent()) {
+            if (field.def.type.isArray()) {
                 Type innerType = field.def.type.arrayElementType().get();
                 if (innerType instanceof Schema)
                     populateSchemaFields((Schema) innerType, fields);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.protocol;
 
-import org.apache.kafka.common.protocol.types.ArrayOf;
 import org.apache.kafka.common.protocol.types.BoundField;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Type;
@@ -43,18 +42,19 @@ public class Protocol {
 
         // Top level fields
         for (BoundField field: schema.fields()) {
-            if (field.def.type instanceof ArrayOf) {
+            Type type = field.def.type;
+            if (type.isArray()) {
                 b.append("[");
                 b.append(field.def.name);
                 b.append("] ");
-                Type innerType = ((ArrayOf) field.def.type).type();
-                if (!subTypes.containsKey(field.def.name))
-                    subTypes.put(field.def.name, innerType);
+                if (!subTypes.containsKey(field.def.name)) {
+                    subTypes.put(field.def.name, type.arrayElementType().get());
+                }
             } else {
                 b.append(field.def.name);
                 b.append(" ");
                 if (!subTypes.containsKey(field.def.name))
-                    subTypes.put(field.def.name, field.def.type);
+                    subTypes.put(field.def.name, type);
             }
         }
         b.append("\n");
@@ -81,8 +81,8 @@ public class Protocol {
     private static void populateSchemaFields(Schema schema, Set<BoundField> fields) {
         for (BoundField field: schema.fields()) {
             fields.add(field);
-            if (field.def.type instanceof ArrayOf) {
-                Type innerType = ((ArrayOf) field.def.type).type();
+            if (field.def.type.arrayElementType().isPresent()) {
+                Type innerType = field.def.type.arrayElementType().get();
                 if (innerType instanceof Schema)
                     populateSchemaFields((Schema) innerType, fields);
             } else if (field.def.type instanceof Schema)

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/ArrayOf.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.protocol.types;
 import org.apache.kafka.common.protocol.types.Type.DocumentedType;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /**
  * Represents a type for an array of a particular type
@@ -91,8 +92,9 @@ public class ArrayOf extends DocumentedType {
         return size;
     }
 
-    public Type type() {
-        return type;
+    @Override
+    public Optional<Type> arrayElementType() {
+        return Optional.of(type);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -209,10 +209,9 @@ public class Schema extends Type {
             visitor.visit(schema);
             for (BoundField f : schema.fields())
                 handleNode(f.def.type, visitor);
-        } else if (node instanceof ArrayOf) {
-            ArrayOf array = (ArrayOf) node;
-            visitor.visit(array);
-            handleNode(array.type(), visitor);
+        } else if (node.isArray()) {
+            visitor.visit(node);
+            handleNode(node.arrayElementType().get(), visitor);
         } else {
             visitor.visit(node);
         }
@@ -223,7 +222,6 @@ public class Schema extends Type {
      */
     public static abstract class Visitor {
         public void visit(Schema schema) {}
-        public void visit(ArrayOf array) {}
         public void visit(Type field) {}
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -418,9 +418,8 @@ public class Struct {
         validateField(field);
         if (field.def.type instanceof Schema) {
             return new Struct((Schema) field.def.type);
-        } else if (field.def.type instanceof ArrayOf) {
-            ArrayOf array = (ArrayOf) field.def.type;
-            return new Struct((Schema) array.type());
+        } else if (field.def.type.isArray()) {
+            return new Struct((Schema) field.def.type.arrayElementType().get());
         } else {
             throw new SchemaException("Field '" + field.def.name + "' is not a container type, it is of type " + field.def.type);
         }
@@ -495,7 +494,7 @@ public class Struct {
             BoundField f = this.schema.get(i);
             b.append(f.def.name);
             b.append('=');
-            if (f.def.type instanceof ArrayOf && this.values[i] != null) {
+            if (f.def.type.isArray() && this.values[i] != null) {
                 Object[] arrayValue = (Object[]) this.values[i];
                 b.append('[');
                 for (int j = 0; j < arrayValue.length; j++) {
@@ -519,7 +518,7 @@ public class Struct {
         int result = 1;
         for (int i = 0; i < this.values.length; i++) {
             BoundField f = this.schema.get(i);
-            if (f.def.type instanceof ArrayOf) {
+            if (f.def.type.isArray()) {
                 if (this.get(f) != null) {
                     Object[] arrayObject = (Object[]) this.get(f);
                     for (Object arrayItem: arrayObject)
@@ -549,7 +548,7 @@ public class Struct {
         for (int i = 0; i < this.values.length; i++) {
             BoundField f = this.schema.get(i);
             boolean result;
-            if (f.def.type instanceof ArrayOf) {
+            if (f.def.type.isArray()) {
                 result = Arrays.equals((Object[]) this.get(f), (Object[]) other.get(f));
             } else {
                 Object thisField = this.get(f);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.Utils;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -62,6 +63,20 @@ public abstract class Type {
      */
     public boolean isNullable() {
         return false;
+    }
+
+    /**
+     * If the type is an array, return the type of the array elements.  Otherwise, return empty.
+     */
+    public Optional<Type> arrayElementType() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns true if the type is an array.
+     */
+    public final boolean isArray() {
+        return arrayElementType().isPresent();
     }
 
     /**
@@ -704,10 +719,9 @@ public abstract class Type {
     };
 
     private static String toHtml() {
-
         DocumentedType[] types = {
             BOOLEAN, INT8, INT16, INT32, INT64,
-            UNSIGNED_INT32, VARINT, VARLONG,
+            UNSIGNED_INT32, VARINT, VARLONG, UUID,
             STRING, NULLABLE_STRING, BYTES, NULLABLE_BYTES,
             RECORDS, new ArrayOf(STRING)};
         final StringBuilder b = new StringBuilder();

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -37,7 +37,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Message;
-import org.apache.kafka.common.protocol.types.ArrayOf;
 import org.apache.kafka.common.protocol.types.BoundField;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.SchemaException;
@@ -699,9 +698,9 @@ public final class MessageTest {
                     entryA, entryA.type.isNullable() ? "nullable" : "non-nullable",
                     entryB, entryB.type.isNullable() ? "nullable" : "non-nullable"));
             }
-            if (entryA.type instanceof ArrayOf) {
-                compareTypes(new NamedType(entryA.name, ((ArrayOf) entryA.type).type()),
-                             new NamedType(entryB.name, ((ArrayOf) entryB.type).type()));
+            if (entryA.type.isArray()) {
+                compareTypes(new NamedType(entryA.name, entryA.type.arrayElementType().get()),
+                             new NamedType(entryB.name, entryB.type.arrayElementType().get()));
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
@@ -21,9 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public final class MessageUtilTest {
@@ -55,5 +57,13 @@ public final class MessageUtilTest {
             MessageUtil.deepToString(Arrays.asList(1, 2, 3).iterator()));
         assertEquals("[foo]",
             MessageUtil.deepToString(Arrays.asList("foo").iterator()));
+    }
+
+    @Test
+    public void testByteBufferToArray() {
+        assertArrayEquals(new byte[] {1, 2, 3},
+                MessageUtil.byteBufferToArray(ByteBuffer.wrap(new byte[] {1, 2, 3})));
+        assertArrayEquals(new byte[] {},
+                MessageUtil.byteBufferToArray(ByteBuffer.wrap(new byte[] {})));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -68,31 +68,32 @@ public class ProtocolSerializationTest {
 
     @Test
     public void testSimple() {
-        check(Type.BOOLEAN, false);
-        check(Type.BOOLEAN, true);
-        check(Type.INT8, (byte) -111);
-        check(Type.INT16, (short) -11111);
-        check(Type.INT32, -11111111);
-        check(Type.INT64, -11111111111L);
-        check(Type.STRING, "");
-        check(Type.STRING, "hello");
-        check(Type.STRING, "A\u00ea\u00f1\u00fcC");
-        check(Type.NULLABLE_STRING, null);
-        check(Type.NULLABLE_STRING, "");
-        check(Type.NULLABLE_STRING, "hello");
-        check(Type.BYTES, ByteBuffer.allocate(0));
-        check(Type.BYTES, ByteBuffer.wrap("abcd".getBytes()));
-        check(Type.NULLABLE_BYTES, null);
-        check(Type.NULLABLE_BYTES, ByteBuffer.allocate(0));
-        check(Type.NULLABLE_BYTES, ByteBuffer.wrap("abcd".getBytes()));
-        check(Type.VARINT, Integer.MAX_VALUE);
-        check(Type.VARINT, Integer.MIN_VALUE);
-        check(Type.VARLONG, Long.MAX_VALUE);
-        check(Type.VARLONG, Long.MIN_VALUE);
-        check(new ArrayOf(Type.INT32), new Object[] {1, 2, 3, 4});
-        check(new ArrayOf(Type.STRING), new Object[] {});
-        check(new ArrayOf(Type.STRING), new Object[] {"hello", "there", "beautiful"});
-        check(ArrayOf.nullable(Type.STRING), null);
+        check(Type.BOOLEAN, false, "BOOLEAN");
+        check(Type.BOOLEAN, true, "BOOLEAN");
+        check(Type.INT8, (byte) -111, "INT8");
+        check(Type.INT16, (short) -11111, "INT16");
+        check(Type.INT32, -11111111, "INT32");
+        check(Type.INT64, -11111111111L, "INT64");
+        check(Type.STRING, "", "STRING");
+        check(Type.STRING, "hello", "STRING");
+        check(Type.STRING, "A\u00ea\u00f1\u00fcC", "STRING");
+        check(Type.NULLABLE_STRING, null, "NULLABLE_STRING");
+        check(Type.NULLABLE_STRING, "", "NULLABLE_STRING");
+        check(Type.NULLABLE_STRING, "hello", "NULLABLE_STRING");
+        check(Type.BYTES, ByteBuffer.allocate(0), "BYTES");
+        check(Type.BYTES, ByteBuffer.wrap("abcd".getBytes()), "BYTES");
+        check(Type.NULLABLE_BYTES, null, "NULLABLE_BYTES");
+        check(Type.NULLABLE_BYTES, ByteBuffer.allocate(0), "NULLABLE_BYTES");
+        check(Type.NULLABLE_BYTES, ByteBuffer.wrap("abcd".getBytes()), "NULLABLE_BYTES");
+        check(Type.VARINT, Integer.MAX_VALUE, "VARINT");
+        check(Type.VARINT, Integer.MIN_VALUE, "VARINT");
+        check(Type.VARLONG, Long.MAX_VALUE, "VARLONG");
+        check(Type.VARLONG, Long.MIN_VALUE, "VARLONG");
+        check(new ArrayOf(Type.INT32), new Object[] {1, 2, 3, 4}, "ARRAY(INT32)");
+        check(new ArrayOf(Type.STRING), new Object[] {}, "ARRAY(STRING)");
+        check(new ArrayOf(Type.STRING), new Object[] {"hello", "there", "beautiful"},
+                "ARRAY(STRING)");
+        check(ArrayOf.nullable(Type.STRING), null, "ARRAY(STRING)");
     }
 
     @Test
@@ -105,7 +106,7 @@ public class ProtocolSerializationTest {
                 if (!f.def.type.isNullable())
                     fail("Should not allow serialization of null value.");
             } catch (SchemaException e) {
-                assertFalse(f.def.type.isNullable());
+                assertFalse(f.toString() + " should not be nullable", f.def.type.isNullable());
             } finally {
                 this.struct.set(f, o);
             }
@@ -259,12 +260,13 @@ public class ProtocolSerializationTest {
         return read;
     }
 
-    private void check(Type type, Object obj) {
+    private void check(Type type, Object obj, String expectedTypeName) {
         Object result = roundtrip(type, obj);
         if (obj instanceof Object[]) {
             obj = Arrays.asList((Object[]) obj);
             result = Arrays.asList((Object[]) result);
         }
+        assertEquals(expectedTypeName, type.toString());
         assertEquals("The object read back should be the same as what was written.", obj, result);
     }
 

--- a/clients/src/test/resources/common/message/TestUUID.json
+++ b/clients/src/test/resources/common/message/TestUUID.json
@@ -16,11 +16,7 @@
   "name": "TestUUID",
   "validVersions": "1",
   "fields": [
-    {
-      "name": "processId",
-      "versions": "1",
-      "type": "uuid"
-    }
+    { "name": "processId", "versions": "1+", "type": "uuid" }
   ],
   "type": "header"
 }


### PR DESCRIPTION
Add UUID to the list of types documented in Type#toHtml.  This was overlooked in the change which added UUIDs as a supported KRPC type.

Type, Protocol, ArrayOf: use Type#isArray and Type#arrayElementType rather than typecasting to handle arrays.  This is cleaner.  It will also make it easier for us to add compact arrays (as specified by KIP-482) as a new array type distinct from the old array type.

Add MessageUtil#byteBufferToArray, as well as a test for it.  We will need this for handling tagged fields of type "bytes".

Schema#Visitor: we don't need a separate function overload for visiting arrays.  We can just call "visit(Type field)".

TestUUID.json: reformat the JSON file to match the others.

ProtocolSerializationTest: improve the error messages on failure.  Check that each type has the name we expect it to have.