### PR TITLE
KAFKA-8649: version probing with upgraded leader

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -612,7 +612,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             int consumerTaskIndex = 0;
 
-            for (final String consumer : consumers.keySet()) {
+            for (final Map.Entry<String, Integer> consumerSubscriptionVersion : consumers.entrySet()) {
+                final String consumer = consumerSubscriptionVersion.getKey();
+                final int consumerVersion = consumerSubscriptionVersion.getValue();
                 final Map<TaskId, Set<TopicPartition>> standby = new HashMap<>();
                 final List<AssignedPartition> assignedPartitions = new ArrayList<>();
 
@@ -643,7 +645,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
                 final int assignmentVersion = sendLatestVersionToAllClients ?
                     minSupportedMetadataVersion :
-                    consumers.get(consumer);
+                    consumerVersion;
 
                 // finally, encode the assignment before sending back to coordinator
                 assignment.put(
@@ -674,7 +676,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // assign previously assigned tasks to "old consumers"
         for (final ClientMetadata clientMetadata : clientsMetadata.values()) {
             final Map<String, Integer> consumers = clientMetadata.consumers;
-            for (final String consumerId : consumers.keySet()) {
+            for (final Map.Entry<String, Integer> consumerSubscriptionVersion : consumers.entrySet()) {
+                final String consumerId = consumerSubscriptionVersion.getKey();
+                final int consumerVersion = consumerSubscriptionVersion.getValue();
 
                 if (futureConsumers.contains(consumerId)) {
                     continue;
@@ -696,7 +700,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 assignment.put(consumerId, new Assignment(
                     assignedPartitions,
                     new AssignmentInfo(
-                        consumers.get(consumerId),
+                        consumerVersion,
                         activeTasks,
                         standbyTasks,
                         partitionsByHostState,


### PR DESCRIPTION
Version probing is currently broken when the leader is chosen from one of the new (already upgraded) instances, as older members will blindly upgrade to a version they don't support (then throw an exception) while newer members will receive an assignment with the older version and trigger a new rebalance (leading to rebalance loop if the older members can't upgrade their subscription) because we always send assignments encoded using the min version seen by any client--see ticket for details.

Note that a real "version probing" rebalance is technically one where the leader is old and receives subscriptions it can't understand. In this case we send an assignment back with the old version, which the receiving consumer then knows to downgrade to and trigger another rebalance. 

When you have a "new" leader however, I propose we:

- always send assignments back using the same version as the corresponding subscription, EXCEPT if we notice that everyone now supports the latest version but some are still using the older version. this signals the rolling upgrade is complete, so send everyone back the latest version
- if you receive a version greater than the one you sent, it must mean the bounce is over and it is safe to now send new versions. upgrade your subscription version and trigger a final rebalance. this will actually only happen when the leader is the last to be bounced
- if the leader is new, it can understand all subscriptions so we just wait for everyone to be bounced and allow new members to keep sending new version subscriptions. once the last member is upgraded everyone will already be using the new subscription and we don't need to trigger a second and final rebalance.
- if you receive a version less than what you sent, this is version probing so downgrade your subscription and trigger another rebalance -- this will now only happen when you are actually on a higher version than the leader, so we know this is true version probing.