### PR TITLE
MINOR: Fixed a division by 0 scenario

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -73,10 +73,13 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
 
     private void assignActive() {
 
-        final int totalCapacity = 1;
+        final int totalCapacity;
         
         if(sumCapacity(clients.value()) > 0) {
             totalCapacity = sumCapacity(clients.value();
+        }
+        else {
+            totalCapacity = 1;
         }
 
         final int tasksPerThread = taskIds.size() / totalCapacity;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -72,7 +72,13 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
     }
 
     private void assignActive() {
-        final int totalCapacity = sumCapacity(clients.values());
+
+        final int totalCapacity = 1;
+        
+        if(sumCapacity(clients.value()) > 0) {
+            totalCapacity = sumCapacity(clients.value();
+        }
+
         final int tasksPerThread = taskIds.size() / totalCapacity;
         final Set<TaskId> assigned = new HashSet<>();
 


### PR DESCRIPTION
MINOR: Fixed a division by 0 scenario by ensuring that totalCapacity had a default value of 1 in the event that sumCapacity was 0, thereby negating a division by 0 event which could have caused a denial of service.

This was tested via static analysis while I was reviewing the code. There is no need for additional unit tests since this is indeed a minor change.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
