### PR TITLE
KAFKA-5609: Connect log4j should also log to a file by default (KIP-521)

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -15,16 +15,20 @@
 
 log4j.rootLogger=INFO, stdout, connectAppender
 
-
+# Send the logs to the console.
+#
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 
+# Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
+# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
+# and copied in the same directory but with a filename that ends in the `DatePattern` option.
+#
 log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
 log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
 
-#
 # The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
 # in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
 # specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.

--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -13,19 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, stdout, connectAppender
 
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
 
 #
 # The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
 # in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
 # specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
 #
-#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+connect.log.pattern=[%d] %p %m (%c:%L)%n
+#connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
 
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR


### PR DESCRIPTION
Enable Kafka Connect to redirect log4j messages to a file by default, additionally to the redirection to standard output. The file-based log4j export is set to be daily and shares the same pattern with the stdout appender. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
