### PR TITLE
KAFKA-8901; Extend consumer group command to use the new Admin API to delete consumer offsets (KIP-496)

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -129,7 +129,7 @@ object ConsumerGroupCommand extends Logging {
       println("%-30s %-15s %-15s".format(
         tp.topic,
         if (tp.partition >= 0) tp.partition else "Not Provided",
-        if (error != null) s"Failed: ${error.getCause.getMessage}" else "Successful"
+        if (error != null) s"Error: ${error.getCause.getMessage}" else "Successful"
       ))
     }
   }

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -48,9 +48,9 @@ object ConsumerGroupCommand extends Logging {
     CommandLineUtils.printHelpAndExitIfNeeded(opts, "This tool helps to list all consumer groups, describe a consumer group, delete consumer group info, or reset consumer group offsets.")
 
     // should have exactly one action
-    val actions = Seq(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt).count(opts.options.has)
+    val actions = Seq(opts.listOpt, opts.describeOpt, opts.deleteOpt, opts.resetOffsetsOpt, opts.deleteOffsetsOpt).count(opts.options.has)
     if (actions != 1)
-      CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets")
+      CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets")
 
     opts.checkArgs()
 
@@ -70,6 +70,10 @@ object ConsumerGroupCommand extends Logging {
           println(exported)
         } else
           printOffsetsToReset(offsetsToReset)
+      }
+      else if (opts.options.has(opts.deleteOffsetsOpt)) {
+        val (error, result) = consumerGroupService.deleteOffsets()
+        printDeletedOffsets(error, result)
       }
     } catch {
       case e: Throwable =>
@@ -111,6 +115,22 @@ object ConsumerGroupCommand extends Logging {
         consumerAssignment.topic,
         consumerAssignment.partition,
         offsetAndMetadata.offset))
+    }
+  }
+
+  def printDeletedOffsets(error: Option[Throwable], result: Map[TopicPartition, Throwable]): Unit = {
+    if (error.isDefined)
+      printError(s"Deletion of offsets failed due to: ${error.get.getCause.getMessage}")
+
+    if (result.nonEmpty)
+      println("\n%-30s %-15s %-15s".format("TOPIC", "PARTITION", "STATUS"))
+
+    result.toList.sortBy(t => t._1.topic + t._1.partition.toString).foreach { case (tp, error) =>
+      println("%-30s %-15s %-15s".format(
+        tp.topic,
+        if (tp.partition >= 0) tp.partition else "Not Provided",
+        if (error != null) s"Failed: ${error.getCause.getMessage}" else "Successful"
+      ))
     }
   }
 
@@ -393,6 +413,61 @@ object ConsumerGroupCommand extends Logging {
             }
         }
       result
