### PR TITLE
KAFKA-8938: Improve allocations during Struct validation in ConnectSchema

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -229,12 +229,17 @@ public class ConnectSchema implements Schema {
                     + " for field: \"" + name + "\"");
 
         boolean foundMatch = false;
-        for (Class<?> expectedClass : expectedClasses) {
-            if (expectedClass.isInstance(value)) {
-                foundMatch = true;
-                break;
+        if (expectedClasses.size() == 1) {
+            foundMatch = expectedClasses.get(0).isInstance(value);
+        } else {
+            for (Class<?> expectedClass : expectedClasses) {
+                if (expectedClass.isInstance(value)) {
+                    foundMatch = true;
+                    break;
+                }
             }
         }
+
         if (!foundMatch)
             throw new DataException("Invalid Java object for schema type " + schema.type()
                     + ": " + value.getClass()


### PR DESCRIPTION

Summary: Struct value validation in Kafka Connect can be optimized
to avoid creating an Iterator when the expectedClasses list is of
size 1. This is a meaningful enhancement for high throughput
connectors.

This contribution is my original work and I license the work to the
project under the project's open source license.

Stack Trace from the Couchbase Kafka Connector:

```
* java.util.Collections.singletonIterator(Object)
* java.util.Collections$SingletonList.iterator()
* org.apache.kafka.connect.data.ConnectSchema.validateValue(String, Schema, Object)
* org.apache.kafka.connect.data.Struct.put(Field, Object)
* org.apache.kafka.connect.data.Struct.put(String, Object)
* com.couchbase.connect.kafka.handler.source.DefaultSchemaSourceHandler.buildValue(SourceHandlerParams, CouchbaseSourceRecord$Builder)
```

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
