### PR TITLE
KAFKA-8896: Check group state before completing delayed heartbeat

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1044,8 +1044,7 @@ class GroupCoordinator(val brokerId: Int,
       val member = group.get(memberId)
       member.shouldKeepAlive(heartbeatDeadline) || member.isLeaving
     } else {
-      error(s"Member id $memberId was not found in ${group.groupId} during heartbeat expiration, " +
-        s"this could be potentially related to KAFKA-8896")
+      info(s"Member id $memberId was not found in ${group.groupId} during heartbeat expiration.")
       false
     }
   }
@@ -1053,7 +1052,7 @@ class GroupCoordinator(val brokerId: Int,
   def onExpireHeartbeat(group: GroupMetadata, memberId: String, isPending: Boolean, heartbeatDeadline: Long): Unit = {
     group.inLock {
       if (group.is(Dead)) {
-        debug(s"Group ${group.groupId} has already been unloaded")
+        info(s"Received notification of heartbeat expiration for member $memberId after group ${group.groupId} had already been unloaded or deleted.")
       } else if (isPending) {
         info(s"Pending member $memberId in group ${group.groupId} has been removed after session timeout expiration.")
         removePendingMemberAndUpdateGroup(group, memberId)

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1027,6 +1027,7 @@ class GroupCoordinator(val brokerId: Int,
       if (group.is(Dead)) {
         forceComplete()
       } else if (isPending) {
+        // complete the heartbeat if the member has joined the group
         if (group.has(memberId)) {
           forceComplete()
         } else false
@@ -1051,7 +1052,9 @@ class GroupCoordinator(val brokerId: Int,
 
   def onExpireHeartbeat(group: GroupMetadata, memberId: String, isPending: Boolean, heartbeatDeadline: Long): Unit = {
     group.inLock {
-      if (isPending) {
+      if (group.is(Dead)) {
+        debug(s"Group ${group.groupId} has already been unloaded")
+      } else if (isPending) {
         info(s"Pending member $memberId in group ${group.groupId} has been removed after session timeout expiration.")
         removePendingMemberAndUpdateGroup(group, memberId)
       } else if (!group.has(memberId)) {

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2888,6 +2888,20 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, thirdResult.error)
   }
 
+  @Test
+  def testUploadAndOffloadGroup(): Unit = {
+    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
+
+    groupCoordinator.handleGroupEmigration(groupPartitionId)
+    timer.advanceClock(1)
+    while (groupCoordinator.groupManager.getGroup(groupId).isDefined) {
+
+    }
+//    assertTrue(groupCoordinator.groupManager.getGroup(groupId).isEmpty)
+
+    groupCoordinator.handleGroupImmigration(groupPartitionId)
+  }
+
   private def getGroup(groupId: String): GroupMetadata = {
     val groupOpt = groupCoordinator.groupManager.getGroup(groupId)
     assertTrue(groupOpt.isDefined)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2901,6 +2901,18 @@ class GroupCoordinatorTest {
     assertTrue(group.has(leaderMemberId))
   }
 
+  @Test
+  def testCompleteHeartbeatWithMemberAlreadyRemoved(): Unit = {
+    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
+    EasyMock.reset(replicaManager)
+    heartbeat(groupId, rebalanceResult.leaderId, rebalanceResult.generation)
+    val group = getGroup(groupId)
+    val leaderMemberId = rebalanceResult.leaderId
+    group.remove(leaderMemberId)
+    assertFalse(groupCoordinator.tryCompleteHeartbeat(group, leaderMemberId, false, DefaultSessionTimeout, () => true))
+    groupCoordinator.onExpireHeartbeat(group, leaderMemberId, false, DefaultSessionTimeout)
+  }
+
   private def getGroup(groupId: String): GroupMetadata = {
     val groupOpt = groupCoordinator.groupManager.getGroup(groupId)
     assertTrue(groupOpt.isDefined)


### PR DESCRIPTION
This PR is a defensive fix for reported bug 8896, which would cause group coordinator crash when the heartbeat member was not found.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
