### PR TITLE
KAFKA-8874: Add consumer metrics to observe user poll behavior (KIP-517)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -567,6 +567,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     // Visible for testing
     final Metrics metrics;
+    final KafkaConsumerMetrics kafkaConsumerMetrics;
 
     private final Logger log;
     private final String clientId;
@@ -595,8 +596,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
     private boolean cachedSubscriptionHashAllFetchPositions;
-
-    private final KafkaConsumerMetrics kafkaConsumerMetrics;
 
     /**
      * A consumer is instantiated by providing a set of key-value pairs as configuration. Valid configuration strings
@@ -2401,7 +2400,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         return clientId;
     }
 
-    private static class KafkaConsumerMetrics {
+    static class KafkaConsumerMetrics {
         private final Metrics metrics;
 
         private Sensor timeBetweenPollSensor;
@@ -2443,16 +2442,16 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     new Avg());
         }
 
-        private void recordPollStart(long pollStartMs) {
+        void recordPollStart(long pollStartMs) {
             this.pollStartMs = pollStartMs;
             this.timeSinceLastPollMs = lastPollMs != 0L ? pollStartMs - lastPollMs : 0;
             this.timeBetweenPollSensor.record(timeSinceLastPollMs);
             this.lastPollMs = pollStartMs;
         }
 
-        private void recordPollEnd(long pollEndMs) {
+        void recordPollEnd(long pollEndMs) {
             long pollTimeMs = pollEndMs - pollStartMs;
-            double pollIdleRatio = pollTimeMs == 0 ? 1.0 : pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+            double pollIdleRatio = pollTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
             this.pollIdleSensor.record(pollIdleRatio);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2452,7 +2452,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
         private void recordPollEnd(long pollEndMs) {
             long pollTimeMs = pollEndMs - pollStartMs;
-            double pollIdleRatio = pollTimeMs == 0 ? 1.0 : pollTimeMs*1.0/(pollTimeMs + timeSinceLastPollMs);
+            double pollIdleRatio = pollTimeMs == 0 ? 1.0 : pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
             this.pollIdleSensor.record(pollIdleRatio);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1206,11 +1206,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private ConsumerRecords<K, V> poll(final Timer timer, final boolean includeMetadataInTimeout) {
         acquireAndEnsureOpen();
         try {
+            this.kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
+
             if (this.subscriptions.hasNoSubscriptionOrUserAssignment()) {
                 throw new IllegalStateException("Consumer is not subscribed to any topics or assigned any partitions");
             }
-
-            this.kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
 
             // poll for new data until the timeout expires
             do {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1213,7 +1213,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 throw new IllegalStateException("Consumer is not subscribed to any topics or assigned any partitions");
             }
 
-            // TODO: Record poll time in this method?
             // Record poll start
             this.kafkaConsumerMetrics.recordPollStart(time.milliseconds());
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1244,8 +1244,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             return ConsumerRecords.empty();
         } finally {
-            this.kafkaConsumerMetrics.recordPollEnd(timer.currentTimeMs());
             release();
+            this.kafkaConsumerMetrics.recordPollEnd(timer.currentTimeMs());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2451,7 +2451,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
         void recordPollEnd(long pollEndMs) {
             long pollTimeMs = pollEndMs - pollStartMs;
-            double pollIdleRatio = pollTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+            double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
             this.pollIdleSensor.record(pollIdleRatio);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -59,8 +59,8 @@ public class KafkaConsumerMetrics {
                 "The max delay between invocations of poll()."),
                 new Max());
 
-        this.pollIdleSensor = metrics.sensor("poll-idle-ratio");
-        this.pollIdleSensor.add(metrics.metricName("poll-idle-ratio",
+        this.pollIdleSensor = metrics.sensor("poll-idle-ratio-avg");
+        this.pollIdleSensor.add(metrics.metricName("poll-idle-ratio-avg",
                 metricGroupName,
                 "The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records."),
                 new Avg());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+
+import java.util.concurrent.TimeUnit;
+
+public class KafkaConsumerMetrics {
+    private final Metrics metrics;
+
+    private Sensor timeBetweenPollSensor;
+    private Sensor pollIdleSensor;
+    private long lastPollMs;
+    private long pollStartMs;
+    private long timeSinceLastPollMs;
+
+    public KafkaConsumerMetrics(Metrics metrics, String metricGrpPrefix) {
+        this.metrics = metrics;
+
+        String metricGroupName = metricGrpPrefix + "-metrics";
+        Measurable lastPoll = (mConfig, now) -> {
+            if (lastPollMs == 0L)
+                // if no poll is ever triggered, just return -1.
+                return -1d;
+            else
+                return TimeUnit.SECONDS.convert(now - lastPollMs, TimeUnit.MILLISECONDS);
+        };
+        metrics.addMetric(metrics.metricName("last-poll-seconds-ago",
+                metricGroupName,
+                "The number of seconds since the last poll() invocation."),
+                lastPoll);
+
+        this.timeBetweenPollSensor = metrics.sensor("time-between-poll");
+        this.timeBetweenPollSensor.add(metrics.metricName("time-between-poll-avg",
+                metricGroupName,
+                "The average delay between invocations of poll()."),
+                new Avg());
+        this.timeBetweenPollSensor.add(metrics.metricName("time-between-poll-max",
+                metricGroupName,
+                "The max delay between invocations of poll()."),
+                new Max());
+
+        this.pollIdleSensor = metrics.sensor("poll-idle-ratio");
+        this.pollIdleSensor.add(metrics.metricName("poll-idle-ratio",
+                metricGroupName,
+                "The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records."),
+                new Avg());
+    }
+
+    public void recordPollStart(long pollStartMs) {
+        this.pollStartMs = pollStartMs;
+        this.timeSinceLastPollMs = lastPollMs != 0L ? pollStartMs - lastPollMs : 0;
+        this.timeBetweenPollSensor.record(timeSinceLastPollMs);
+        this.lastPollMs = pollStartMs;
+    }
+
+    public void recordPollEnd(long pollEndMs) {
+        long pollTimeMs = pollEndMs - pollStartMs;
+        double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+        this.pollIdleSensor.record(pollIdleRatio);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2126,7 +2126,7 @@ public class KafkaConsumerTest {
         KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, metadata, assignor, true, groupInstanceId);
         // MetricName object to check
         Metrics metrics = consumer.metrics;
-        MetricName pollIdleRatio = metrics.metricName("poll-idle-ratio", "consumer-metrics");
+        MetricName pollIdleRatio = metrics.metricName("poll-idle-ratio-avg", "consumer-metrics");
         // Test default value
         assertEquals(Double.NaN, consumer.metrics().get(pollIdleRatio).metricValue());
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1371,6 +1371,21 @@
 
   The following metrics are available on consumer instances.
 
+  <table class="data-table">
+    <tbody>
+    <tr>
+      <th>Metric/Attribute name</th>
+      <th>Description</th>
+      <th>Mbean name</th>
+    </tr>
+    <tr>
+      <td>poll-idle-ratio-avg</td>
+      <td>The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records.</td>
+      <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
+    </tr>
+    </tbody>
+  </table>
+
   <h5><a id="consumer_group_monitoring" href="#consumer_group_monitoring">Consumer Group Metrics</a></h5>
   <table class="data-table">
     <tbody>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1373,16 +1373,31 @@
 
   <table class="data-table">
     <tbody>
-    <tr>
-      <th>Metric/Attribute name</th>
-      <th>Description</th>
-      <th>Mbean name</th>
-    </tr>
-    <tr>
-      <td>poll-idle-ratio-avg</td>
-      <td>The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records.</td>
-      <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
-    </tr>
+      <tr>
+        <th>Metric/Attribute name</th>
+        <th>Description</th>
+        <th>Mbean name</th>
+      </tr>
+      <tr>
+        <td>time-between-poll-avg</td>
+        <td>The average delay between invocations of poll().</td>
+        <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>time-between-poll-max</td>
+        <td>The max delay between invocations of poll().</td>
+        <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>last-poll-seconds-ago</td>
+        <td>The number of seconds since the last poll() invocation.</td>
+        <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>poll-idle-ratio-avg</td>
+        <td>The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records.</td>
+        <td>kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/KAFKA/KIP-517%3A+Add+consumer+metrics+to+observe+user+poll+behavior

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
