### PR TITLE
MINOR: Fix static membership link in Streams upgrade notes

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -259,7 +259,7 @@
 
     <p>
         We are introducing static membership towards Kafka Streams user. This feature reduces unnecessary rebalances during normal application upgrades or rolling bounces.
-        For more details on how to use it, checkout <a href="/{{version}}/design/#static_membership">static membership design</a>.
+        For more details on how to use it, checkout <a href="/{{version}}/documentation/#static_membership">static membership design</a>.
         Note, Kafka Streams uses the same <code>ConsumerConfig#GROUP_INSTANCE_ID_CONFIG</code>, and you only need to make sure it is uniquely defined across
         different stream instances in one application.
     </p>


### PR DESCRIPTION
Fix broken link in Streams docs.
Same as https://github.com/apache/kafka/commit/11337afecb9a4fd0b993402c5195ef33dbd7a539#diff-8100f2416b657c1e1e4238dabf8a15e0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
