### PR TITLE
[2.2 branch] KAFKA-8398 Prevent NPE when trying to forceUnmap

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -318,6 +318,9 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * Forcefully free the buffer's mmap.
    */
   protected[log] def forceUnmap() {
+    if (mmap == null) {
+        return
+    }
     try MappedByteBuffers.unmap(file.getAbsolutePath, mmap)
     finally mmap = null // Accessing unmapped mmap crashes JVM by SEGV so we null it out to be safe
   }


### PR DESCRIPTION
The commit here includes a simple change to fix a NPE that reported in https://issues.apache.org/jira/browse/KAFKA-8398