### PR TITLE
MINOR: Shutdown RockDB metrics recording trigger thread

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -141,7 +141,7 @@ public class KafkaStreams implements AutoCloseable {
     private final StateDirectory stateDirectory;
     private final StreamsMetadataState streamsMetadataState;
     private final ScheduledExecutorService stateDirCleaner;
-    private ScheduledExecutorService rocksDBMetricsRecordingTriggerThread;
+    private final ScheduledExecutorService rocksDBMetricsRecordingService;
     private final QueryableStoreProvider queryableStoreProvider;
     private final Admin adminClient;
 
@@ -763,11 +763,11 @@ public class KafkaStreams implements AutoCloseable {
             return thread;
         });
 
-        rocksDBMetricsRecordingTriggerThread = maybeGetRocksDBMetricsRecordingTriggerThread(clientId, config);
+        rocksDBMetricsRecordingService = maybeCreateRocksDBMetricsRecordingService(clientId, config);
     }
 
-    private static ScheduledExecutorService maybeGetRocksDBMetricsRecordingTriggerThread(final String clientId,
-                                                                                         final StreamsConfig config) {
+    private static ScheduledExecutorService maybeCreateRocksDBMetricsRecordingService(final String clientId,
+                                                                                      final StreamsConfig config) {
         if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
             return Executors.newSingleThreadScheduledExecutor(r -> {
                 final Thread thread = new Thread(r, clientId + "-RocksDBMetricsRecordingTrigger");
@@ -833,8 +833,8 @@ public class KafkaStreams implements AutoCloseable {
 
             final long recordingDelay = 0;
             final long recordingInterval = 1;
-            if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
-                rocksDBMetricsRecordingTriggerThread.scheduleAtFixedRate(
+            if (rocksDBMetricsRecordingService != null) {
+                rocksDBMetricsRecordingService.scheduleAtFixedRate(
                     rocksDBMetricsRecordingTrigger,
                     recordingDelay,
                     recordingInterval,
@@ -889,6 +889,9 @@ public class KafkaStreams implements AutoCloseable {
             log.info("Already in the pending shutdown state, wait to complete shutdown");
         } else {
             stateDirCleaner.shutdownNow();
+            if (rocksDBMetricsRecordingService != null) {
+                rocksDBMetricsRecordingService.shutdownNow();
+            }
 
             // wait for all threads to join in a separate thread;
             // save the current thread so that if it is a stream thread
@@ -929,9 +932,6 @@ public class KafkaStreams implements AutoCloseable {
                 setState(State.NOT_RUNNING);
             }, "kafka-streams-close-thread");
 
-            if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
-                rocksDBMetricsRecordingTriggerThread.shutdownNow();
-            }
             shutdownThread.setDaemon(true);
             shutdownThread.start();
         }


### PR DESCRIPTION
- added shutdown for thread that triggers recording of RocksDBMetrics
- added unit tests to verify the start and shutdown of the thread
- refactored a bit of code

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
