### PR TITLE
KAFKA-8991: Enable scalac optimizer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -419,6 +419,22 @@ subprojects {
         "-Xlint:constant",
         "-Xlint:unused"
       ]
+
+      // Inline more aggressively when compiling the `core` jar since it's not meant to be used as a library.
+      // More specifically, inline classes from the Scala library so that we can inline methods like `Option.exists`
+      // and avoid lambda allocations. This is only safe if the Scala library version is the same at compile time
+      // and runtime. We cannot guarantee this for libraries like kafka streams, so only inline classes from the
+      // Kafka project in that case.
+      List<String> inlineFrom
+      if (project.name.equals('core'))
+        inlineFrom = ["-opt-inline-from:scala.**", "-opt-inline-from:kafka.**", "-opt-inline-from:org.apache.kafka.**"]
+      else
+        inlineFrom = ["-opt-inline-from:org.apache.kafka.**"]
+
+      // Somewhat confusingly, `-opt:l:inline` enables all optimizations. `inlineFrom` configures what can be inlined.
+      // See https://www.lightbend.com/blog/scala-inliner-optimizer for more information about the optimizer.
+      scalaCompileOptions.additionalParameters += ["-opt:l:inline"]
+      scalaCompileOptions.additionalParameters += inlineFrom
     }
     
   // these options are valid for Scala versions < 2.13 only

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -405,8 +405,8 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
 
   private def compareIndexEntry(indexEntry: IndexEntry, target: Long, searchEntity: IndexSearchEntity): Int = {
     searchEntity match {
-      case IndexSearchType.KEY => indexEntry.indexKey.compareTo(target)
-      case IndexSearchType.VALUE => indexEntry.indexValue.compareTo(target)
+      case IndexSearchType.KEY => java.lang.Long.compare(indexEntry.indexKey, target)
+      case IndexSearchType.VALUE => java.lang.Long.compare(indexEntry.indexValue, target)
     }
   }
 

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -104,10 +104,8 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- Suppression for the equals() for extensiom methods. -->
-        <Or>
-            <Class name="kafka.api.package$ElectLeadersRequestOps"/>
-        </Or>
+        <!-- Suppression for the equals() for extension methods. -->
+        <Class name="kafka.api.package$ElectLeadersRequestOps"/>
         <Bug pattern="EQ_UNUSUAL"/>
     </Match>
 
@@ -116,6 +114,24 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Source name="Json.scala"/>
         <Package name="kafka.utils"/>
         <Bug pattern="BC_VACUOUS_INSTANCEOF"/>
+    </Match>
+
+    <Match>
+        <!-- A spurious null check after inlining by the scalac optimizer confuses spotBugs -->
+        <Class name="kafka.log.Log"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION"/>
+    </Match>
+
+    <Match>
+        <!-- A spurious null check after inlining by the scalac optimizer confuses spotBugs -->
+        <Class name="kafka.tools.StateChangeLogMerger$"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
+
+    <Match>
+        <!-- Unboxing to Int to make scalac happy makes spotBugs unhappy -->
+        <Class name="kafka.tools.ConsoleConsumer$ConsumerConfig"/>
+        <Bug pattern="BX_UNBOXING_IMMEDIATELY_REBOXED"/>
     </Match>
 
     <Match>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -135,6 +135,41 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="AdminUtils.scala"/>
+        <Package name="kafka.admin"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+    </Match>
+
+    <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="ControllerContext.scala"/>
+        <Package name="kafka.controller"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+    </Match>
+
+    <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="LogManager.scala"/>
+        <Package name="kafka.log"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+    </Match>
+
+    <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="DelayedElectLeader.scala"/>
+        <Package name="kafka.server"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+    </Match>
+
+    <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="AdminZkClient.scala"/>
+        <Package name="kafka.zk"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+    </Match>
+
+    <Match>
         <!-- Suppress a warning about some static initializers in Schema using instances of a
              subclass. -->
         <Or>


### PR DESCRIPTION
The scalac optimizer is able to inline methods to avoid lambda allocations, eliminating
the runtime cost of higher order functions in many cases. The compilation parameters
we are using here were introduced in 2.12.x, so we don't enable them for Scala 2.11.
Also, we enable a more aggressive inlining policy for the `core` project since it's
not meant to be used as a library.

See https://www.lightbend.com/blog/scala-inliner-optimizer for more information about
the optimizer.

I verified that the lambda allocation in the code below (from LogCleaner.scala) went away
after this change with Scala 2.12 and 2.13.

```scala
private def consumeAbortedTxnsUpTo(offset: Long): Unit = {
  while (abortedTransactions.headOption.exists(_.firstOffset <= offset)) {
    val abortedTxn = abortedTransactions.dequeue()
    ongoingAbortedTxns.getOrElseUpdate(abortedTxn.producerId, new AbortedTransactionMetadata(abortedTxn))
  }
}
```

The relevant part of the bytecode when compiled with Scala 2.13 looks like:

```text
private void consumeAbortedTxnsUpTo(long);
    Code:
       0: aload_0
       1: invokespecial #54                 // Method abortedTransactions:()Lscala/collection/mutable/PriorityQueue;
       4: invokevirtual #175                // Method scala/collection/mutable/PriorityQueue.headOption:()Lscala/Option;
       7: dup
       8: ifnonnull     13
      11: aconst_null
      12: athrow
      13: astore        4
      15: aload         4
      17: invokevirtual #145                // Method scala/Option.isEmpty:()Z
      20: ifne          48
      23: aload         4
      25: invokevirtual #148                // Method scala/Option.get:()Ljava/lang/Object;
      28: checkcast     #177                // class kafka/log/AbortedTxn
```

The increased inlining causes some spurious spotBugs warnings, I added a few suppressions
and fixed one warning by avoiding unnecessary boxing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
