### PR TITLE
MINOR: Make `TopicDescription`'s other constructor public

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
@@ -72,7 +72,7 @@ public class TopicDescription {
      *                   leadership and replica information for that partition.
      * @param authorizedOperations authorized operations for this topic, or null if this is not known.
      */
-    TopicDescription(String name, boolean internal, List<TopicPartitionInfo> partitions,
+    public TopicDescription(String name, boolean internal, List<TopicPartitionInfo> partitions,
                             Set<AclOperation> authorizedOperations) {
         this.name = name;
         this.internal = internal;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
@@ -33,7 +33,7 @@ public class TopicDescription {
     private final String name;
     private final boolean internal;
     private final List<TopicPartitionInfo> partitions;
-    private Set<AclOperation> authorizedOperations;
+    private final Set<AclOperation> authorizedOperations;
 
     @Override
     public boolean equals(final Object o) {


### PR DESCRIPTION
Make the other TopicDescriptions package private constructor public, so that it can be used by clients.

For example, KSQL needs the constructor for its use of proxies around Kafka APIs.  Another common use case would likely be tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
