### PR TITLE
KAFKA-8934: Create version file during build for Streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1171,10 +1171,39 @@ project(':streams') {
     duplicatesStrategy 'exclude'
   }
 
-  task createStreamsVersionFile(dependsOn: ':clients:createVersionFile', type: Copy) {
-    from "${project(':clients').buildDir}/kafka/${project(':clients').buildVersionFileName }"
-    into "$buildDir/kafka"
-    rename "${project(':clients').buildVersionFileName}", "$buildStreamsVersionFileName"
+  task determineCommitId {
+    def takeFromHash = 16
+    if (commitId) {
+      commitId = commitId.take(takeFromHash)
+    } else if (file("$rootDir/.git/HEAD").exists()) {
+      def headRef = file("$rootDir/.git/HEAD").text
+      if (headRef.contains('ref: ')) {
+        headRef = headRef.replaceAll('ref: ', '').trim()
+        if (file("$rootDir/.git/$headRef").exists()) {
+          commitId = file("$rootDir/.git/$headRef").text.trim().take(takeFromHash)
+        }
+      } else {
+        commitId = headRef.trim().take(takeFromHash)
+      }
+    } else {
+      commitId = "unknown"
+    }
+  }
+
+  task createStreamsVersionFile(dependsOn: determineCommitId) {
+    ext.receiptFile = file("$buildDir/kafka/$buildStreamsVersionFileName")
+    outputs.file receiptFile
+    outputs.upToDateWhen { false }
+    doLast {
+      def data = [
+              commitId: commitId,
+              version: version,
+      ]
+
+      receiptFile.parentFile.mkdirs()
+      def content = data.entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
+      receiptFile.setText(content, "ISO-8859-1")
+    }
   }
 
   jar {

--- a/build.gradle
+++ b/build.gradle
@@ -1123,6 +1123,7 @@ project(':tools') {
 
 project(':streams') {
   archivesBaseName = "kafka-streams"
+  ext.buildStreamsVersionFileName = "kafka-streams-version.properties"
 
   dependencies {
     compile project(':clients')
@@ -1170,7 +1171,17 @@ project(':streams') {
     duplicatesStrategy 'exclude'
   }
 
+  task createStreamsVersionFile(dependsOn: ':clients:createVersionFile', type: Copy) {
+    from "${project(':clients').buildDir}/kafka/${project(':clients').buildVersionFileName }"
+    into "$buildDir/kafka"
+    rename "${project(':clients').buildVersionFileName}", "$buildStreamsVersionFileName"
+  }
+
   jar {
+    dependsOn 'createStreamsVersionFile'
+    from("$buildDir") {
+      include "kafka/$buildStreamsVersionFileName"
+    }
     dependsOn 'copyDependantLibs'
   }
 


### PR DESCRIPTION
The Kafka Clients library includes a version file that
contains its version and Git commit ID.
Since Kafka Streams wants to expose version and commit ID
in the metrics it needs to read the version file.
To enable the users to check during runtime for
version mismatches between the Streams library and the Clients
library, a version file is also created for Streams during build
time and during runtime only the Streams version file is read.
If Streams would read the Clients' version file during runtime, it
would read a wrong version and commit ID if the libraries were
built from repositories in different states.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
