### PR TITLE
KAFKA-8931: just restart current reconfigurated connectorTask, not all cached updateTasks

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -13,19 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, connectAppender
 
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-
-#
-# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
-# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
-# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
-#
-#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.connectAppender.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -56,6 +56,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -633,8 +634,11 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                     connectorTaskCounts.put(connectorName, newTaskCount);
                 }
 
-                if (started)
+                if (started) {
+                    // just restart current reconfigurated connectorTask, not all cached updateTasks
+                    updatedTasks = updatedTasks.stream().filter(tasksId -> tasksId.connector().equals(connectorName)).collect(Collectors.toList());
                     updateListener.onTaskConfigUpdate(updatedTasks);
+                } 
             } else {
                 log.error("Discarding config update record with invalid key: {}", record.key());
             }


### PR DESCRIPTION
While testing Kafka Connect KIP-415, it don't work well under new connector commited, which will restart all tasks before the one current commited.

Filter `updatedTasks` with current reconfigurated `connectorName` ensure just restart current reconfigurated connectorTask, not all cached `updateTasks` ;