### PR TITLE
KAFKA-8609: Add consumer rebalance metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -39,7 +39,6 @@ import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.metrics.Measurable;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1070,26 +1070,20 @@ public abstract class AbstractCoordinator implements Closeable {
                 new Rate(TimeUnit.HOURS, new WindowedCount())
             );
 
-            Measurable lastRebalance =
-                new Measurable() {
-                    public double measure(MetricConfig config, long now) {
-                        if (lastRebalanceEndMs == -1L)
-                            return -1d;
-                        else
-                            return TimeUnit.SECONDS.convert(now - lastRebalanceEndMs, TimeUnit.MILLISECONDS);
-                    }
-                };
+            Measurable lastRebalance = (config, now) -> {
+                if (lastRebalanceEndMs == -1L)
+                    // if no rebalance is ever triggered, we just return -1.
+                    return -1d;
+                else
+                    return TimeUnit.SECONDS.convert(now - lastRebalanceEndMs, TimeUnit.MILLISECONDS);
+            };
             metrics.addMetric(metrics.metricName("last-rebalance-seconds-ago",
                 this.metricGrpName,
                 "The number of seconds since the last successful rebalance event"),
                 lastRebalance);
 
-            Measurable lastHeartbeat =
-                new Measurable() {
-                    public double measure(MetricConfig config, long now) {
-                        return TimeUnit.SECONDS.convert(now - heartbeat.lastHeartbeatSend(), TimeUnit.MILLISECONDS);
-                    }
-                };
+            Measurable lastHeartbeat = (config, now) ->
+                TimeUnit.SECONDS.convert(now - heartbeat.lastHeartbeatSend(), TimeUnit.MILLISECONDS);
             metrics.addMetric(metrics.metricName("last-heartbeat-seconds-ago",
                 this.metricGrpName,
                 "The number of seconds since the last coordinator heartbeat was sent"),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1028,26 +1028,26 @@ public abstract class AbstractCoordinator implements Closeable {
 
             this.heartbeatSensor = metrics.sensor("heartbeat-latency");
             this.heartbeatSensor.add(metrics.metricName("heartbeat-response-time-max",
-                    this.metricGrpName,
-                    "The max time taken to receive a response to a heartbeat request"), new Max());
+                this.metricGrpName,
+                "The max time taken to receive a response to a heartbeat request"), new Max());
             this.heartbeatSensor.add(createMeter(metrics, metricGrpName, "heartbeat", "heartbeats"));
 
             this.joinSensor = metrics.sensor("join-latency");
             this.joinSensor.add(metrics.metricName("join-time-avg",
-                    this.metricGrpName,
-                    "The average time taken for a group rejoin"), new Avg());
+                this.metricGrpName,
+                "The average time taken for a group rejoin"), new Avg());
             this.joinSensor.add(metrics.metricName("join-time-max",
-                    this.metricGrpName,
-                    "The max time taken for a group rejoin"), new Max());
+                this.metricGrpName,
+                "The max time taken for a group rejoin"), new Max());
             this.joinSensor.add(createMeter(metrics, metricGrpName, "join", "group joins"));
 
             this.syncSensor = metrics.sensor("sync-latency");
             this.syncSensor.add(metrics.metricName("sync-time-avg",
-                    this.metricGrpName,
-                    "The average time taken for a group sync"), new Avg());
+                this.metricGrpName,
+                "The average time taken for a group sync"), new Avg());
             this.syncSensor.add(metrics.metricName("sync-time-max",
-                    this.metricGrpName,
-                    "The max time taken for a group sync"), new Max());
+                this.metricGrpName,
+                "The max time taken for a group sync"), new Max());
             this.syncSensor.add(createMeter(metrics, metricGrpName, "sync", "group syncs"));
 
             this.successfulRebalanceSensor = metrics.sensor("rebalance-latency");
@@ -1102,8 +1102,13 @@ public abstract class AbstractCoordinator implements Closeable {
                 "The number of seconds since the last successful rebalance event"),
                 lastRebalance);
 
