### PR TITLE
KAFKA-8969 Log the partition being made online due to unclean leader election.

### DIFF
--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -42,9 +42,9 @@ object Election extends Logging {
         val newLeaderAndIsrOpt = leaderOpt.map { case (leader, uncleanElection) =>
           if (uncleanElection) {
             controllerContext.stats.uncleanLeaderElectionRate.mark()
-            warn(s"Unclean leader election. Partition $partition has been assigned leader $leader from deposed " +
+            info(s"Unclean leader election. Partition $partition has been assigned leader $leader from deposed " +
               s"leader ${leaderAndIsr.leader}.")
-            }
+          }
           val newIsr = if (isr.contains(leader)) isr.filter(replica => controllerContext.isReplicaOnline(replica, partition))
           else List(leader)
           leaderAndIsr.newLeaderAndIsr(leader, newIsr)

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -17,13 +17,14 @@
 package kafka.controller
 
 import kafka.api.LeaderAndIsr
+import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.Seq
 
 case class ElectionResult(topicPartition: TopicPartition, leaderAndIsr: Option[LeaderAndIsr], liveReplicas: Seq[Int])
 
-object Election {
+object Election extends Logging {
 
   private def leaderForOffline(partition: TopicPartition,
                                leaderAndIsrOpt: Option[LeaderAndIsr],
@@ -32,12 +33,18 @@ object Election {
 
     val assignment = controllerContext.partitionReplicaAssignment(partition)
     val liveReplicas = assignment.filter(replica => controllerContext.isReplicaOnline(replica, partition))
+
     leaderAndIsrOpt match {
       case Some(leaderAndIsr) =>
         val isr = leaderAndIsr.isr
         val leaderOpt = PartitionLeaderElectionAlgorithms.offlinePartitionLeaderElection(
-          assignment, isr, liveReplicas.toSet, uncleanLeaderElectionEnabled, controllerContext)
-        val newLeaderAndIsrOpt = leaderOpt.map { leader =>
+          assignment, isr, liveReplicas.toSet, uncleanLeaderElectionEnabled)
+        val newLeaderAndIsrOpt = leaderOpt.map { case (leader, uncleanElection) =>
+          if (uncleanElection) {
+            controllerContext.stats.uncleanLeaderElectionRate.mark()
+            warn(s"Unclean leader election. Partition $partition has been assigned leader $leader from deposed " +
+              s"leader ${leaderAndIsr.leader}.")
+            }
           val newIsr = if (isr.contains(leader)) isr.filter(replica => controllerContext.isReplicaOnline(replica, partition))
           else List(leader)
           leaderAndIsr.newLeaderAndIsr(leader, newIsr)

--- a/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
@@ -20,13 +20,6 @@ import org.junit.Assert._
 import org.junit.{Before, Test}
 
 class PartitionLeaderElectionAlgorithmsTest {
-  private var controllerContext: ControllerContext = null
-
-  @Before
-  def setUp(): Unit = {
-    controllerContext = new ControllerContext
-    controllerContext.stats.removeMetric("UncleanLeaderElectionsPerSec")
-  }
 
   @Test
   def testOfflinePartitionLeaderElection(): Unit = {
@@ -36,9 +29,8 @@ class PartitionLeaderElectionAlgorithmsTest {
     val leaderOpt = PartitionLeaderElectionAlgorithms.offlinePartitionLeaderElection(assignment,
       isr,
       liveReplicas,
-      uncleanLeaderElectionEnabled = false,
-      controllerContext)
-    assertEquals(Option(4), leaderOpt)
+      uncleanLeaderElectionEnabled = false)
+    assertEquals(Option(4, false), leaderOpt)
   }
 
   @Test
@@ -49,10 +41,8 @@ class PartitionLeaderElectionAlgorithmsTest {
     val leaderOpt = PartitionLeaderElectionAlgorithms.offlinePartitionLeaderElection(assignment,
       isr,
       liveReplicas,
-      uncleanLeaderElectionEnabled = false,
-      controllerContext)
+      uncleanLeaderElectionEnabled = false)
     assertEquals(None, leaderOpt)
-    assertEquals(0, controllerContext.stats.uncleanLeaderElectionRate.count())
   }
 
   @Test
@@ -63,10 +53,8 @@ class PartitionLeaderElectionAlgorithmsTest {
     val leaderOpt = PartitionLeaderElectionAlgorithms.offlinePartitionLeaderElection(assignment,
       isr,
       liveReplicas,
-      uncleanLeaderElectionEnabled = true,
-      controllerContext)
-    assertEquals(Option(4), leaderOpt)
-    assertEquals(1, controllerContext.stats.uncleanLeaderElectionRate.count())
+      uncleanLeaderElectionEnabled = true)
+    assertEquals(Option(4, true), leaderOpt)
   }
 
   @Test


### PR DESCRIPTION
Minor refactor to PartitionLeaderElectionAlgorithms and Election to move side effects outside of PartitionLeaderElectionAlgorithms and into higher level Election.

Added a unit test to the PartitionStateMachine to verify that unclean leader election correctly assigns a partition and increments the ule metric.
