### PR TITLE
MINOR: Fix stale comment in partition reassignment javadoc

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -562,8 +562,8 @@ class KafkaController(val config: KafkaConfig,
    *   . OVRS denotes the overlapping replica set - replicas which are part of the AR of the ongoing reassignment and will be part of the overriding reassignment
    *       (it is essentially (RS - ORS) - URS)
    *
-   *   1 Set RS = ORS + OVRS, AR = OVRS, RS = [] in memory
-   *   2 Send LeaderAndIsr request with RS = ORS + OVRS, AR = OVRS, RS = [] to all brokers in ORS + OVRS
+   *   1 Set RS = ORS + OVRS, AR = OVRS, RR = [] in memory
+   *   2 Send LeaderAndIsr request with RS = ORS + OVRS, AR = OVRS, RR = [] to all brokers in ORS + OVRS
    *     (because the ongoing reassignment is in phase A, we know we wouldn't have a leader in URS
    *      unless a preferred leader election was triggered while the reassignment was happening)
    *   3 Replicas in URS -> Offline (force those replicas out of ISR)

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -563,7 +563,7 @@ class KafkaController(val config: KafkaConfig,
    *       (it is essentially (RS - ORS) - URS)
    *
    *   1 Set RS = ORS + OVRS, AR = OVRS, RS = [] in memory
-   *   2 Send LeaderAndIsr request with RS = ORS + OVRS, AR = [], RS = [] to all brokers in ORS + OVRS
+   *   2 Send LeaderAndIsr request with RS = ORS + OVRS, AR = OVRS, RS = [] to all brokers in ORS + OVRS
    *     (because the ongoing reassignment is in phase A, we know we wouldn't have a leader in URS
    *      unless a preferred leader election was triggered while the reassignment was happening)
    *   3 Replicas in URS -> Offline (force those replicas out of ISR)


### PR DESCRIPTION
During the cleanup phase of an overriding reassignment, we failed to mention that we still add replicas in the adding_replicas field for the initial LeaderAndIsr request