### PR TITLE
Fix type of timestampDelta in documentation

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -85,7 +85,7 @@
 		length: varint
 		attributes: int8
 			bit 0~7: unused
-		timestampDelta: varint
+		timestampDelta: varlong
 		offsetDelta: varint
 		keyLength: varint
 		key: byte[]


### PR DESCRIPTION
According to the `DefaultRecord` implementation, Kafka uses `varlong` instead of `varint` for the timestamp delta.

More info: https://github.com/apache/kafka/blob/9aa660786e46c1efbf5605a6a69136a1dac6edb9/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java#L190