### PR TITLE
Update record timestamp in MockProducer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -255,11 +255,11 @@ public class MockProducer<K, V> implements Producer<K, V> {
             partition = partition(record, this.cluster);
         TopicPartition topicPartition = new TopicPartition(record.topic(), partition);
         ProduceRequestResult result = new ProduceRequestResult(topicPartition);
-        FutureRecordMetadata future = new FutureRecordMetadata(result, 0, RecordBatch.NO_TIMESTAMP,
+        FutureRecordMetadata future = new FutureRecordMetadata(result, 0, record.timestamp() == 0 ? RecordBatch.NO_TIMESTAMP : record.timestamp(),
                 0L, 0, 0, Time.SYSTEM);
         long offset = nextOffset(topicPartition);
         Completion completion = new Completion(offset, new RecordMetadata(topicPartition, 0, offset,
-                RecordBatch.NO_TIMESTAMP, Long.valueOf(0L), 0, 0), result, callback);
+                record.timestamp() == 0 ? RecordBatch.NO_TIMESTAMP : record.timestamp(), Long.valueOf(0L), 0, 0), result, callback);
 
         if (!this.transactionInFlight)
             this.sent.add(record);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -255,11 +255,11 @@ public class MockProducer<K, V> implements Producer<K, V> {
             partition = partition(record, this.cluster);
         TopicPartition topicPartition = new TopicPartition(record.topic(), partition);
         ProduceRequestResult result = new ProduceRequestResult(topicPartition);
-        FutureRecordMetadata future = new FutureRecordMetadata(result, 0, record.timestamp() == 0 ? RecordBatch.NO_TIMESTAMP : record.timestamp(),
+        FutureRecordMetadata future = new FutureRecordMetadata(result, 0, (record.timestamp() == null || record.timestamp() == 0) ? RecordBatch.NO_TIMESTAMP : record.timestamp(),
                 0L, 0, 0, Time.SYSTEM);
         long offset = nextOffset(topicPartition);
         Completion completion = new Completion(offset, new RecordMetadata(topicPartition, 0, offset,
-                record.timestamp() == 0 ? RecordBatch.NO_TIMESTAMP : record.timestamp(), Long.valueOf(0L), 0, 0), result, callback);
+                (record.timestamp() == null || record.timestamp() == 0) ? RecordBatch.NO_TIMESTAMP : record.timestamp(), Long.valueOf(0L), 0, 0), result, callback);
 
         if (!this.transactionInFlight)
             this.sent.add(record);


### PR DESCRIPTION
The timestamp in the callback is returning -1. It should rather return the timestamp in the ProducerRecord object if available or return NO_TIMESTAMP if not available.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