+    }
+
+    def deleteOffsets(): (Option[Throwable], Map[TopicPartition, Throwable]) = {
+      val groupId = opts.options.valueOf(opts.groupOpt)
+      val topics = opts.options.valuesOf(opts.topicOpt)
+
+      val (topicWithPartitions, topicWithoutPartitions) = topics.asScala.partition(_.contains(":"))
+
+      val knownPartitions = topicWithPartitions.flatMap { topicArg =>
+        val split = topicArg.split(":")
+        split(1).split(",").map { partition =>
+          new TopicPartition(split(0), partition.toInt)
+        }
+      }
+
+      val describeTopicsResult = adminClient.describeTopics(
+        topicWithoutPartitions.asJava,
+        withTimeoutMs(new DescribeTopicsOptions))
+
+      var result: Map[TopicPartition, Throwable] = mutable.HashMap()
+
+      val unknownPartitions = describeTopicsResult.values().asScala.flatMap { case (topic, future) =>
+        Try(future.get()) match {
+          case Success(description) => description.partitions().asScala.map { partition =>
+            new TopicPartition(topic, partition.partition())
+          }
+          case Failure(e) =>
+            result += new TopicPartition(topic, -1) -> e
+            List.empty
+        }
+      }
+
+      val partitions = knownPartitions ++ unknownPartitions
+
+      val deleteResult = adminClient.deleteConsumerGroupOffsets(
+        groupId,
+        partitions.toSet.asJava,
+        withTimeoutMs(new DeleteConsumerGroupOffsetsOptions)
+      )
+
+      try {
+        deleteResult.all().get()
+
+        partitions.foreach { partition =>
+          Try(deleteResult.partitionResult(partition).get()) match {
+            case Success(_) => result += partition -> null
+            case Failure(e) => result += partition -> e
+          }
+        }
+
+        None -> result
+      } catch {
+        case e: Exception =>
+          Some(e) -> Map.empty
+      }
     }
 
     private[admin] def describeConsumerGroups(groupIds: Seq[String]): mutable.Map[String, ConsumerGroupDescription] = {
@@ -850,6 +925,7 @@ object ConsumerGroupCommand extends Logging {
       "Example: --bootstrap-server localhost:9092 --describe --group group1 --offsets"
     val StateDoc = "Describe the group state. This option may be used with '--describe' and '--bootstrap-server' options only." + nl +
       "Example: --bootstrap-server localhost:9092 --describe --group group1 --state"
+    val DeleteOffsetsDoc = "Delete offsets of consumer group. Supports one consumer group at the time, and multiple topics."
 
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
@@ -878,6 +954,7 @@ object ConsumerGroupCommand extends Logging {
                                   .describedAs("command config property file")
                                   .ofType(classOf[String])
     val resetOffsetsOpt = parser.accepts("reset-offsets", ResetOffsetsDoc)
+    val deleteOffsetsOpt = parser.accepts("delete-offsets", DeleteOffsetsDoc)
     val dryRunOpt = parser.accepts("dry-run", DryRunDoc)
     val executeOpt = parser.accepts("execute", ExecuteDoc)
     val exportOpt = parser.accepts("export", ExportDoc)
@@ -921,6 +998,7 @@ object ConsumerGroupCommand extends Logging {
     val allConsumerGroupLevelOpts: Set[OptionSpec[_]]  = Set(listOpt, describeOpt, deleteOpt, resetOffsetsOpt)
     val allResetOffsetScenarioOpts: Set[OptionSpec[_]] = Set(resetToOffsetOpt, resetShiftByOpt,
       resetToDatetimeOpt, resetByDurationOpt, resetToEarliestOpt, resetToLatestOpt, resetToCurrentOpt, resetFromFileOpt)
+    val allDeleteOffsetsOpts: Set[OptionSpec[_]] = Set(groupOpt, topicOpt)
 
     def checkArgs(): Unit = {
 
@@ -942,6 +1020,12 @@ object ConsumerGroupCommand extends Logging {
         if (options.has(topicOpt))
           CommandLineUtils.printUsageAndDie(parser, s"The consumer does not support topic-specific offset " +
             "deletion from a consumer group.")
+      }
+
+      if (options.has(deleteOffsetsOpt)) {
+        if (!options.has(groupOpt) || !options.has(topicOpt))
+          CommandLineUtils.printUsageAndDie(parser,
+            s"Option $deleteOffsetsOpt takes the following options: ${allDeleteOffsetsOpts.mkString(", ")}")
       }
 
       if (options.has(resetOffsetsOpt)) {

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1054,14 +1054,6 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     TestUtils.pollUntilTrue(consumer, () => !consumer.assignment.isEmpty, "Expected non-empty assignment")
   }
 
-  private def subscribeAndWaitForRecords(topic: String, consumer: KafkaConsumer[Array[Byte], Array[Byte]]): Unit = {
-    consumer.subscribe(Collections.singletonList(topic))
-    TestUtils.pollRecordsUntilTrue(
-      consumer,
-      (records: ConsumerRecords[Array[Byte], Array[Byte]]) => !records.isEmpty,
-      "Expected records" )
-  }
-
   private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
                           numRecords: Int,
                           topicPartition: TopicPartition): Unit = {
@@ -1390,7 +1382,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       val consumer = createConsumer(configOverrides = newConsumerConfig)
 
       try {
-        subscribeAndWaitForRecords(testTopicName, consumer)
+        TestUtils.subscribeAndWaitForRecords(testTopicName, consumer)
         consumer.commitSync()
 
         // Test offset deletion while consuming

--- a/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
@@ -94,8 +94,9 @@ class ConsumerGroupCommandTest extends KafkaServerTestHarness {
                                topic: String = topic,
                                group: String = group,
                                strategy: String = classOf[RangeAssignor].getName,
-                               customPropsOpt: Option[Properties] = None): ConsumerGroupExecutor = {
-    val executor = new ConsumerGroupExecutor(brokerList, numConsumers, group, topic, strategy, customPropsOpt)
+                               customPropsOpt: Option[Properties] = None,
+                               syncCommit: Boolean = false): ConsumerGroupExecutor = {
+    val executor = new ConsumerGroupExecutor(brokerList, numConsumers, group, topic, strategy, customPropsOpt, syncCommit)
     addExecutor(executor)
     executor
   }
@@ -116,7 +117,8 @@ class ConsumerGroupCommandTest extends KafkaServerTestHarness {
 
 object ConsumerGroupCommandTest {
 
-  abstract class AbstractConsumerRunnable(broker: String, groupId: String, customPropsOpt: Option[Properties] = None) extends Runnable {
+  abstract class AbstractConsumerRunnable(broker: String, groupId: String, customPropsOpt: Option[Properties] = None,
+                                          syncCommit: Boolean = false) extends Runnable {
     val props = new Properties
     configure(props)
     customPropsOpt.foreach(props.asScala ++= _.asScala)
@@ -134,8 +136,11 @@ object ConsumerGroupCommandTest {
     def run(): Unit = {
       try {
         subscribe()
-        while (true)
+        while (true) {
           consumer.poll(Duration.ofMillis(Long.MaxValue))
+          if (syncCommit)
+            consumer.commitSync()
+        }
       } catch {
         case _: WakeupException => // OK
       } finally {
@@ -148,8 +153,9 @@ object ConsumerGroupCommandTest {
     }
   }
 
-  class ConsumerRunnable(broker: String, groupId: String, topic: String, strategy: String, customPropsOpt: Option[Properties] = None)
-    extends AbstractConsumerRunnable(broker, groupId, customPropsOpt) {
+  class ConsumerRunnable(broker: String, groupId: String, topic: String, strategy: String,
+                         customPropsOpt: Option[Properties] = None, syncCommit: Boolean = false)
+    extends AbstractConsumerRunnable(broker, groupId, customPropsOpt, syncCommit) {
 
     override def configure(props: Properties): Unit = {
       super.configure(props)
@@ -186,11 +192,11 @@ object ConsumerGroupCommandTest {
   }
 
   class ConsumerGroupExecutor(broker: String, numConsumers: Int, groupId: String, topic: String, strategy: String,
-                              customPropsOpt: Option[Properties] = None)
+                              customPropsOpt: Option[Properties] = None, syncCommit: Boolean = false)
     extends AbstractConsumerGroupExecutor(numConsumers) {
 
     for (_ <- 1 to numConsumers) {
-      submit(new ConsumerRunnable(broker, groupId, topic, strategy, customPropsOpt))
+      submit(new ConsumerRunnable(broker, groupId, topic, strategy, customPropsOpt, syncCommit))
     }
 
   }

--- a/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandIntegrationTest.scala
@@ -62,22 +62,22 @@ class DeleteOffsetsConsumerGroupCommandIntegrationTest extends ConsumerGroupComm
   }
 
   @Test
-  def testDeleteOffsetsOfSableConsumerGroupWithTopicPartition(): Unit = {
+  def testDeleteOffsetsOfStableConsumerGroupWithTopicPartition(): Unit = {
     testWithStableConsumerGroup(topic, 0, 0, Errors.GROUP_SUBSCRIBED_TO_TOPIC)
   }
 
   @Test
-  def testDeleteOffsetsOfSableConsumerGroupWithTopicOnly(): Unit = {
+  def testDeleteOffsetsOfStableConsumerGroupWithTopicOnly(): Unit = {
     testWithStableConsumerGroup(topic, -1, 0, Errors.GROUP_SUBSCRIBED_TO_TOPIC)
   }
 
   @Test
-  def testDeleteOffsetsOfSableConsumerGroupWithUnknownTopicPartition(): Unit = {
+  def testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicPartition(): Unit = {
     testWithStableConsumerGroup("foobar", 0, 0, Errors.UNKNOWN_TOPIC_OR_PARTITION)
   }
 
   @Test
-  def testDeleteOffsetsOfSableConsumerGroupWithUnknownTopicOnly(): Unit = {
+  def testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicOnly(): Unit = {
     testWithStableConsumerGroup("foobar", -1, -1, Errors.UNKNOWN_TOPIC_OR_PARTITION)
   }
 

--- a/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandTest.scala
@@ -1,0 +1,176 @@
+package kafka.admin
+
+import java.util.Properties
+
+import kafka.server.Defaults
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.utils.Utils
+import org.junit.Test
+import org.junit.Assert._
+
+class DeleteOffsetsConsumerGroupCommandTest extends ConsumerGroupCommandTest {
+
+  @Test
+  def testDeletOffsetsNonExistingGroup(): Unit = {
+    val missingGroup = "missing.group"
+
+    val cgcArgs = Array(
+      "--bootstrap-server", brokerList,
+      "--delete-offsets",
+      "--group", missingGroup,
+      "--topic", "foo:1")
+    val service = getConsumerGroupService(cgcArgs)
+
+    val (global, _) = service.deleteOffsets()
+    assertEquals(Errors.GROUP_ID_NOT_FOUND.exception, global.get.getCause)
+  }
+
+  @Test
+  def testDeleteOffsetsWithTopicPartition(): Unit = {
+    val producer = createProducer()
+    try {
+      producer.send(new ProducerRecord(topic, 0, null, null)).get()
+    } finally {
+      Utils.closeQuietly(producer, "producer")
+    }
+
+    val consumer = createConsumer()
+    try {
+      TestUtils.subscribeAndWaitForRecords(topic, consumer)
+      consumer.commitSync()
+
+      val cgcArgs = Array(
+        "--bootstrap-server", brokerList,
+        "--delete-offsets",
+        "--group", group,
+        "--topic", topic + ":0")
+      val service = getConsumerGroupService(cgcArgs)
+
+      val (global, partitions) = service.deleteOffsets()
+      assertEquals(None, global)
+      // Unknown because the consumer has not committed any offsets yet.
+      assertEquals(Errors.GROUP_SUBSCRIBED_TO_TOPIC.exception, partitions(new TopicPartition(topic, 0)).getCause)
+    } finally {
+      Utils.closeQuietly(consumer, "consumer")
+    }
+  }
+
+  @Test
+  def testDeleteOffsetsWithTopic(): Unit = {
+    val producer = createProducer()
+    try {
+      producer.send(new ProducerRecord(topic, 0, null, null)).get()
+    } finally {
+      Utils.closeQuietly(producer, "producer")
+    }
+
+    val consumer = createConsumer()
+    try {
+      TestUtils.subscribeAndWaitForRecords(topic, consumer)
+      consumer.commitSync()
+
+      val cgcArgs = Array(
+        "--bootstrap-server", brokerList,
+        "--delete-offsets",
+        "--group", group,
+        "--topic", topic)
+      val service = getConsumerGroupService(cgcArgs)
+
+      val (global, partitions) = service.deleteOffsets()
+      assertEquals(None, global)
+      assertEquals(Errors.GROUP_SUBSCRIBED_TO_TOPIC.exception, partitions(new TopicPartition(topic, 0)).getCause)
+    } finally {
+      Utils.closeQuietly(consumer, "consumer")
+    }
+  }
+
+  @Test
+  def testDeleteOffsetsWithTopicEmpty(): Unit = {
+    val producer = createProducer()
+    try {
+      producer.send(new ProducerRecord(topic, 0, null, null)).get()
+    } finally {
+      Utils.closeQuietly(producer, "producer")
+    }
+
+    val consumer = createConsumer()
+    try {
+      TestUtils.subscribeAndWaitForRecords(topic, consumer)
+      consumer.commitSync()
+    } finally {
+      Utils.closeQuietly(consumer, "consumer")
+    }
+
+    val cgcArgs = Array(
+      "--bootstrap-server", brokerList,
+      "--delete-offsets",
+      "--group", group,
+      "--topic", topic)
+    val service = getConsumerGroupService(cgcArgs)
+
+    val (global, partitions) = service.deleteOffsets()
+    assertEquals(None, global)
+    assertNull(partitions(new TopicPartition(topic, 0)))
+  }
+
+  @Test
+  def testDeleteOffsetsWithUnknownTopic(): Unit = {
+    val producer = createProducer()
+    try {
+      producer.send(new ProducerRecord(topic, 0, null, null)).get()
+    } finally {
+      Utils.closeQuietly(producer, "producer")
+    }
+
+    val consumer = createConsumer()
+    try {
+      TestUtils.subscribeAndWaitForRecords(topic, consumer)
+      consumer.commitSync()
+
+      val cgcArgs = Array(
+        "--bootstrap-server", brokerList,
+        "--delete-offsets",
+        "--group", group,
+        "--topic", "foobar")
+      val service = getConsumerGroupService(cgcArgs)
+
+      val (global, partitions) = service.deleteOffsets()
+      assertEquals(None, global)
+      assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception, partitions(new TopicPartition("foobar", -1)).getCause)
+    } finally {
+      Utils.closeQuietly(consumer, "consumer")
+    }
+  }
+
+  private def createProducer(config: Properties = new Properties()): KafkaProducer[Array[Byte], Array[Byte]] = {
+    config.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    config.putIfAbsent(ProducerConfig.ACKS_CONFIG, "-1")
+    config.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+    config.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+
+    new KafkaProducer(config)
+  }
+
+  private def createConsumer(config: Properties = new Properties()): KafkaConsumer[Array[Byte], Array[Byte]] = {
+    config.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    config.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    config.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, group)
+    config.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    config.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    // Increase timeouts to avoid having a rebalance during the test
+    config.putIfAbsent(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, Integer.MAX_VALUE.toString)
+    config.putIfAbsent(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Defaults.GroupMaxSessionTimeoutMs.toString)
+
+    new KafkaConsumer(config)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandTest.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.admin
 
 import java.util.Properties

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -795,6 +795,14 @@ object TestUtils extends Logging {
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }
 
+  def subscribeAndWaitForRecords(topic: String, consumer: KafkaConsumer[Array[Byte], Array[Byte]]): Unit = {
+    consumer.subscribe(Collections.singletonList(topic))
+    pollRecordsUntilTrue(
+      consumer,
+      (records: ConsumerRecords[Array[Byte], Array[Byte]]) => !records.isEmpty,
+      "Expected records" )
+  }
+
   /**
    * Wait for the presence of an optional value.
    *

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -795,12 +795,15 @@ object TestUtils extends Logging {
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }
 
-  def subscribeAndWaitForRecords(topic: String, consumer: KafkaConsumer[Array[Byte], Array[Byte]]): Unit = {
+  def subscribeAndWaitForRecords(topic: String,
+                                 consumer: KafkaConsumer[Array[Byte], Array[Byte]],
+                                 waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
     consumer.subscribe(Collections.singletonList(topic))
     pollRecordsUntilTrue(
       consumer,
       (records: ConsumerRecords[Array[Byte], Array[Byte]]) => !records.isEmpty,
-      "Expected records" )
+      "Expected records",
+      waitTimeMs)
   }
 
   /**


### PR DESCRIPTION
It add support to delete offsets in the `kafka-consumer-group`.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
