### PR TITLE
KAFKA-8859: Refactor cache-level metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -444,7 +444,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
 
-    public static void addAvgAndMaxToSensor(final Sensor sensor,
+    private static void addAvgAndMaxToSensor(final Sensor sensor,
                                             final String group,
                                             final Map<String, String> tags,
                                             final String operation,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -80,6 +80,11 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String TOTAL_SUFFIX = "-total";
     public static final String RATIO_SUFFIX = "-ratio";
 
+    public static final String AVG_VALUE_DOC = "The average value of ";
+    public static final String MAX_VALUE_DOC = "The maximum value of ";
+    public static final String AVG_LATENCY_DOC = "The average latency of ";
+    public static final String MAX_LATENCY_DOC = "The maximum latency of ";
+
     public static final String GROUP_PREFIX_WO_DELIMITER = "stream";
     public static final String GROUP_PREFIX = GROUP_PREFIX_WO_DELIMITER + "-";
     public static final String GROUP_SUFFIX = "-metrics";
@@ -472,8 +477,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             group,
             tags,
             operation,
-            "The average value of " + operation + ".",
-            "The maximum value of " + operation + "."
+            AVG_VALUE_DOC + operation + ".",
+            MAX_VALUE_DOC + operation + "."
         );
     }
 
@@ -485,7 +490,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             new MetricName(
                 operation + "-latency-avg",
                 group,
-                "The average latency of " + operation + " operation.",
+                AVG_LATENCY_DOC + operation + " operation.",
                 tags),
             new Avg()
         );
