### PR TITLE
fix-bug

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -286,7 +286,7 @@ if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   # 10 -> java version "10" 2018-03-20
   # 10.0.1 -> java version "10.0.1" 2018-04-17
   # We need to match to the end of the line to prevent sed from printing the characters that do not match
-  JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+  JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -n '1p'|awk -F '.' '{print $2}')
   if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
     KAFKA_GC_LOG_OPTS="-Xlog:gc*:file=$LOG_DIR/$GC_LOG_FILE_NAME:time,tags:filecount=10,filesize=102400"
   else

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -31,14 +31,22 @@ fi
 
 EXTRA_ARGS=${EXTRA_ARGS-'-name kafkaServer -loggc'}
 
+CONFDIR="${base_dir}/../config"
+
 COMMAND=$1
 case $COMMAND in
   -daemon)
     EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    CONFPATH=$CONFDIR"/"$2
+    shift
+    shift
+    ;;
+  server.properties)
+    CONFPATH=$CONFDIR"/"$1
     shift
     ;;
   *)
     ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"
+exce  $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka $CONFPATH  "$@"


### PR DESCRIPTION
1. fix the error 'sed: invalid option -- 'E''  , when the  bin/kafka-run-class.sh scripts run on the centos 7; 
2. fix the error 'java.nio.file.NoSuchFileException: server.properties' , when run the command 'kafka-server-start.sh   server.properties'  in anyother directory; 