### PR TITLE
KAFKA-8934: Introduce instance-level metrics for streams applications

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.internals.metrics;
+
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class ClientMetrics {
+    private ClientMetrics() {}
+
+    private static final Logger log = LoggerFactory.getLogger(ClientMetrics.class);
+    private static final String VERSION = "version";
+    private static final String COMMIT_ID = "commit-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String TOPOLOGY_DESCRIPTION = "topology-description";
+    private static final String STATE = "state";
+    private static final String VERSION_FROM_FILE;
+    private static final String COMMIT_ID_FROM_FILE;
+    private static final String DEFAULT_VALUE = "unknown";
+
+    static {
+        final Properties props = new Properties();
+        try (InputStream resourceStream = ClientMetrics.class.getResourceAsStream("/kafka/kafka-version.properties")) {
+            props.load(resourceStream);
+        } catch (final Exception exception) {
+            log.warn("Error while loading kafka-streams-version.properties: {}", exception.getMessage());
+        }
+        VERSION_FROM_FILE = props.getProperty("version", DEFAULT_VALUE).trim();
+        COMMIT_ID_FROM_FILE = props.getProperty("commitId", DEFAULT_VALUE).trim();
+    }
+
+    private static final String VERSION_DESCRIPTION = "The version of the Kafka Streams client";
+    private static final String COMMIT_ID_DESCRIPTION = "The version control commit ID of the Kafka Streams client";
+    private static final String APPLICATION_ID_DESCRIPTION = "The application ID of the Kafka Streams client";
+    private static final String TOPOLOGY_DESCRIPTION_DESCRIPTION =
+        "The description of the topology executed in the Kafka Streams client";
+    private static final String STATE_DESCRIPTION = "The state of the Kafka Streams client";
+
+    public static String version() {
+        return VERSION_FROM_FILE;
+    }
+
+    public static String commitId() {
+        return COMMIT_ID_FROM_FILE;
+    }
+
+    public static void addVersionMetric(final StreamsMetricsImpl streamsMetrics) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            VERSION,
+            VERSION_DESCRIPTION,
+            RecordingLevel.INFO,
+            VERSION_FROM_FILE
+        );
+    }
+
+    public static void addCommitIdMetric(final StreamsMetricsImpl streamsMetrics) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            COMMIT_ID,
+            COMMIT_ID_DESCRIPTION,
+            RecordingLevel.INFO,
+            COMMIT_ID_FROM_FILE
+        );
+    }
+
+    public static void addApplicationIdMetric(final StreamsMetricsImpl streamsMetrics, final String applicationId) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            APPLICATION_ID,
+            APPLICATION_ID_DESCRIPTION,
+            RecordingLevel.INFO,
+            applicationId
+        );
+    }
+
+    public static void addTopologyDescriptionMetric(final StreamsMetricsImpl streamsMetrics,
+                                                    final String topologyDescription) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            TOPOLOGY_DESCRIPTION,
+            TOPOLOGY_DESCRIPTION_DESCRIPTION,
+            RecordingLevel.INFO,
+            topologyDescription
+        );
+    }
+
+    public static void addStateMetric(final StreamsMetricsImpl streamsMetrics,
+                                      final Gauge<State> stateProvider) {
+        streamsMetrics.addClientLevelMutableMetric(
+            STATE,
+            STATE_DESCRIPTION,
+            RecordingLevel.INFO,
+            stateProvider
+        );
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
@@ -41,7 +41,9 @@ public class ClientMetrics {
 
     static {
         final Properties props = new Properties();
-        try (InputStream resourceStream = ClientMetrics.class.getResourceAsStream("/kafka/kafka-version.properties")) {
+        try (InputStream resourceStream = ClientMetrics.class.getResourceAsStream(
+            "/kafka/kafka-streams-version.properties")) {
+
             props.load(resourceStream);
         } catch (final Exception exception) {
             log.warn("Error while loading kafka-streams-version.properties: {}", exception.getMessage());

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
@@ -46,7 +46,7 @@ public class ClientMetrics {
 
             props.load(resourceStream);
         } catch (final Exception exception) {
-            log.warn("Error while loading kafka-streams-version.properties: {}", exception.getMessage());
+            log.warn("Error while loading kafka-streams-version.properties", exception);
         }
         VERSION_FROM_FILE = props.getProperty("version", DEFAULT_VALUE).trim();
         COMMIT_ID_FROM_FILE = props.getProperty("commitId", DEFAULT_VALUE).trim();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -67,7 +67,7 @@ public class KStreamAggregate<K, V, T> implements KStreamAggProcessorSupplier<K,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             store = (TimestampedKeyValueStore<K, T>) context.getStateStore(storeName);
             tupleForwarder = new TimestampedTupleForwarder<>(
                 store,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -65,7 +65,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
 
             otherWindow = (WindowStore<K, V2>) context.getStateStore(otherWindowName);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -52,7 +52,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
     public void init(final ProcessorContext context) {
         super.init(context);
         metrics = (StreamsMetricsImpl) context.metrics();
-        skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+        skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
 
         valueGetter.init(context);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -65,7 +65,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             store = (TimestampedKeyValueStore<K, V>) context.getStateStore(storeName);
             tupleForwarder = new TimestampedTupleForwarder<>(
                 store,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -94,7 +94,7 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
             internalProcessorContext = (InternalProcessorContext) context;
             metrics = (StreamsMetricsImpl) context.metrics();
             lateRecordDropSensor = Sensors.lateRecordDropSensor(internalProcessorContext);
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
 
             store = (SessionStore<K, Agg>) context.getStateStore(storeName);
             tupleForwarder = new SessionTupleForwarder<>(store, context, new SessionCacheFlushListener<>(context), sendOldValues);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -92,7 +92,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
             metrics = internalProcessorContext.metrics();
 
             lateRecordDropSensor = Sensors.lateRecordDropSensor(internalProcessorContext);
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             windowStore = (TimestampedWindowStore<K, Agg>) context.getStateStore(storeName);
             tupleForwarder = new TimestampedTupleForwarder<>(
                 windowStore,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -78,7 +78,7 @@ class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             valueGetter.init(context);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -77,7 +77,7 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             valueGetter.init(context);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -76,7 +76,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             valueGetter.init(context);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -75,7 +75,7 @@ class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             valueGetter.init(context);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -79,7 +79,7 @@ public class KTableSource<K, V> implements ProcessorSupplier<K, V> {
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
             if (queryableName != null) {
                 store = (TimestampedKeyValueStore<K, V>) context.getStateStore(queryableName);
                 tupleForwarder = new TimestampedTupleForwarder<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
@@ -64,7 +64,8 @@ public class ForeignJoinSubscriptionProcessorSupplier<K, KO, VO> implements Proc
         public void init(final ProcessorContext context) {
             super.init(context);
             final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(internalProcessorContext.metrics());
+            skippedRecordsSensor =
+                ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), internalProcessorContext.metrics());
             store = internalProcessorContext.getStateStore(storeBuilder);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
@@ -65,7 +65,7 @@ public class SubscriptionStoreReceiveProcessorSupplier<K, KO>
                 final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
 
                 metrics = internalProcessorContext.metrics();
-                skippedRecordsSensor = ThreadMetrics.skipRecordSensor(metrics);
+                skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
                 store = internalProcessorContext.getStateStore(storeBuilder);
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/metrics/Sensors.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/metrics/Sensors.java
@@ -38,7 +38,10 @@ public class Sensors {
 
     public static Sensor lateRecordDropSensor(final InternalProcessorContext context) {
         final StreamsMetricsImpl metrics = context.metrics();
+        final String threadId = Thread.currentThread().getName();
+
         final Sensor sensor = metrics.nodeLevelSensor(
+            threadId,
             context.taskId().toString(),
             context.currentNode().name(),
             LATE_RECORD_DROP,
@@ -47,7 +50,13 @@ public class Sensors {
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             sensor,
             PROCESSOR_NODE_METRICS_GROUP,
-            metrics.tagMap("task-id", context.taskId().toString(), PROCESSOR_NODE_ID_TAG, context.currentNode().name()),
+            metrics.tagMap(
+                threadId,
+                "task-id",
+                context.taskId().toString(),
+                PROCESSOR_NODE_ID_TAG,
+                context.currentNode().name()
+            ),
             LATE_RECORD_DROP
         );
         return sensor;
@@ -55,15 +64,19 @@ public class Sensors {
 
     public static Sensor recordLatenessSensor(final InternalProcessorContext context) {
         final StreamsMetricsImpl metrics = context.metrics();
+        final String threadId = Thread.currentThread().getName();
 
         final Sensor sensor = metrics.taskLevelSensor(
+            threadId,
             context.taskId().toString(),
             "record-lateness",
             Sensor.RecordingLevel.DEBUG
         );
 
         final Map<String, String> tags = metrics.tagMap(
-            "task-id", context.taskId().toString()
+            threadId,
+            "task-id",
+            context.taskId().toString()
         );
         sensor.add(
             new MetricName(
@@ -86,8 +99,10 @@ public class Sensors {
 
     public static Sensor suppressionEmitSensor(final InternalProcessorContext context) {
         final StreamsMetricsImpl metrics = context.metrics();
+        final String threadId = Thread.currentThread().getName();
 
         final Sensor sensor = metrics.nodeLevelSensor(
+            threadId,
             context.taskId().toString(),
             context.currentNode().name(),
             "suppression-emit",
@@ -95,8 +110,11 @@ public class Sensors {
         );
 
         final Map<String, String> tags = metrics.tagMap(
-            "task-id", context.taskId().toString(),
-            PROCESSOR_NODE_ID_TAG, context.currentNode().name()
+            threadId,
+            "task-id",
+            context.taskId().toString(),
+            PROCESSOR_NODE_ID_TAG,
+            context.currentNode().name()
         );
 
         sensor.add(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -70,7 +70,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
                     source,
                     deserializationExceptionHandler,
                     logContext,
-                    ThreadMetrics.skipRecordSensor(processorContext.metrics())
+                    ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), processorContext.metrics())
                 )
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -33,7 +32,6 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -180,27 +178,21 @@ public class GlobalStreamThread extends Thread {
                               final Consumer<byte[], byte[]> globalConsumer,
                               final StateDirectory stateDirectory,
                               final long cacheSizeBytes,
-                              final Metrics metrics,
+                              final StreamsMetricsImpl streamsMetrics,
                               final Time time,
                               final String threadClientId,
-                              final StateRestoreListener stateRestoreListener,
-                              final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger) {
+                              final StateRestoreListener stateRestoreListener) {
         super(threadClientId);
         this.time = time;
         this.config = config;
         this.topology = topology;
         this.globalConsumer = globalConsumer;
         this.stateDirectory = stateDirectory;
-        streamsMetrics = new StreamsMetricsImpl(
-            metrics,
-            threadClientId,
-            config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
-        );
-        streamsMetrics.setRocksDBMetricsRecordingTrigger(rocksDBMetricsRecordingTrigger);
+        this.streamsMetrics = streamsMetrics;
         this.logPrefix = String.format("global-stream-thread [%s] ", threadClientId);
         this.logContext = new LogContext(logPrefix);
         this.log = logContext.logger(getClass());
-        this.cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
+        this.cache = new ThreadCache(logContext, cacheSizeBytes, this.streamsMetrics);
         this.stateRestoreListener = stateRestoreListener;
     }
 
@@ -286,7 +278,7 @@ public class GlobalStreamThread extends Thread {
             setState(State.DEAD);
 
             log.warn("Error happened during initialization of the global state store; this thread has shutdown");
-            streamsMetrics.removeAllThreadLevelSensors();
+            streamsMetrics.removeAllThreadLevelSensors(getName());
 
             return;
         }
@@ -310,7 +302,7 @@ public class GlobalStreamThread extends Thread {
                 log.error("Failed to close state maintainer due to the following error:", e);
             }
 
-            streamsMetrics.removeAllThreadLevelSensors();
+            streamsMetrics.removeAllThreadLevelSensors(getName());
 
             setState(DEAD);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_METRICS_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxLatencyToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
 
 public class ProcessorNode<K, V> {
 
@@ -166,13 +167,27 @@ public class ProcessorNode<K, V> {
         private NodeMetrics(final StreamsMetricsImpl metrics, final String processorNodeName, final ProcessorContext context) {
             this.metrics = metrics;
 
+            final String threadId = Thread.currentThread().getName();
             final String taskName = context.taskId().toString();
-            final Map<String, String> tagMap = metrics.tagMap("task-id", context.taskId().toString(), PROCESSOR_NODE_ID_TAG, processorNodeName);
-            final Map<String, String> allTagMap = metrics.tagMap("task-id", context.taskId().toString(), PROCESSOR_NODE_ID_TAG, "all");
+            final Map<String, String> tagMap = metrics.tagMap(
+                threadId,
+                "task-id",
+                context.taskId().toString(),
+                PROCESSOR_NODE_ID_TAG,
+                processorNodeName
+            );
+            final Map<String, String> allTagMap = metrics.tagMap(
+                threadId,
+                "task-id",
+                context.taskId().toString(),
+                PROCESSOR_NODE_ID_TAG,
+                "all"
+            );
 
             nodeProcessTimeSensor = createTaskAndNodeLatencyAndThroughputSensors(
                 "process",
                 metrics,
+                threadId,
                 taskName,
                 processorNodeName,
                 allTagMap,
@@ -182,6 +197,7 @@ public class ProcessorNode<K, V> {
             nodePunctuateTimeSensor = createTaskAndNodeLatencyAndThroughputSensors(
                 "punctuate",
                 metrics,
+                threadId,
                 taskName,
                 processorNodeName,
                 allTagMap,
@@ -191,6 +207,7 @@ public class ProcessorNode<K, V> {
             nodeCreationSensor = createTaskAndNodeLatencyAndThroughputSensors(
                 "create",
                 metrics,
+                threadId,
                 taskName,
                 processorNodeName,
                 allTagMap,
@@ -201,6 +218,7 @@ public class ProcessorNode<K, V> {
             nodeDestructionSensor = createTaskAndNodeLatencyAndThroughputSensors(
                 "destroy",
                 metrics,
+                threadId,
                 taskName,
                 processorNodeName,
                 allTagMap,
@@ -210,6 +228,7 @@ public class ProcessorNode<K, V> {
             sourceNodeForwardSensor = createTaskAndNodeLatencyAndThroughputSensors(
                 "forward",
                 metrics,
+                threadId,
                 taskName,
                 processorNodeName,
                 allTagMap,
@@ -221,24 +240,35 @@ public class ProcessorNode<K, V> {
         }
 
         private void removeAllSensors() {
-            metrics.removeAllNodeLevelSensors(taskName, processorNodeName);
+            metrics.removeAllNodeLevelSensors(Thread.currentThread().getName(), taskName, processorNodeName);
         }
 
         private static Sensor createTaskAndNodeLatencyAndThroughputSensors(final String operation,
                                                                            final StreamsMetricsImpl metrics,
+                                                                           final String threadId,
                                                                            final String taskName,
                                                                            final String processorNodeName,
                                                                            final Map<String, String> taskTags,
                                                                            final Map<String, String> nodeTags) {
-            final Sensor parent = metrics.taskLevelSensor(taskName, operation, Sensor.RecordingLevel.DEBUG);
+            final Sensor parent = metrics.taskLevelSensor(
+                threadId,
+                taskName,
+                operation,
+                Sensor.RecordingLevel.DEBUG
+            );
             addAvgAndMaxLatencyToSensor(parent, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
-            StreamsMetricsImpl
-                .addInvocationRateAndCountToSensor(parent, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
+            addInvocationRateAndCountToSensor(parent, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
 
-            final Sensor sensor = metrics.nodeLevelSensor(taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent);
+            final Sensor sensor = metrics.nodeLevelSensor(
+                threadId,
+                taskName,
+                processorNodeName,
+                operation,
+                Sensor.RecordingLevel.DEBUG,
+                parent
+            );
             addAvgAndMaxLatencyToSensor(sensor, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
-            StreamsMetricsImpl
-                .addInvocationRateAndCountToSensor(sensor, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
+            addInvocationRateAndCountToSensor(sensor, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
 
             return sensor;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -62,7 +62,8 @@ public class RecordQueue {
         this.fifoQueue = new ArrayDeque<>();
         this.timestampExtractor = timestampExtractor;
         this.processorContext = processorContext;
-        skipRecordsSensor = ThreadMetrics.skipRecordSensor(processorContext.metrics());
+        skipRecordsSensor =
+            ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), processorContext.metrics());
         recordDeserializer = new RecordDeserializer(
             source,
             deserializationExceptionHandler,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -63,7 +63,8 @@ public class StandbyTask extends AbstractTask {
                 final StateDirectory stateDirectory) {
         super(id, partitions, topology, consumer, changelogReader, true, stateDirectory, config);
 
-        closeTaskSensor = metrics.threadLevelSensor("task-closed", Sensor.RecordingLevel.INFO);
+        closeTaskSensor = metrics
+            .threadLevelSensor(Thread.currentThread().getName(), "task-closed", Sensor.RecordingLevel.INFO);
         processorContext = new StandbyContextImpl(id, config, stateMgr, metrics);
 
         final Set<String> changelogTopicNames = new HashSet<>(topology.storeToChangelogTopic().values());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -96,19 +96,23 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         final StreamsMetricsImpl metrics;
         final Sensor taskCommitTimeSensor;
         final Sensor taskEnforcedProcessSensor;
+        private final String threadId;
         private final String taskName;
 
-        TaskMetrics(final TaskId id, final StreamsMetricsImpl metrics) {
-            taskName = id.toString();
+        TaskMetrics(final String threadId, final TaskId taskId, final StreamsMetricsImpl metrics) {
+            this.threadId = threadId;
+            taskName = taskId.toString();
             this.metrics = metrics;
             final String group = "stream-task-metrics";
 
             // first add the global operation metrics if not yet, with the global tags only
-            final Sensor parent = ThreadMetrics.commitOverTasksSensor(metrics);
+            final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, metrics);
 
             // add the operation metrics with additional tags
-            final Map<String, String> tagMap = metrics.tagMap("task-id", taskName);
-            taskCommitTimeSensor = metrics.taskLevelSensor(taskName, "commit", Sensor.RecordingLevel.DEBUG, parent);
+            final Map<String, String> tagMap =
+                metrics.tagMap(Thread.currentThread().getName(), "task-id", taskName);
+            taskCommitTimeSensor =
+                metrics.taskLevelSensor(threadId, taskName, "commit", Sensor.RecordingLevel.DEBUG, parent);
             taskCommitTimeSensor.add(
                 new MetricName("commit-latency-avg", group, "The average latency of commit operation.", tagMap),
                 new Avg()
@@ -127,7 +131,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             );
 
             // add the metrics for enforced processing
-            taskEnforcedProcessSensor = metrics.taskLevelSensor(taskName, "enforced-processing", Sensor.RecordingLevel.DEBUG, parent);
+            taskEnforcedProcessSensor = metrics.taskLevelSensor(
+                threadId,
+                taskName,
+                "enforced-processing",
+                Sensor.RecordingLevel.DEBUG,
+                parent
+            );
             taskEnforcedProcessSensor.add(
                     new MetricName("enforced-processing-rate", group, "The average number of occurrence of enforced-processing operation per second.", tagMap),
                     new Rate(TimeUnit.SECONDS, new WindowedCount())
@@ -140,7 +150,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         void removeAllSensors() {
-            metrics.removeAllTaskLevelSensors(taskName);
+            metrics.removeAllTaskLevelSensors(threadId, taskName);
         }
     }
 
@@ -179,9 +189,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         this.time = time;
         this.producerSupplier = producerSupplier;
         this.producer = producerSupplier.get();
-        this.taskMetrics = new TaskMetrics(id, streamsMetrics);
+        final String threadId = Thread.currentThread().getName();
+        this.taskMetrics = new TaskMetrics(threadId, id, streamsMetrics);
 
-        closeTaskSensor = ThreadMetrics.closeTaskSensor(streamsMetrics);
+        closeTaskSensor = ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
 
         final ProductionExceptionHandler productionExceptionHandler = config.defaultProductionExceptionHandler();
 
@@ -190,7 +201,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 id.toString(),
                 logContext,
                 productionExceptionHandler,
-                ThreadMetrics.skipRecordSensor(streamsMetrics));
+                ThreadMetrics.skipRecordSensor(threadId, streamsMetrics));
         } else {
             this.recordCollector = recordCollector;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -99,7 +99,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         private final String threadId;
         private final String taskName;
 
-        TaskMetrics(final String threadId, final TaskId taskId, final StreamsMetricsImpl metrics) {
+        TaskMetrics(final String threadId,
+                    final TaskId taskId,
+                    final StreamsMetricsImpl metrics) {
             this.threadId = threadId;
             taskName = taskId.toString();
             this.metrics = metrics;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.LogContext;
@@ -46,7 +45,6 @@ import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -315,7 +313,7 @@ public class StreamThread extends Thread {
     static class TaskCreator extends AbstractTaskCreator<StreamTask> {
         private final ThreadCache cache;
         private final KafkaClientSupplier clientSupplier;
-        private final String threadClientId;
+        private final String threadId;
         private final Producer<byte[], byte[]> threadProducer;
         private final Sensor createTaskSensor;
 
@@ -328,7 +326,7 @@ public class StreamThread extends Thread {
                     final Time time,
                     final KafkaClientSupplier clientSupplier,
                     final Producer<byte[], byte[]> threadProducer,
-                    final String threadClientId,
+                    final String threadId,
                     final Logger log) {
             super(
                 builder,
@@ -341,8 +339,8 @@ public class StreamThread extends Thread {
             this.cache = cache;
             this.clientSupplier = clientSupplier;
             this.threadProducer = threadProducer;
-            this.threadClientId = threadClientId;
-            createTaskSensor = ThreadMetrics.createTaskSensor(streamsMetrics);
+            this.threadId = threadId;
+            createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
         }
 
         @Override
@@ -368,7 +366,7 @@ public class StreamThread extends Thread {
         private Producer<byte[], byte[]> createProducer(final TaskId id) {
             // eos
             if (threadProducer == null) {
-                final Map<String, Object> producerConfigs = config.getProducerConfigs(getTaskProducerClientId(threadClientId, id));
+                final Map<String, Object> producerConfigs = config.getProducerConfigs(getTaskProducerClientId(threadId, id));
                 log.info("Creating producer client for task {}", id);
                 producerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, applicationId + "-" + id);
                 return clientSupplier.getProducer(producerConfigs);
@@ -398,6 +396,7 @@ public class StreamThread extends Thread {
                            final StateDirectory stateDirectory,
                            final ChangelogReader storeChangelogReader,
                            final Time time,
+                           final String threadId,
                            final Logger log) {
             super(
                 builder,
@@ -407,7 +406,7 @@ public class StreamThread extends Thread {
                 storeChangelogReader,
                 time,
                 log);
-            createTaskSensor = ThreadMetrics.createTaskSensor(streamsMetrics);
+            createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
         }
 
         @Override
@@ -480,21 +479,21 @@ public class StreamThread extends Thread {
                                       final Admin adminClient,
                                       final UUID processId,
                                       final String clientId,
-                                      final Metrics metrics,
+                                      final StreamsMetricsImpl streamsMetrics,
                                       final Time time,
                                       final StreamsMetadataState streamsMetadataState,
                                       final long cacheSizeBytes,
                                       final StateDirectory stateDirectory,
                                       final StateRestoreListener userStateRestoreListener,
                                       final int threadIdx) {
-        final String threadClientId = clientId + "-StreamThread-" + threadIdx;
+        final String threadId = clientId + "-StreamThread-" + threadIdx;
 
-        final String logPrefix = String.format("stream-thread [%s] ", threadClientId);
+        final String logPrefix = String.format("stream-thread [%s] ", threadId);
         final LogContext logContext = new LogContext(logPrefix);
         final Logger log = logContext.logger(StreamThread.class);
 
         log.info("Creating restore consumer client");
-        final Map<String, Object> restoreConsumerConfigs = config.getRestoreConsumerConfigs(getRestoreConsumerClientId(threadClientId));
+        final Map<String, Object> restoreConsumerConfigs = config.getRestoreConsumerConfigs(getRestoreConsumerClientId(threadId));
         final Consumer<byte[], byte[]> restoreConsumer = clientSupplier.getRestoreConsumer(restoreConsumerConfigs);
         final Duration pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         final StoreChangelogReader changelogReader = new StoreChangelogReader(restoreConsumer, pollTime, userStateRestoreListener, logContext);
@@ -502,16 +501,10 @@ public class StreamThread extends Thread {
         Producer<byte[], byte[]> threadProducer = null;
         final boolean eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
         if (!eosEnabled) {
-            final Map<String, Object> producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadClientId));
+            final Map<String, Object> producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
             log.info("Creating shared producer client");
             threadProducer = clientSupplier.getProducer(producerConfigs);
         }
-
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
-            metrics,
-            threadClientId,
-            config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
-        );
 
         final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
 
@@ -525,7 +518,7 @@ public class StreamThread extends Thread {
             time,
             clientSupplier,
             threadProducer,
-            threadClientId,
+            threadId,
             log);
         final AbstractTaskCreator<StandbyTask> standbyTaskCreator = new StandbyTaskCreator(
             builder,
@@ -534,6 +527,7 @@ public class StreamThread extends Thread {
             stateDirectory,
             changelogReader,
             time,
+            threadId,
             log);
         final TaskManager taskManager = new TaskManager(
             changelogReader,
@@ -549,7 +543,7 @@ public class StreamThread extends Thread {
 
         log.info("Creating consumer client");
         final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-        final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadClientId), threadIdx);
+        final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadId), threadIdx);
         consumerConfigs.put(StreamsConfig.InternalConfig.TASK_MANAGER_FOR_PARTITION_ASSIGNOR, taskManager);
         final AtomicInteger assignmentErrorCode = new AtomicInteger();
         consumerConfigs.put(StreamsConfig.InternalConfig.ASSIGNMENT_ERROR_CODE, assignmentErrorCode);
@@ -572,7 +566,7 @@ public class StreamThread extends Thread {
             taskManager,
             streamsMetrics,
             builder,
-            threadClientId,
+            threadId,
             logContext,
             assignmentErrorCode)
             .updateThreadMetadata(getSharedAdminClientId(clientId));
@@ -587,29 +581,29 @@ public class StreamThread extends Thread {
                         final TaskManager taskManager,
                         final StreamsMetricsImpl streamsMetrics,
                         final InternalTopologyBuilder builder,
-                        final String threadClientId,
+                        final String threadId,
                         final LogContext logContext,
                         final AtomicInteger assignmentErrorCode) {
-        super(threadClientId);
+        super(threadId);
 
         this.stateLock = new Object();
         this.standbyRecords = new HashMap<>();
 
         this.streamsMetrics = streamsMetrics;
-        this.commitSensor = ThreadMetrics.commitSensor(streamsMetrics);
-        this.pollSensor = ThreadMetrics.pollSensor(streamsMetrics);
-        this.processSensor = ThreadMetrics.processSensor(streamsMetrics);
-        this.punctuateSensor = ThreadMetrics.punctuateSensor(streamsMetrics);
+        this.commitSensor = ThreadMetrics.commitSensor(threadId, streamsMetrics);
+        this.pollSensor = ThreadMetrics.pollSensor(threadId, streamsMetrics);
+        this.processSensor = ThreadMetrics.processSensor(threadId, streamsMetrics);
+        this.punctuateSensor = ThreadMetrics.punctuateSensor(threadId, streamsMetrics);
 
         // The following sensors are created here but their references are not stored in this object, since within
         // this object they are not recorded. The sensors are created here so that the stream threads starts with all
         // its metrics initialised. Otherwise, those sensors would have been created during processing, which could
         // lead to missing metrics. For instance, if no task were created, the metrics for created and closed
         // tasks would never be added to the metrics.
-        ThreadMetrics.createTaskSensor(streamsMetrics);
-        ThreadMetrics.closeTaskSensor(streamsMetrics);
-        ThreadMetrics.skipRecordSensor(streamsMetrics);
-        ThreadMetrics.commitOverTasksSensor(streamsMetrics);
+        ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
+        ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
+        ThreadMetrics.skipRecordSensor(threadId, streamsMetrics);
+        ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
 
         this.time = time;
         this.builder = builder;
@@ -657,10 +651,6 @@ public class StreamThread extends Thread {
     // currently admin client is shared among all threads
     public static String getSharedAdminClientId(final String clientId) {
         return clientId + "-admin";
-    }
-
-    public void setRocksDBMetricsRecordingTrigger(final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger) {
-        streamsMetrics.setRocksDBMetricsRecordingTrigger(rocksDBMetricsRecordingTrigger);
     }
 
     /**
@@ -1131,7 +1121,7 @@ public class StreamThread extends Thread {
         } catch (final Throwable e) {
             log.error("Failed to close restore consumer due to the following error:", e);
         }
-        streamsMetrics.removeAllThreadLevelSensors();
+        streamsMetrics.removeAllThreadLevelSensors(getName());
 
         setState(State.DEAD);
         log.info("Shutdown complete");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
@@ -51,12 +53,43 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         FROM_100_TO_23
     }
 
+    static class ImmutableValue<T> implements Gauge<T> {
+        private final T value;
+
+        public ImmutableValue(final T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T value(final MetricConfig config, final long now) {
+            return value;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final ImmutableValue<?> that = (ImmutableValue<?>) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
     private final Metrics metrics;
     private final Map<Sensor, Sensor> parentSensors;
-    private final String threadName;
+    private final String clientId;
 
     private final Version version;
-    private final Deque<String> threadLevelSensors = new LinkedList<>();
+    private final Deque<MetricName> clientLevelMetrics = new LinkedList<>();
+    private final Map<String, Deque<String>> threadLevelSensors = new HashMap<>();
     private final Map<String, Deque<String>> taskLevelSensors = new HashMap<>();
     private final Map<String, Deque<String>> nodeLevelSensors = new HashMap<>();
     private final Map<String, Deque<String>> cacheLevelSensors = new HashMap<>();
@@ -67,6 +100,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     private static final String SENSOR_PREFIX_DELIMITER = ".";
     private static final String SENSOR_NAME_DELIMITER = ".s.";
 
+    public static final String CLIENT_ID_TAG = "client-id";
     public static final String THREAD_ID_TAG = "thread-id";
     public static final String THREAD_ID_TAG_0100_TO_23 = "client-id";
     public static final String TASK_ID_TAG = "task-id";
@@ -92,6 +126,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String GROUP_PREFIX = GROUP_PREFIX_WO_DELIMITER + "-";
     public static final String GROUP_SUFFIX = "-metrics";
     public static final String STATE_LEVEL_GROUP_SUFFIX = "-state" + GROUP_SUFFIX;
+    public static final String CLIENT_LEVEL_GROUP = GROUP_PREFIX_WO_DELIMITER + GROUP_SUFFIX;
     public static final String THREAD_LEVEL_GROUP = GROUP_PREFIX_WO_DELIMITER + GROUP_SUFFIX;
     public static final String TASK_LEVEL_GROUP = GROUP_PREFIX + "task" + GROUP_SUFFIX;
     public static final String STATE_LEVEL_GROUP = GROUP_PREFIX + "state" + GROUP_SUFFIX;
@@ -103,12 +138,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String EXPIRED_WINDOW_RECORD_DROP = "expired-window-record-drop";
     public static final String LATE_RECORD_DROP = "late-record-drop";
 
-    public StreamsMetricsImpl(final Metrics metrics, final String threadName, final String builtInMetricsVersion) {
+    public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {
         Objects.requireNonNull(metrics, "Metrics cannot be null");
         Objects.requireNonNull(builtInMetricsVersion, "Built-in metrics version cannot be null");
         this.metrics = metrics;
-        this.threadName = threadName;
-        this.version = parseBuiltInMetricsVersion(builtInMetricsVersion);
+        this.clientId = clientId;
+        version = parseBuiltInMetricsVersion(builtInMetricsVersion);
 
         this.parentSensors = new HashMap<>();
     }
@@ -133,29 +168,62 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return rocksDBMetricsRecordingTrigger;
     }
 
-    public final Sensor threadLevelSensor(final String sensorName,
+    public <T> void addClientLevelImmutableMetric(final String name,
+                                                  final String description,
+                                                  final RecordingLevel recordingLevel,
+                                                  final T value) {
+        final MetricName metricName = metrics.metricName(name, CLIENT_LEVEL_GROUP, description, clientLevelTagMap());
+        final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
+        synchronized (clientLevelMetrics) {
+            metrics.addMetric(metricName, metricConfig, new ImmutableValue<>(value));
+            clientLevelMetrics.push(metricName);
+        }
+    }
+
+    public <T> void addClientLevelMutableMetric(final String name,
+                                                final String description,
+                                                final RecordingLevel recordingLevel,
+                                                final Gauge<T> valueProvider) {
+        final MetricName metricName = metrics.metricName(name, CLIENT_LEVEL_GROUP, description, clientLevelTagMap());
+        final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
+        synchronized (clientLevelMetrics) {
+            metrics.addMetric(metricName, metricConfig, valueProvider);
+            clientLevelMetrics.push(metricName);
+        }
+    }
+
+    public final Sensor threadLevelSensor(final String threadId,
+                                          final String sensorName,
                                           final RecordingLevel recordingLevel,
                                           final Sensor... parents) {
+        final String key = threadSensorPrefix(threadId);
         synchronized (threadLevelSensors) {
-            final String fullSensorName = threadSensorPrefix() + SENSOR_NAME_DELIMITER + sensorName;
+            threadLevelSensors.putIfAbsent(key, new LinkedList<>());
+            final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
             final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-            threadLevelSensors.push(fullSensorName);
+            threadLevelSensors.get(key).push(fullSensorName);
             return sensor;
         }
     }
 
-    private String threadSensorPrefix() {
-        return "internal" + SENSOR_PREFIX_DELIMITER + threadName;
+    private String threadSensorPrefix(final String threadId) {
+        return "internal" + SENSOR_PREFIX_DELIMITER + threadId;
     }
 
-    public Map<String, String> threadLevelTagMap() {
+    public Map<String, String> clientLevelTagMap() {
         final Map<String, String> tagMap = new LinkedHashMap<>();
-        tagMap.put(THREAD_ID_TAG_0100_TO_23, threadName);
+        tagMap.put(CLIENT_ID_TAG, clientId);
         return tagMap;
     }
 
-    public Map<String, String> threadLevelTagMap(final String... tags) {
-        final Map<String, String> tagMap = threadLevelTagMap();
+    public Map<String, String> threadLevelTagMap(final String threadId) {
+        final Map<String, String> tagMap = new LinkedHashMap<>();
+        tagMap.put(THREAD_ID_TAG_0100_TO_23, threadId);
+        return tagMap;
+    }
+
+    public Map<String, String> threadLevelTagMap(final String threadId, final String... tags) {
+        final Map<String, String> tagMap = threadLevelTagMap(threadId);
         if (tags != null) {
             if ((tags.length % 2) != 0) {
                 throw new IllegalArgumentException("Tags needs to be specified in key-value pairs");
@@ -168,48 +236,58 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return tagMap;
     }
 
-    public final void removeAllThreadLevelSensors() {
-        synchronized (threadLevelSensors) {
-            while (!threadLevelSensors.isEmpty()) {
-                metrics.removeSensor(threadLevelSensors.pop());
+    public final void removeAllClientLevelMetrics() {
+        synchronized (clientLevelMetrics) {
+            while (!clientLevelMetrics.isEmpty()) {
+                metrics.removeMetric(clientLevelMetrics.pop());
             }
         }
     }
 
-    public Map<String, String> taskLevelTagMap(final String taskName) {
-        final Map<String, String> tagMap = threadLevelTagMap();
-        tagMap.put(TASK_ID_TAG, taskName);
+    public final void removeAllThreadLevelSensors(final String threadId) {
+        final String key = threadSensorPrefix(threadId);
+        synchronized (threadLevelSensors) {
+            final Deque<String> sensors = threadLevelSensors.remove(key);
+            while (sensors != null && !sensors.isEmpty()) {
+                metrics.removeSensor(sensors.pop());
+            }
+        }
+    }
+
+    public Map<String, String> taskLevelTagMap(final String threadId, final String taskId) {
+        final Map<String, String> tagMap = threadLevelTagMap(threadId);
+        tagMap.put(TASK_ID_TAG, taskId);
         return tagMap;
     }
 
-    public Map<String, String> storeLevelTagMap(final String taskName, final String storeType, final String storeName) {
-        final Map<String, String> tagMap = taskLevelTagMap(taskName);
+    public Map<String, String> storeLevelTagMap(final String threadId,
+                                                final String taskName,
+                                                final String storeType,
+                                                final String storeName) {
+        final Map<String, String> tagMap = taskLevelTagMap(threadId, taskName);
         tagMap.put(storeType + "-" + STORE_ID_TAG, storeName);
         return tagMap;
     }
 
-    public final Sensor taskLevelSensor(final String taskName,
+    public final Sensor taskLevelSensor(final String threadId,
+                                        final String taskId,
                                         final String sensorName,
                                         final RecordingLevel recordingLevel,
                                         final Sensor... parents) {
-        final String key = taskSensorPrefix(taskName);
+        final String key = taskSensorPrefix(threadId, taskId);
         synchronized (taskLevelSensors) {
             if (!taskLevelSensors.containsKey(key)) {
                 taskLevelSensors.put(key, new LinkedList<>());
             }
-
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-
             final Sensor sensor = metrics.sensor(fullSensorName, recordingLevel, parents);
-
             taskLevelSensors.get(key).push(fullSensorName);
-
             return sensor;
         }
     }
 
-    public final void removeAllTaskLevelSensors(final String taskName) {
-        final String key = taskSensorPrefix(taskName);
+    public final void removeAllTaskLevelSensors(final String threadId, final String taskId) {
+        final String key = taskSensorPrefix(threadId, taskId);
         synchronized (taskLevelSensors) {
             final Deque<String> sensors = taskLevelSensors.remove(key);
             while (sensors != null && !sensors.isEmpty()) {
@@ -218,16 +296,17 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    private String taskSensorPrefix(final String taskName) {
-        return threadSensorPrefix() + SENSOR_PREFIX_DELIMITER + "task" + SENSOR_PREFIX_DELIMITER + taskName;
+    private String taskSensorPrefix(final String threadId, final String taskId) {
+        return threadSensorPrefix(threadId) + SENSOR_PREFIX_DELIMITER + "task" + SENSOR_PREFIX_DELIMITER + taskId;
     }
 
-    public Sensor nodeLevelSensor(final String taskName,
+    public Sensor nodeLevelSensor(final String threadId,
+                                  final String taskId,
                                   final String processorNodeName,
                                   final String sensorName,
                                   final Sensor.RecordingLevel recordingLevel,
                                   final Sensor... parents) {
-        final String key = nodeSensorPrefix(taskName, processorNodeName);
+        final String key = nodeSensorPrefix(threadId, taskId, processorNodeName);
         synchronized (nodeLevelSensors) {
             if (!nodeLevelSensors.containsKey(key)) {
                 nodeLevelSensors.put(key, new LinkedList<>());
@@ -243,8 +322,10 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public final void removeAllNodeLevelSensors(final String taskName, final String processorNodeName) {
-        final String key = nodeSensorPrefix(taskName, processorNodeName);
+    public final void removeAllNodeLevelSensors(final String threadId,
+                                                final String taskId,
+                                                final String processorNodeName) {
+        final String key = nodeSensorPrefix(threadId, taskId, processorNodeName);
         synchronized (nodeLevelSensors) {
             final Deque<String> sensors = nodeLevelSensors.remove(key);
             while (sensors != null && !sensors.isEmpty()) {
@@ -253,16 +334,18 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    private String nodeSensorPrefix(final String taskName, final String processorNodeName) {
-        return taskSensorPrefix(taskName) + SENSOR_PREFIX_DELIMITER + "node" + SENSOR_PREFIX_DELIMITER + processorNodeName;
+    private String nodeSensorPrefix(final String threadId, final String taskId, final String processorNodeName) {
+        return taskSensorPrefix(threadId, taskId)
+            + SENSOR_PREFIX_DELIMITER + "node" + SENSOR_PREFIX_DELIMITER + processorNodeName;
     }
 
-    public Sensor cacheLevelSensor(final String taskName,
+    public Sensor cacheLevelSensor(final String threadId,
+                                   final String taskName,
                                    final String storeName,
                                    final String sensorName,
                                    final Sensor.RecordingLevel recordingLevel,
                                    final Sensor... parents) {
-        final String key = cacheSensorPrefix(taskName, storeName);
+        final String key = cacheSensorPrefix(threadId, taskName, storeName);
         synchronized (cacheLevelSensors) {
             if (!cacheLevelSensors.containsKey(key)) {
                 cacheLevelSensors.put(key, new LinkedList<>());
@@ -278,20 +361,20 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public Map<String, String> cacheLevelTagMap(final String taskName, final String storeName) {
+    public Map<String, String> cacheLevelTagMap(final String threadId, final String taskId, final String storeName) {
         final Map<String, String> tagMap = new LinkedHashMap<>();
-        tagMap.put(TASK_ID_TAG, taskName);
-        tagMap.put(RECORD_CACHE_ID_TAG, storeName);
         if (version == Version.FROM_100_TO_23) {
-            tagMap.put(THREAD_ID_TAG_0100_TO_23, Thread.currentThread().getName());
+            tagMap.put(THREAD_ID_TAG_0100_TO_23, threadId);
         } else {
-            tagMap.put(THREAD_ID_TAG, Thread.currentThread().getName());
+            tagMap.put(THREAD_ID_TAG, threadId);
         }
+        tagMap.put(TASK_ID_TAG, taskId);
+        tagMap.put(RECORD_CACHE_ID_TAG, storeName);
         return tagMap;
     }
 
-    public final void removeAllCacheLevelSensors(final String taskName, final String cacheName) {
-        final String key = cacheSensorPrefix(taskName, cacheName);
+    public final void removeAllCacheLevelSensors(final String threadId, final String taskId, final String cacheName) {
+        final String key = cacheSensorPrefix(threadId, taskId, cacheName);
         synchronized (cacheLevelSensors) {
             final Deque<String> strings = cacheLevelSensors.remove(key);
             while (strings != null && !strings.isEmpty()) {
@@ -300,16 +383,18 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    private String cacheSensorPrefix(final String taskName, final String cacheName) {
-        return taskSensorPrefix(taskName) + SENSOR_PREFIX_DELIMITER + "cache" + SENSOR_PREFIX_DELIMITER + cacheName;
+    private String cacheSensorPrefix(final String threadId, final String taskId, final String cacheName) {
+        return taskSensorPrefix(threadId, taskId)
+            + SENSOR_PREFIX_DELIMITER + "cache" + SENSOR_PREFIX_DELIMITER + cacheName;
     }
 
-    public final Sensor storeLevelSensor(final String taskName,
+    public final Sensor storeLevelSensor(final String threadId,
+                                         final String taskId,
                                          final String storeName,
                                          final String sensorName,
                                          final Sensor.RecordingLevel recordingLevel,
                                          final Sensor... parents) {
-        final String key = storeSensorPrefix(taskName, storeName);
+        final String key = storeSensorPrefix(threadId, taskId, storeName);
         synchronized (storeLevelSensors) {
             if (!storeLevelSensors.containsKey(key)) {
                 storeLevelSensors.put(key, new LinkedList<>());
@@ -323,8 +408,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public final void removeAllStoreLevelSensors(final String taskName, final String storeName) {
-        final String key = storeSensorPrefix(taskName, storeName);
+    public final void removeAllStoreLevelSensors(final String threadId, final String taskId, final String storeName) {
+        final String key = storeSensorPrefix(threadId, taskId, storeName);
         synchronized (storeLevelSensors) {
             final Deque<String> sensors = storeLevelSensors.remove(key);
             while (sensors != null && !sensors.isEmpty()) {
@@ -333,8 +418,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    private String storeSensorPrefix(final String taskName, final String storeName) {
-        return taskSensorPrefix(taskName) + SENSOR_PREFIX_DELIMITER + "store" + SENSOR_PREFIX_DELIMITER + storeName;
+    private String storeSensorPrefix(final String threadId, final String taskId, final String storeName) {
+        return taskSensorPrefix(threadId, taskId)
+            + SENSOR_PREFIX_DELIMITER + "store" + SENSOR_PREFIX_DELIMITER + storeName;
     }
 
     @Override
@@ -362,9 +448,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         sensor.record(value);
     }
 
-    public final Map<String, String> tagMap(final String... tags) {
+    public final Map<String, String> tagMap(final String threadId, final String... tags) {
         final Map<String, String> tagMap = new LinkedHashMap<>();
-        tagMap.put("client-id", threadName);
+        tagMap.put(THREAD_ID_TAG_0100_TO_23, threadId);
         if (tags != null) {
             if ((tags.length % 2) != 0) {
                 throw new IllegalArgumentException("Tags needs to be specified in key-value pairs");
@@ -378,11 +464,14 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
 
-    private Map<String, String> constructTags(final String scopeName, final String entityName, final String... tags) {
+    private Map<String, String> constructTags(final String threadId,
+                                              final String scopeName,
+                                              final String entityName,
+                                              final String... tags) {
         final String[] updatedTags = Arrays.copyOf(tags, tags.length + 2);
         updatedTags[tags.length] = scopeName + "-id";
         updatedTags[tags.length + 1] = entityName;
-        return tagMap(updatedTags);
+        return tagMap(threadId, updatedTags);
     }
 
 
@@ -397,16 +486,21 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String... tags) {
         final String group = groupNameFromScope(scopeName);
 
-        final Map<String, String> tagMap = constructTags(scopeName, entityName, tags);
-        final Map<String, String> allTagMap = constructTags(scopeName, "all", tags);
+        final String threadId = Thread.currentThread().getName();
+        final Map<String, String> tagMap = constructTags(threadId, scopeName, entityName, tags);
+        final Map<String, String> allTagMap = constructTags(threadId, scopeName, "all", tags);
 
         // first add the global operation metrics if not yet, with the global tags only
-        final Sensor parent = metrics.sensor(externalParentSensorName(operationName), recordingLevel);
+        final Sensor parent = metrics.sensor(externalParentSensorName(threadId, operationName), recordingLevel);
         addAvgAndMaxLatencyToSensor(parent, group, allTagMap, operationName);
         addInvocationRateAndCountToSensor(parent, group, allTagMap, operationName);
 
         // add the operation metrics with additional tags
-        final Sensor sensor = metrics.sensor(externalChildSensorName(operationName, entityName), recordingLevel, parent);
+        final Sensor sensor = metrics.sensor(
+            externalChildSensorName(threadId, operationName, entityName),
+            recordingLevel,
+            parent
+        );
         addAvgAndMaxLatencyToSensor(sensor, group, tagMap, operationName);
         addInvocationRateAndCountToSensor(sensor, group, tagMap, operationName);
 
@@ -427,15 +521,23 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                       final String... tags) {
         final String group = groupNameFromScope(scopeName);
 
-        final Map<String, String> tagMap = constructTags(scopeName, entityName, tags);
-        final Map<String, String> allTagMap = constructTags(scopeName, "all", tags);
+        final String threadId = Thread.currentThread().getName();
+        final Map<String, String> tagMap = constructTags(threadId, scopeName, entityName, tags);
+        final Map<String, String> allTagMap = constructTags(threadId, scopeName, "all", tags);
 
         // first add the global operation metrics if not yet, with the global tags only
-        final Sensor parent = metrics.sensor(externalParentSensorName(operationName), recordingLevel);
+        final Sensor parent = metrics.sensor(
+            externalParentSensorName(threadId, operationName),
+            recordingLevel
+        );
         addInvocationRateAndCountToSensor(parent, group, allTagMap, operationName);
 
         // add the operation metrics with additional tags
-        final Sensor sensor = metrics.sensor(externalChildSensorName(operationName, entityName), recordingLevel, parent);
+        final Sensor sensor = metrics.sensor(
+            externalChildSensorName(threadId, operationName, entityName),
+            recordingLevel,
+            parent
+        );
         addInvocationRateAndCountToSensor(sensor, group, tagMap, operationName);
 
         parentSensors.put(sensor, parent);
@@ -444,14 +546,14 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     }
 
-    private String externalChildSensorName(final String operationName, final String entityName) {
-        return "external" + SENSOR_PREFIX_DELIMITER + threadName
+    private String externalChildSensorName(final String threadId, final String operationName, final String entityName) {
+        return "external" + SENSOR_PREFIX_DELIMITER + threadId
             + SENSOR_PREFIX_DELIMITER + "entity" + SENSOR_PREFIX_DELIMITER + entityName
             + SENSOR_NAME_DELIMITER + operationName;
     }
 
-    private String externalParentSensorName(final String operationName) {
-        return "external" + SENSOR_PREFIX_DELIMITER + threadName + SENSOR_NAME_DELIMITER + operationName;
+    private String externalParentSensorName(final String threadId, final String operationName) {
+        return "external" + SENSOR_PREFIX_DELIMITER + threadId + SENSOR_NAME_DELIMITER + operationName;
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -72,108 +72,124 @@ public class ThreadMetrics {
     private static final String PROCESS_LATENCY = PROCESS + LATENCY_SUFFIX;
     private static final String PUNCTUATE_LATENCY = PUNCTUATE + LATENCY_SUFFIX;
 
-    public static Sensor createTaskSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor createTaskSensor = streamsMetrics.threadLevelSensor(CREATE_TASK, RecordingLevel.INFO);
-        addInvocationRateAndCountToSensor(createTaskSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  streamsMetrics.threadLevelTagMap(),
-                                  CREATE_TASK,
-                                  CREATE_TASK_TOTAL_DESCRIPTION,
-                                  CREATE_TASK_RATE_DESCRIPTION);
+    public static Sensor createTaskSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor createTaskSensor = streamsMetrics.threadLevelSensor(threadId, CREATE_TASK, RecordingLevel.INFO);
+        addInvocationRateAndCountToSensor(
+            createTaskSensor,
+            THREAD_LEVEL_GROUP,
+            streamsMetrics.threadLevelTagMap(threadId),
+            CREATE_TASK,
+            CREATE_TASK_TOTAL_DESCRIPTION,
+            CREATE_TASK_RATE_DESCRIPTION
+        );
         return createTaskSensor;
     }
 
-    public static Sensor closeTaskSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor closeTaskSensor = streamsMetrics.threadLevelSensor(CLOSE_TASK, RecordingLevel.INFO);
-        addInvocationRateAndCountToSensor(closeTaskSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  streamsMetrics.threadLevelTagMap(),
-                                  CLOSE_TASK,
-                                  CLOSE_TASK_TOTAL_DESCRIPTION,
-                                  CLOSE_TASK_RATE_DESCRIPTION);
+    public static Sensor closeTaskSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor closeTaskSensor = streamsMetrics.threadLevelSensor(threadId, CLOSE_TASK, RecordingLevel.INFO);
+        addInvocationRateAndCountToSensor(
+            closeTaskSensor,
+            THREAD_LEVEL_GROUP,
+            streamsMetrics.threadLevelTagMap(threadId),
+            CLOSE_TASK,
+            CLOSE_TASK_TOTAL_DESCRIPTION,
+            CLOSE_TASK_RATE_DESCRIPTION
+        );
         return closeTaskSensor;
     }
 
-    public static Sensor commitSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor commitSensor = streamsMetrics.threadLevelSensor(COMMIT, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap();
+    public static Sensor commitSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor commitSensor = streamsMetrics.threadLevelSensor(threadId, COMMIT, Sensor.RecordingLevel.INFO);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(commitSensor, THREAD_LEVEL_GROUP, tagMap, COMMIT_LATENCY);
-        addInvocationRateAndCountToSensor(commitSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  tagMap,
-                                  COMMIT,
-                                  COMMIT_TOTAL_DESCRIPTION,
-                                  COMMIT_RATE_DESCRIPTION);
+        addInvocationRateAndCountToSensor(
+            commitSensor,
+            THREAD_LEVEL_GROUP,
+            tagMap,
+            COMMIT,
+            COMMIT_TOTAL_DESCRIPTION,
+            COMMIT_RATE_DESCRIPTION
+        );
         return commitSensor;
     }
 
-    public static Sensor pollSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor pollSensor = streamsMetrics.threadLevelSensor(POLL, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap();
+    public static Sensor pollSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor pollSensor = streamsMetrics.threadLevelSensor(threadId, POLL, Sensor.RecordingLevel.INFO);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(pollSensor, THREAD_LEVEL_GROUP, tagMap, POLL_LATENCY);
-        addInvocationRateAndCountToSensor(pollSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  tagMap,
-                                  POLL,
-                                  POLL_TOTAL_DESCRIPTION,
-                                  POLL_RATE_DESCRIPTION);
+        addInvocationRateAndCountToSensor(
+            pollSensor,
+            THREAD_LEVEL_GROUP,
+            tagMap,
+            POLL,
+            POLL_TOTAL_DESCRIPTION,
+            POLL_RATE_DESCRIPTION
+        );
         return pollSensor;
     }
 
-    public static Sensor processSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor processSensor = streamsMetrics.threadLevelSensor(PROCESS, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap();
+    public static Sensor processSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor processSensor = streamsMetrics.threadLevelSensor(threadId, PROCESS, Sensor.RecordingLevel.INFO);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(processSensor, THREAD_LEVEL_GROUP, tagMap, PROCESS_LATENCY);
-        addInvocationRateAndCountToSensor(processSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  tagMap,
-                                  PROCESS,
-                                  PROCESS_TOTAL_DESCRIPTION,
-                                  PROCESS_RATE_DESCRIPTION);
-
+        addInvocationRateAndCountToSensor(
+            processSensor,
+            THREAD_LEVEL_GROUP,
+            tagMap,
+            PROCESS,
+            PROCESS_TOTAL_DESCRIPTION,
+            PROCESS_RATE_DESCRIPTION
+        );
         return processSensor;
     }
 
-    public static Sensor punctuateSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor punctuateSensor = streamsMetrics.threadLevelSensor(PUNCTUATE, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap();
+    public static Sensor punctuateSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor punctuateSensor = streamsMetrics.threadLevelSensor(threadId, PUNCTUATE, Sensor.RecordingLevel.INFO);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(punctuateSensor, THREAD_LEVEL_GROUP, tagMap, PUNCTUATE_LATENCY);
-        addInvocationRateAndCountToSensor(punctuateSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  tagMap,
-                                  PUNCTUATE,
-                                  PUNCTUATE_TOTAL_DESCRIPTION,
-                                  PUNCTUATE_RATE_DESCRIPTION);
-
+        addInvocationRateAndCountToSensor(
+            punctuateSensor,
+            THREAD_LEVEL_GROUP,
+            tagMap,
+            PUNCTUATE,
+            PUNCTUATE_TOTAL_DESCRIPTION,
+            PUNCTUATE_RATE_DESCRIPTION
+        );
         return punctuateSensor;
     }
 
-    public static Sensor skipRecordSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor skippedRecordsSensor = streamsMetrics.threadLevelSensor(SKIP_RECORD, Sensor.RecordingLevel.INFO);
-        addInvocationRateAndCountToSensor(skippedRecordsSensor,
-                                  THREAD_LEVEL_GROUP,
-                                  streamsMetrics.threadLevelTagMap(),
-                                  SKIP_RECORD,
-                                  SKIP_RECORD_TOTAL_DESCRIPTION,
-                                  SKIP_RECORD_RATE_DESCRIPTION);
-
+    public static Sensor skipRecordSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor skippedRecordsSensor =
+            streamsMetrics.threadLevelSensor(threadId, SKIP_RECORD, Sensor.RecordingLevel.INFO);
+        addInvocationRateAndCountToSensor(
+            skippedRecordsSensor,
+            THREAD_LEVEL_GROUP,
+            streamsMetrics.threadLevelTagMap(threadId),
+            SKIP_RECORD,
+            SKIP_RECORD_TOTAL_DESCRIPTION,
+            SKIP_RECORD_RATE_DESCRIPTION
+        );
         return skippedRecordsSensor;
     }
 
-    public static Sensor commitOverTasksSensor(final StreamsMetricsImpl streamsMetrics) {
-        final Sensor commitOverTasksSensor = streamsMetrics.threadLevelSensor(COMMIT, Sensor.RecordingLevel.DEBUG);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(TASK_ID_TAG, ROLLUP_VALUE);
-        addAvgAndMaxToSensor(commitOverTasksSensor,
-                     TASK_LEVEL_GROUP,
-                     tagMap,
-                     COMMIT_LATENCY);
-        addInvocationRateAndCountToSensor(commitOverTasksSensor,
-                                  TASK_LEVEL_GROUP,
-                                  tagMap,
-                                  COMMIT,
-                                  COMMIT_OVER_TASKS_TOTAL_DESCRIPTION,
-                                  COMMIT_OVER_TASKS_RATE_DESCRIPTION);
-
+    public static Sensor commitOverTasksSensor(final String threadId, final StreamsMetricsImpl streamsMetrics) {
+        final Sensor commitOverTasksSensor =
+            streamsMetrics.threadLevelSensor(threadId, COMMIT, Sensor.RecordingLevel.DEBUG);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId, TASK_ID_TAG, ROLLUP_VALUE);
+        addAvgAndMaxToSensor(
+            commitOverTasksSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            COMMIT_LATENCY
+        );
+        addInvocationRateAndCountToSensor(
+            commitOverTasksSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            COMMIT,
+            COMMIT_OVER_TASKS_TOTAL_DESCRIPTION,
+            COMMIT_OVER_TASKS_RATE_DESCRIPTION
+        );
         return commitOverTasksSensor;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -174,9 +174,11 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         this.context = (InternalProcessorContext) context;
 
         final StreamsMetricsImpl metrics = this.context.metrics();
+        final String threadId = Thread.currentThread().getName();
         final String taskName = context.taskId().toString();
 
         expiredRecordSensor = metrics.storeLevelSensor(
+            threadId,
             taskName,
             name(),
             EXPIRED_WINDOW_RECORD_DROP,
@@ -185,7 +187,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         addInvocationRateAndCountToSensor(
             expiredRecordSensor,
             "stream-" + metricScope + "-metrics",
-            metrics.tagMap("task-id", taskName, metricScope + "-id", name()),
+            metrics.tagMap(threadId, "task-id", taskName, metricScope + "-id", name()),
             EXPIRED_WINDOW_RECORD_DROP
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -75,8 +75,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
         final StreamsMetricsImpl metrics = ((InternalProcessorContext) context).metrics();
+        final String threadId = Thread.currentThread().getName();
         final String taskName = context.taskId().toString();
         expiredRecordSensor = metrics.storeLevelSensor(
+            threadId,
             taskName,
             name(),
             EXPIRED_WINDOW_RECORD_DROP,
@@ -85,7 +87,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         addInvocationRateAndCountToSensor(
             expiredRecordSensor,
             "stream-" + metricScope + "-metrics",
-            metrics.tagMap("task-id", taskName, metricScope + "-id", name()),
+            metrics.tagMap(threadId, "task-id", taskName, metricScope + "-id", name()),
             EXPIRED_WINDOW_RECORD_DROP
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -91,8 +91,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         this.context = (InternalProcessorContext) context;
 
         final StreamsMetricsImpl metrics = this.context.metrics();
+        final String threadId = Thread.currentThread().getName();
         final String taskName = context.taskId().toString();
         expiredRecordSensor = metrics.storeLevelSensor(
+            threadId,
             taskName,
             name(),
             EXPIRED_WINDOW_RECORD_DROP,
@@ -101,7 +103,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         addInvocationRateAndCountToSensor(
             expiredRecordSensor,
             "stream-" + metricScope + "-metrics",
-            metrics.tagMap("task-id", taskName, metricScope + "-id", name()),
+            metrics.tagMap(threadId, "task-id", taskName, metricScope + "-id", name()),
             EXPIRED_WINDOW_RECORD_DROP
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -31,7 +31,7 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
                      final long retentionPeriod,
                      final long segmentInterval) {
         super(name, retentionPeriod, segmentInterval);
-        metricsRecorder = new RocksDBMetricsRecorder(metricsScope, name);
+        metricsRecorder = new RocksDBMetricsRecorder(metricsScope, Thread.currentThread().getName(), name);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -60,7 +60,12 @@ class NamedCache {
         this.streamsMetrics = streamsMetrics;
         storeName = ThreadCache.underlyingStoreNamefromCacheName(name);
         taskName = ThreadCache.taskIDfromCacheName(name);
-        hitRatioSensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, taskName, storeName);
+        hitRatioSensor = NamedCacheMetrics.hitRatioSensor(
+            streamsMetrics,
+            Thread.currentThread().getName(),
+            taskName,
+            storeName
+        );
     }
 
     synchronized final String name() {
@@ -315,7 +320,7 @@ class NamedCache {
         currentSizeBytes = 0;
         dirtyKeys.clear();
         cache.clear();
-        streamsMetrics.removeAllCacheLevelSensors(taskName, storeName);
+        streamsMetrics.removeAllCacheLevelSensors(Thread.currentThread().getName(), taskName, storeName);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -115,7 +115,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
 
     RocksDBStore(final String name,
                  final String metricsScope) {
-        this(name, DB_FILE_DIR, new RocksDBMetricsRecorder(metricsScope, name));
+        this(name, DB_FILE_DIR, new RocksDBMetricsRecorder(metricsScope, Thread.currentThread().getName(), name));
     }
 
     RocksDBStore(final String name,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -31,7 +31,7 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
                         final long retentionPeriod,
                         final long segmentInterval) {
         super(name, retentionPeriod, segmentInterval);
-        metricsRecorder = new RocksDBMetricsRecorder(metricsScope, name);
+        metricsRecorder = new RocksDBMetricsRecorder(metricsScope, Thread.currentThread().getName(), name);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
@@ -35,6 +35,7 @@ public class NamedCacheMetrics {
 
 
     public static Sensor hitRatioSensor(final StreamsMetricsImpl streamsMetrics,
+                                        final String threadId,
                                         final String taskName,
                                         final String storeName) {
 
@@ -43,6 +44,7 @@ public class NamedCacheMetrics {
         if (streamsMetrics.version() == FROM_100_TO_23) {
             hitRatioName = HIT_RATIO_0100_TO_23;
             final Sensor taskLevelHitRatioSensor = streamsMetrics.taskLevelSensor(
+                threadId,
                 taskName,
                 hitRatioName,
                 Sensor.RecordingLevel.DEBUG
@@ -50,13 +52,14 @@ public class NamedCacheMetrics {
             addAvgAndMinAndMaxToSensor(
                 taskLevelHitRatioSensor,
                 CACHE_LEVEL_GROUP,
-                streamsMetrics.cacheLevelTagMap(taskName, ROLLUP_VALUE),
+                streamsMetrics.cacheLevelTagMap(threadId, taskName, ROLLUP_VALUE),
                 hitRatioName,
                 HIT_RATIO_AVG_DESCRIPTION,
                 HIT_RATIO_MIN_DESCRIPTION,
                 HIT_RATIO_MAX_DESCRIPTION
             );
             hitRatioSensor = streamsMetrics.cacheLevelSensor(
+                threadId,
                 taskName,
                 storeName,
                 hitRatioName,
@@ -66,6 +69,7 @@ public class NamedCacheMetrics {
         } else {
             hitRatioName = HIT_RATIO;
             hitRatioSensor = streamsMetrics.cacheLevelSensor(
+                threadId,
                 taskName,
                 storeName,
                 hitRatioName,
@@ -75,7 +79,7 @@ public class NamedCacheMetrics {
         addAvgAndMinAndMaxToSensor(
             hitRatioSensor,
             CACHE_LEVEL_GROUP,
-            streamsMetrics.cacheLevelTagMap(taskName, storeName),
+            streamsMetrics.cacheLevelTagMap(threadId, taskName, storeName),
             hitRatioName,
             HIT_RATIO_AVG_DESCRIPTION,
             HIT_RATIO_MIN_DESCRIPTION,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
@@ -101,7 +101,10 @@ public class RocksDBMetrics {
         private final String metricsScope;
         private final String storeName;
 
-        public RocksDBMetricContext(final String threadId, final String taskName, final String metricsScope, final String storeName) {
+        public RocksDBMetricContext(final String threadId,
+                                    final String taskName,
+                                    final String metricsScope,
+                                    final String storeName) {
             this.threadId = threadId;
             this.taskName = taskName;
             this.metricsScope = metricsScope;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
@@ -96,16 +96,21 @@ public class RocksDBMetrics {
     private static final String NUMBER_OF_FILE_ERRORS_DESCRIPTION = "Total number of file errors occurred";
 
     public static class RocksDBMetricContext {
+        private final String threadId;
         private final String taskName;
         private final String metricsScope;
         private final String storeName;
 
-        public RocksDBMetricContext(final String taskName, final String metricsScope, final String storeName) {
+        public RocksDBMetricContext(final String threadId, final String taskName, final String metricsScope, final String storeName) {
+            this.threadId = threadId;
             this.taskName = taskName;
             this.metricsScope = metricsScope;
             this.storeName = storeName;
         }
 
+        public String threadId() {
+            return threadId;
+        }
         public String taskName() {
             return taskName;
         }
@@ -125,14 +130,15 @@ public class RocksDBMetrics {
                 return false;
             }
             final RocksDBMetricContext that = (RocksDBMetricContext) o;
-            return Objects.equals(taskName, that.taskName) &&
+            return Objects.equals(threadId, that.threadId) &&
+                Objects.equals(taskName, that.taskName) &&
                 Objects.equals(metricsScope, that.metricsScope) &&
                 Objects.equals(storeName, that.storeName);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(taskName, metricsScope, storeName);
+            return Objects.hash(threadId, taskName, metricsScope, storeName);
         }
     }
 
@@ -142,8 +148,12 @@ public class RocksDBMetrics {
         addRateOfSumAndSumMetricsToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BYTES_WRITTEN_TO_DB,
             BYTES_WRITTEN_TO_DB_RATE_DESCRIPTION,
             BYTES_WRITTEN_TO_DB_TOTAL_DESCRIPTION
@@ -157,8 +167,12 @@ public class RocksDBMetrics {
         addRateOfSumAndSumMetricsToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BYTES_READ_FROM_DB,
             BYTES_READ_FROM_DB_RATE_DESCRIPTION,
             BYTES_READ_FROM_DB_TOTAL_DESCRIPTION
@@ -172,8 +186,12 @@ public class RocksDBMetrics {
         addRateOfSumAndSumMetricsToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             MEMTABLE_BYTES_FLUSHED,
             MEMTABLE_BYTES_FLUSHED_RATE_DESCRIPTION,
             MEMTABLE_BYTES_FLUSHED_TOTAL_DESCRIPTION
@@ -187,8 +205,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             MEMTABLE_HIT_RATIO,
             MEMTABLE_HIT_RATIO_DESCRIPTION
         );
@@ -201,8 +223,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             MEMTABLE_FLUSH_TIME_AVG,
             MEMTABLE_FLUSH_TIME_AVG_DESCRIPTION
         );
@@ -215,8 +241,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             MEMTABLE_FLUSH_TIME_MIN,
             MEMTABLE_FLUSH_TIME_MIN_DESCRIPTION
         );
@@ -229,8 +259,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             MEMTABLE_FLUSH_TIME_MAX,
             MEMTABLE_FLUSH_TIME_MAX_DESCRIPTION
         );
@@ -243,8 +277,12 @@ public class RocksDBMetrics {
         addAvgAndSumMetricsToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             WRITE_STALL_DURATION,
             WRITE_STALL_DURATION_AVG_DESCRIPTION,
             WRITE_STALL_DURATION_TOTAL_DESCRIPTION
@@ -258,8 +296,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BLOCK_CACHE_DATA_HIT_RATIO,
             BLOCK_CACHE_DATA_HIT_RATIO_DESCRIPTION
         );
@@ -272,7 +314,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics.storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BLOCK_CACHE_INDEX_HIT_RATIO,
             BLOCK_CACHE_INDEX_HIT_RATIO_DESCRIPTION
         );
@@ -285,8 +332,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BLOCK_CACHE_FILTER_HIT_RATIO,
             BLOCK_CACHE_FILTER_HIT_RATIO_DESCRIPTION
         );
@@ -299,8 +350,12 @@ public class RocksDBMetrics {
         addRateOfSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BYTES_READ_DURING_COMPACTION,
             BYTES_READ_DURING_COMPACTION_DESCRIPTION
         );
@@ -313,8 +368,12 @@ public class RocksDBMetrics {
         addRateOfSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             BYTES_WRITTEN_DURING_COMPACTION,
             BYTES_WRITTEN_DURING_COMPACTION_DESCRIPTION
         );
@@ -327,8 +386,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             COMPACTION_TIME_AVG,
             COMPACTION_TIME_AVG_DESCRIPTION
         );
@@ -341,8 +404,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             COMPACTION_TIME_MIN,
             COMPACTION_TIME_MIN_DESCRIPTION
         );
@@ -355,8 +422,12 @@ public class RocksDBMetrics {
         addValueMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             COMPACTION_TIME_MAX,
             COMPACTION_TIME_MAX_DESCRIPTION
         );
@@ -369,8 +440,12 @@ public class RocksDBMetrics {
         addSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             NUMBER_OF_OPEN_FILES,
             false,
             NUMBER_OF_OPEN_FILES_DESCRIPTION
@@ -384,8 +459,12 @@ public class RocksDBMetrics {
         addSumMetricToSensor(
             sensor,
             STATE_LEVEL_GROUP,
-            streamsMetrics
-                .storeLevelTagMap(metricContext.taskName(), metricContext.metricsScope(), metricContext.storeName()),
+            streamsMetrics.storeLevelTagMap(
+                metricContext.threadId(),
+                metricContext.taskName(),
+                metricContext.metricsScope(),
+                metricContext.storeName()
+            ),
             NUMBER_OF_FILE_ERRORS,
             NUMBER_OF_FILE_ERRORS_DESCRIPTION
         );
@@ -396,6 +475,7 @@ public class RocksDBMetrics {
                                        final RocksDBMetricContext metricContext,
                                        final String sensorName) {
         return streamsMetrics.storeLevelSensor(
+            metricContext.threadId(),
             metricContext.taskName(),
             metricContext.storeName(),
             sensorName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -48,12 +48,14 @@ public class RocksDBMetricsRecorder {
     private final Map<String, Statistics> statisticsToRecord = new ConcurrentHashMap<>();
     private final String metricsScope;
     private final String storeName;
+    private final String threadId;
     private TaskId taskId;
     private StreamsMetricsImpl streamsMetrics;
     private boolean isInitialized = false;
 
-    public RocksDBMetricsRecorder(final String metricsScope, final String storeName) {
+    public RocksDBMetricsRecorder(final String metricsScope, final String threadId, final String storeName) {
         this.metricsScope = metricsScope;
+        this.threadId = threadId;
         this.storeName = storeName;
         final LogContext logContext = new LogContext(String.format("[RocksDB Metrics Recorder for %s] ", storeName));
         logger = logContext.logger(RocksDBMetricsRecorder.class);
@@ -97,7 +99,8 @@ public class RocksDBMetricsRecorder {
     }
 
     private void initSensors(final StreamsMetricsImpl streamsMetrics, final TaskId taskId) {
-        final RocksDBMetricContext metricContext = new RocksDBMetricContext(taskId.toString(), metricsScope, storeName);
+        final RocksDBMetricContext metricContext =
+            new RocksDBMetricContext(threadId, taskId.toString(), metricsScope, storeName);
         bytesWrittenToDatabaseSensor = RocksDBMetrics.bytesWrittenToDatabaseSensor(streamsMetrics, metricContext);
         bytesReadFromDatabaseSensor = RocksDBMetrics.bytesReadFromDatabaseSensor(streamsMetrics, metricContext);
         memtableBytesFlushedSensor = RocksDBMetrics.memtableBytesFlushedSensor(streamsMetrics, metricContext);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -53,7 +53,9 @@ public class RocksDBMetricsRecorder {
     private StreamsMetricsImpl streamsMetrics;
     private boolean isInitialized = false;
 
-    public RocksDBMetricsRecorder(final String metricsScope, final String threadId, final String storeName) {
+    public RocksDBMetricsRecorder(final String metricsScope,
+                                  final String threadId,
+                                  final String storeName) {
         this.metricsScope = metricsScope;
         this.threadId = threadId;
         this.storeName = storeName;

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.StateRestoreListener;
@@ -37,10 +38,10 @@ import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.MockProcessorSupplier;
@@ -84,10 +85,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({KafkaStreams.class, StreamThread.class})
+@PrepareForTest({KafkaStreams.class, StreamThread.class, ClientMetrics.class})
 public class KafkaStreamsTest {
 
     private static final int NUM_THREADS = 2;
+    private final static String APPLICATION_ID = "appId";
 
     @Rule
     public TestName testName = new TestName();
@@ -139,7 +141,7 @@ public class KafkaStreamsTest {
         metricsReportersCapture = EasyMock.newCapture();
 
         props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
         props.put(StreamsConfig.CLIENT_ID_CONFIG, "clientId");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2018");
         props.put(StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
@@ -169,6 +171,15 @@ public class KafkaStreamsTest {
             return null;
         }).anyTimes();
 
+        PowerMock.mockStatic(ClientMetrics.class);
+        EasyMock.expect(ClientMetrics.version()).andReturn("1.56");
+        EasyMock.expect(ClientMetrics.commitId()).andReturn("1a2b3c4d5e");
+        ClientMetrics.addVersionMetric(anyObject(StreamsMetricsImpl.class));
+        ClientMetrics.addCommitIdMetric(anyObject(StreamsMetricsImpl.class));
+        ClientMetrics.addApplicationIdMetric(anyObject(StreamsMetricsImpl.class), EasyMock.eq(APPLICATION_ID));
+        ClientMetrics.addTopologyDescriptionMetric(anyObject(StreamsMetricsImpl.class), anyString());
+        ClientMetrics.addStateMetric(anyObject(StreamsMetricsImpl.class), anyObject());
+
         // setup stream threads
         PowerMock.mockStatic(StreamThread.class);
         EasyMock.expect(StreamThread.create(
@@ -178,7 +189,7 @@ public class KafkaStreamsTest {
             anyObject(Admin.class),
             anyObject(UUID.class),
             anyObject(String.class),
-            anyObject(Metrics.class),
+            anyObject(StreamsMetricsImpl.class),
             anyObject(Time.class),
             anyObject(StreamsMetadataState.class),
             anyLong(),
@@ -203,11 +214,10 @@ public class KafkaStreamsTest {
             anyObject(Consumer.class),
             anyObject(StateDirectory.class),
             anyLong(),
-            anyObject(Metrics.class),
+            anyObject(StreamsMetricsImpl.class),
             anyObject(Time.class),
             anyString(),
-            anyObject(StateRestoreListener.class),
-            anyObject(RocksDBMetricsRecordingTrigger.class)
+            anyObject(StateRestoreListener.class)
         ).andReturn(globalStreamThread).anyTimes();
         EasyMock.expect(globalStreamThread.state()).andAnswer(globalThreadState::get).anyTimes();
         globalStreamThread.setStateListener(EasyMock.capture(threadStatelistenerCapture));
@@ -240,7 +250,16 @@ public class KafkaStreamsTest {
         globalStreamThread.join();
         EasyMock.expectLastCall().anyTimes();
 
-        PowerMock.replay(StreamThread.class, Metrics.class, metrics, streamThreadOne, streamThreadTwo, GlobalStreamThread.class, globalStreamThread);
+        PowerMock.replay(
+            StreamThread.class,
+            Metrics.class,
+            metrics,
+            ClientMetrics.class,
+            streamThreadOne,
+            streamThreadTwo,
+            GlobalStreamThread.class,
+            globalStreamThread
+        );
     }
 
     private void prepareStreamThread(final StreamThread thread, final boolean terminable) throws Exception {
@@ -248,8 +267,6 @@ public class KafkaStreamsTest {
         EasyMock.expect(thread.state()).andAnswer(state::get).anyTimes();
 
         thread.setStateListener(EasyMock.capture(threadStatelistenerCapture));
-        EasyMock.expectLastCall().anyTimes();
-        thread.setRocksDBMetricsRecordingTrigger(EasyMock.anyObject(RocksDBMetricsRecordingTrigger.class));
         EasyMock.expectLastCall().anyTimes();
 
         thread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.MockProcessorSupplier;

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.internals.metrics;
+
+
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.and;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.not;
+import static org.easymock.EasyMock.notNull;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
+
+public class ClientMetricsTest {
+
+    private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
+
+    private interface OneParamMetricAdder {
+        void addMetric(final StreamsMetricsImpl streamsMetrics);
+    }
+
+    private interface TwoParamMetricAdder {
+        void addMetric(final StreamsMetricsImpl streamsMetrics, final String value);
+    }
+
+    @Test
+    public void shouldAddVersionMetric() {
+        final String name = "version";
+        final String description = "The version of the Kafka Streams client";
+        setUpAndVerifyMetricOneParam(name, description, ClientMetrics::addVersionMetric);
+    }
+
+    @Test
+    public void shouldAddCommitIdMetric() {
+        final String name = "commit-id";
+        final String description = "The version control commit ID of the Kafka Streams client";
+        setUpAndVerifyMetricOneParam(name, description, ClientMetrics::addCommitIdMetric);
+    }
+
+    @Test
+    public void shouldAddApplicationIdMetric() {
+        final String name = "application-id";
+        final String description = "The application ID of the Kafka Streams client";
+        setUpAndVerifyMetricTwoParam(name, description, "thisIsAnID", ClientMetrics::addApplicationIdMetric);
+    }
+
+    @Test
+    public void shouldAddTopologyDescriptionMetric() {
+        final String name = "topology-description";
+        final String description = "The description of the topology executed in the Kafka Streams client";
+        setUpAndVerifyMetricTwoParam(
+            name,
+            description,
+            "thisIsATopologyDescription",
+            ClientMetrics::addTopologyDescriptionMetric
+        );
+    }
+
+    @Test
+    public void shouldAddStateMetric() {
+        final String name = "state";
+        final String description = "The state of the Kafka Streams client";
+        final Gauge<State> stateProvider = (config, now) -> State.RUNNING;
+        streamsMetrics.addClientLevelMutableMetric(
+            eq(name),
+            eq(description),
+            eq(RecordingLevel.INFO),
+            eq(stateProvider)
+        );
+        replay(streamsMetrics);
+
+        ClientMetrics.addStateMetric(streamsMetrics, stateProvider);
+
+        verify(streamsMetrics);
+    }
+
+    private void setUpAndVerifyMetricOneParam(final String name,
+                                              final String description,
+                                              final OneParamMetricAdder metricAdder) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            eq(name),
+            eq(description),
+            eq(RecordingLevel.INFO),
+            and(not(eq("unknown")), notNull())
+        );
+        replay(streamsMetrics);
+
+        metricAdder.addMetric(streamsMetrics);
+
+        verify(streamsMetrics);
+    }
+
+    private void setUpAndVerifyMetricTwoParam(final String name,
+                                              final String description,
+                                              final String value,
+                                              final TwoParamMetricAdder metricAdder) {
+        streamsMetrics.addClientLevelImmutableMetric(
+            eq(name),
+            eq(description),
+            eq(RecordingLevel.INFO),
+            eq(value)
+        );
+        replay(streamsMetrics);
+
+        metricAdder.addMetric(streamsMetrics, value);
+
+        verify(streamsMetrics);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -43,6 +43,10 @@ public class ClientMetricsTest {
         void addMetric(final StreamsMetricsImpl streamsMetrics, final String value);
     }
 
+    /*
+     * This test may fail when executed from a IDE since it expects the /kafka/kafka-streams-version.properties on the
+     * class path.
+     */
     @Test
     public void shouldAddVersionMetric() {
         final String name = "version";
@@ -50,6 +54,10 @@ public class ClientMetricsTest {
         setUpAndVerifyMetricOneParam(name, description, ClientMetrics::addVersionMetric);
     }
 
+    /*
+     * This test may fail when executed from a IDE since it expects the /kafka/kafka-streams-version.properties on the
+     * class path.
+     */
     @Test
     public void shouldAddCommitIdMetric() {
         final String name = "commit-id";

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -70,6 +70,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private static final long GAP_MS = 5 * 60 * 1000L;
     private static final String STORE_NAME = "session-store";
 
+    private final String threadId = Thread.currentThread().getName();
     private final ToInternal toInternal = new ToInternal();
     private final Initializer<Long> initializer = () -> 0L;
     private final Aggregator<String, String, Long> aggregator = (aggKey, value, aggregate) -> aggregate + 1;
@@ -93,7 +94,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
         final File stateDir = TestUtils.tempDirectory();
         metrics = new Metrics();
         final MockStreamsMetrics metrics = new MockStreamsMetrics(KStreamSessionWindowAggregateProcessorTest.this.metrics);
-        ThreadMetrics.skipRecordSensor(metrics);
+        ThreadMetrics.skipRecordSensor(threadId, metrics);
 
         context = new InternalMockProcessorContext(
             stateDir,
@@ -420,7 +421,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-processor-node-metrics",
             "The total number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "test"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "TESTING_NODE")
             )
@@ -433,7 +434,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-processor-node-metrics",
             "The average number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "test"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "TESTING_NODE")
             )
@@ -494,7 +495,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-processor-node-metrics",
             "The total number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "test"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "TESTING_NODE")
             )
@@ -507,7 +508,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             "stream-processor-node-metrics",
             "The average number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "test"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "TESTING_NODE")
             )

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -65,6 +65,7 @@ public class KStreamWindowAggregateTest {
     private final ConsumerRecordFactory<String, String> recordFactory =
         new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private final String threadId = Thread.currentThread().getName();
 
     @Test
     public void testAggBasic() {
@@ -394,7 +395,7 @@ public class KStreamWindowAggregateTest {
             "stream-processor-node-metrics",
             "The total number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "topology-test-driver-virtual-thread"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
@@ -406,7 +407,7 @@ public class KStreamWindowAggregateTest {
             "stream-processor-node-metrics",
             "The average number of occurrence of late-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "topology-test-driver-virtual-thread"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
             )
@@ -418,7 +419,7 @@ public class KStreamWindowAggregateTest {
             "stream-task-metrics",
             "The max observed lateness of records.",
             mkMap(
-                mkEntry("client-id", "topology-test-driver-virtual-thread"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0")
             )
         );
@@ -429,7 +430,7 @@ public class KStreamWindowAggregateTest {
             "stream-task-metrics",
             "The average observed lateness of records.",
             mkMap(
-                mkEntry("client-id", "topology-test-driver-virtual-thread"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0")
             )
         );

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -43,90 +43,91 @@ import static org.hamcrest.core.Is.is;
 
 public class KTableSuppressProcessorMetricsTest {
     private static final long ARBITRARY_LONG = 5L;
+    private final String threadId = Thread.currentThread().getName();
 
-    private static final MetricName EVICTION_TOTAL_METRIC = new MetricName(
+    private final MetricName evictionTotalMetric = new MetricName(
         "suppression-emit-total",
         "stream-processor-node-metrics",
         "The total number of occurrence of suppression-emit operations.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("processor-node-id", "testNode")
         )
     );
 
-    private static final MetricName EVICTION_RATE_METRIC = new MetricName(
+    private final MetricName evictionRateMetric = new MetricName(
         "suppression-emit-rate",
         "stream-processor-node-metrics",
         "The average number of occurrence of suppression-emit operation per second.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("processor-node-id", "testNode")
         )
     );
 
-    private static final MetricName BUFFER_SIZE_AVG_METRIC = new MetricName(
+    private final MetricName bufferSizeAvgMetric = new MetricName(
         "suppression-buffer-size-avg",
         "stream-buffer-metrics",
         "The average size of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
     );
 
-    private static final MetricName BUFFER_SIZE_CURRENT_METRIC = new MetricName(
+    private final MetricName bufferSizeCurrentMetric = new MetricName(
         "suppression-buffer-size-current",
         "stream-buffer-metrics",
         "The current size of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
     );
 
-    private static final MetricName BUFFER_SIZE_MAX_METRIC = new MetricName(
+    private final MetricName bufferSizeMaxMetric = new MetricName(
         "suppression-buffer-size-max",
         "stream-buffer-metrics",
         "The max size of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
     );
 
-    private static final MetricName BUFFER_COUNT_AVG_METRIC = new MetricName(
+    private final MetricName bufferCountAvgMetric = new MetricName(
         "suppression-buffer-count-avg",
         "stream-buffer-metrics",
         "The average count of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
     );
 
-    private static final MetricName BUFFER_COUNT_CURRENT_METRIC = new MetricName(
+    private final MetricName bufferCountCurrentMetric = new MetricName(
         "suppression-buffer-count-current",
         "stream-buffer-metrics",
         "The current count of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
     );
 
-    private static final MetricName BUFFER_COUNT_MAX_METRIC = new MetricName(
+    private final MetricName bufferCountMaxMetric = new MetricName(
         "suppression-buffer-count-max",
         "stream-buffer-metrics",
         "The max count of buffered records.",
         mkMap(
-            mkEntry("client-id", "mock-processor-context-virtual-thread"),
+            mkEntry("client-id", threadId),
             mkEntry("task-id", "0_0"),
             mkEntry("buffer-id", "test-store")
         )
@@ -166,14 +167,14 @@ public class KTableSuppressProcessorMetricsTest {
         {
             final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
 
-            verifyMetric(metrics, EVICTION_RATE_METRIC, is(0.0));
-            verifyMetric(metrics, EVICTION_TOTAL_METRIC, is(0.0));
-            verifyMetric(metrics, BUFFER_SIZE_AVG_METRIC, is(21.5));
-            verifyMetric(metrics, BUFFER_SIZE_CURRENT_METRIC, is(43.0));
-            verifyMetric(metrics, BUFFER_SIZE_MAX_METRIC, is(43.0));
-            verifyMetric(metrics, BUFFER_COUNT_AVG_METRIC, is(0.5));
-            verifyMetric(metrics, BUFFER_COUNT_CURRENT_METRIC, is(1.0));
-            verifyMetric(metrics, BUFFER_COUNT_MAX_METRIC, is(1.0));
+            verifyMetric(metrics, evictionRateMetric, is(0.0));
+            verifyMetric(metrics, evictionTotalMetric, is(0.0));
+            verifyMetric(metrics, bufferSizeAvgMetric, is(21.5));
+            verifyMetric(metrics, bufferSizeCurrentMetric, is(43.0));
+            verifyMetric(metrics, bufferSizeMaxMetric, is(43.0));
+            verifyMetric(metrics, bufferCountAvgMetric, is(0.5));
+            verifyMetric(metrics, bufferCountCurrentMetric, is(1.0));
+            verifyMetric(metrics, bufferCountMaxMetric, is(1.0));
         }
 
         context.setRecordMetadata("", 0, 1L, null, timestamp + 1);
@@ -182,14 +183,14 @@ public class KTableSuppressProcessorMetricsTest {
         {
             final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
 
-            verifyMetric(metrics, EVICTION_RATE_METRIC, greaterThan(0.0));
-            verifyMetric(metrics, EVICTION_TOTAL_METRIC, is(1.0));
-            verifyMetric(metrics, BUFFER_SIZE_AVG_METRIC, is(41.0));
-            verifyMetric(metrics, BUFFER_SIZE_CURRENT_METRIC, is(39.0));
-            verifyMetric(metrics, BUFFER_SIZE_MAX_METRIC, is(82.0));
-            verifyMetric(metrics, BUFFER_COUNT_AVG_METRIC, is(1.0));
-            verifyMetric(metrics, BUFFER_COUNT_CURRENT_METRIC, is(1.0));
-            verifyMetric(metrics, BUFFER_COUNT_MAX_METRIC, is(2.0));
+            verifyMetric(metrics, evictionRateMetric, greaterThan(0.0));
+            verifyMetric(metrics, evictionTotalMetric, is(1.0));
+            verifyMetric(metrics, bufferSizeAvgMetric, is(41.0));
+            verifyMetric(metrics, bufferSizeCurrentMetric, is(39.0));
+            verifyMetric(metrics, bufferSizeMaxMetric, is(82.0));
+            verifyMetric(metrics, bufferCountAvgMetric, is(1.0));
+            verifyMetric(metrics, bufferCountCurrentMetric, is(1.0));
+            verifyMetric(metrics, bufferCountMaxMetric, is(2.0));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.TimestampedKeyValueStoreMaterializer;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestUtils;
@@ -107,11 +108,10 @@ public class GlobalStreamThreadTest {
             mockConsumer,
             new StateDirectory(config, time, true),
             0,
-            new Metrics(),
+            new StreamsMetricsImpl(new Metrics(), "test-client", StreamsConfig.METRICS_LATEST),
             new MockTime(),
             "clientId",
-            stateRestoreListener,
-            null
+            stateRestoreListener
         );
     }
 
@@ -143,11 +143,10 @@ public class GlobalStreamThreadTest {
             mockConsumer,
             new StateDirectory(config, time, true),
             0,
-            new Metrics(),
+            new StreamsMetricsImpl(new Metrics(), "test-client", StreamsConfig.METRICS_LATEST),
             new MockTime(),
             "clientId",
-            stateRestoreListener,
-            null
+            stateRestoreListener
         );
 
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -104,13 +104,14 @@ public class ProcessorNodeTest {
         final ProcessorNode<Object, Object> node = new ProcessorNode<>("name", new NoOpProcessor(), Collections.<String>emptySet());
         node.init(context);
 
+        final String threadId = Thread.currentThread().getName();
         final String[] latencyOperations = {"process", "punctuate", "create", "destroy"};
         final String throughputOperation = "forward";
         final String groupName = "stream-processor-node-metrics";
         final Map<String, String> metricTags = new LinkedHashMap<>();
         metricTags.put("processor-node-id", node.name());
         metricTags.put("task-id", context.taskId().toString());
-        metricTags.put("client-id", "mock");
+        metricTags.put("client-id", threadId);
 
         for (final String opName : latencyOperations) {
             StreamsTestUtils.getMetricByNameFilterByTags(metrics.metrics(), opName + "-latency-avg", groupName, metricTags);
@@ -137,8 +138,8 @@ public class ProcessorNodeTest {
 
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean(String.format("kafka.streams:type=%s,client-id=mock,task-id=%s,processor-node-id=%s",
-                groupName, context.taskId().toString(), node.name())));
+        assertTrue(reporter.containsMbean(String.format("kafka.streams:type=%s,client-id=%s,task-id=%s,processor-node-id=%s",
+                groupName, threadId, context.taskId().toString(), node.name())));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -97,6 +97,7 @@ import static org.junit.Assert.fail;
 
 public class StandbyTaskTest {
 
+    private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 1);
     private StandbyTask task;
     private final Serializer<Integer> intSerializer = new IntegerSerializer();
@@ -782,7 +783,7 @@ public class StandbyTaskTest {
 
     private MetricName setupCloseTaskMetric() {
         final MetricName metricName = new MetricName("name", "group", "description", Collections.emptyMap());
-        final Sensor sensor = streamsMetrics.threadLevelSensor("task-closed", Sensor.RecordingLevel.INFO);
+        final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, "task-closed", Sensor.RecordingLevel.INFO);
         sensor.add(metricName, new CumulativeSum());
         return metricName;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -414,10 +414,18 @@ public class StreamTaskTest {
         assertNotNull(getMetric("%s-latency-max", "The max latency of %s operation.", "all"));
         assertNotNull(getMetric("%s-rate", "The average number of occurrence of %s operation per second.", "all"));
 
+        final String threadId = Thread.currentThread().getName();
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-task-metrics,client-id=test,task-id=%s", task.id.toString())));
-        assertTrue(reporter.containsMbean("kafka.streams:type=stream-task-metrics,client-id=test,task-id=all"));
+        assertTrue(reporter.containsMbean(String.format(
+            "kafka.streams:type=stream-task-metrics,client-id=%s,task-id=%s",
+            threadId,
+            task.id.toString()
+        )));
+        assertTrue(reporter.containsMbean(String.format(
+            "kafka.streams:type=stream-task-metrics,client-id=%s,task-id=all",
+            threadId
+        )));
     }
 
     private KafkaMetric getMetric(final String nameFormat, final String descriptionFormat, final String taskId) {
@@ -425,7 +433,7 @@ public class StreamTaskTest {
             String.format(nameFormat, "commit"),
             "stream-task-metrics",
             String.format(descriptionFormat, "commit"),
-            mkMap(mkEntry("task-id", taskId), mkEntry("client-id", "test"))
+            mkMap(mkEntry("task-id", taskId), mkEntry("client-id", Thread.currentThread().getName()))
         ));
     }
 
@@ -760,7 +768,11 @@ public class StreamTaskTest {
         task.initializeStateStores();
         task.initializeTopology();
 
-        final MetricName enforcedProcessMetric = metrics.metricName("enforced-processing-total", "stream-task-metrics", mkMap(mkEntry("client-id", "test"), mkEntry("task-id", taskId00.toString())));
+        final MetricName enforcedProcessMetric = metrics.metricName(
+            "enforced-processing-total",
+            "stream-task-metrics",
+            mkMap(mkEntry("client-id", Thread.currentThread().getName()), mkEntry("task-id", taskId00.toString()))
+        );
 
         assertFalse(task.isProcessable(0L));
         assertEquals(0.0, metrics.metric(enforcedProcessMetric).metricValue());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -758,16 +758,18 @@ public class StreamThreadTest {
         final MockStreamThreadConsumer<byte[], byte[]> mockStreamThreadConsumer =
             new MockStreamThreadConsumer<>(OffsetResetStrategy.EARLIEST);
 
-        final TaskManager taskManager = new TaskManager(new MockChangelogReader(),
+        final TaskManager taskManager = new TaskManager(
+            new MockChangelogReader(),
             PROCESS_ID,
-                                                        "log-prefix",
-                                                        mockStreamThreadConsumer,
-                                                        streamsMetadataState,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        new AssignedStreamsTasks(new LogContext()),
-                                                        new AssignedStandbyTasks(new LogContext()));
+            "log-prefix",
+            mockStreamThreadConsumer,
+            streamsMetadataState,
+            null,
+            null,
+            null,
+            new AssignedStreamsTasks(new LogContext()),
+            new AssignedStandbyTasks(new LogContext())
+        );
         taskManager.setConsumer(mockStreamThreadConsumer);
         taskManager.setAssignmentMetadata(Collections.emptyMap(), Collections.emptyMap());
         taskManager.setPartitionsToTaskId(Collections.emptyMap());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -101,6 +101,7 @@ import static org.apache.kafka.streams.processor.internals.StreamThread.getShare
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -112,11 +113,15 @@ import static org.junit.Assert.fail;
 
 public class StreamThreadTest {
 
-    private final String clientId = "clientId";
-    private final String applicationId = "stream-thread-test";
+    private final static String APPLICATION_ID = "stream-thread-test";
+    private final static UUID PROCESS_ID = UUID.fromString("87bf53a8-54f2-485f-a4b6-acdbec0a8b3d");
+    private final static String CLIENT_ID = APPLICATION_ID + "-" + PROCESS_ID;
+
     private final int threadIdx = 1;
     private final MockTime mockTime = new MockTime();
     private final Metrics metrics = new Metrics();
+    private final StreamsMetricsImpl streamsMetrics =
+        new StreamsMetricsImpl(metrics, APPLICATION_ID, StreamsConfig.METRICS_LATEST);
     private final MockClientSupplier clientSupplier = new MockClientSupplier();
     private final InternalStreamsBuilder internalStreamsBuilder = new InternalStreamsBuilder(new InternalTopologyBuilder());
     private final StreamsConfig config = new StreamsConfig(configProps(false));
@@ -124,16 +129,14 @@ public class StreamThreadTest {
     private final StateDirectory stateDirectory = new StateDirectory(config, mockTime, true);
     private final ConsumedInternal<Object, Object> consumed = new ConsumedInternal<>();
 
-    private UUID processId = UUID.randomUUID();
     private InternalTopologyBuilder internalTopologyBuilder;
     private StreamsMetadataState streamsMetadataState;
 
     @Before
     public void setUp() {
-        processId = UUID.randomUUID();
-
+        Thread.currentThread().setName(CLIENT_ID + "-StreamThread-" + threadIdx);
         internalTopologyBuilder = InternalStreamsBuilderTest.internalTopologyBuilder(internalStreamsBuilder);
-        internalTopologyBuilder.setApplicationId(applicationId);
+        internalTopologyBuilder.setApplicationId(APPLICATION_ID);
         streamsMetadataState = new StreamsMetadataState(internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST);
     }
 
@@ -151,7 +154,7 @@ public class StreamThreadTest {
 
     private Properties configProps(final boolean enableEoS) {
         return mkProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
             mkEntry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
             mkEntry(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName()),
@@ -164,7 +167,7 @@ public class StreamThreadTest {
     public void testPartitionAssignmentChangeForSingleGroup() {
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         final StateListenerStub stateListener = new StateListenerStub();
         thread.setStateListener(stateListener);
@@ -201,7 +204,7 @@ public class StreamThreadTest {
 
     @Test
     public void testStateChangeStartClose() throws Exception {
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         final StateListenerStub stateListener = new StateListenerStub();
         thread.setStateListener(stateListener);
@@ -238,7 +241,7 @@ public class StreamThreadTest {
                                             final StreamsConfig config,
                                             final boolean eosEnabled) {
         if (eosEnabled) {
-            clientSupplier.setApplicationIdForProducer(applicationId);
+            clientSupplier.setApplicationIdForProducer(APPLICATION_ID);
         }
 
         clientSupplier.setClusterForAdminClient(createCluster());
@@ -248,9 +251,9 @@ public class StreamThreadTest {
             config,
             clientSupplier,
             clientSupplier.getAdmin(config.getAdminConfigs(clientId)),
-            processId,
+            PROCESS_ID,
             clientId,
-            metrics,
+            streamsMetrics,
             mockTime,
             streamsMetadataState,
             0,
@@ -262,7 +265,7 @@ public class StreamThreadTest {
 
     @Test
     public void testMetricsCreatedAtStartup() {
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final String defaultGroupName = "stream-metrics";
         final Map<String, String> defaultTags = Collections.singletonMap("client-id", thread.getName());
         final String descriptionIsNotVerified = "";
@@ -324,7 +327,7 @@ public class StreamThreadTest {
 
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
-        assertEquals(clientId + "-StreamThread-1", thread.getName());
+        assertEquals(CLIENT_ID + "-StreamThread-1", thread.getName());
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=%s,client-id=%s",
                    defaultGroupName, 
                    thread.getName())));
@@ -342,7 +345,7 @@ public class StreamThreadTest {
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final TaskManager taskManager = mockTaskManagerCommit(consumer, 1, 1);
 
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -353,7 +356,7 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
         );
@@ -375,12 +378,12 @@ public class StreamThreadTest {
 
         final Properties properties = new Properties();
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig(applicationId,
+        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig(APPLICATION_ID,
             "localhost:2171",
             Serdes.ByteArraySerde.class.getName(),
             Serdes.ByteArraySerde.class.getName(),
             properties));
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -470,7 +473,7 @@ public class StreamThreadTest {
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final TaskManager taskManager = mockTaskManagerCommit(consumer, 1, 0);
 
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -481,7 +484,7 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
         );
@@ -505,7 +508,7 @@ public class StreamThreadTest {
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final TaskManager taskManager = mockTaskManagerCommit(consumer, 2, 1);
 
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -516,7 +519,7 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
         );
@@ -543,7 +546,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
         internalStreamsBuilder.buildAndOptimizeTopology();
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptyList());
@@ -580,7 +583,7 @@ public class StreamThreadTest {
     public void shouldInjectProducerPerTaskUsingClientSupplierOnCreateIfEosEnable() {
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
 
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptyList());
@@ -619,7 +622,7 @@ public class StreamThreadTest {
     public void shouldCloseAllTaskProducersOnCloseIfEosEnabled() {
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
 
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptyList());
@@ -660,7 +663,7 @@ public class StreamThreadTest {
         EasyMock.replay(taskManager, consumer);
 
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -671,10 +674,10 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
-        ).updateThreadMetadata(getSharedAdminClientId(clientId));
+        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.setStateListener(
             (t, newState, oldState) -> {
                 if (oldState == StreamThread.State.CREATED && newState == StreamThread.State.STARTING) {
@@ -694,7 +697,7 @@ public class StreamThreadTest {
         EasyMock.replay(taskManager, consumer);
 
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -705,10 +708,10 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
-        ).updateThreadMetadata(getSharedAdminClientId(clientId));
+        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         EasyMock.verify(taskManager);
     }
@@ -756,7 +759,7 @@ public class StreamThreadTest {
             new MockStreamThreadConsumer<>(OffsetResetStrategy.EARLIEST);
 
         final TaskManager taskManager = new TaskManager(new MockChangelogReader(),
-                                                        processId,
+            PROCESS_ID,
                                                         "log-prefix",
                                                         mockStreamThreadConsumer,
                                                         streamsMetadataState,
@@ -770,7 +773,7 @@ public class StreamThreadTest {
         taskManager.setPartitionsToTaskId(Collections.emptyMap());
 
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -781,10 +784,10 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
-        ).updateThreadMetadata(getSharedAdminClientId(clientId));
+        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         mockStreamThreadConsumer.setStreamThread(thread);
         mockStreamThreadConsumer.assign(assignedPartitions);
@@ -805,7 +808,7 @@ public class StreamThreadTest {
         EasyMock.replay(taskManager, consumer);
 
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
@@ -816,10 +819,10 @@ public class StreamThreadTest {
             taskManager,
             streamsMetrics,
             internalTopologyBuilder,
-            clientId,
+            CLIENT_ID,
             new LogContext(""),
             new AtomicInteger()
-        ).updateThreadMetadata(getSharedAdminClientId(clientId));
+        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         // Execute the run method. Verification of the mock will check that shutdown was only done once
         thread.run();
@@ -831,7 +834,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "name", null, null, null, "topic");
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptyList());
@@ -852,7 +855,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "source", null, null, null, topic1);
         internalTopologyBuilder.addSink("sink", "dummyTopic", null, null, null, "source");
 
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
 
         final MockConsumer<byte[], byte[]> consumer = clientSupplier.consumer;
 
@@ -914,7 +917,7 @@ public class StreamThreadTest {
 
     @Test
     public void shouldCloseTaskAsZombieAndRemoveFromActiveTasksIfProducerGotFencedInCommitTransactionWhenSuspendingTaks() {
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
 
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
@@ -953,7 +956,7 @@ public class StreamThreadTest {
 
     @Test
     public void shouldCloseTaskAsZombieAndRemoveFromActiveTasksIfProducerGotFencedInCloseTransactionWhenSuspendingTasks() {
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
 
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
@@ -1015,7 +1018,7 @@ public class StreamThreadTest {
     public void shouldReturnActiveTaskMetadataWhileRunningState() {
         internalTopologyBuilder.addSource(null, "source", null, null, null, topic1);
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptySet());
@@ -1047,11 +1050,11 @@ public class StreamThreadTest {
         assertTrue("#threadState() was: " + metadata.threadState() + "; expected either RUNNING, STARTING, PARTITIONS_REVOKED, PARTITIONS_ASSIGNED, or CREATED",
             Arrays.asList("RUNNING", "STARTING", "PARTITIONS_REVOKED", "PARTITIONS_ASSIGNED", "CREATED").contains(metadata.threadState()));
         final String threadName = metadata.threadName();
-        assertTrue(threadName.startsWith("clientId-StreamThread-"));
+        assertThat(threadName, startsWith(CLIENT_ID + "-StreamThread-" + threadIdx));
         assertEquals(threadName + "-consumer", metadata.consumerClientId());
         assertEquals(threadName + "-restore-consumer", metadata.restoreConsumerClientId());
         assertEquals(Collections.singleton(threadName + "-producer"), metadata.producerClientIds());
-        assertEquals("clientId-admin", metadata.adminClientId());
+        assertEquals(CLIENT_ID + "-admin", metadata.adminClientId());
     }
 
     @Test
@@ -1060,7 +1063,7 @@ public class StreamThreadTest {
             .groupByKey().count(Materialized.as("count-one"));
 
         internalStreamsBuilder.buildAndOptimizeTopology();
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
         restoreConsumer.updatePartitions(
             "stream-thread-test-count-one-changelog",
@@ -1106,8 +1109,8 @@ public class StreamThreadTest {
     public void shouldUpdateStandbyTask() throws Exception {
         final String storeName1 = "count-one";
         final String storeName2 = "table-two";
-        final String changelogName1 = applicationId + "-" + storeName1 + "-changelog";
-        final String changelogName2 = applicationId + "-" + storeName2 + "-changelog";
+        final String changelogName1 = APPLICATION_ID + "-" + storeName1 + "-changelog";
+        final String changelogName2 = APPLICATION_ID + "-" + storeName2 + "-changelog";
         final TopicPartition partition1 = new TopicPartition(changelogName1, 1);
         final TopicPartition partition2 = new TopicPartition(changelogName2, 1);
         internalStreamsBuilder
@@ -1119,7 +1122,7 @@ public class StreamThreadTest {
         internalStreamsBuilder.table(topic2, new ConsumedInternal<>(), materialized);
 
         internalStreamsBuilder.buildAndOptimizeTopology();
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
         restoreConsumer.updatePartitions(changelogName1,
             singletonList(
@@ -1227,7 +1230,7 @@ public class StreamThreadTest {
         final LogContext logContext = new LogContext("test");
         final Logger log = logContext.logger(StreamThreadTest.class);
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread.StandbyTaskCreator standbyTaskCreator = new StreamThread.StandbyTaskCreator(
             internalTopologyBuilder,
             config,
@@ -1235,6 +1238,7 @@ public class StreamThreadTest {
             stateDirectory,
             new MockChangelogReader(),
             mockTime,
+            CLIENT_ID,
             log);
         return standbyTaskCreator.createTask(
             new MockConsumer<>(OffsetResetStrategy.EARLIEST),
@@ -1264,7 +1268,7 @@ public class StreamThreadTest {
         internalStreamsBuilder.stream(Collections.singleton(topic1), consumed).process(punctuateProcessor);
         internalStreamsBuilder.buildAndOptimizeTopology();
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener.onPartitionsRevoked(Collections.emptySet());
@@ -1321,7 +1325,7 @@ public class StreamThreadTest {
 
     @Test
     public void shouldAlwaysUpdateTasksMetadataAfterChangingState() {
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         ThreadMetadata metadata = thread.threadMetadata();
         assertEquals(StreamThread.State.CREATED.name(), metadata.threadState());
 
@@ -1339,7 +1343,7 @@ public class StreamThreadTest {
             .groupByKey().count(Materialized.as("count-one"));
         internalStreamsBuilder.buildAndOptimizeTopology();
 
-        final StreamThread thread = createStreamThread(clientId, config, false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
         restoreConsumer.updatePartitions("stream-thread-test-count-one-changelog",
             asList(
@@ -1500,7 +1504,7 @@ public class StreamThreadTest {
             StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
             LogAndContinueExceptionHandler.class.getName());
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(config), false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(config), false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -1571,7 +1575,7 @@ public class StreamThreadTest {
         config.setProperty(
             StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
             LogAndSkipOnInvalidTimestamp.class.getName());
-        final StreamThread thread = createStreamThread(clientId, new StreamsConfig(config), false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(config), false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -1672,21 +1676,21 @@ public class StreamThreadTest {
         final TaskManager taskManager = mockTaskManagerCommit(consumer, 1, 0);
 
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+            new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
-                mockTime,
-                config,
-                producer,
-                consumer,
-                consumer,
-                null,
-                taskManager,
-                streamsMetrics,
-                internalTopologyBuilder,
-                clientId,
-                new LogContext(""),
-                new AtomicInteger()
-                );
+            mockTime,
+            config,
+            producer,
+            consumer,
+            consumer,
+            null,
+            taskManager,
+            streamsMetrics,
+            internalTopologyBuilder,
+            CLIENT_ID,
+            new LogContext(""),
+            new AtomicInteger()
+        );
         final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),
@@ -1711,21 +1715,21 @@ public class StreamThreadTest {
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
 
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, clientId, StreamsConfig.METRICS_LATEST);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST);
         final StreamThread thread = new StreamThread(
-                mockTime,
-                config,
-                producer,
-                consumer,
-                consumer,
-                null,
-                taskManager,
-                streamsMetrics,
-                internalTopologyBuilder,
-                clientId,
-                new LogContext(""),
-                new AtomicInteger()
-                );
+            mockTime,
+            config,
+            producer,
+            consumer,
+            consumer,
+            null,
+            taskManager,
+            streamsMetrics,
+            internalTopologyBuilder,
+            CLIENT_ID,
+            new LogContext(""),
+            new AtomicInteger()
+        );
         final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ImmutableMetricValue;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
@@ -176,7 +177,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
         final String value = "immutable-value";
-        final StreamsMetricsImpl.ImmutableValue immutableValue = new StreamsMetricsImpl.ImmutableValue<>(value);
+        final ImmutableMetricValue immutableValue = new ImmutableMetricValue<>(value);
         expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
             .andReturn(metricName1);
         metrics.addMetric(eq(metricName1), eqMetricConfig(metricConfig), eq(immutableValue));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -27,6 +28,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
+import org.easymock.IArgumentMatcher;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -36,54 +38,222 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CLIENT_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_METRICS_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxLatencyToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.resetToDefault;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.equalToObject;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class StreamsMetricsImplTest extends EasyMockSupport {
 
     private final static String SENSOR_PREFIX_DELIMITER = ".";
     private final static String SENSOR_NAME_DELIMITER = ".s.";
     private final static String INTERNAL_PREFIX = "internal";
-    private final static String THREAD_NAME = "test-thread";
     private final static String VERSION = StreamsConfig.METRICS_LATEST;
+    private final static String CLIENT_ID = "test-client";
+    private final static String THREAD_ID = "test-thread";
+    private final static String TASK_ID = "test-task";
+    private final static String METRIC_NAME1 = "test-metric1";
+    private final static String METRIC_NAME2 = "test-metric2";
 
     private final Metrics metrics = new Metrics();
     private final Sensor sensor = metrics.sensor("dummy");
+    private final String storeName = "store";
+    private final String sensorName1 = "sensor1";
+    private final String sensorName2 = "sensor2";
     private final String metricNamePrefix = "metric";
     private final String group = "group";
     private final Map<String, String> tags = mkMap(mkEntry("tag", "value"));
     private final String description1 = "description number one";
     private final String description2 = "description number two";
     private final String description3 = "description number three";
+    private final Map<String, String> clientLevelTags = mkMap(mkEntry("client-id", CLIENT_ID));
+    private final MetricName metricName1 =
+        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags);
+    private final MetricName metricName2 =
+        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description2, clientLevelTags);
     private final MockTime time = new MockTime(0);
-    private final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_NAME, VERSION);
+    private final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+    private static MetricConfig eqMetricConfig(final MetricConfig metricConfig) {
+        EasyMock.reportMatcher(new IArgumentMatcher() {
+            private final StringBuffer message = new StringBuffer();
+
+            @Override
+            public boolean matches(final Object argument) {
+                if (argument instanceof MetricConfig) {
+                    final MetricConfig otherMetricConfig = (MetricConfig) argument;
+                    final boolean equalsComparisons =
+                        (otherMetricConfig.quota() == metricConfig.quota() ||
+                        otherMetricConfig.quota().equals(metricConfig.quota())) &&
+                        otherMetricConfig.tags().equals(metricConfig.tags());
+                    if (otherMetricConfig.eventWindow() == metricConfig.eventWindow() &&
+                        otherMetricConfig.recordLevel() == metricConfig.recordLevel() &&
+                        equalsComparisons &&
+                        otherMetricConfig.samples() == metricConfig.samples() &&
+                        otherMetricConfig.timeWindowMs() == metricConfig.timeWindowMs()) {
+
+                        return true;
+                    } else {
+                        message.append("{ ");
+                        message.append("eventWindow=");
+                        message.append(otherMetricConfig.eventWindow());
+                        message.append(", ");
+                        message.append("recordLevel=");
+                        message.append(otherMetricConfig.recordLevel());
+                        message.append(", ");
+                        message.append("quota=");
+                        message.append(otherMetricConfig.quota().toString());
+                        message.append(", ");
+                        message.append("samples=");
+                        message.append(otherMetricConfig.samples());
+                        message.append(", ");
+                        message.append("tags=");
+                        message.append(otherMetricConfig.tags().toString());
+                        message.append(", ");
+                        message.append("timeWindowMs=");
+                        message.append(otherMetricConfig.timeWindowMs());
+                        message.append(" }");
+                    }
+                }
+                message.append("not a MetricConfig object");
+                return false;
+            }
+
+            @Override
+            public void appendTo(final StringBuffer buffer) {
+                buffer.append(message);
+            }
+        });
+        return null;
+    }
+
+
+    private void addSensorsOnAllLevels(final Metrics metrics, final StreamsMetricsImpl streamsMetrics) {
+        expect(metrics.sensor(anyString(), anyObject(RecordingLevel.class), anyObject(Sensor[].class)))
+            .andStubReturn(sensor);
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+            .andReturn(metricName1);
+        expect(metrics.metricName(METRIC_NAME2, CLIENT_LEVEL_GROUP, description2, clientLevelTags))
+            .andReturn(metricName2);
+        replay(metrics);
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, description1, RecordingLevel.INFO, "value");
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME2, description2, RecordingLevel.INFO, "value");
+        streamsMetrics.threadLevelSensor(THREAD_ID, sensorName1, RecordingLevel.INFO);
+        streamsMetrics.threadLevelSensor(THREAD_ID, sensorName2, RecordingLevel.INFO);
+        streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, sensorName1, RecordingLevel.INFO);
+        streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, sensorName2, RecordingLevel.INFO);
+        streamsMetrics.storeLevelSensor(THREAD_ID, TASK_ID, storeName, sensorName1, RecordingLevel.INFO);
+        streamsMetrics.storeLevelSensor(THREAD_ID, TASK_ID, storeName, sensorName2, RecordingLevel.INFO);
+    }
+
+    private void setupGetSensorTest(final Metrics metrics,
+                                    final String level,
+                                    final RecordingLevel recordingLevel) {
+        final String fullSensorName =
+            INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER + sensorName1;
+        final Sensor[] parents = {};
+        expect(metrics.sensor(fullSensorName, recordingLevel, parents)).andReturn(sensor);
+        replay(metrics);
+    }
+
+    @Test
+    public void shouldAddClientLevelImmutableMetric() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
+        final String value = "immutable-value";
+        final StreamsMetricsImpl.ImmutableValue immutableValue = new StreamsMetricsImpl.ImmutableValue<>(value);
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+            .andReturn(metricName1);
+        metrics.addMetric(eq(metricName1), eqMetricConfig(metricConfig), eq(immutableValue));
+        replay(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, description1, recordingLevel, value);
+
+        verify(metrics);
+    }
+
+    @Test
+    public void shouldAddClientLevelMutableMetric() {
+        final Metrics metrics = mock(Metrics.class);
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
+        final Gauge<String> valueProvider = (config, now) -> "mutable-value";
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+            .andReturn(metricName1);
+        metrics.addMetric(eq(metricName1), eqMetricConfig(metricConfig), eq(valueProvider));
+        replay(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        streamsMetrics.addClientLevelMutableMetric(METRIC_NAME1, description1, recordingLevel, valueProvider);
+
+        verify(metrics);
+    }
 
     @Test
     public void shouldGetThreadLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_NAME, VERSION);
-        final String sensorName = "sensor1";
-        final String expectedFullSensorName =
-            INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + THREAD_NAME + SENSOR_NAME_DELIMITER + sensorName;
-        final RecordingLevel recordingLevel = RecordingLevel.DEBUG;
+        final RecordingLevel recordingLevel = RecordingLevel.INFO;
+        setupGetSensorTest(metrics, THREAD_ID, recordingLevel);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+
+        final Sensor actualSensor = streamsMetrics.threadLevelSensor(THREAD_ID, sensorName1, recordingLevel);
+
+        verify(metrics);
+        assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    private void setupRemoveSensorsTest(final Metrics metrics,
+                                        final String level,
+                                        final RecordingLevel recordingLevel) {
+        final String fullSensorNamePrefix = INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER;
         final Sensor[] parents = {};
-        EasyMock.expect(metrics.sensor(expectedFullSensorName, recordingLevel, parents)).andReturn(null);
+        resetToDefault(metrics);
+        metrics.removeSensor(fullSensorNamePrefix + sensorName1);
+        metrics.removeSensor(fullSensorNamePrefix + sensorName2);
+        replay(metrics);
+    }
 
-        replayAll();
+    @Test
+    public void shouldRemoveClientLevelMetrics() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+        addSensorsOnAllLevels(metrics, streamsMetrics);
+        resetToDefault(metrics);
+        expect(metrics.removeMetric(metricName1)).andStubReturn(null);
+        expect(metrics.removeMetric(metricName2)).andStubReturn(null);
+        replay(metrics);
 
-        final Sensor sensor = streamsMetrics.threadLevelSensor(sensorName, recordingLevel);
+        streamsMetrics.removeAllClientLevelMetrics();
 
-        verifyAll();
+        verify(metrics);
+    }
 
-        assertNull(sensor);
+    @Test
+    public void shouldRemoveThreadLevelSensors() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
+        addSensorsOnAllLevels(metrics, streamsMetrics);
+        setupRemoveSensorsTest(metrics, THREAD_ID, RecordingLevel.INFO);
+
+        streamsMetrics.removeAllThreadLevelSensors(THREAD_ID);
+
+        verify(metrics);
     }
 
     @Test(expected = NullPointerException.class)
@@ -121,7 +291,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
     @Test
     public void testMultiLevelSensorRemoval() {
         final Metrics registry = new Metrics();
-        final StreamsMetricsImpl metrics = new StreamsMetricsImpl(registry, THREAD_NAME, VERSION);
+        final StreamsMetricsImpl metrics = new StreamsMetricsImpl(registry, THREAD_ID, VERSION);
         for (final MetricName defaultMetric : registry.metrics().keySet()) {
             registry.removeMetric(defaultMetric);
         }
@@ -133,39 +303,39 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
         final String processorNodeName = "processorNodeName";
         final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
 
-        final Sensor parent1 = metrics.taskLevelSensor(taskName, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent1, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation, "", "");
 
         final int numberOfTaskMetrics = registry.metrics().size();
 
-        final Sensor sensor1 = metrics.nodeLevelSensor(taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent1);
+        final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent1);
         addAvgAndMaxLatencyToSensor(sensor1, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor1, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
-        metrics.removeAllNodeLevelSensors(taskName, processorNodeName);
+        metrics.removeAllNodeLevelSensors(THREAD_ID, taskName, processorNodeName);
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor parent2 = metrics.taskLevelSensor(taskName, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent2, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent2, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation, "", "");
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor sensor2 = metrics.nodeLevelSensor(taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent2);
+        final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent2);
         addAvgAndMaxLatencyToSensor(sensor2, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor2, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
-        metrics.removeAllNodeLevelSensors(taskName, processorNodeName);
+        metrics.removeAllNodeLevelSensors(THREAD_ID, taskName, processorNodeName);
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        metrics.removeAllTaskLevelSensors(taskName);
+        metrics.removeAllTaskLevelSensors(THREAD_ID, taskName);
 
         assertThat(registry.metrics().size(), equalTo(0));
     }
@@ -231,7 +401,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
             "stream-scope-metrics",
             "",
             "client-id",
-            "",
+            Thread.currentThread().getName(),
             "scope-id",
             "entity"
         );
@@ -245,15 +415,23 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
     }
 
     @Test
+    public void shouldGetClientLevelTagMap() {
+        final Map<String, String> tagMap = streamsMetrics.clientLevelTagMap();
+
+        assertThat(tagMap.size(), equalTo(1));
+        assertThat(tagMap.get(StreamsMetricsImpl.CLIENT_ID_TAG), equalTo(CLIENT_ID));
+    }
+
+    @Test
     public void shouldGetStoreLevelTagMap() {
         final String taskName = "test-task";
         final String storeType = "remote-window";
         final String storeName = "window-keeper";
 
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskName, storeType, storeName);
+        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(THREAD_ID, taskName, storeType, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
-        assertThat(tagMap.get(StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_23), equalTo(THREAD_NAME));
+        assertThat(tagMap.get(StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_23), equalTo(THREAD_ID));
         assertThat(tagMap.get(StreamsMetricsImpl.TASK_ID_TAG), equalTo(taskName));
         assertThat(tagMap.get(storeType + "-" + StreamsMetricsImpl.STORE_ID_TAG), equalTo(storeName));
     }
@@ -270,18 +448,18 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
 
     private void shouldGetCacheLevelTagMap(final String builtInMetricsVersion) {
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, THREAD_NAME, builtInMetricsVersion);
+            new StreamsMetricsImpl(metrics, THREAD_ID, builtInMetricsVersion);
         final String taskName = "taskName";
         final String storeName = "storeName";
 
-        final Map<String, String> tagMap = streamsMetrics.cacheLevelTagMap(taskName, storeName);
+        final Map<String, String> tagMap = streamsMetrics.cacheLevelTagMap(THREAD_ID, taskName, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
         assertThat(
             tagMap.get(
                 builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? StreamsMetricsImpl.THREAD_ID_TAG
                     : StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_23),
-            equalTo(Thread.currentThread().getName())
+            equalTo(THREAD_ID)
         );
         assertThat(tagMap.get(StreamsMetricsImpl.TASK_ID_TAG), equalTo(taskName));
         assertThat(tagMap.get(StreamsMetricsImpl.RECORD_CACHE_ID_TAG), equalTo(storeName));
@@ -372,7 +550,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
     @Test
     public void shouldReturnMetricsVersionCurrent() {
         assertThat(
-            new StreamsMetricsImpl(metrics, THREAD_NAME, StreamsConfig.METRICS_LATEST).version(),
+            new StreamsMetricsImpl(metrics, THREAD_ID, StreamsConfig.METRICS_LATEST).version(),
             equalTo(Version.LATEST)
         );
     }
@@ -380,7 +558,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
     @Test
     public void shouldReturnMetricsVersionFrom100To23() {
         assertThat(
-            new StreamsMetricsImpl(metrics, THREAD_NAME, StreamsConfig.METRICS_0100_TO_23).version(),
+            new StreamsMetricsImpl(metrics, THREAD_ID, StreamsConfig.METRICS_0100_TO_23).version(),
             equalTo(Version.FROM_100_TO_23)
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -43,6 +43,7 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 @PrepareForTest(StreamsMetricsImpl.class)
 public class ThreadMetricsTest {
 
+    private static final String THREAD_ID = "thread-id";
     private static final String THREAD_LEVEL_GROUP = "stream-metrics";
     private static final String TASK_LEVEL_GROUP = "stream-task-metrics";
 
@@ -57,15 +58,15 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of newly created tasks";
         final String rateDescription = "The average per-second number of newly created tasks";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
 
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.createTaskSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.createTaskSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -79,15 +80,15 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of closed tasks";
         final String rateDescription = "The average per-second number of closed tasks";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
 
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.closeTaskSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.closeTaskSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -102,8 +103,8 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of commit calls";
         final String rateDescription = "The average per-second number of commit calls";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -112,7 +113,7 @@ public class ThreadMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.commitSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.commitSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -127,8 +128,8 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of poll calls";
         final String rateDescription = "The average per-second number of poll calls";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -137,7 +138,7 @@ public class ThreadMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.pollSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.pollSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -152,8 +153,8 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of process calls";
         final String rateDescription = "The average per-second number of process calls";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -162,7 +163,7 @@ public class ThreadMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.processSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.processSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -177,8 +178,8 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of punctuate calls";
         final String rateDescription = "The average per-second number of punctuate calls";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -187,7 +188,7 @@ public class ThreadMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.punctuateSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.punctuateSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -201,15 +202,15 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of skipped records";
         final String rateDescription = "The average per-second number of skipped records";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.INFO)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap()).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, THREAD_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
 
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.skipRecordSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.skipRecordSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);
@@ -224,8 +225,8 @@ public class ThreadMetricsTest {
         final String totalDescription = "The total number of commit calls over all tasks";
         final String rateDescription = "The average per-second number of commit calls over all tasks";
         mockStatic(StreamsMetricsImpl.class);
-        expect(streamsMetrics.threadLevelSensor(operation, RecordingLevel.DEBUG)).andReturn(dummySensor);
-        expect(streamsMetrics.threadLevelTagMap(TASK_ID_TAG, ROLLUP_VALUE)).andReturn(dummyTagMap);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(dummySensor);
+        expect(streamsMetrics.threadLevelTagMap(THREAD_ID, TASK_ID_TAG, ROLLUP_VALUE)).andReturn(dummyTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             dummySensor, TASK_LEVEL_GROUP, dummyTagMap, operation, totalDescription, rateDescription);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -234,7 +235,7 @@ public class ThreadMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = ThreadMetrics.commitOverTasksSensor(streamsMetrics);
+        final Sensor sensor = ThreadMetrics.commitOverTasksSensor(THREAD_ID, streamsMetrics);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -415,13 +415,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         LogCaptureAppender.unregister(appender);
 
         final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
+        final String threadId = Thread.currentThread().getName();
 
         final Metric dropTotal = metrics.get(new MetricName(
             "expired-window-record-drop-total",
             "stream-metrics-scope-metrics",
             "The total number of occurrence of expired-window-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("metrics-scope-id", "bytes-store")
             )
@@ -432,7 +433,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             "stream-metrics-scope-metrics",
             "The average number of occurrence of expired-window-record-drop operation per second.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry("metrics-scope-id", "bytes-store")
             )

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
@@ -39,7 +39,8 @@ import static org.junit.Assert.assertTrue;
 
 public class KeyValueSegmentTest {
 
-    private final RocksDBMetricsRecorder metricsRecorder = new RocksDBMetricsRecorder("metrics-scope", "store-name");
+    private final RocksDBMetricsRecorder metricsRecorder =
+        new RocksDBMetricsRecorder("metrics-scope", "thread-id", "store-name");
 
     @Test
     public void shouldDeleteStateDirectoryOnDestroy() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -63,7 +63,7 @@ public class MeteredKeyValueStoreTest {
 
     private final TaskId taskId = new TaskId(0, 0);
     private final Map<String, String> tags = mkMap(
-        mkEntry("client-id", "test"),
+        mkEntry("client-id", Thread.currentThread().getName()),
         mkEntry("task-id", taskId.toString()),
         mkEntry("scope-state-id", "metered")
     );
@@ -106,9 +106,9 @@ public class MeteredKeyValueStoreTest {
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "metered")));
+                "scope", Thread.currentThread().getName(), taskId.toString(), "scope", "metered")));
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "all")));
+                "scope", Thread.currentThread().getName(), taskId.toString(), "scope", "all")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -63,9 +63,10 @@ import static org.junit.Assert.assertTrue;
 @RunWith(EasyMockRunner.class)
 public class MeteredSessionStoreTest {
 
+    private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0);
     private final Map<String, String> tags = mkMap(
-        mkEntry("client-id", "test"),
+        mkEntry("client-id", threadId),
         mkEntry("task-id", taskId.toString()),
         mkEntry("scope-state-id", "metered")
     );
@@ -105,9 +106,9 @@ public class MeteredSessionStoreTest {
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "metered")));
+                "scope", threadId, taskId.toString(), "scope", "metered")));
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "all")));
+                "scope", threadId, taskId.toString(), "scope", "all")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -64,9 +64,10 @@ import static org.junit.Assert.fail;
 @RunWith(EasyMockRunner.class)
 public class MeteredTimestampedKeyValueStoreTest {
 
+    private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0);
     private final Map<String, String> tags = mkMap(
-        mkEntry("client-id", "test"),
+        mkEntry("client-id", threadId),
         mkEntry("task-id", taskId.toString()),
         mkEntry("scope-state-id", "metered")
     );
@@ -111,9 +112,9 @@ public class MeteredTimestampedKeyValueStoreTest {
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "metered")));
+                "scope", threadId, taskId.toString(), "scope", "metered")));
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", taskId.toString(), "scope", "all")));
+                "scope", threadId, taskId.toString(), "scope", "all")));
     }
     @Test
     public void shouldWriteBytesToInnerStoreAndRecordPutMetric() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -95,10 +95,11 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
         final JmxReporter reporter = new JmxReporter("kafka.streams");
         metrics.addReporter(reporter);
+        final String threadId = Thread.currentThread().getName();
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", context.taskId().toString(), "scope", "mocked-store")));
+                "scope", threadId, context.taskId().toString(), "scope", "mocked-store")));
         assertTrue(reporter.containsMbean(String.format("kafka.streams:type=stream-%s-state-metrics,client-id=%s,task-id=%s,%s-state-id=%s",
-                "scope", "test", context.taskId().toString(), "scope", "all")));
+                "scope", threadId, context.taskId().toString(), "scope", "all")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -41,7 +41,8 @@ import static org.junit.Assert.assertTrue;
 
 public class SegmentIteratorTest {
 
-    private final RocksDBMetricsRecorder rocksDBMetricsRecorder = new RocksDBMetricsRecorder("metrics-scope", "store-name");
+    private final RocksDBMetricsRecorder rocksDBMetricsRecorder =
+        new RocksDBMetricsRecorder("metrics-scope", "thread-id", "store-name");
     private final KeyValueSegment segmentOne =
         new KeyValueSegment("one", "one", 0, rocksDBMetricsRecorder);
     private final KeyValueSegment segmentTwo =

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -443,13 +443,14 @@ public abstract class SessionBytesStoreTest {
         final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
 
         final String metricScope = getMetricsScope();
+        final String threadId = Thread.currentThread().getName();
 
         final Metric dropTotal = metrics.get(new MetricName(
             "expired-window-record-drop-total",
             "stream-" + metricScope + "-metrics",
             "The total number of occurrence of expired-window-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry(metricScope + "-id", sessionStore.name())
             )
@@ -460,7 +461,7 @@ public abstract class SessionBytesStoreTest {
             "stream-" + metricScope + "-metrics",
             "The average number of occurrence of expired-window-record-drop operation per second.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry(metricScope + "-id", sessionStore.name())
             )

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
@@ -39,7 +39,8 @@ import static org.junit.Assert.assertTrue;
 
 public class TimestampedSegmentTest {
 
-    private final RocksDBMetricsRecorder metricsRecorder = new RocksDBMetricsRecorder("metrics-scope", "store-name");
+    private final RocksDBMetricsRecorder metricsRecorder =
+        new RocksDBMetricsRecorder("metrics-scope", "thread-id", "store-name");
 
     @Test
     public void shouldDeleteStateDirectoryOnDestroy() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
@@ -892,13 +892,14 @@ public abstract class WindowBytesStoreTest {
         final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
 
         final String metricScope = getMetricsScope();
+        final String threadId = Thread.currentThread().getName();
 
         final Metric dropTotal = metrics.get(new MetricName(
             "expired-window-record-drop-total",
             "stream-" + metricScope + "-metrics",
             "The total number of occurrence of expired-window-record-drop operations.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry(metricScope + "-id", windowStore.name())
             )
@@ -909,7 +910,7 @@ public abstract class WindowBytesStoreTest {
             "stream-" + metricScope + "-metrics",
             "The average number of occurrence of expired-window-record-drop operation per second.",
             mkMap(
-                mkEntry("client-id", "mock"),
+                mkEntry("client-id", threadId),
                 mkEntry("task-id", "0_0"),
                 mkEntry(metricScope + "-id", windowStore.name())
             )

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -43,7 +43,8 @@ import static org.powermock.api.easymock.PowerMock.verify;
 @PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
 public class NamedCacheMetricsTest {
 
-    private static final String TASK_NAME = "taskName";
+    private static final String THREAD_ID = "test-thread";
+    private static final String TASK_ID = "test-task";
     private static final String STORE_NAME = "storeName";
     private static final String HIT_RATIO_AVG_DESCRIPTION = "The average cache hit ratio";
     private static final String HIT_RATIO_MIN_DESCRIPTION = "The minimum cache hit ratio";
@@ -61,7 +62,7 @@ public class NamedCacheMetricsTest {
         replay(streamsMetrics);
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, TASK_NAME, STORE_NAME);
+        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, THREAD_ID, TASK_ID, STORE_NAME);
 
         verifyResult(sensor);
     }
@@ -73,8 +74,9 @@ public class NamedCacheMetricsTest {
         final RecordingLevel recordingLevel = RecordingLevel.DEBUG;
         mockStatic(StreamsMetricsImpl.class);
         final Sensor parentSensor = mock(Sensor.class);
-        expect(streamsMetrics.taskLevelSensor(TASK_NAME, hitRatio, recordingLevel)).andReturn(parentSensor);
-        expect(streamsMetrics.cacheLevelTagMap(TASK_NAME, StreamsMetricsImpl.ROLLUP_VALUE)).andReturn(parentTagMap);
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, hitRatio, recordingLevel)).andReturn(parentSensor);
+        expect(streamsMetrics.cacheLevelTagMap(THREAD_ID, TASK_ID, StreamsMetricsImpl.ROLLUP_VALUE))
+            .andReturn(parentTagMap);
         StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
             parentSensor,
             StreamsMetricsImpl.CACHE_LEVEL_GROUP,
@@ -87,7 +89,7 @@ public class NamedCacheMetricsTest {
         replay(streamsMetrics);
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, TASK_NAME, STORE_NAME);
+        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, THREAD_ID, TASK_ID, STORE_NAME);
 
         verifyResult(sensor);
     }
@@ -96,9 +98,9 @@ public class NamedCacheMetricsTest {
                                      final String hitRatio,
                                      final Sensor... parents) {
         expect(streamsMetrics.version()).andReturn(builtInMetricsVersion);
-        expect(streamsMetrics.cacheLevelSensor(TASK_NAME, STORE_NAME, hitRatio, RecordingLevel.DEBUG, parents))
+        expect(streamsMetrics.cacheLevelSensor(THREAD_ID, TASK_ID, STORE_NAME, hitRatio, RecordingLevel.DEBUG, parents))
             .andReturn(expectedSensor);
-        expect(streamsMetrics.cacheLevelTagMap(TASK_NAME, STORE_NAME)).andReturn(tagMap);
+        expect(streamsMetrics.cacheLevelTagMap(THREAD_ID, TASK_ID, STORE_NAME)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
             expectedSensor,
             StreamsMetricsImpl.CACHE_LEVEL_GROUP,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -47,6 +47,7 @@ import static org.powermock.api.easymock.PowerMock.verify;
 @PrepareForTest({RocksDBMetrics.class, Sensor.class})
 public class RocksDBMetricsRecorderTest {
     private final static String METRICS_SCOPE = "metrics-scope";
+    private final static String THREAD_ID = "thread-id";
     private final static String STORE_NAME = "store-name";
     private final static String SEGMENT_STORE_NAME_1 = "segment-store-name-1";
     private final static String SEGMENT_STORE_NAME_2 = "segment-store-name-2";
@@ -72,7 +73,7 @@ public class RocksDBMetricsRecorderTest {
     private final TaskId taskId1 = new TaskId(0, 0);
     private final TaskId taskId2 = new TaskId(0, 2);
 
-    private final RocksDBMetricsRecorder recorder = new RocksDBMetricsRecorder(METRICS_SCOPE, STORE_NAME);
+    private final RocksDBMetricsRecorder recorder = new RocksDBMetricsRecorder(METRICS_SCOPE, THREAD_ID, STORE_NAME);
 
     @Before
     public void setUp() {
@@ -327,7 +328,7 @@ public class RocksDBMetricsRecorderTest {
     private void setUpMetricsMock() {
         mockStatic(RocksDBMetrics.class);
         final RocksDBMetricContext metricsContext =
-            new RocksDBMetricContext(taskId1.toString(), METRICS_SCOPE, STORE_NAME);
+            new RocksDBMetricContext(THREAD_ID, taskId1.toString(), METRICS_SCOPE, STORE_NAME);
         expect(RocksDBMetrics.bytesWrittenToDatabaseSensor(eq(streamsMetrics), eq(metricsContext)))
             .andReturn(bytesWrittenToDatabaseSensor);
         expect(RocksDBMetrics.bytesReadFromDatabaseSensor(eq(streamsMetrics), eq(metricsContext)))

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -44,9 +44,10 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 public class RocksDBMetricsTest {
 
     private static final String STATE_LEVEL_GROUP = "stream-state-metrics";
-    private final String taskName = "task";
-    private final String storeType = "test-state-id";
-    private final String storeName = "store";
+    private static final String THREAD_ID = "test-thread";
+    private static final String TASK_ID = "test-task";
+    private static final String STORE_TYPE = "test-store-type";
+    private static final String STORE_NAME = "store";
     private final Metrics metrics = new Metrics();
     private final Sensor sensor = metrics.sensor("dummy");
     private final StreamsMetricsImpl streamsMetrics = createStrictMock(StreamsMetricsImpl.class);
@@ -267,15 +268,17 @@ public class RocksDBMetricsTest {
     private void setupStreamsMetricsMock(final String metricNamePrefix) {
         mockStatic(StreamsMetricsImpl.class);
         expect(streamsMetrics.storeLevelSensor(
-            taskName,
-            storeName,
+            THREAD_ID,
+            TASK_ID,
+            STORE_NAME,
             metricNamePrefix,
             RecordingLevel.DEBUG
         )).andReturn(sensor);
         expect(streamsMetrics.storeLevelTagMap(
-            taskName,
-            storeType,
-            storeName
+            THREAD_ID,
+            TASK_ID,
+            STORE_TYPE,
+            STORE_NAME
         )).andReturn(tags);
     }
 
@@ -284,7 +287,7 @@ public class RocksDBMetricsTest {
         replay(StreamsMetricsImpl.class);
 
         final Sensor sensor =
-            sensorCreator.sensor(streamsMetrics, new RocksDBMetricContext(taskName, storeType, storeName));
+            sensorCreator.sensor(streamsMetrics, new RocksDBMetricContext(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME));
 
         verifyAll();
         verify(StreamsMetricsImpl.class);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -280,24 +280,25 @@ public class TopologyTestDriver implements Closeable {
 
         metrics = new Metrics(metricConfig, mockWallClockTime);
 
-        final String threadName = "topology-test-driver-virtual-thread";
+        final String threadId = Thread.currentThread().getName();
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,
-            threadName,
+            "test-client",
             StreamsConfig.METRICS_LATEST
         );
         streamsMetrics.setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
-        final Sensor skippedRecordsSensor = streamsMetrics.threadLevelSensor("skipped-records", Sensor.RecordingLevel.INFO);
+        final Sensor skippedRecordsSensor =
+            streamsMetrics.threadLevelSensor(threadId, "skipped-records", Sensor.RecordingLevel.INFO);
         final String threadLevelGroup = "stream-metrics";
         skippedRecordsSensor.add(new MetricName("skipped-records-rate",
                                                 threadLevelGroup,
                                                 "The average per-second number of skipped records",
-                                                streamsMetrics.tagMap()),
+                                                streamsMetrics.tagMap(threadId)),
                                  new Rate(TimeUnit.SECONDS, new WindowedCount()));
         skippedRecordsSensor.add(new MetricName("skipped-records-total",
                                                 threadLevelGroup,
                                                 "The total number of skipped records",
-                                                streamsMetrics.tagMap()),
+                                                streamsMetrics.tagMap(threadId)),
                                  new CumulativeSum());
         final ThreadCache cache = new ThreadCache(
             new LogContext("topology-test-driver "),

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -213,9 +213,9 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
         this.stateDir = stateDir;
         final MetricConfig metricConfig = new MetricConfig();
         metricConfig.recordLevel(Sensor.RecordingLevel.DEBUG);
-        final String threadName = "mock-processor-context-virtual-thread";
-        this.metrics = new StreamsMetricsImpl(new Metrics(metricConfig), threadName, StreamsConfig.METRICS_LATEST);
-        ThreadMetrics.skipRecordSensor(metrics);
+        final String threadId = Thread.currentThread().getName();
+        this.metrics = new StreamsMetricsImpl(new Metrics(metricConfig), threadId, StreamsConfig.METRICS_LATEST);
+        ThreadMetrics.skipRecordSensor(threadId, metrics);
     }
 
     @Override


### PR DESCRIPTION
- Moves `StreamsMetricsImpl` from `StreamThread` to `KafkaStreams`
- Adds instance-level metrics as specified in KIP-444, i.e.:
-- version
-- commit-id
-- application-id
-- topology-description
-- state

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