@@ -493,7 +498,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             new MetricName(
                 operation + "-latency-max",
                 group,
-                "The max latency of " + operation + " operation.",
+                MAX_LATENCY_DOC + operation + " operation.",
                 tags),
             new Max()
         );

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -19,14 +19,12 @@ package org.apache.kafka.streams.state.internals;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.apache.kafka.common.MetricName;
+
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Min;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.metrics.NamedCacheMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,19 +32,22 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 class NamedCache {
     private static final Logger log = LoggerFactory.getLogger(NamedCache.class);
     private final String name;
+    private final String storeName;
+    private final String taskName;
     private final NavigableMap<Bytes, LRUNode> cache = new TreeMap<>();
     private final Set<Bytes> dirtyKeys = new LinkedHashSet<>();
     private ThreadCache.DirtyEntryFlushListener listener;
     private LRUNode tail;
     private LRUNode head;
     private long currentSizeBytes;
-    private final NamedCacheMetrics namedCacheMetrics;
+
+    private final StreamsMetricsImpl streamsMetrics;
+    private final Sensor hitRatioSensor;
 
     // internal stats
     private long numReadHits = 0;
@@ -54,9 +55,12 @@ class NamedCache {
     private long numOverwrites = 0;
     private long numFlushes = 0;
 
-    NamedCache(final String name, final StreamsMetricsImpl metrics) {
+    NamedCache(final String name, final StreamsMetricsImpl streamsMetrics) {
         this.name = name;
-        this.namedCacheMetrics = new NamedCacheMetrics(metrics, name);
+        this.streamsMetrics = streamsMetrics;
+        storeName = ThreadCache.underlyingStoreNamefromCacheName(name);
+        taskName = ThreadCache.taskIDfromCacheName(name);
+        hitRatioSensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, taskName, storeName);
     }
 
     synchronized final String name() {
@@ -187,7 +191,7 @@ class NamedCache {
             return null;
         } else {
             numReadHits++;
-            namedCacheMetrics.hitRatioSensor.record((double) numReadHits / (double) (numReadHits + numReadMisses));
+            hitRatioSensor.record((double) numReadHits / (double) (numReadHits + numReadMisses));
         }
         return node;
     }
@@ -311,7 +315,7 @@ class NamedCache {
         currentSizeBytes = 0;
         dirtyKeys.clear();
         cache.clear();
-        namedCacheMetrics.removeAllSensors();
+        streamsMetrics.removeAllCacheLevelSensors(taskName, storeName);
     }
 
     /**
@@ -357,68 +361,4 @@ class NamedCache {
         }
     }
 
-    private static class NamedCacheMetrics {
-        private final StreamsMetricsImpl metrics;
-
-        private final Sensor hitRatioSensor;
-        private final String taskName;
-        private final String cacheName;
-
-        private NamedCacheMetrics(final StreamsMetricsImpl metrics, final String cacheName) {
-            taskName = ThreadCache.taskIDfromCacheName(cacheName);
-            this.cacheName = cacheName;
-            this.metrics = metrics;
-            final String group = "stream-record-cache-metrics";
-
-            // add parent
-            final Map<String, String> allMetricTags = metrics.tagMap(
-                 "task-id", taskName,
-                "record-cache-id", "all"
-            );
-            final Sensor taskLevelHitRatioSensor = metrics.taskLevelSensor(taskName, "hitRatio", Sensor.RecordingLevel.DEBUG);
-            taskLevelHitRatioSensor.add(
-                new MetricName("hitRatio-avg", group, "The average cache hit ratio.", allMetricTags),
-                new Avg()
-            );
-            taskLevelHitRatioSensor.add(
-                new MetricName("hitRatio-min", group, "The minimum cache hit ratio.", allMetricTags),
-                new Min()
-            );
-            taskLevelHitRatioSensor.add(
-                new MetricName("hitRatio-max", group, "The maximum cache hit ratio.", allMetricTags),
-                new Max()
-            );
-
-            // add child
-            final Map<String, String> metricTags = metrics.tagMap(
-                 "task-id", taskName,
-                "record-cache-id", ThreadCache.underlyingStoreNamefromCacheName(cacheName)
-            );
-
-            hitRatioSensor = metrics.cacheLevelSensor(
-                taskName,
-                cacheName,
-                "hitRatio",
-                Sensor.RecordingLevel.DEBUG,
-                taskLevelHitRatioSensor
-            );
-            hitRatioSensor.add(
-                new MetricName("hitRatio-avg", group, "The average cache hit ratio.", metricTags),
-                new Avg()
-            );
-            hitRatioSensor.add(
-                new MetricName("hitRatio-min", group, "The minimum cache hit ratio.", metricTags),
-                new Min()
-            );
-            hitRatioSensor.add(
-                new MetricName("hitRatio-max", group, "The maximum cache hit ratio.", metricTags),
-                new Max()
-            );
-
-        }
-
-        private void removeAllSensors() {
-            metrics.removeAllCacheLevelSensors(taskName, cacheName);
-        }
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals.metrics;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CACHE_LEVEL_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version.FROM_100_TO_23;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMinAndMaxToSensor;
+
+public class NamedCacheMetrics {
+    private NamedCacheMetrics() {}
+
+    private static final String HIT_RATIO_BEFORE_24 = "hitRatio";
+    private static final String HIT_RATIO = "hit-ratio";
+    private static final String HIT_RATIO_AVG_DESCRIPTION = "The average cache hit ratio";
+    private static final String HIT_RATIO_MIN_DESCRIPTION = "The minimum cache hit ratio";
+    private static final String HIT_RATIO_MAX_DESCRIPTION = "The maximum cache hit ratio";
+
+
+    public static Sensor hitRatioSensor(final StreamsMetricsImpl streamsMetrics,
+                                        final String taskName,
+                                        final String storeName) {
+
+        final Sensor hitRatioSensor;
+        final String hitRatioName;
+        if (streamsMetrics.version() == FROM_100_TO_23) {
+            hitRatioName = HIT_RATIO_BEFORE_24;
+            final Sensor taskLevelHitRatioSensor = streamsMetrics.taskLevelSensor(
+                taskName,
+                hitRatioName,
+                Sensor.RecordingLevel.DEBUG
+            );
+            addAvgAndMinAndMaxToSensor(
+                taskLevelHitRatioSensor,
+                CACHE_LEVEL_GROUP,
+                streamsMetrics.cacheLevelTagMap(taskName, ROLLUP_VALUE),
+                hitRatioName,
+                HIT_RATIO_AVG_DESCRIPTION,
+                HIT_RATIO_MIN_DESCRIPTION,
+                HIT_RATIO_MAX_DESCRIPTION
+            );
+            hitRatioSensor = streamsMetrics.cacheLevelSensor(
+                taskName,
+                storeName,
+                hitRatioName,
+                Sensor.RecordingLevel.DEBUG,
+                taskLevelHitRatioSensor
+            );
+        } else {
+            hitRatioName = HIT_RATIO;
+            hitRatioSensor = streamsMetrics.cacheLevelSensor(
+                taskName,
+                storeName,
+                hitRatioName,
+                Sensor.RecordingLevel.DEBUG
+            );
+        }
+        addAvgAndMinAndMaxToSensor(
+            hitRatioSensor,
+            CACHE_LEVEL_GROUP,
+            streamsMetrics.cacheLevelTagMap(taskName, storeName),
+            hitRatioName,
+            HIT_RATIO_AVG_DESCRIPTION,
+            HIT_RATIO_MIN_DESCRIPTION,
+            HIT_RATIO_MAX_DESCRIPTION
+        );
+        return hitRatioSensor;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
@@ -27,7 +27,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 public class NamedCacheMetrics {
     private NamedCacheMetrics() {}
 
-    private static final String HIT_RATIO_BEFORE_24 = "hitRatio";
+    private static final String HIT_RATIO_0100_TO_23 = "hitRatio";
     private static final String HIT_RATIO = "hit-ratio";
     private static final String HIT_RATIO_AVG_DESCRIPTION = "The average cache hit ratio";
     private static final String HIT_RATIO_MIN_DESCRIPTION = "The minimum cache hit ratio";
@@ -41,7 +41,7 @@ public class NamedCacheMetrics {
         final Sensor hitRatioSensor;
         final String hitRatioName;
         if (streamsMetrics.version() == FROM_100_TO_23) {
-            hitRatioName = HIT_RATIO_BEFORE_24;
+            hitRatioName = HIT_RATIO_0100_TO_23;
             final Sensor taskLevelHitRatioSensor = streamsMetrics.taskLevelSensor(
                 taskName,
                 hitRatioName,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -56,6 +56,7 @@ public class ThreadMetricsTest {
         final String operation = "task-created";
         final String totalDescription = "The total number of newly created tasks";
         final String rateDescription = "The average per-second number of newly created tasks";
+        mockStatic(StreamsMetricsImpl.class);
         expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
         expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -56,7 +56,6 @@ public class ThreadMetricsTest {
         final String operation = "task-created";
         final String totalDescription = "The total number of newly created tasks";
         final String rateDescription = "The average per-second number of newly created tasks";
-        mockStatic(StreamsMetricsImpl.class);
         expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
         expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
@@ -29,20 +28,15 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByNameFilterByTags;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 public class NamedCacheTest {
 
@@ -61,7 +55,7 @@ public class NamedCacheTest {
     }
 
     @Test
-    public void shouldKeepTrackOfMostRecentlyAndLeastRecentlyUsed() throws IOException {
+    public void shouldKeepTrackOfMostRecentlyAndLeastRecentlyUsed() {
         final List<KeyValue<String, String>> toInsert = Arrays.asList(
                 new KeyValue<>("K1", "V1"),
                 new KeyValue<>("K2", "V2"),
@@ -81,31 +75,6 @@ public class NamedCacheTest {
             assertEquals(cache.misses(), 0);
             assertEquals(cache.overwrites(), 0);
         }
-    }
-
-    @Test
-    public void testMetrics() {
-        final Map<String, String> metricTags = new LinkedHashMap<>();
-        metricTags.put("record-cache-id", underlyingStoreName);
-        metricTags.put("task-id", taskIDString);
-        metricTags.put("client-id", "test");
-
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-avg", "stream-record-cache-metrics", metricTags);
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-min", "stream-record-cache-metrics", metricTags);
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-max", "stream-record-cache-metrics", metricTags);
-
-        // test "all"
-        metricTags.put("record-cache-id", "all");
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-avg", "stream-record-cache-metrics", metricTags);
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-min", "stream-record-cache-metrics", metricTags);
-        getMetricByNameFilterByTags(metrics.metrics(), "hitRatio-max", "stream-record-cache-metrics", metricTags);
-
-        final JmxReporter reporter = new JmxReporter("kafka.streams");
-        innerMetrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-record-cache-metrics,client-id=test,task-id=%s,record-cache-id=%s",
-                taskIDString, underlyingStoreName)));
-        assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-record-cache-metrics,client-id=test,task-id=%s,record-cache-id=%s",
-                taskIDString, "all")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals.metrics;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
+public class NamedCacheMetricsTest {
+
+    private static final String TASK_NAME = "taskName";
+    private static final String STORE_NAME = "storeName";
+    private static final String HIT_RATIO_AVG_DESCRIPTION = "The average cache hit ratio";
+    private static final String HIT_RATIO_MIN_DESCRIPTION = "The minimum cache hit ratio";
+    private static final String HIT_RATIO_MAX_DESCRIPTION = "The maximum cache hit ratio";
+
+    private final StreamsMetricsImpl streamsMetrics = createMock(StreamsMetricsImpl.class);
+    private final Sensor expectedSensor = mock(Sensor.class);
+    private final Map<String, String> tagMap = mkMap(mkEntry("key", "value"));
+
+    @Test
+    public void shouldGetHitRatioSensorWithBuiltInMetricsVersionCurrent() {
+        final String hitRatio = "hit-ratio";
+        mockStatic(StreamsMetricsImpl.class);
+        setUpStreamsMetrics(Version.LATEST, hitRatio);
+        replay(streamsMetrics);
+        replay(StreamsMetricsImpl.class);
+
+        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, TASK_NAME, STORE_NAME);
+
+        verifyResult(sensor);
+    }
+
+    @Test
+    public void shouldGetHitRatioSensorWithBuiltInMetricsVersionBefore24() {
+        final Map<String, String> parentTagMap = mkMap(mkEntry("key", "all"));
+        final String hitRatio = "hitRatio";
+        final RecordingLevel recordingLevel = RecordingLevel.DEBUG;
+        mockStatic(StreamsMetricsImpl.class);
+        final Sensor parentSensor = mock(Sensor.class);
+        expect(streamsMetrics.taskLevelSensor(TASK_NAME, hitRatio, recordingLevel)).andReturn(parentSensor);
+        expect(streamsMetrics.cacheLevelTagMap(TASK_NAME, StreamsMetricsImpl.ROLLUP_VALUE)).andReturn(parentTagMap);
+        StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
+            parentSensor,
+            StreamsMetricsImpl.CACHE_LEVEL_GROUP,
+            parentTagMap,
+            hitRatio,
+            HIT_RATIO_AVG_DESCRIPTION,
+            HIT_RATIO_MIN_DESCRIPTION,
+            HIT_RATIO_MAX_DESCRIPTION);
+        setUpStreamsMetrics(Version.FROM_100_TO_23, hitRatio, parentSensor);
+        replay(streamsMetrics);
+        replay(StreamsMetricsImpl.class);
+
+        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, TASK_NAME, STORE_NAME);
+
+        verifyResult(sensor);
+    }
+
+    private void setUpStreamsMetrics(final Version builtInMetricsVersion,
+                                     final String hitRatio,
+                                     final Sensor... parents) {
+        expect(streamsMetrics.version()).andReturn(builtInMetricsVersion);
+        expect(streamsMetrics.cacheLevelSensor(TASK_NAME, STORE_NAME, hitRatio, RecordingLevel.DEBUG, parents))
+            .andReturn(expectedSensor);
+        expect(streamsMetrics.cacheLevelTagMap(TASK_NAME, STORE_NAME)).andReturn(tagMap);
+        StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
+            expectedSensor,
+            StreamsMetricsImpl.CACHE_LEVEL_GROUP,
+            tagMap,
+            hitRatio,
+            HIT_RATIO_AVG_DESCRIPTION,
+            HIT_RATIO_MIN_DESCRIPTION,
+            HIT_RATIO_MAX_DESCRIPTION);
+    }
+
+    private void verifyResult(final Sensor sensor) {
+        verify(streamsMetrics);
+        verify(StreamsMetricsImpl.class);
+        assertThat(sensor, is(expectedSensor));
+    }
+}


### PR DESCRIPTION
Cache-level metrics are refactor according to KIP-444:
- tag `client-id` changed to `thread-id`
- name `hitRatio` changed to `hit-ratio`
- made backward compatible by using streams config `built.in.metrics.version`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
