### PR TITLE
KAFKA-8855; Collect and Expose Client's Name and Version in the Brokers (KIP-511 Part 2)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
@@ -53,6 +53,22 @@ public interface Authenticator extends Closeable {
     KafkaPrincipal principal();
 
     /**
+     * Returns the ClientSoftwareName extracted from the ApiVersionsRequest which may
+     * have been received by the Authenticator or an empty String.
+     */
+    default String clientSoftwareName() {
+        return "";
+    }
+
+    /**
+     * Returns the ClientSoftwareVersion extracted from the ApiVersionsRequest which may
+     * have been received by the Authenticator or an empty String.
+     */
+    default String clientSoftwareVersion() {
+        return "";
+    }
+
+    /**
      * returns true if authentication is complete otherwise returns false;
      */
     boolean complete();

--- a/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
@@ -54,7 +54,8 @@ public interface Authenticator extends Closeable {
 
     /**
      * Returns the ClientSoftwareName extracted from the ApiVersionsRequest which may
-     * have been received by the Authenticator or an empty String.
+     * have been received by the Authenticator or an empty String if the remote end
+     * did not provide it.
      */
     default String clientSoftwareName() {
         return "";
@@ -62,7 +63,8 @@ public interface Authenticator extends Closeable {
 
     /**
      * Returns the ClientSoftwareVersion extracted from the ApiVersionsRequest which may
-     * have been received by the Authenticator or an empty String.
+     * have been received by the Authenticator or an empty String if the remote end
+     * did not provide it.
      */
     default String clientSoftwareVersion() {
         return "";

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+public class ConnectionMetadata {
+    static final String CLIENT_ID_KEY = "ClientId";
+    static final String CLIENT_SOFTWARE_NAME_KEY = "ClientSoftwareName";
+    static final String CLIENT_SOFTWARE_VERSION_KEY = "ClientSoftwareVersion";
+    static final String LISTENER_NAME_KEY = "ListenerName";
+    static final String SECURITY_PROTOCOL_KEY = "SecurityProtocol";
+    static final String CLIENT_ADDRESS_KEY = "ClientAddress";
+    static final String PRINCIPAL_KEY = "Principal";
+
+    public static final String UNKNOWN_NAME_OR_VERSION = "Unknown";
+
+    private String clientId;
+    private ListenerName listenerName;
+    private SecurityProtocol securityProtocol;
+    private InetAddress clientAddress;
+    private KafkaPrincipal principal;
+
+    /* They could be updated by the ConnectionRegistry */
+    String clientSoftwareName;
+    String clientSoftwareVersion;
+
+    ConnectionMetadata(
+        String clientId,
+        String clientSoftwareName,
+        String clientSoftwareVersion,
+        ListenerName listenerName,
+        SecurityProtocol securityProtocol,
+        InetAddress clientAddress,
+        KafkaPrincipal principal) {
+
+        this.clientId = clientId;
+        this.clientSoftwareName = clientSoftwareName;
+        this.clientSoftwareVersion = clientSoftwareVersion;
+        this.listenerName = listenerName;
+        this.securityProtocol = securityProtocol;
+        this.clientAddress = clientAddress;
+        this.principal = principal;
+    }
+
+    public String clientId() {
+        return this.clientId;
+    }
+
+    public String clientSoftwareName() {
+        if (this.clientSoftwareName == null || this.clientSoftwareName.isEmpty())
+            return UNKNOWN_NAME_OR_VERSION;
+        else
+            return this.clientSoftwareName;
+    }
+
+    public String clientSoftwareVersion() {
+        if (this.clientSoftwareVersion == null || this.clientSoftwareVersion.isEmpty())
+            return UNKNOWN_NAME_OR_VERSION;
+        else
+            return this.clientSoftwareVersion;
+    }
+
+    public ListenerName listenerName() {
+        return this.listenerName;
+    }
+
+    public SecurityProtocol securityProtocol() {
+        return this.securityProtocol;
+    }
+
+    public InetAddress clientAddress() {
+        return this.clientAddress;
+    }
+
+    public KafkaPrincipal principal() {
+        return this.principal;
+    }
+
+    public Map<String, String> asMap() {
+        Map<String, String> map = new HashMap<>(7);
+        map.put(CLIENT_ID_KEY, clientId());
+        map.put(CLIENT_SOFTWARE_NAME_KEY, clientSoftwareName());
+        map.put(CLIENT_SOFTWARE_VERSION_KEY, clientSoftwareVersion());
+        map.put(LISTENER_NAME_KEY, listenerName().value());
+        map.put(SECURITY_PROTOCOL_KEY, securityProtocol().name);
+        map.put(CLIENT_ADDRESS_KEY, clientAddress().getHostAddress());
+        map.put(PRINCIPAL_KEY, principal().getName());
+        return map;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
@@ -22,6 +22,9 @@ import java.util.Map;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
+/**
+ * Maintains metadata about an active connection.
+ */
 public class ConnectionMetadata {
     static final String CLIENT_ID_KEY = "ClientId";
     static final String CLIENT_SOFTWARE_NAME_KEY = "ClientSoftwareName";

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionMetadata.java
@@ -33,15 +33,15 @@ public class ConnectionMetadata {
 
     public static final String UNKNOWN_NAME_OR_VERSION = "Unknown";
 
-    private String clientId;
-    private ListenerName listenerName;
-    private SecurityProtocol securityProtocol;
-    private InetAddress clientAddress;
-    private KafkaPrincipal principal;
+    private final String clientId;
+    private final ListenerName listenerName;
+    private final SecurityProtocol securityProtocol;
+    private final InetAddress clientAddress;
+    private final KafkaPrincipal principal;
 
     /* They could be updated by the ConnectionRegistry */
-    String clientSoftwareName;
-    String clientSoftwareVersion;
+    private String clientSoftwareName;
+    private String clientSoftwareVersion;
 
     ConnectionMetadata(
         String clientId,
@@ -59,6 +59,11 @@ public class ConnectionMetadata {
         this.securityProtocol = securityProtocol;
         this.clientAddress = clientAddress;
         this.principal = principal;
+    }
+
+    void updateClientSoftwareNameAndVersion(String clientSoftwareName, String clientSoftwareVersion) {
+        this.clientSoftwareName = clientSoftwareName;
+        this.clientSoftwareVersion = clientSoftwareVersion;
     }
 
     public String clientId() {

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+public class ConnectionRegistry {
+    private static final String METRICS_GROUP_NAME = "ClientMetrics";
+
+    private static class CounterMetric implements Gauge<Integer> {
+        private MetricName name;
+        private int count;
+
+        CounterMetric(MetricName name) {
+            this.name = name;
+        }
+
+        MetricName name() {
+            return name;
+        }
+
+        int inc() {
+            count += 1;
+            return count;
+        }
+
+        int dec() {
+            count -= 1;
+            return count;
+        }
+
+        @Override
+        public Integer value(final MetricConfig config, final long now) {
+            return count;
+        }
+
+    }
+
+    private final Metrics metrics;
+    private final String metricsGroup;
+    private final MetricName connectionsMetricName;
+    private final MetricName connectedClientsMetricName;
+
+    private final Map<String, CounterMetric> counters;
+    private final Map<String, ConnectionMetadata> connections;
+
+    public ConnectionRegistry(Metrics metrics, String metricsGroup) {
+        this.metrics = metrics;
+        this.metricsGroup = metricsGroup;
+        this.counters = new HashMap<>();
+        this.connections = new HashMap<>();
+
+        this.connectionsMetricName =
+            new MetricName("Connections", metricsGroup,
+                "List of connected clients with detailed metadata.",
+                Collections.emptyMap());
+        this.connectedClientsMetricName =
+            new MetricName("ConnectedClients", metricsGroup,
+                "Number of connected clients.",
+                Collections.emptyMap());
+
+        metrics.addMetric(connectionsMetricName,
+            new Gauge<List<Map<String, String>>>() {
+                @Override
+                public List<Map<String, String>> value(final MetricConfig config, final long now) {
+                    List<Map<String, String>> list = new LinkedList<>();
+                    for (ConnectionMetadata client : connections.values()) {
+                        list.add(client.asMap());
+                    }
+                    return list;
+                }
+            }
+        );
+
+        metrics.addMetric(connectedClientsMetricName,
+            new Gauge<Integer>() {
+                @Override
+                public Integer value(final MetricConfig config, final long now) {
+                    return connections.size();
+                }
+            }
+        );
+    }
+
+    public ConnectionRegistry(Metrics metrics) {
+        this(metrics, METRICS_GROUP_NAME);
+    }
+
+    public synchronized ConnectionMetadata register(
+            String connectionId,
+            String clientId,
+            String clientSoftwareName,
+            String clientSoftwareVersion,
+            ListenerName listenerName,
+            SecurityProtocol securityProtocol,
+            InetAddress clientAddress,
+            KafkaPrincipal principal) {
+
+        ConnectionMetadata connection = new ConnectionMetadata(
+            clientId,
+            clientSoftwareName,
+            clientSoftwareVersion,
+            listenerName,
+            securityProtocol,
+            clientAddress,
+            principal
+        );
+
+        connections.put(connectionId, connection);
+
+        incCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
+
+        return connection;
+    }
+
+    public synchronized ConnectionMetadata updateClientSoftwareNameAndVersion(
+            String connectionId,
+            String clientSoftwareName,
+            String clientSoftwareVersion) {
+
+        ConnectionMetadata connection = connections.get(connectionId);
+
+        if (connection != null) {
+            decCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
+            connection.clientSoftwareName = clientSoftwareName;
+            connection.clientSoftwareVersion = clientSoftwareVersion;
+            incCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
+        }
+
+        return connection;
+    }
+
+    public synchronized void remove(String connectionId) {
+        ConnectionMetadata connection = connections.remove(connectionId);
+
+        if (connection != null) {
+            decCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
+        }
+    }
+
+    public synchronized void close() {
+        for (CounterMetric counter : counters.values()) {
+            metrics.removeMetric(counter.name());
+        }
+        metrics.removeMetric(connectedClientsMetricName);
+        metrics.removeMetric(connectionsMetricName);
+        counters.clear();
+        connections.clear();
+    }
+
+    public ConnectionMetadata get(String connectionId) {
+        return connections.get(connectionId);
+    }
+
+    private void incCounterFor(String clientSoftwareName, String clientSoftwareVersion) {
+        String counterId = counterId(clientSoftwareName, clientSoftwareVersion);
+
+        CounterMetric counter = counters.get(counterId);
+        if (counter == null) {
+            MetricName name = metricNameFor(clientSoftwareName, clientSoftwareVersion);
+            counter = new CounterMetric(name);
+            counters.put(counterId, counter);
+            metrics.addMetric(name, counter);
+        }
+
+        counter.inc();
+    }
+
+    private void decCounterFor(String clientSoftwareName, String clientSoftwareVersion) {
+        String counterId = counterId(clientSoftwareName, clientSoftwareVersion);
+
+        CounterMetric counter = counters.get(counterId);
+        if (counter != null) {
+            if (counter.dec() == 0) {
+                metrics.removeMetric(counter.name());
+                counters.remove(counterId);
+            }
+        }
+    }
+
+    private String counterId(String clientSoftwareName, String clientSoftwareVersion) {
+        return clientSoftwareName + ":" + clientSoftwareVersion;
+    }
+
+    private MetricName metricNameFor(String clientSoftwareName, String clientSoftwareVersion) {
+        Map<String, String> tags = new HashMap<>(2);
+        tags.put("softwarename", clientSoftwareName);
+        tags.put("softwareversion", clientSoftwareVersion);
+        return new MetricName("ConnectedClients", metricsGroup,
+            String.format(
+                "Number of connected clients with ClientSoftwareName={} and ClientSoftwareVersion={}",
+                clientSoftwareName, clientSoftwareVersion),
+            tags);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
@@ -147,8 +147,7 @@ public class ConnectionRegistry {
 
         if (connection != null) {
             decCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
-            connection.clientSoftwareName = clientSoftwareName;
-            connection.clientSoftwareVersion = clientSoftwareVersion;
+            connection.updateClientSoftwareNameAndVersion(clientSoftwareName, clientSoftwareVersion);
             incCounterFor(connection.clientSoftwareName(), connection.clientSoftwareVersion());
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ConnectionRegistry.java
@@ -124,8 +124,6 @@ public class ConnectionRegistry {
 
     /**
      * Register metadata about a connection.
-     *
-     * Note that the method is synchronized to guard the counters.
      */
     public synchronized ConnectionMetadata register(
             String connectionId,
@@ -156,8 +154,6 @@ public class ConnectionRegistry {
 
     /**
      * Updates the client software name and version.
-     *
-     * Note that the method is synchronized to guard the counters.
      */
     public synchronized ConnectionMetadata updateClientSoftwareNameAndVersion(
             String connectionId,
@@ -177,8 +173,6 @@ public class ConnectionRegistry {
 
     /**
      * Removes metadata about a connection.
-     *
-     * Note that the method is synchronized to guard the counters.
      */
     public synchronized void remove(String connectionId) {
         ConnectionMetadata connection = connections.remove(connectionId);
@@ -203,15 +197,8 @@ public class ConnectionRegistry {
 
     /**
      * Gets metadata about a connection.
-     *
-     * Note that the method is NOT synchronized. A lookup is made for each request in the
-     * processor to enrich the request with the metadata (e.g. client software name and version).
-     * We have made the choice to not synchronize this to minimize the contention between the
-     * processor threads, risking that metadata could be stale or inconsistent for few requests. This
-     * should rarely happen in practice because the metadata is only updated by the ApiVersionsRequest
-     * and there are normally no concurrent requests within the connection.
      */
-    public ConnectionMetadata get(String connectionId) {
+    public synchronized ConnectionMetadata get(String connectionId) {
         return connections.get(connectionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -159,6 +159,22 @@ public class KafkaChannel implements AutoCloseable {
     }
 
     /**
+     * Returns the ClientSoftwareName extracted from the ApiVersionsRequest which may
+     * have been received by the Authenticator or an empty String.
+     */
+    public String clientSoftwareName() {
+        return authenticator.clientSoftwareName();
+    }
+
+    /**
+     * Returns the ClientSoftwareVersion extracted from the ApiVersionsRequest which may
+     * have been received by the Authenticator or an empty String.
+     */
+    public String clientSoftwareVersion() {
+        return authenticator.clientSoftwareVersion();
+    }
+
+    /**
      * Does handshake of transportLayer and authentication using configured authenticator.
      * For SSL with client authentication enabled, {@link TransportLayer#handshake()} performs
      * authentication. For SASL, authentication is performed by {@link Authenticator#authenticate()}.

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -160,7 +160,8 @@ public class KafkaChannel implements AutoCloseable {
 
     /**
      * Returns the ClientSoftwareName extracted from the ApiVersionsRequest which may
-     * have been received by the Authenticator or an empty String.
+     * have been received by the Authenticator or an empty String if the remote end
+     * did not provide it.
      */
     public String clientSoftwareName() {
         return authenticator.clientSoftwareName();
@@ -168,7 +169,8 @@ public class KafkaChannel implements AutoCloseable {
 
     /**
      * Returns the ClientSoftwareVersion extracted from the ApiVersionsRequest which may
-     * have been received by the Authenticator or an empty String.
+     * have been received by the Authenticator or an empty String if the remote end
+     * did not provide it.
      */
     public String clientSoftwareVersion() {
         return authenticator.clientSoftwareVersion();

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        public static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
 
         private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
             .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -154,7 +154,7 @@ public class RequestContext implements AuthorizableRequestContext {
         return clientSoftwareName;
     }
 
-    public String getClientSoftwareVersion() {
+    public String clientSoftwareVersion() {
         return clientSoftwareVersion;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -18,7 +18,6 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
-import org.apache.kafka.common.network.ConnectionMetadata;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -59,17 +58,6 @@ public class RequestContext implements AuthorizableRequestContext {
         this.securityProtocol = securityProtocol;
         this.clientSoftwareName = clientSoftwareName;
         this.clientSoftwareVersion = clientSoftwareVersion;
-    }
-
-    public RequestContext(
-            RequestHeader header,
-            String connectionId,
-            InetAddress clientAddress,
-            KafkaPrincipal principal,
-            ListenerName listenerName,
-            SecurityProtocol securityProtocol) {
-        this(header, connectionId, clientAddress, principal, listenerName, securityProtocol,
-            ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION);
     }
 
     public RequestAndSize parseRequest(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.network.ConnectionMetadata;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -38,19 +39,37 @@ public class RequestContext implements AuthorizableRequestContext {
     public final KafkaPrincipal principal;
     public final ListenerName listenerName;
     public final SecurityProtocol securityProtocol;
+    public final String clientSoftwareName;
+    public final String clientSoftwareVersion;
 
-    public RequestContext(RequestHeader header,
-                          String connectionId,
-                          InetAddress clientAddress,
-                          KafkaPrincipal principal,
-                          ListenerName listenerName,
-                          SecurityProtocol securityProtocol) {
+    public RequestContext(
+            RequestHeader header,
+            String connectionId,
+            InetAddress clientAddress,
+            KafkaPrincipal principal,
+            ListenerName listenerName,
+            SecurityProtocol securityProtocol,
+            String clientSoftwareName,
+            String clientSoftwareVersion) {
         this.header = header;
         this.connectionId = connectionId;
         this.clientAddress = clientAddress;
         this.principal = principal;
         this.listenerName = listenerName;
         this.securityProtocol = securityProtocol;
+        this.clientSoftwareName = clientSoftwareName;
+        this.clientSoftwareVersion = clientSoftwareVersion;
+    }
+
+    public RequestContext(
+            RequestHeader header,
+            String connectionId,
+            InetAddress clientAddress,
+            KafkaPrincipal principal,
+            ListenerName listenerName,
+            SecurityProtocol securityProtocol) {
+        this(header, connectionId, clientAddress, principal, listenerName, securityProtocol,
+            ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION);
     }
 
     public RequestAndSize parseRequest(ByteBuffer buffer) {
@@ -129,5 +148,13 @@ public class RequestContext implements AuthorizableRequestContext {
     @Override
     public int correlationId() {
         return header.correlationId();
+    }
+
+    public String clientSoftwareName() {
+        return clientSoftwareName;
+    }
+
+    public String getClientSoftwareVersion() {
+        return clientSoftwareVersion;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -143,6 +143,10 @@ public class SaslServerAuthenticator implements Authenticator {
     // flag indicating if sasl tokens are sent as Kafka SaslAuthenticate request/responses
     private boolean enableKafkaSaslAuthenticateHeaders;
 
+    // Metadata extracted from the ApiVersionsRequest
+    private String clientSoftwareName = "";
+    private String clientSoftwareVersion = "";
+
     public SaslServerAuthenticator(Map<String, ?> configs,
                                    Map<String, AuthenticateCallbackHandler> callbackHandlers,
                                    String connectionId,
@@ -316,6 +320,16 @@ public class SaslServerAuthenticator implements Authenticator {
             principal.tokenAuthenticated(true);
         }
         return principal;
+    }
+
+    @Override
+    public String clientSoftwareName() {
+        return clientSoftwareName;
+    }
+
+    @Override
+    public String clientSoftwareVersion() {
+        return clientSoftwareVersion;
     }
 
     @Override
@@ -585,6 +599,8 @@ public class SaslServerAuthenticator implements Authenticator {
         else if (!apiVersionsRequest.isValid())
             sendKafkaResponse(context, apiVersionsRequest.getErrorResponse(0, Errors.INVALID_REQUEST.exception()));
         else {
+            clientSoftwareName = apiVersionsRequest.data.clientSoftwareName();
+            clientSoftwareVersion = apiVersionsRequest.data.clientSoftwareVersion();
             sendKafkaResponse(context, apiVersionsResponse());
             setSaslState(SaslState.HANDSHAKE_REQUEST);
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -440,7 +440,7 @@ public class SaslServerAuthenticator implements Authenticator {
             ApiKeys apiKey = header.apiKey();
             short version = header.apiVersion();
             RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(),
-                    KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol);
+                    KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol, "", "");
             RequestAndSize requestAndSize = requestContext.parseRequest(requestBuffer);
             if (apiKey != ApiKeys.SASL_AUTHENTICATE) {
                 IllegalSaslStateException e = new IllegalSaslStateException("Unexpected Kafka request of type " + apiKey + " during SASL authentication.");
@@ -526,7 +526,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
 
             RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(),
-                    KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol);
+                    KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol, "", "");
             RequestAndSize requestAndSize = requestContext.parseRequest(requestBuffer);
             if (apiKey == ApiKeys.API_VERSIONS)
                 handleApiVersionsRequest(requestContext, (ApiVersionsRequest) requestAndSize.request);

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -385,7 +385,7 @@ public class NetworkClientTest {
 
         // ApiVersionsRequest has been sent
         assertEquals(1, selector.completedSends().size());
-        
+
         buffer = selector.completedSendBuffers().get(0).buffer();
         header = parseHeader(buffer);
         assertEquals(ApiKeys.API_VERSIONS, header.apiKey());

--- a/clients/src/test/java/org/apache/kafka/common/network/ConnectionMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ConnectionMetadataTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import java.net.InetAddress;
+import java.util.Map;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectionMetadataTest {
+
+    @Test
+    public void testAsMap() {
+        ConnectionMetadata connection = new ConnectionMetadata(
+            "clientId",
+            "",
+            "",
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS
+        );
+
+        Map<String, String> map = connection.asMap();
+
+        assertEquals("clientId", map.get(ConnectionMetadata.CLIENT_ID_KEY));
+        assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION,
+            map.get(ConnectionMetadata.CLIENT_SOFTWARE_NAME_KEY));
+        assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION,
+            map.get(ConnectionMetadata.CLIENT_SOFTWARE_VERSION_KEY));
+        assertEquals(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT).value(),
+            map.get(ConnectionMetadata.LISTENER_NAME_KEY));
+        assertEquals(SecurityProtocol.PLAINTEXT.name,
+            map.get(ConnectionMetadata.SECURITY_PROTOCOL_KEY));
+        assertEquals(InetAddress.getLoopbackAddress().getHostAddress(),
+            map.get(ConnectionMetadata.CLIENT_ADDRESS_KEY));
+        assertEquals(KafkaPrincipal.ANONYMOUS.getName(),
+            map.get(ConnectionMetadata.PRINCIPAL_KEY));
+
+        connection.clientSoftwareName = "name";
+        connection.clientSoftwareVersion = "version";
+
+        map = connection.asMap();
+
+        assertEquals("name", map.get(ConnectionMetadata.CLIENT_SOFTWARE_NAME_KEY));
+        assertEquals("version", map.get(ConnectionMetadata.CLIENT_SOFTWARE_VERSION_KEY));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/ConnectionMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ConnectionMetadataTest.java
@@ -54,8 +54,7 @@ public class ConnectionMetadataTest {
         assertEquals(KafkaPrincipal.ANONYMOUS.getName(),
             map.get(ConnectionMetadata.PRINCIPAL_KEY));
 
-        connection.clientSoftwareName = "name";
-        connection.clientSoftwareVersion = "version";
+        connection.updateClientSoftwareNameAndVersion("name", "version");
 
         map = connection.asMap();
 

--- a/clients/src/test/java/org/apache/kafka/common/network/ConnectionRegistryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ConnectionRegistryTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConnectionRegistryTest {
+
+    private Metrics metrics;
+    private ConnectionRegistry registry;
+
+    @Before
+    public void setUp() {
+        metrics = new Metrics();
+        registry = new ConnectionRegistry(metrics);
+    }
+
+    @After
+    public void tearDown() {
+        registry.close();
+        registry = null;
+        metrics.close();
+        metrics = null;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBasicRegistry() {
+        KafkaMetric connections = findMetric("Connections", "ClientMetrics");
+        KafkaMetric connectedClients = findMetric("ConnectedClients", "ClientMetrics");
+
+        assertNotNull(connections);
+        assertNotNull(connectedClients);
+
+        assertTrue(((List<Map<String, String>>) connections.metricValue()).isEmpty());
+        assertEquals(0, connectedClients.metricValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddingRemovingConnections() {
+        KafkaMetric connections = findMetric("Connections", "ClientMetrics");
+        KafkaMetric connectedClients = findMetric("ConnectedClients", "ClientMetrics");
+
+        assertNotNull(connections);
+        assertNotNull(connectedClients);
+
+        ConnectionMetadata con1 = registry.register(
+            "con1",
+            "client1",
+            "",
+            "",
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS
+        );
+
+        assertEquals(con1, registry.get("con1"));
+
+        assertEquals(1, ((List<Map<String, String>>) connections.metricValue()).size());
+        assertTrue(((List<Map<String, String>>) connections.metricValue()).get(0).equals(con1.asMap()));
+        assertEquals(1, connectedClients.metricValue());
+
+        KafkaMetric clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+
+        assertNotNull(clientNameVersion);
+        assertEquals(1, clientNameVersion.metricValue());
+
+        registry.remove("con1");
+        assertEquals(0, clientNameVersion.metricValue());
+
+        // It should have been removed
+        clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+        assertNull(clientNameVersion);
+
+        assertTrue(((List<Map<String, String>>) connections.metricValue()).isEmpty());
+        assertEquals(0, connectedClients.metricValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUpdateClientSoftwareNameAndVersion() {
+        KafkaMetric connections = findMetric("Connections", "ClientMetrics");
+        KafkaMetric connectedClients = findMetric("ConnectedClients", "ClientMetrics");
+
+        assertNotNull(connections);
+        assertNotNull(connectedClients);
+
+        ConnectionMetadata con1 = registry.register(
+            "con1",
+            "client1",
+            "",
+            "",
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS
+        );
+
+        assertEquals(con1, registry.get("con1"));
+
+        assertEquals(1, ((List<Map<String, String>>) connections.metricValue()).size());
+        assertEquals(1, connectedClients.metricValue());
+
+        KafkaMetric clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+
+        assertNotNull(clientNameVersion);
+        assertEquals(1, clientNameVersion.metricValue());
+
+        registry.updateClientSoftwareNameAndVersion("con1", "name", "version");
+
+        assertEquals(0, clientNameVersion.metricValue());
+
+        // It should have been removed
+        clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+        assertNull(clientNameVersion);
+
+        // New one should be there
+        clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags("name", "version"));
+        assertNotNull(clientNameVersion);
+        assertEquals(1, clientNameVersion.metricValue());
+
+        assertEquals(1, ((List<Map<String, String>>) connections.metricValue()).size());
+        assertEquals(1, connectedClients.metricValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testClose() {
+        KafkaMetric connections = findMetric("Connections", "ClientMetrics");
+        KafkaMetric connectedClients = findMetric("ConnectedClients", "ClientMetrics");
+
+        assertNotNull(connections);
+        assertNotNull(connectedClients);
+
+        ConnectionMetadata con1 = registry.register(
+            "con1",
+            "client1",
+            "",
+            "",
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS
+        );
+
+        assertEquals(con1, registry.get("con1"));
+
+        assertEquals(1, ((List<Map<String, String>>) connections.metricValue()).size());
+        assertEquals(1, connectedClients.metricValue());
+
+        KafkaMetric clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+
+        assertNotNull(clientNameVersion);
+        assertEquals(1, clientNameVersion.metricValue());
+
+        registry.close();
+
+        // Metrics should be gone
+        clientNameVersion = findMetric("ConnectedClients", "ClientMetrics",
+            tags(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, ConnectionMetadata.UNKNOWN_NAME_OR_VERSION));
+        connections = findMetric("Connections", "ClientMetrics");
+        connectedClients = findMetric("ConnectedClients", "ClientMetrics");
+        assertNull(clientNameVersion);
+        assertNull(connections);
+        assertNull(connectedClients);
+    }
+
+    private KafkaMetric findMetric(String name, String group) {
+        return findMetric(name, group, emptyTags());
+    }
+
+    private KafkaMetric findMetric(String name, String group, Map<String, String> tags) {
+        MetricName metricName = new MetricName(name, group, "", tags);
+        for (Entry<MetricName, KafkaMetric> entry : metrics.metrics().entrySet()) {
+            if (entry.getKey().equals(metricName))
+                return entry.getValue();
+        }
+
+        return null;
+    }
+
+    private Map<String, String> emptyTags() {
+        return Collections.emptyMap();
+    }
+
+    private Map<String, String> tags(String clientSoftwareName, String clientSoftwareVersion) {
+        Map<String, String> tags = new HashMap<>(2);
+        tags.put("softwarename", clientSoftwareName);
+        tags.put("softwareversion", clientSoftwareVersion);
+        return tags;
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -41,7 +41,7 @@ public class RequestContextTest {
 
         RequestHeader header = new RequestHeader(ApiKeys.API_VERSIONS, Short.MAX_VALUE, "", correlationId);
         RequestContext context = new RequestContext(header, "0", InetAddress.getLocalHost(), KafkaPrincipal.ANONYMOUS,
-                new ListenerName("ssl"), SecurityProtocol.SASL_SSL);
+                new ListenerName("ssl"), SecurityProtocol.SASL_SSL, "", "");
         assertEquals(0, context.apiVersion());
 
         // Write some garbage to the request buffer. This should be ignored since we will treat

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -53,8 +53,6 @@ import static org.mockito.Mockito.when;
 
 public class SaslServerAuthenticatorTest {
 
-
-
     @Test(expected = InvalidReceiveException.class)
     public void testOversizeRequest() throws IOException {
         TransportLayer transportLayer = mock(TransportLayer.class);
@@ -100,17 +98,18 @@ public class SaslServerAuthenticatorTest {
     }
 
     @Test
-    public void testApiVersionsRequestV0() throws IOException {
+    public void testOldestApiVersionsRequest() throws IOException {
+        final short version = ApiKeys.API_VERSIONS.oldestVersion();
         TransportLayer transportLayer = mock(TransportLayer.class, Answers.RETURNS_DEEP_STUBS);
         Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
             Collections.singletonList(SCRAM_SHA_256.mechanismName()));
         SaslServerAuthenticator authenticator = setupAuthenticator(configs, transportLayer, SCRAM_SHA_256.mechanismName());
 
-        final RequestHeader header = new RequestHeader(ApiKeys.API_VERSIONS, (short) 0, "clientId", 0);
+        final RequestHeader header = new RequestHeader(ApiKeys.API_VERSIONS, version, "clientId", 0);
         final Struct headerStruct = header.toStruct();
 
-        final ApiVersionsRequest request = new ApiVersionsRequest.Builder().build((short) 0);
-        final Struct requestStruct = request.data.toStruct((short) 0);
+        final ApiVersionsRequest request = new ApiVersionsRequest.Builder().build(version);
+        final Struct requestStruct = request.data.toStruct(version);
 
         when(transportLayer.socketChannel().socket().getInetAddress()).thenReturn(InetAddress.getLoopbackAddress());
 
@@ -132,17 +131,18 @@ public class SaslServerAuthenticatorTest {
     }
 
     @Test
-    public void testApiVersionsRequestV3() throws IOException {
+    public void testLatestApiVersionsRequest() throws IOException {
+        final short version = ApiKeys.API_VERSIONS.latestVersion();
         TransportLayer transportLayer = mock(TransportLayer.class, Answers.RETURNS_DEEP_STUBS);
         Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
             Collections.singletonList(SCRAM_SHA_256.mechanismName()));
         SaslServerAuthenticator authenticator = setupAuthenticator(configs, transportLayer, SCRAM_SHA_256.mechanismName());
 
-        final RequestHeader header = new RequestHeader(ApiKeys.API_VERSIONS, (short) 3, "clientId", 0);
+        final RequestHeader header = new RequestHeader(ApiKeys.API_VERSIONS, version, "clientId", 0);
         final Struct headerStruct = header.toStruct();
 
-        final ApiVersionsRequest request = new ApiVersionsRequest.Builder().build((short) 3);
-        final Struct requestStruct = request.data.toStruct((short) 3);
+        final ApiVersionsRequest request = new ApiVersionsRequest.Builder().build(version);
+        final Struct requestStruct = request.data.toStruct(version);
 
         when(transportLayer.socketChannel().socket().getInetAddress()).thenReturn(InetAddress.getLoopbackAddress());
 

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -162,8 +162,8 @@ object BrokerApiVersionsCommand {
 
     private def getApiVersions(node: Node): ApiVersionsResponseKeyCollection = {
       val response = send(node, ApiKeys.API_VERSIONS, new ApiVersionsRequest.Builder()).asInstanceOf[ApiVersionsResponse]
-      Errors.forCode(response.data.errorCode()).maybeThrow()
-      response.data.apiKeys()
+      Errors.forCode(response.data.errorCode).maybeThrow()
+      response.data.apiKeys
     }
 
     /**

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -197,6 +197,8 @@ object RequestChannel extends Logging {
           .append(",securityProtocol:").append(context.securityProtocol)
           .append(",principal:").append(session.principal)
           .append(",listener:").append(context.listenerName.value)
+          .append(",clientSoftwareName:").append(context.clientSoftwareName)
+          .append(",clientSoftwareVersion:").append(context.clientSoftwareVersion)
         if (temporaryMemoryBytes > 0)
           builder.append(",temporaryMemoryBytes:").append(temporaryMemoryBytes)
         if (messageConversionsTimeMs > 0)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -233,13 +233,13 @@ class SocketServerTest {
     // Check connection metadata
     assertNotNull(connectionRegistry.get(connId))
     val connection = connectionRegistry.get(connId)
-    assertEquals(clientId, connection.clientId())
-    assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, connection.clientSoftwareName())
-    assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, connection.clientSoftwareVersion())
-    assertEquals(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT), connection.listenerName())
-    assertEquals(SecurityProtocol.PLAINTEXT, connection.securityProtocol())
-    assertEquals(address, connection.clientAddress())
-    assertEquals(KafkaPrincipal.ANONYMOUS, connection.principal())
+    assertEquals(clientId, connection.clientId)
+    assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, connection.clientSoftwareName)
+    assertEquals(ConnectionMetadata.UNKNOWN_NAME_OR_VERSION, connection.clientSoftwareVersion)
+    assertEquals(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT), connection.listenerName)
+    assertEquals(SecurityProtocol.PLAINTEXT, connection.securityProtocol)
+    assertEquals(address, connection.clientAddress)
+    assertEquals(KafkaPrincipal.ANONYMOUS, connection.principal)
 
     // Close the socket
     plainSocket.setSoLinger(true, 0)

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -832,7 +832,7 @@ class AclAuthorizerTest extends ZooKeeperTestHarness {
   private def newRequestContext(principal: KafkaPrincipal, clientAddress: InetAddress, apiKey: ApiKeys = ApiKeys.PRODUCE): RequestContext = {
     val securityProtocol = SecurityProtocol.SASL_PLAINTEXT
     val header = new RequestHeader(apiKey, 2, "", 1) //ApiKeys apiKey, short version, String clientId, int correlation
-    new RequestContext(header, "", clientAddress, principal, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol)
+    new RequestContext(header, "", clientAddress, principal, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol, "", "")
   }
 
   private def authorize(authorizer: AclAuthorizer, requestContext: RequestContext, operation: AclOperation, resource: ResourcePattern): Boolean = {

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -65,7 +65,7 @@ class ClientQuotaManagerTest {
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
-      listenerName, SecurityProtocol.PLAINTEXT)
+      listenerName, SecurityProtocol.PLAINTEXT, "", "")
     (request, new RequestChannel.Request(processor = 1, context = context, startTimeNanos =  0, MemoryPool.NONE, buffer,
       requestChannelMetrics))
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -852,7 +852,7 @@ class KafkaApisTest {
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
-      listenerName, SecurityProtocol.PLAINTEXT)
+      listenerName, SecurityProtocol.PLAINTEXT, "", "")
     (request, new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0, MemoryPool.NONE, buffer,
       requestChannelMetrics))
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -138,11 +138,11 @@ class KafkaApisTest {
     val response = readResponse(ApiKeys.API_VERSIONS, apiVersionsRequest, capturedResponse)
       .asInstanceOf[ApiVersionsResponse]
 
-    assertEquals(Errors.NONE.code(), response.data.errorCode())
+    assertEquals(Errors.NONE.code, response.data.errorCode)
   }
 
   @Test
-  def testApiVersionsRequestV0UpdateConnectionMetadata(): Unit = {
+  def testApiVersionsRequestOldestUpdateConnectionMetadata(): Unit = {
     EasyMock.reset(connectionRegistry, clientRequestQuotaManager, requestChannel)
     val connection: ConnectionMetadata = EasyMock.mock(classOf[ConnectionMetadata])
 
@@ -159,7 +159,7 @@ class KafkaApisTest {
     val response = readResponse(ApiKeys.API_VERSIONS, apiVersionsRequest, capturedResponse)
       .asInstanceOf[ApiVersionsResponse]
 
-    assertEquals(Errors.NONE.code(), response.data.errorCode())
+    assertEquals(Errors.NONE.code, response.data.errorCode)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
@@ -68,7 +68,7 @@ class SaslApiVersionsRequestTest extends BaseRequestTest with SaslSetup {
     try {
       sendSaslHandshakeRequestValidateResponse(plaintextSocket)
       val response = sendApiVersionsRequest(plaintextSocket, new ApiVersionsRequest.Builder().build(0))
-      assertEquals(Errors.ILLEGAL_SASL_STATE.code(), response.data.errorCode())
+      assertEquals(Errors.ILLEGAL_SASL_STATE.code, response.data.errorCode)
     } finally {
       plaintextSocket.close()
     }
@@ -80,7 +80,7 @@ class SaslApiVersionsRequestTest extends BaseRequestTest with SaslSetup {
     try {
       val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0)
       val apiVersionsResponse = sendApiVersionsRequest(plaintextSocket, apiVersionsRequest, Some(Short.MaxValue))
-      assertEquals(Errors.UNSUPPORTED_VERSION.code(), apiVersionsResponse.data.errorCode())
+      assertEquals(Errors.UNSUPPORTED_VERSION.code, apiVersionsResponse.data.errorCode)
       val apiVersionsResponse2 = sendApiVersionsRequest(plaintextSocket, new ApiVersionsRequest.Builder().build(0))
       ApiVersionsRequestTest.validateApiVersionsResponse(apiVersionsResponse2)
       sendSaslHandshakeRequestValidateResponse(plaintextSocket)

--- a/core/src/test/scala/unit/kafka/server/ThrottledChannelExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ThrottledChannelExpirationTest.scala
@@ -55,7 +55,7 @@ class ThrottledChannelExpirationTest {
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
-      listenerName, SecurityProtocol.PLAINTEXT)
+      listenerName, SecurityProtocol.PLAINTEXT, "", "")
     (request, new RequestChannel.Request(processor = 1, context = context, startTimeNanos =  0, MemoryPool.NONE, buffer,
       requestChannelMetrics))
   }


### PR DESCRIPTION
This PR implements the second part of KIP-511:
* Connection Registry
* Integration in the Processor and the KafkaApis
* Integration with SaslServerAuthenticator
* New Metrics
* Enrichment of the RequestLog

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
