### PR TITLE
KAFKA-8920: Add a new property to enable/disable token clean scheduler

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -315,7 +315,7 @@ class KafkaController(val config: KafkaConfig,
       scheduleAutoLeaderRebalanceTask(delay = 5, unit = TimeUnit.SECONDS)
     }
 
-    if (config.tokenAuthEnabled) {
+    if (config.tokenCleanSchedulerEnable) {
       info("starting the token expiry check scheduler")
       tokenCleanScheduler.startup()
       tokenCleanScheduler.schedule(name = "delete-expired-tokens",

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -246,6 +246,7 @@ object Defaults {
   val DelegationTokenMaxLifeTimeMsDefault = 7 * 24 * 60 * 60 * 1000L
   val DelegationTokenExpiryTimeMsDefault = 24 * 60 * 60 * 1000L
   val DelegationTokenExpiryCheckIntervalMsDefault = 1 * 60 * 60 * 1000L
+  val DelegationTokenCleanSchedulerEnableDefault = true
 
   /** ********* Password encryption configuration for dynamic configs *********/
   val PasswordEncoderCipherAlgorithm = "AES/CBC/PKCS5Padding"
@@ -480,6 +481,7 @@ object KafkaConfig {
   val DelegationTokenMaxLifeTimeProp = "delegation.token.max.lifetime.ms"
   val DelegationTokenExpiryTimeMsProp = "delegation.token.expiry.time.ms"
   val DelegationTokenExpiryCheckIntervalMsProp = "delegation.token.expiry.check.interval.ms"
+  val DelegationTokenCleanSchedulerEnableProp = "delegation.token.clean.scheduler.enable"
 
   /** ********* Password encryption configuration for dynamic configs *********/
   val PasswordEncoderSecretProp = "password.encoder.secret"
@@ -838,6 +840,7 @@ object KafkaConfig {
   val DelegationTokenMaxLifeTimeDoc = "The token has a maximum lifetime beyond which it cannot be renewed anymore. Default value 7 days."
   val DelegationTokenExpiryTimeMsDoc = "The token validity time in miliseconds before the token needs to be renewed. Default value 1 day."
   val DelegationTokenExpiryCheckIntervalDoc = "Scan interval to remove expired delegation tokens."
+  val DelegationTokenCleanSchedulerEnableDoc = "Enable the token expiry check scheduler to clean up expired tokens"
 
   /** ********* Password encryption configuration for dynamic configs *********/
   val PasswordEncoderSecretDoc = "The secret used for encoding dynamically configured passwords for this broker."
@@ -1084,6 +1087,7 @@ object KafkaConfig {
       .define(DelegationTokenMaxLifeTimeProp, LONG, Defaults.DelegationTokenMaxLifeTimeMsDefault, atLeast(1), MEDIUM, DelegationTokenMaxLifeTimeDoc)
       .define(DelegationTokenExpiryTimeMsProp, LONG, Defaults.DelegationTokenExpiryTimeMsDefault, atLeast(1), MEDIUM, DelegationTokenExpiryTimeMsDoc)
       .define(DelegationTokenExpiryCheckIntervalMsProp, LONG, Defaults.DelegationTokenExpiryCheckIntervalMsDefault, atLeast(1), LOW, DelegationTokenExpiryCheckIntervalDoc)
+      .define(DelegationTokenCleanSchedulerEnableProp, BOOLEAN, Defaults.DelegationTokenCleanSchedulerEnableDefault, LOW, DelegationTokenCleanSchedulerEnableDoc)
 
       /** ********* Password encryption configuration for dynamic configs *********/
       .define(PasswordEncoderSecretProp, PASSWORD, null, MEDIUM, PasswordEncoderSecretDoc)
@@ -1342,6 +1346,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val delegationTokenMaxLifeMs = getLong(KafkaConfig.DelegationTokenMaxLifeTimeProp)
   val delegationTokenExpiryTimeMs = getLong(KafkaConfig.DelegationTokenExpiryTimeMsProp)
   val delegationTokenExpiryCheckIntervalMs = getLong(KafkaConfig.DelegationTokenExpiryCheckIntervalMsProp)
+  val tokenCleanSchedulerEnable = tokenAuthEnabled && getBoolean(KafkaConfig.DelegationTokenCleanSchedulerEnableProp)
 
   /** ********* Password encryption configuration for dynamic configs *********/
   def passwordEncoderSecret = Option(getPassword(KafkaConfig.PasswordEncoderSecretProp))

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -806,6 +806,7 @@ class KafkaConfigTest {
     assertEquals(SnappyCompressionCodec, config.offsetsTopicCompressionCodec)
     assertEquals(Sensor.RecordingLevel.DEBUG.toString, config.metricRecordingLevel)
     assertEquals(false, config.tokenAuthEnabled)
+    assertEquals(false, config.tokenCleanSchedulerEnable)
     assertEquals(7 * 24 * 60L * 60L * 1000L, config.delegationTokenMaxLifeMs)
     assertEquals(24 * 60L * 60L * 1000L, config.delegationTokenExpiryTimeMs)
     assertEquals(1 * 60L * 1000L * 60, config.delegationTokenExpiryCheckIntervalMs)
@@ -813,6 +814,11 @@ class KafkaConfigTest {
     defaults.put(KafkaConfig.DelegationTokenMasterKeyProp, "1234567890")
     val config1 = KafkaConfig.fromProps(defaults)
     assertEquals(true, config1.tokenAuthEnabled)
+    assertEquals(true, config1.tokenCleanSchedulerEnable)
+
+    defaults.put(KafkaConfig.DelegationTokenCleanSchedulerEnableProp, "false")
+    val config2 = KafkaConfig.fromProps(defaults)
+    assertEquals(false, config2.tokenCleanSchedulerEnable)
   }
 
   @Test


### PR DESCRIPTION
**Detail:** Introduce a new property to enable/disable the expired token clean scheduler
Providing this new property would allow the developers to manipulate expired tokens externally by themselves, and Kafka process does not need to spend its resource to clean up the expired tokens, which is not the main feature.

**The testing strategy:** ensure the value of scheduler enabling flag is based on
- PasswordEncoderSecret Property is set or not (same as variable: tokenAuthEnabled)
- DelegationTokenCleanSchedulerEnable Property
If one of them is false, this flag must be false

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
