### PR TITLE
MINOR: Address review comments for KIP-504 authorizer changes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Endpoint.java
+++ b/clients/src/main/java/org/apache/kafka/common/Endpoint.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.common;
 
 import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
@@ -27,23 +29,24 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 @InterfaceStability.Evolving
 public class Endpoint {
 
-    private final String listener;
+    private final String listenerName;
     private final SecurityProtocol securityProtocol;
     private final String host;
     private final int port;
 
-    public Endpoint(String listener, SecurityProtocol securityProtocol, String host, int port) {
-        this.listener = listener;
+    public Endpoint(String listenerName, SecurityProtocol securityProtocol, String host, int port) {
+        this.listenerName = listenerName;
         this.securityProtocol = securityProtocol;
         this.host = host;
         this.port = port;
     }
 
     /**
-     * Returns the listener name of this endpoint.
+     * Returns the listener name of this endpoint. This is non-empty for endpoints provided
+     * to broker plugins, but may be empty when used in clients.
      */
-    public String listener() {
-        return listener;
+    public Optional<String> listenerName() {
+        return Optional.ofNullable(listenerName);
     }
 
     /**
@@ -77,7 +80,7 @@ public class Endpoint {
         }
 
         Endpoint that = (Endpoint) o;
-        return Objects.equals(this.listener, that.listener) &&
+        return Objects.equals(this.listenerName, that.listenerName) &&
             Objects.equals(this.securityProtocol, that.securityProtocol) &&
             Objects.equals(this.host, that.host) &&
             this.port == that.port;
@@ -86,13 +89,13 @@ public class Endpoint {
 
     @Override
     public int hashCode() {
-        return Objects.hash(listener, securityProtocol, host, port);
+        return Objects.hash(listenerName, securityProtocol, host, port);
     }
 
     @Override
     public String toString() {
         return "Endpoint(" +
-            "listener='" + listener + '\'' +
+            "listenerName='" + listenerName + '\'' +
             ", securityProtocol=" + securityProtocol +
             ", host='" + host + '\'' +
             ", port=" + port +

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -91,7 +91,7 @@ public class RequestContext implements AuthorizableRequestContext {
     }
 
     @Override
-    public String listener() {
+    public String listenerName() {
         return listenerName.value();
     }
 

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
@@ -32,7 +32,7 @@ public interface AuthorizableRequestContext {
     /**
      * Returns name of listener on which request was received.
      */
-    String listener();
+    String listenerName();
 
     /**
      * Returns the security protocol for the listener on which request was received.

--- a/core/src/main/scala/kafka/cluster/Broker.scala
+++ b/core/src/main/scala/kafka/cluster/Broker.scala
@@ -29,6 +29,13 @@ import org.apache.kafka.server.authorizer.AuthorizerServerInfo
 import scala.collection.Seq
 import scala.collection.JavaConverters._
 
+object Broker {
+  private[cluster] case class ServerInfo(clusterResource: ClusterResource,
+                                         brokerId: Int,
+                                         endpoints: util.List[Endpoint],
+                                         interBrokerEndpoint: Endpoint) extends AuthorizerServerInfo
+}
+
 /**
  * A Kafka broker.
  * A broker has an id, a collection of end-points, an optional rack and a listener to security protocol map.
@@ -75,15 +82,8 @@ case class Broker(id: Int, endPoints: Seq[EndPoint], rack: Option[String]) {
 
   def toServerInfo(clusterId: String, config: KafkaConfig): AuthorizerServerInfo = {
     val clusterResource: ClusterResource = new ClusterResource(clusterId)
-    val interBrokerEndpoint: Endpoint = endPoint(config.interBrokerListenerName)
-    val brokerEndpoints: util.List[Endpoint] = endPoints.toList.map(_.asInstanceOf[Endpoint]).asJava
-    BrokerEndpointInfo(clusterResource, id, brokerEndpoints, interBrokerEndpoint)
+    val interBrokerEndpoint: Endpoint = endPoint(config.interBrokerListenerName).toJava
+    val brokerEndpoints: util.List[Endpoint] = endPoints.toList.map(_.toJava).asJava
+    Broker.ServerInfo(clusterResource, id, brokerEndpoints, interBrokerEndpoint)
   }
-
-  case class BrokerEndpointInfo(clusterResource: ClusterResource,
-                                brokerId: Int,
-                                endpoints: util.List[Endpoint],
-                                interBrokerEndpoint: Endpoint)
-    extends AuthorizerServerInfo
-
 }

--- a/core/src/main/scala/kafka/cluster/EndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/EndPoint.scala
@@ -62,8 +62,7 @@ object EndPoint {
 /**
  * Part of the broker definition - matching host/port pair to a protocol
  */
-case class EndPoint(override val host: String, override val port: Int, listenerName: ListenerName, override val securityProtocol: SecurityProtocol)
-    extends JEndpoint(Option(listenerName).map(_.value).orNull, securityProtocol, host, port) {
+case class EndPoint(host: String, port: Int, listenerName: ListenerName, securityProtocol: SecurityProtocol) {
   def connectionString: String = {
     val hostport =
       if (host == null)
@@ -73,7 +72,7 @@ case class EndPoint(override val host: String, override val port: Int, listenerN
     listenerName.value + "://" + hostport
   }
 
-  // to keep spotbugs happy
-  override def equals(o: scala.Any): Boolean = super.equals(o)
-  override def hashCode(): Int = super.hashCode()
+  def toJava: JEndpoint = {
+    new JEndpoint(listenerName.value, securityProtocol, host, port)
+  }
 }

--- a/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AuthorizerUtils.scala
@@ -84,7 +84,7 @@ object AuthorizerUtils {
     new AuthorizableRequestContext {
       override def clientId(): String = ""
       override def requestType(): Int = -1
-      override def listener(): String = ""
+      override def listenerName(): String = ""
       override def clientAddress(): InetAddress = session.clientAddress
       override def principal(): KafkaPrincipal = session.principal
       override def securityProtocol(): SecurityProtocol = null

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -299,7 +299,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           case Some(authZ) =>
             authZ.start(brokerInfo.broker.toServerInfo(clusterId, config)).asScala.mapValues(_.toCompletableFuture).toMap
           case None =>
-            brokerInfo.broker.endPoints.map{ ep => (ep.asInstanceOf[Endpoint], CompletableFuture.completedFuture[Void](null)) }.toMap
+            brokerInfo.broker.endPoints.map { ep => ep.toJava -> CompletableFuture.completedFuture[Void](null) }.toMap
         }
 
         val fetchManager = new FetchManager(Time.SYSTEM,

--- a/core/src/test/scala/integration/kafka/api/SslAdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslAdminClientIntegrationTest.scala
@@ -127,7 +127,7 @@ class SslAdminClientIntegrationTest extends SaslSslAdminClientIntegrationTest {
 
     def validateRequestContext(context: AuthorizableRequestContext, apiKey: ApiKeys): Unit = {
       assertEquals(SecurityProtocol.SSL, context.securityProtocol)
-      assertEquals("SSL", context.listener)
+      assertEquals("SSL", context.listenerName)
       assertEquals(KafkaPrincipal.ANONYMOUS, context.principal)
       assertEquals(apiKey.id.toInt, context.requestType)
       assertEquals(apiKey.latestVersion.toInt, context.requestVersion)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -204,7 +204,7 @@ class SocketServerTest {
     testableServer.startup(startupProcessors = false)
     val updatedEndPoints = config.advertisedListeners.map { endpoint =>
       endpoint.copy(port = testableServer.boundPort(endpoint.listenerName))
-    }.map(_.asInstanceOf[Endpoint])
+    }.map(_.toJava)
 
     val externalReadyFuture = new CompletableFuture[Void]()
     val executor = Executors.newSingleThreadExecutor()
@@ -225,7 +225,7 @@ class SocketServerTest {
       sendAndReceiveControllerRequest(socket1, testableServer)
 
       val externalListener = new ListenerName("EXTERNAL")
-      val externalEndpoint = updatedEndPoints.find(e => e.listener() == externalListener.value).get
+      val externalEndpoint = updatedEndPoints.find(e => e.listenerName.get == externalListener.value).get
       val futures =  Map(externalEndpoint -> externalReadyFuture)
       val startFuture = executor.submit(CoreUtils.runnable(testableServer.startDataPlaneProcessors(futures)))
       TestUtils.waitUntilTrue(() => listenerStarted(config.interBrokerListenerName), "Inter-broker listener not started")


### PR DESCRIPTION
Addressing these review comments from @ijuma :
- Rename `listener` in interfaces to `listenerName`
- Make `Endpoint#listenerName` Optional since it is in common package
- Remove inheritance in the internal Scala EndPoint class
- Move inner classes to companion object

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
