### PR TITLE
KAFKA-8671: NullPointerException occurs if topic associated with GlobalKTable changes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -131,18 +131,18 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         }
 
         final List<StateStore> stateStores = topology.globalStateStores();
-        final Map<String, String> storeNameToTopic = topology.storeToChangelogTopic();
-        final Set<String> stateStoreTopics = new HashSet<>();
+        final Map<String, String> storeNameToChangelog = topology.storeToChangelogTopic();
+        final Set<String> changelogTopics = new HashSet<>();
         for (final StateStore stateStore : stateStores) {
             globalStoreNames.add(stateStore.name());
-            final String sourceTopic = storeNameToTopic.get(stateStore.name());
-            stateStoreTopics.add(sourceTopic);
+            final String sourceTopic = storeNameToChangelog.get(stateStore.name());
+            changelogTopics.add(sourceTopic);
             stateStore.init(globalProcessorContext, stateStore);
         }
 
         // make sure each topic-partition from checkpointFileCache is associated with a global state store
         checkpointFileCache.keySet().forEach(tp -> {
-            if (!stateStoreTopics.contains(tp.topic())) {
+            if (!changelogTopics.contains(tp.topic())) {
                 log.error("Encountered a topic-partition in the global checkpoint file not associated with any global" +
                     " state store, topic-partition: {}, checkpoint file: {}. If this topic-partition is no longer valid," +
                     " an application reset and state store directory cleanup will be required.",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -171,6 +171,28 @@ public class GlobalStateManagerImplTest {
         assertEquals(expected, offsets);
     }
 
+    @Test(expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionForOldTopicPartitions() throws IOException {
+        final HashMap<TopicPartition, Long> expectedOffsets = new HashMap<>();
+        expectedOffsets.put(t1, 1L);
+        expectedOffsets.put(t2, 1L);
+        expectedOffsets.put(t3, 1L);
+        expectedOffsets.put(t4, 1L);
+
+        // add an old topic (a topic not associated with any global state store)
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>(expectedOffsets);
+        final TopicPartition tOld = new TopicPartition("oldTopic", 1);
+        startOffsets.put(tOld, 1L);
+
+        // start with a checkpoint file will all topic-partitions: expected and old (not
+        // associated with any global state store).
+        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
+        checkpoint.write(startOffsets);
+
+        // initialize will throw exception
+        stateManager.initialize();
+    }
+
     @Test
     public void shouldNotDeleteCheckpointFileAfterLoaded() throws IOException {
         writeCheckpoint();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -64,7 +64,11 @@ import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class GlobalStateManagerImplTest {
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -191,7 +191,7 @@ public class GlobalStateManagerImplTest {
         checkpoint.write(startOffsets);
 
         // initialize will throw exception
-        StreamsException e = assertThrows(StreamsException.class, () -> stateManager.initialize());
+        final StreamsException e = assertThrows(StreamsException.class, () -> stateManager.initialize());
         assertThat(e.getMessage(), equalTo("Encountered a topic-partition not associated with any global state store"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -64,10 +64,7 @@ import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class GlobalStateManagerImplTest {
 
@@ -171,7 +168,7 @@ public class GlobalStateManagerImplTest {
         assertEquals(expected, offsets);
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionForOldTopicPartitions() throws IOException {
         final HashMap<TopicPartition, Long> expectedOffsets = new HashMap<>();
         expectedOffsets.put(t1, 1L);
@@ -190,7 +187,8 @@ public class GlobalStateManagerImplTest {
         checkpoint.write(startOffsets);
 
         // initialize will throw exception
-        stateManager.initialize();
+        StreamsException e = assertThrows(StreamsException.class, () -> stateManager.initialize());
+        assertThat(e.getMessage(), equalTo("Encountered a topic-partition not associated with any global state store"));
     }
 
     @Test


### PR DESCRIPTION
A NullPointerException occurs when the global/.checkpoint file contains a line with an obsolete (but valid) topic. Log an error and throw exception when non-relevant topic-partitions from checkpoint file are encountered.

Added a unit test to verify that non-relevant topics are detected and an exception is thrown. Also, manually ran a streams application with a modified global/.checkpoint file containing an obsolete topic partition and verified that the error is logged and initialization fails.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