-            Measurable lastHeartbeat = (config, now) ->
-                TimeUnit.SECONDS.convert(now - heartbeat.lastHeartbeatSend(), TimeUnit.MILLISECONDS);
+            Measurable lastHeartbeat = (config, now) -> {
+                if (heartbeat.lastHeartbeatSend() == 0L)
+                    // if no heartbeat is ever triggered, just return -1.
+                    return -1d;
+                else
+                    return TimeUnit.SECONDS.convert(now - heartbeat.lastHeartbeatSend(), TimeUnit.MILLISECONDS);
+            };
             metrics.addMetric(metrics.metricName("last-heartbeat-seconds-ago",
                 this.metricGrpName,
                 "The number of seconds since the last coordinator heartbeat was sent"),
@@ -1311,5 +1316,9 @@ public abstract class AbstractCoordinator implements Closeable {
     // For testing only
     public Heartbeat heartbeat() {
         return heartbeat;
+    }
+
+    public void setLastRebalanceTime(final long timestamp) {
+        lastRebalanceEndMs = timestamp;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1284,7 +1284,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             this.loseLatency.add(metrics.metricName("partition-lost-latency-avg",
                 this.metricGrpName,
                 "The average time taken for a partition-lost rebalance listener callback"), new Avg());
-            this.loseLatency.add(metrics.metricName("commit-latency-max",
+            this.loseLatency.add(metrics.metricName("partition-lost-latency-max",
                 this.metricGrpName,
                 "The max time taken for a partition-lost rebalance listener callback"), new Max());
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -270,7 +270,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         try {
             final long startMs = time.milliseconds();
             listener.onPartitionsAssigned(assignedPartitions);
-            sensors.assignLatency.record(time.milliseconds() - startMs);
+            sensors.assignCallbackSensor.record(time.milliseconds() - startMs);
         } catch (WakeupException | InterruptException e) {
             throw e;
         } catch (Exception e) {
@@ -289,7 +289,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         try {
             final long startMs = time.milliseconds();
             listener.onPartitionsRevoked(revokedPartitions);
-            sensors.revokeLatency.record(time.milliseconds() - startMs);
+            sensors.revokeCallbackSensor.record(time.milliseconds() - startMs);
         } catch (WakeupException | InterruptException e) {
             throw e;
         } catch (Exception e) {
@@ -308,7 +308,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         try {
             final long startMs = time.milliseconds();
             listener.onPartitionsLost(lostPartitions);
-            sensors.loseLatency.record(time.milliseconds() - startMs);
+            sensors.loseCallbackSensor.record(time.milliseconds() - startMs);
         } catch (WakeupException | InterruptException e) {
             throw e;
         } catch (Exception e) {
@@ -1084,7 +1084,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
         @Override
         public void handle(OffsetCommitResponse commitResponse, RequestFuture<Void> future) {
-            sensors.commitLatency.record(response.requestLatencyMs());
+            sensors.commitSensor.record(response.requestLatencyMs());
             Set<String> unauthorizedTopics = new HashSet<>();
 
             for (OffsetCommitResponseData.OffsetCommitResponseTopic topic : commitResponse.data().topics()) {
@@ -1247,44 +1247,44 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
     private class ConsumerCoordinatorMetrics {
         private final String metricGrpName;
-        private final Sensor commitLatency;
-        private final Sensor revokeLatency;
-        private final Sensor assignLatency;
-        private final Sensor loseLatency;
+        private final Sensor commitSensor;
+        private final Sensor revokeCallbackSensor;
+        private final Sensor assignCallbackSensor;
+        private final Sensor loseCallbackSensor;
 
         private ConsumerCoordinatorMetrics(Metrics metrics, String metricGrpPrefix) {
             this.metricGrpName = metricGrpPrefix + "-coordinator-metrics";
 
-            this.commitLatency = metrics.sensor("commit-latency");
-            this.commitLatency.add(metrics.metricName("commit-latency-avg",
+            this.commitSensor = metrics.sensor("commit-latency");
+            this.commitSensor.add(metrics.metricName("commit-latency-avg",
                 this.metricGrpName,
                 "The average time taken for a commit request"), new Avg());
-            this.commitLatency.add(metrics.metricName("commit-latency-max",
+            this.commitSensor.add(metrics.metricName("commit-latency-max",
                 this.metricGrpName,
                 "The max time taken for a commit request"), new Max());
-            this.commitLatency.add(createMeter(metrics, metricGrpName, "commit", "commit calls"));
+            this.commitSensor.add(createMeter(metrics, metricGrpName, "commit", "commit calls"));
 
-            this.revokeLatency = metrics.sensor("partition-revoked-latency");
-            this.revokeLatency.add(metrics.metricName("partition-revoked-latency-avg",
+            this.revokeCallbackSensor = metrics.sensor("partition-revoked-latency");
+            this.revokeCallbackSensor.add(metrics.metricName("partition-revoked-latency-avg",
                 this.metricGrpName,
                 "The average time taken for a partition-revoked rebalance listener callback"), new Avg());
-            this.revokeLatency.add(metrics.metricName("partition-revoked-latency-max",
+            this.revokeCallbackSensor.add(metrics.metricName("partition-revoked-latency-max",
                 this.metricGrpName,
                 "The max time taken for a partition-revoked rebalance listener callback"), new Max());
 
-            this.assignLatency = metrics.sensor("partition-assigned-latency");
-            this.assignLatency.add(metrics.metricName("partition-assigned-latency-avg",
+            this.assignCallbackSensor = metrics.sensor("partition-assigned-latency");
+            this.assignCallbackSensor.add(metrics.metricName("partition-assigned-latency-avg",
                 this.metricGrpName,
                 "The average time taken for a partition-assigned rebalance listener callback"), new Avg());
-            this.assignLatency.add(metrics.metricName("partition-assigned-latency-max",
+            this.assignCallbackSensor.add(metrics.metricName("partition-assigned-latency-max",
                 this.metricGrpName,
                 "The max time taken for a partition-assigned rebalance listener callback"), new Max());
 
-            this.loseLatency = metrics.sensor("partition-lost-latency");
-            this.loseLatency.add(metrics.metricName("partition-lost-latency-avg",
+            this.loseCallbackSensor = metrics.sensor("partition-lost-latency");
+            this.loseCallbackSensor.add(metrics.metricName("partition-lost-latency-avg",
                 this.metricGrpName,
                 "The average time taken for a partition-lost rebalance listener callback"), new Avg());
-            this.loseLatency.add(metrics.metricName("partition-lost-latency-max",
+            this.loseCallbackSensor.add(metrics.metricName("partition-lost-latency-max",
                 this.metricGrpName,
                 "The max time taken for a partition-lost rebalance listener callback"), new Max());
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -31,7 +31,7 @@ public final class Heartbeat {
     private final Timer sessionTimer;
     private final Timer pollTimer;
 
-    private volatile long lastHeartbeatSend;
+    private volatile long lastHeartbeatSend = 0L;
 
     public Heartbeat(GroupRebalanceConfig config,
                      Time time) {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -78,6 +78,7 @@ public class JmxReporter implements MetricsReporter {
     public boolean containsMbean(String mbeanName) {
         return mbeans.containsKey(mbeanName);
     }
+
     @Override
     public void metricChange(KafkaMetric metric) {
         synchronized (LOCK) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -176,7 +176,7 @@ public class AbstractCoordinatorTest {
     }
 
     private KafkaMetric getMetric(final String name) {
-        return metrics.metrics().get(metrics.metricName(name,"consumer-coordinator-metrics"));
+        return metrics.metrics().get(metrics.metricName(name, "consumer-coordinator-metrics"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -32,6 +32,8 @@ import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -88,12 +90,13 @@ public class AbstractCoordinatorTest {
     private static final String GROUP_ID = "dummy-group";
     private static final String METRIC_GROUP_PREFIX = "consumer";
 
-    private MockClient mockClient;
-    private MockTime mockTime;
     private Node node;
+    private Metrics metrics;
+    private MockTime mockTime;
     private Node coordinatorNode;
-    private ConsumerNetworkClient consumerClient;
+    private MockClient mockClient;
     private DummyCoordinator coordinator;
+    private ConsumerNetworkClient consumerClient;
 
     private final String memberId = "memberId";
     private final String leaderId = "leaderId";
@@ -124,7 +127,7 @@ public class AbstractCoordinatorTest {
                                                         retryBackoffMs,
                                                         REQUEST_TIMEOUT_MS,
                                                         HEARTBEAT_INTERVAL_MS);
-        Metrics metrics = new Metrics();
+        metrics = new Metrics();
 
         mockClient.updateMetadata(TestUtils.metadataUpdateWith(1, emptyMap()));
         this.node = metadata.fetch().nodes().get(0);
@@ -141,6 +144,39 @@ public class AbstractCoordinatorTest {
                                                 consumerClient,
                                                 metrics,
                                                 mockTime);
+    }
+
+    @Test
+    public void testMetrics() {
+        setupCoordinator();
+
+        assertNotNull(getMetric("heartbeat-response-time-max"));
+        assertNotNull(getMetric("heartbeat-rate"));
+        assertNotNull(getMetric("heartbeat-total"));
+        assertNotNull(getMetric("last-heartbeat-seconds-ago"));
+        assertNotNull(getMetric("join-time-avg"));
+        assertNotNull(getMetric("join-time-max"));
+        assertNotNull(getMetric("join-rate"));
+        assertNotNull(getMetric("join-total"));
+        assertNotNull(getMetric("sync-time-avg"));
+        assertNotNull(getMetric("sync-time-max"));
+        assertNotNull(getMetric("sync-rate"));
+        assertNotNull(getMetric("sync-total"));
+        assertNotNull(getMetric("rebalance-latency-avg"));
+        assertNotNull(getMetric("rebalance-latency-max"));
+        assertNotNull(getMetric("rebalance-rate-per-hour"));
+        assertNotNull(getMetric("rebalance-total"));
+        assertNotNull(getMetric("failed-rebalance-rate-per-hour"));
+        assertNotNull(getMetric("failed-rebalance-total"));
+        assertNotNull(getMetric("last-rebalance-seconds-ago"));
+
+        final JmxReporter reporter = new JmxReporter("kafka.streams");
+        metrics.addReporter(reporter);
+        assertTrue(reporter.containsMbean("kafka.streams:type=consumer-coordinator-metrics"));
+    }
+
+    private KafkaMetric getMetric(final String name) {
+        return metrics.metrics().get(metrics.metricName(name,"consumer-coordinator-metrics"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.message.SyncGroupResponseData;
-import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -127,7 +126,7 @@ public class AbstractCoordinatorTest {
                                                         retryBackoffMs,
                                                         REQUEST_TIMEOUT_MS,
                                                         HEARTBEAT_INTERVAL_MS);
-        metrics = new Metrics();
+        metrics = new Metrics(mockTime);
 
         mockClient.updateMetadata(TestUtils.metadataUpdateWith(1, emptyMap()));
         this.node = metadata.fetch().nodes().get(0);
@@ -150,29 +149,78 @@ public class AbstractCoordinatorTest {
     public void testMetrics() {
         setupCoordinator();
 
+        metrics.sensor("heartbeat-latency").record(1.0d);
+        metrics.sensor("heartbeat-latency").record(2.0d);
+        metrics.sensor("heartbeat-latency").record(6.0d);
+
         assertNotNull(getMetric("heartbeat-response-time-max"));
         assertNotNull(getMetric("heartbeat-rate"));
         assertNotNull(getMetric("heartbeat-total"));
+        assertEquals(6.0d, getMetric("heartbeat-response-time-max").metricValue());
+        assertEquals(0.1d, getMetric("heartbeat-rate").metricValue());
+        assertEquals(3.0d, getMetric("heartbeat-total").metricValue());
+
         assertNotNull(getMetric("last-heartbeat-seconds-ago"));
+        assertEquals(-1.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
+        coordinator.heartbeat().sentHeartbeat(mockTime.milliseconds());
+        assertEquals(0.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
+        mockTime.sleep(10 * 1000L);
+        assertEquals(10.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
+
+        metrics.sensor("join-latency").record(1.0d);
+        metrics.sensor("join-latency").record(2.0d);
+        metrics.sensor("join-latency").record(6.0d);
+
         assertNotNull(getMetric("join-time-avg"));
         assertNotNull(getMetric("join-time-max"));
         assertNotNull(getMetric("join-rate"));
         assertNotNull(getMetric("join-total"));
+        assertEquals(3.0d, getMetric("join-time-avg").metricValue());
+        assertEquals(6.0d, getMetric("join-time-max").metricValue());
+        assertEquals(0.1d, getMetric("join-rate").metricValue());
+        assertEquals(3.0d, getMetric("join-total").metricValue());
+
+        metrics.sensor("sync-latency").record(1.0d);
+        metrics.sensor("sync-latency").record(2.0d);
+        metrics.sensor("sync-latency").record(6.0d);
+
         assertNotNull(getMetric("sync-time-avg"));
         assertNotNull(getMetric("sync-time-max"));
         assertNotNull(getMetric("sync-rate"));
         assertNotNull(getMetric("sync-total"));
+        assertEquals(3.0d, getMetric("sync-time-avg").metricValue());
+        assertEquals(6.0d, getMetric("sync-time-max").metricValue());
+        assertEquals(0.1d, getMetric("sync-rate").metricValue());
+        assertEquals(3.0d, getMetric("sync-total").metricValue());
+
+        metrics.sensor("rebalance-latency").record(1.0d);
+        metrics.sensor("rebalance-latency").record(2.0d);
+        metrics.sensor("rebalance-latency").record(6.0d);
+
         assertNotNull(getMetric("rebalance-latency-avg"));
         assertNotNull(getMetric("rebalance-latency-max"));
         assertNotNull(getMetric("rebalance-rate-per-hour"));
         assertNotNull(getMetric("rebalance-total"));
+        assertEquals(3.0d, getMetric("rebalance-latency-avg").metricValue());
+        assertEquals(6.0d, getMetric("rebalance-latency-max").metricValue());
+        assertEquals(360.0d, getMetric("rebalance-rate-per-hour").metricValue());
+        assertEquals(3.0d, getMetric("rebalance-total").metricValue());
+
+        metrics.sensor("failed-rebalance").record(1.0d);
+        metrics.sensor("failed-rebalance").record(2.0d);
+        metrics.sensor("failed-rebalance").record(6.0d);
+
         assertNotNull(getMetric("failed-rebalance-rate-per-hour"));
         assertNotNull(getMetric("failed-rebalance-total"));
-        assertNotNull(getMetric("last-rebalance-seconds-ago"));
+        assertEquals(360.0d, getMetric("failed-rebalance-rate-per-hour").metricValue());
+        assertEquals(3.0d, getMetric("failed-rebalance-total").metricValue());
 
-        final JmxReporter reporter = new JmxReporter("kafka.streams");
-        metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean("kafka.streams:type=consumer-coordinator-metrics"));
+        assertNotNull(getMetric("last-rebalance-seconds-ago"));
+        assertEquals(-1.0d, getMetric("last-rebalance-seconds-ago").metricValue());
+        coordinator.setLastRebalanceTime(mockTime.milliseconds());
+        assertEquals(0.0d, getMetric("last-rebalance-seconds-ago").metricValue());
+        mockTime.sleep(10 * 1000L);
+        assertEquals(10.0d, getMetric("last-rebalance-seconds-ago").metricValue());
     }
 
     private KafkaMetric getMetric(final String name) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -149,18 +149,34 @@ public class AbstractCoordinatorTest {
     public void testMetrics() {
         setupCoordinator();
 
-        metrics.sensor("heartbeat-latency").record(1.0d);
-        metrics.sensor("heartbeat-latency").record(2.0d);
-        metrics.sensor("heartbeat-latency").record(6.0d);
-
         assertNotNull(getMetric("heartbeat-response-time-max"));
         assertNotNull(getMetric("heartbeat-rate"));
         assertNotNull(getMetric("heartbeat-total"));
+        assertNotNull(getMetric("last-heartbeat-seconds-ago"));
+        assertNotNull(getMetric("join-time-avg"));
+        assertNotNull(getMetric("join-time-max"));
+        assertNotNull(getMetric("join-rate"));
+        assertNotNull(getMetric("join-total"));
+        assertNotNull(getMetric("sync-time-avg"));
+        assertNotNull(getMetric("sync-time-max"));
+        assertNotNull(getMetric("sync-rate"));
+        assertNotNull(getMetric("sync-total"));
+        assertNotNull(getMetric("rebalance-latency-avg"));
+        assertNotNull(getMetric("rebalance-latency-max"));
+        assertNotNull(getMetric("rebalance-rate-per-hour"));
+        assertNotNull(getMetric("rebalance-total"));
+        assertNotNull(getMetric("last-rebalance-seconds-ago"));
+        assertNotNull(getMetric("failed-rebalance-rate-per-hour"));
+        assertNotNull(getMetric("failed-rebalance-total"));
+
+        metrics.sensor("heartbeat-latency").record(1.0d);
+        metrics.sensor("heartbeat-latency").record(6.0d);
+        metrics.sensor("heartbeat-latency").record(2.0d);
+
         assertEquals(6.0d, getMetric("heartbeat-response-time-max").metricValue());
         assertEquals(0.1d, getMetric("heartbeat-rate").metricValue());
         assertEquals(3.0d, getMetric("heartbeat-total").metricValue());
 
-        assertNotNull(getMetric("last-heartbeat-seconds-ago"));
         assertEquals(-1.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
         coordinator.heartbeat().sentHeartbeat(mockTime.milliseconds());
         assertEquals(0.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
@@ -168,54 +184,39 @@ public class AbstractCoordinatorTest {
         assertEquals(10.0d, getMetric("last-heartbeat-seconds-ago").metricValue());
 
         metrics.sensor("join-latency").record(1.0d);
-        metrics.sensor("join-latency").record(2.0d);
         metrics.sensor("join-latency").record(6.0d);
+        metrics.sensor("join-latency").record(2.0d);
 
-        assertNotNull(getMetric("join-time-avg"));
-        assertNotNull(getMetric("join-time-max"));
-        assertNotNull(getMetric("join-rate"));
-        assertNotNull(getMetric("join-total"));
         assertEquals(3.0d, getMetric("join-time-avg").metricValue());
         assertEquals(6.0d, getMetric("join-time-max").metricValue());
         assertEquals(0.1d, getMetric("join-rate").metricValue());
         assertEquals(3.0d, getMetric("join-total").metricValue());
 
         metrics.sensor("sync-latency").record(1.0d);
-        metrics.sensor("sync-latency").record(2.0d);
         metrics.sensor("sync-latency").record(6.0d);
+        metrics.sensor("sync-latency").record(2.0d);
 
-        assertNotNull(getMetric("sync-time-avg"));
-        assertNotNull(getMetric("sync-time-max"));
-        assertNotNull(getMetric("sync-rate"));
-        assertNotNull(getMetric("sync-total"));
         assertEquals(3.0d, getMetric("sync-time-avg").metricValue());
         assertEquals(6.0d, getMetric("sync-time-max").metricValue());
         assertEquals(0.1d, getMetric("sync-rate").metricValue());
         assertEquals(3.0d, getMetric("sync-total").metricValue());
 
         metrics.sensor("rebalance-latency").record(1.0d);
-        metrics.sensor("rebalance-latency").record(2.0d);
         metrics.sensor("rebalance-latency").record(6.0d);
+        metrics.sensor("rebalance-latency").record(2.0d);
 
-        assertNotNull(getMetric("rebalance-latency-avg"));
-        assertNotNull(getMetric("rebalance-latency-max"));
-        assertNotNull(getMetric("rebalance-rate-per-hour"));
-        assertNotNull(getMetric("rebalance-total"));
         assertEquals(3.0d, getMetric("rebalance-latency-avg").metricValue());
         assertEquals(6.0d, getMetric("rebalance-latency-max").metricValue());
         assertEquals(360.0d, getMetric("rebalance-rate-per-hour").metricValue());
         assertEquals(3.0d, getMetric("rebalance-total").metricValue());
 
         metrics.sensor("failed-rebalance").record(1.0d);
-        metrics.sensor("failed-rebalance").record(2.0d);
         metrics.sensor("failed-rebalance").record(6.0d);
+        metrics.sensor("failed-rebalance").record(2.0d);
 
-        assertNotNull(getMetric("failed-rebalance-rate-per-hour"));
-        assertNotNull(getMetric("failed-rebalance-total"));
         assertEquals(360.0d, getMetric("failed-rebalance-rate-per-hour").metricValue());
         assertEquals(3.0d, getMetric("failed-rebalance-total").metricValue());
 
-        assertNotNull(getMetric("last-rebalance-seconds-ago"));
         assertEquals(-1.0d, getMetric("last-rebalance-seconds-ago").metricValue());
         coordinator.setLastRebalanceTime(mockTime.milliseconds());
         assertEquals(0.0d, getMetric("last-rebalance-seconds-ago").metricValue());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -49,9 +49,9 @@ import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
-import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractRequest;
@@ -204,25 +204,53 @@ public class ConsumerCoordinatorTest {
 
     @Test
     public void testMetrics() {
+        metrics.sensor("commit-latency").record(1.0d);
+        metrics.sensor("commit-latency").record(2.0d);
+        metrics.sensor("commit-latency").record(6.0d);
+
         assertNotNull(getMetric("commit-latency-avg"));
         assertNotNull(getMetric("commit-latency-max"));
         assertNotNull(getMetric("commit-rate"));
         assertNotNull(getMetric("commit-total"));
+        assertEquals(3.0d, getMetric("commit-latency-avg").metricValue());
+        assertEquals(6.0d, getMetric("commit-latency-max").metricValue());
+        assertEquals(0.1d, getMetric("commit-rate").metricValue());
+        assertEquals(3.0d, getMetric("commit-total").metricValue());
+
+        metrics.sensor("partition-revoked-latency").record(1.0d);
+        metrics.sensor("partition-revoked-latency").record(2.0d);
+        metrics.sensor("partition-assigned-latency").record(1.0d);
+        metrics.sensor("partition-assigned-latency").record(2.0d);
+        metrics.sensor("partition-lost-latency").record(1.0d);
+        metrics.sensor("partition-lost-latency").record(2.0d);
+
         assertNotNull(getMetric("partition-revoked-latency-avg"));
         assertNotNull(getMetric("partition-revoked-latency-max"));
         assertNotNull(getMetric("partition-assigned-latency-avg"));
         assertNotNull(getMetric("partition-assigned-latency-max"));
         assertNotNull(getMetric("partition-lost-latency-avg"));
         assertNotNull(getMetric("partition-lost-latency-max"));
-        assertNotNull(getMetric("assigned-partitions"));
+        assertEquals(1.5d, getMetric("partition-revoked-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-revoked-latency-max").metricValue());
+        assertEquals(1.5d, getMetric("partition-assigned-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-assigned-latency-max").metricValue());
+        assertEquals(1.5d, getMetric("partition-lost-latency-avg").metricValue());
+        assertEquals(2.0d, getMetric("partition-lost-latency-max").metricValue());
 
-        final JmxReporter reporter = new JmxReporter("kafka.streams");
-        metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean("kafka.streams:type=consumer" + groupId + "-coordinator-metrics"));
+        assertNotNull(getMetric("assigned-partitions"));
+        assertEquals(0.0d, getMetric("assigned-partitions").metricValue());
+        subscriptions.assignFromUser(Collections.singleton(t1p));
+        assertEquals(1.0d, getMetric("assigned-partitions").metricValue());
+        subscriptions.assignFromUser(Utils.mkSet(t1p, t2p));
+        assertEquals(2.0d, getMetric("assigned-partitions").metricValue());
     }
 
     private KafkaMetric getMetric(final String name) {
         return metrics.metrics().get(metrics.metricName(name, "consumer" + groupId + "-coordinator-metrics"));
+    }
+
+    private Sensor getSensor(final String name) {
+        return metrics.sensor(name);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -222,7 +222,7 @@ public class ConsumerCoordinatorTest {
     }
 
     private KafkaMetric getMetric(final String name) {
-        return metrics.metrics().get(metrics.metricName(name,"consumer" + groupId + "-coordinator-metrics"));
+        return metrics.metrics().get(metrics.metricName(name, "consumer" + groupId + "-coordinator-metrics"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -204,14 +204,22 @@ public class ConsumerCoordinatorTest {
 
     @Test
     public void testMetrics() {
-        metrics.sensor("commit-latency").record(1.0d);
-        metrics.sensor("commit-latency").record(2.0d);
-        metrics.sensor("commit-latency").record(6.0d);
-
         assertNotNull(getMetric("commit-latency-avg"));
         assertNotNull(getMetric("commit-latency-max"));
         assertNotNull(getMetric("commit-rate"));
         assertNotNull(getMetric("commit-total"));
+        assertNotNull(getMetric("partition-revoked-latency-avg"));
+        assertNotNull(getMetric("partition-revoked-latency-max"));
+        assertNotNull(getMetric("partition-assigned-latency-avg"));
+        assertNotNull(getMetric("partition-assigned-latency-max"));
+        assertNotNull(getMetric("partition-lost-latency-avg"));
+        assertNotNull(getMetric("partition-lost-latency-max"));
+        assertNotNull(getMetric("assigned-partitions"));
+
+        metrics.sensor("commit-latency").record(1.0d);
+        metrics.sensor("commit-latency").record(6.0d);
+        metrics.sensor("commit-latency").record(2.0d);
+
         assertEquals(3.0d, getMetric("commit-latency-avg").metricValue());
         assertEquals(6.0d, getMetric("commit-latency-max").metricValue());
         assertEquals(0.1d, getMetric("commit-rate").metricValue());
@@ -224,12 +232,6 @@ public class ConsumerCoordinatorTest {
         metrics.sensor("partition-lost-latency").record(1.0d);
         metrics.sensor("partition-lost-latency").record(2.0d);
 
-        assertNotNull(getMetric("partition-revoked-latency-avg"));
-        assertNotNull(getMetric("partition-revoked-latency-max"));
-        assertNotNull(getMetric("partition-assigned-latency-avg"));
-        assertNotNull(getMetric("partition-assigned-latency-max"));
-        assertNotNull(getMetric("partition-lost-latency-avg"));
-        assertNotNull(getMetric("partition-lost-latency-max"));
         assertEquals(1.5d, getMetric("partition-revoked-latency-avg").metricValue());
         assertEquals(2.0d, getMetric("partition-revoked-latency-max").metricValue());
         assertEquals(1.5d, getMetric("partition-assigned-latency-avg").metricValue());
@@ -237,7 +239,6 @@ public class ConsumerCoordinatorTest {
         assertEquals(1.5d, getMetric("partition-lost-latency-avg").metricValue());
         assertEquals(2.0d, getMetric("partition-lost-latency-max").metricValue());
 
-        assertNotNull(getMetric("assigned-partitions"));
         assertEquals(0.0d, getMetric("assigned-partitions").metricValue());
         subscriptions.assignFromUser(Collections.singleton(t1p));
         assertEquals(1.0d, getMetric("assigned-partitions").metricValue());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -49,6 +49,8 @@ import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
@@ -198,6 +200,29 @@ public class ConsumerCoordinatorTest {
     public void teardown() {
         this.metrics.close();
         this.coordinator.close(time.timer(0));
+    }
+
+    @Test
+    public void testMetrics() {
+        assertNotNull(getMetric("commit-latency-avg"));
+        assertNotNull(getMetric("commit-latency-max"));
+        assertNotNull(getMetric("commit-rate"));
+        assertNotNull(getMetric("commit-total"));
+        assertNotNull(getMetric("partition-revoked-latency-avg"));
+        assertNotNull(getMetric("partition-revoked-latency-max"));
+        assertNotNull(getMetric("partition-assigned-latency-avg"));
+        assertNotNull(getMetric("partition-assigned-latency-max"));
+        assertNotNull(getMetric("partition-lost-latency-avg"));
+        assertNotNull(getMetric("partition-lost-latency-max"));
+        assertNotNull(getMetric("assigned-partitions"));
+
+        final JmxReporter reporter = new JmxReporter("kafka.streams");
+        metrics.addReporter(reporter);
+        assertTrue(reporter.containsMbean("kafka.streams:type=consumer" + groupId + "-coordinator-metrics"));
+    }
+
+    private KafkaMetric getMetric(final String name) {
+        return metrics.metrics().get(metrics.metricName(name,"consumer" + groupId + "-coordinator-metrics"));
     }
 
     @Test


### PR DESCRIPTION
Adding the following metrics in 

1. AbstractCoordinator (for both consumer and connect)

* rebalance-latency-avg
* rebalance-latency-max
* rebalance-total
* rebalance-rate-per-hour
* failed-rebalance-total
* failed-rebalance-rate-per-hour
* last-rebalance-seconds-ago

2. ConsumerCoordinator

* partition-revoked-latency-avg
* partition-revoked-latency-max
* partition-assigned-latency-avg
* partition-assigned-latency-max
* partition-lost-latency-avg
* partition-lost-latency-max


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
