### PR TITLE
KAFKA-8609: add rebalance-total-time

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.metrics.stats.Rate;
@@ -1059,6 +1060,10 @@ public abstract class AbstractCoordinator implements Closeable {
                 this.metricGrpName,
                 "The max time taken for a group to complete a successful rebalance, which may be composed of " +
                     "several failed re-trials until it succeeded"), new Max());
+            this.successfulRebalanceSensor.add(metrics.metricName("rebalance-latency-total",
+                this.metricGrpName,
+                "The total number of milliseconds this consumer has spent in successful rebalances since creation"),
+                new CumulativeSum());
             this.successfulRebalanceSensor.add(
                 metrics.metricName("rebalance-total",
                     this.metricGrpName,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -163,6 +163,7 @@ public class AbstractCoordinatorTest {
         assertNotNull(getMetric("sync-total"));
         assertNotNull(getMetric("rebalance-latency-avg"));
         assertNotNull(getMetric("rebalance-latency-max"));
+        assertNotNull(getMetric("rebalance-latency-total"));
         assertNotNull(getMetric("rebalance-rate-per-hour"));
         assertNotNull(getMetric("rebalance-total"));
         assertNotNull(getMetric("last-rebalance-seconds-ago"));
@@ -207,6 +208,7 @@ public class AbstractCoordinatorTest {
 
         assertEquals(3.0d, getMetric("rebalance-latency-avg").metricValue());
         assertEquals(6.0d, getMetric("rebalance-latency-max").metricValue());
+        assertEquals(9.0d, getMetric("rebalance-latency-total").metricValue());
         assertEquals(360.0d, getMetric("rebalance-rate-per-hour").metricValue());
         assertEquals(3.0d, getMetric("rebalance-total").metricValue());
 


### PR DESCRIPTION
In addition to the existing metrics added in KAFKA-8609, add the total (cumulative) time spent during rebalances.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
