### PR TITLE
HOTFIX: fix Kafka Streams upgrade note for broker backward compatibility

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -53,8 +53,10 @@
     </ul>
 
     <p>
-        Note, that a brokers must be on version 0.10.1 or higher to run a Kafka Streams application version 0.10.1 or higher;
-        On-disk message format must be 0.10 or higher to run a Kafka Streams application version 1.0 or higher.
+        To run a Kafka Streams application version 2.2.1, 2.3.0, or higher a broker version 0.11.0 or higher is required
+        and the on-disk message format must be 0.11 or higher.
+        Brokers must be on version 0.10.1 or higher to run a Kafka Streams application version 0.10.1 to 2.2.0.
+        Additionally, on-disk message format must be 0.10 or higher to run a Kafka Streams application version 1.0 to 2.2.0.
         For Kafka Streams 0.10.0, broker version 0.10.0 or higher is required.
     </p>
 
@@ -137,6 +139,12 @@
         RocksDB dependency was updated to version <code>5.18.3</code>.
         The new version allows to specify more RocksDB configurations, including <code>WriteBufferManager</code> which helps to limit RocksDB off-heap memory usage.
         For more details please read <a href="https://issues.apache.org/jira/browse/KAFKA-8215">KAFKA-8215</a>.
+    </p>
+
+    <h3><a id="streams_notable_changes_221" href="#streams_api_changes_221">Notable changes in Kafka Streams 2.2.1</a></h3>
+    <p>
+        As of Kafka Streams 2.2.1 a message format 0.11 or higher is required;
+        this implies that brokers must be on version 0.11.0 or higher.
     </p>
 
     <h3><a id="streams_api_changes_220" href="#streams_api_changes_220">Streams API changes in 2.2.0</a></h3>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -99,6 +99,7 @@
     <li> Kafka Streams DSL switches its used store types. While this change is mainly transparent to users, there are some corner cases that may require code changes.
         See the <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_230">Kafka Streams upgrade section</a> for more details.
     </li>
+    <li>Kafka Streams 2.3.0 requires 0.11 message format or higher and does not work with older message format.</li>
 </ul>
 
 <h4><a id="upgrade_2_2_0" href="#upgrade_2_2_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, 2.0.x or 2.1.x to 2.2.0</a></h4>
@@ -142,6 +143,11 @@
         the newer Java clients must be used.
     </li>
 </ol>
+
+<h5><a id="upgrade_221_notable" href="#upgrade_221_notable">Notable changes in 2.2.1</a></h5>
+<ul>
+    <li>Kafka Streams 2.2.1 requires 0.11 message format or higher and does not work with older message format.</li>
+</ul>
 
 <h5><a id="upgrade_220_notable" href="#upgrade_220_notable">Notable changes in 2.2.0</a></h5>
 <ul>


### PR DESCRIPTION
Fix should be cherry-picked to 2.3 branch.

For 2.2 branch, cf #7364 

Also compare kafka-site PR https://github.com/apache/kafka-site/pull/229