### PR TITLE
KAFKA-8997; Make Errors a first class type in the auto-generated protocol.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -852,10 +852,10 @@ public class NetworkClient implements KafkaClient {
     private void handleApiVersionsResponse(List<ClientResponse> responses,
                                            InFlightRequest req, long now, ApiVersionsResponse apiVersionsResponse) {
         final String node = req.destination;
-        if (apiVersionsResponse.data.errorCode() != Errors.NONE.code()) {
-            if (req.request.version() == 0 || apiVersionsResponse.data.errorCode() != Errors.UNSUPPORTED_VERSION.code()) {
+        if (apiVersionsResponse.data.errorCode() != Errors.NONE) {
+            if (req.request.version() == 0 || apiVersionsResponse.data.errorCode() != Errors.UNSUPPORTED_VERSION) {
                 log.warn("Received error {} from node {} when making an ApiVersionsRequest with correlation id {}. Disconnecting.",
-                        Errors.forCode(apiVersionsResponse.data.errorCode()), node, req.header.correlationId());
+                        apiVersionsResponse.data.errorCode(), node, req.header.correlationId());
                 this.selector.close(node);
                 processDisconnection(responses, node, now, ChannelState.LOCAL_CLOSE);
             } else {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -56,4 +56,8 @@ public interface Readable {
     default UUID readUUID() {
         return new UUID(readLong(), readLong());
     }
+
+    default Errors readErrors() {
+        return Errors.forCode(readShort());
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Writable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Writable.java
@@ -33,4 +33,8 @@ public interface Writable {
         writeLong(uuid.getMostSignificantBits());
         writeLong(uuid.getLeastSignificantBits());
     }
+
+    default void writeErrors(Errors error) {
+        writeShort(error.code());
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Field.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Field.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import org.apache.kafka.common.protocol.Errors;
+
 public class Field {
     public final String name;
     public final String docString;
@@ -82,6 +84,16 @@ public class Field {
 
         public UUID(String name, String docString, UUID defaultValue) {
             super(name, Type.UUID, docString, true, defaultValue);
+        }
+    }
+
+    public static class Errors extends Field {
+        public Errors(String name, String docString) {
+            super(name, Type.ERRORS, docString, false, null);
+        }
+
+        public Errors(String name, String docString, org.apache.kafka.common.protocol.Errors defaultValue) {
+            super(name, Type.ERRORS, docString, true, defaultValue);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import org.apache.kafka.common.protocol.types.Field.Errors;
 import org.apache.kafka.common.record.BaseRecords;
 
 import java.nio.ByteBuffer;
@@ -93,6 +94,10 @@ public class Struct {
         return getUUID(field.name);
     }
 
+    public org.apache.kafka.common.protocol.Errors get(Errors field) {
+        return getErrors(field.name);
+    }
+
     public Short get(Field.Int16 field) {
         return getShort(field.name);
     }
@@ -126,6 +131,13 @@ public class Struct {
     public UUID getOrElse(Field.UUID field, UUID alternative) {
         if (hasField(field.name))
             return getUUID(field.name);
+        return alternative;
+    }
+
+    public org.apache.kafka.common.protocol.Errors getOrElse(
+        Errors field, org.apache.kafka.common.protocol.Errors alternative) {
+        if (hasField(field.name))
+            return getErrors(field.name);
         return alternative;
     }
 
@@ -288,6 +300,14 @@ public class Struct {
         return (Boolean) get(name);
     }
 
+    public org.apache.kafka.common.protocol.Errors getErrors(BoundField field) {
+        return (org.apache.kafka.common.protocol.Errors) get(field);
+    }
+
+    public org.apache.kafka.common.protocol.Errors getErrors(String name) {
+        return (org.apache.kafka.common.protocol.Errors) get(name);
+    }
+
     public ByteBuffer getBytes(BoundField field) {
         Object result = get(field);
         if (result instanceof byte[])
@@ -362,6 +382,10 @@ public class Struct {
     }
 
     public Struct set(Field.UUID def, UUID value) {
+        return set(def.name, value);
+    }
+
+    public Struct set(Errors def, org.apache.kafka.common.protocol.Errors value) {
         return set(def.name, value);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.protocol.types;
 
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
@@ -326,6 +327,43 @@ public abstract class Type {
         public String documentation() {
             return "Represents an integer between -2<sup>63</sup> and 2<sup>63</sup>-1 inclusive. " +
                     "The values are encoded using eight bytes in network byte order (big-endian).";
+        }
+    };
+
+    public static final DocumentedType ERRORS = new DocumentedType() {
+        @Override
+        public void write(ByteBuffer buffer, Object o) {
+            Errors error = (Errors) o;
+            buffer.putShort(error.code());
+        }
+
+        @Override
+        public Object read(ByteBuffer buffer) {
+            return Errors.forCode(buffer.getShort());
+        }
+
+        @Override
+        public int sizeOf(Object o) {
+            return 2;
+        }
+
+        @Override
+        public String typeName() {
+            return "ERRORS";
+        }
+
+        @Override
+        public Errors validate(Object item) {
+            if (item instanceof Errors)
+                return (Errors) item;
+            else
+                throw new SchemaException(item + " is not an Errors.");
+        }
+
+        @Override
+        public String documentation() {
+            return "Represents a org.apache.kafka.common.protocol.Errors. " +
+                "The values are encoded using two bytes in network byte order (big-endian).";
         }
     };
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -103,7 +103,7 @@ public class ApiVersionsRequest extends AbstractRequest {
     @Override
     public ApiVersionsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ApiVersionsResponseData data = new ApiVersionsResponseData()
-            .setErrorCode(Errors.forException(e).code());
+            .setErrorCode(Errors.forException(e));
 
         if (version() >= 1) {
             data.setThrottleTimeMs(throttleTimeMs);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -64,7 +64,7 @@ public class ApiVersionsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(Errors.forCode(this.data.errorCode()));
+        return errorCounts(this.data.errorCode());
     }
 
     @Override
@@ -133,7 +133,7 @@ public class ApiVersionsResponse extends AbstractResponse {
 
         ApiVersionsResponseData data = new ApiVersionsResponseData();
         data.setThrottleTimeMs(throttleTimeMs);
-        data.setErrorCode(Errors.NONE.code());
+        data.setErrorCode(Errors.NONE);
         data.setApiKeys(apiKeys);
 
         return new ApiVersionsResponse(data);

--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -30,8 +30,8 @@
   "validVersions": "0-3",
   "flexibleVersions": "3+",
   "fields": [
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
-      "about": "The top-level error code." },
+    { "name": "ErrorCode", "type": "error", "versions": "0+",
+      "about": "The top-level error." },
     { "name": "ApiKeys", "type": "[]ApiVersionsResponseKey", "versions": "0+",
       "about": "The APIs supported by the broker.", "fields": [
       { "name": "ApiKey", "type": "int16", "versions": "0+", "mapKey": true,

--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -83,6 +83,8 @@ There are several primitive field types available.
 
 * "bytes": binary data.
 
+* "error": an org.apache.kafka.common.protocol.Errors encoded as a 16-bit integer.  This takes up 2 bytes on the wire.
+
 In addition to these primitive field types, there is also an array type.  Array
 types start with a "[]" and end with the name of the element type.  For
 example, []Foo declares an array of "Foo" objects.  Array fields have their own
@@ -194,7 +196,7 @@ default to true rather than false, and so forth.
 Note that the default must be valid for the field type.  So the default for an
 int16 field must by an integer that fits in 16 bits, and so forth.  You may
 specify hex or octal values, as long as they are prefixed with 0x or 0.  It is
-currently not possible to specify a custom default for bytes or array fields.
+currently not possible to specify a custom default for bytes, array or error fields.
 
 Custom defaults are useful when an older message version lacked some
 information.  For example, if an older request lacked a timeout field, you may

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -239,7 +239,7 @@ public class NetworkClientTest {
         delayedApiVersionsResponse(0, ApiKeys.API_VERSIONS.latestVersion(),
             new ApiVersionsResponse(
                 new ApiVersionsResponseData()
-                    .setErrorCode(Errors.INVALID_REQUEST.code())
+                    .setErrorCode(Errors.INVALID_REQUEST)
                     .setThrottleTimeMs(0)
             ));
 
@@ -307,7 +307,7 @@ public class NetworkClientTest {
         delayedApiVersionsResponse(0, (short) 0,
             new ApiVersionsResponse(
                 new ApiVersionsResponseData()
-                    .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+                    .setErrorCode(Errors.UNSUPPORTED_VERSION)
                     .setApiKeys(apiKeys)
             ));
 
@@ -375,7 +375,7 @@ public class NetworkClientTest {
         delayedApiVersionsResponse(0, (short) 0,
             new ApiVersionsResponse(
                 new ApiVersionsResponseData()
-                    .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+                    .setErrorCode(Errors.UNSUPPORTED_VERSION)
             ));
 
         // handle ApiVersionResponse, initiate second ApiVersionRequest
@@ -517,7 +517,7 @@ public class NetworkClientTest {
             }
         }
         return new ApiVersionsResponse(new ApiVersionsResponseData()
-            .setErrorCode(Errors.NONE.code())
+            .setErrorCode(Errors.NONE)
             .setThrottleTimeMs(0)
             .setApiKeys(versionList));
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -59,7 +59,7 @@ public class RequestContextTest {
 
         Send send = context.buildResponse(new ApiVersionsResponse(new ApiVersionsResponseData()
             .setThrottleTimeMs(0)
-            .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+            .setErrorCode(Errors.UNSUPPORTED_VERSION)
             .setApiKeys(new ApiVersionsResponseKeyCollection())));
         ByteBufferChannel channel = new ByteBufferChannel(256);
         send.writeTo(channel);
@@ -75,7 +75,7 @@ public class RequestContextTest {
         Struct struct = ApiKeys.API_VERSIONS.parseResponse((short) 0, responseBuffer);
         ApiVersionsResponse response = (ApiVersionsResponse)
             AbstractResponse.parseResponse(ApiKeys.API_VERSIONS, struct, (short) 0);
-        assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.data.errorCode());
+        assertEquals(Errors.UNSUPPORTED_VERSION, response.data.errorCode());
         assertTrue(response.data.apiKeys().isEmpty());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -829,7 +829,7 @@ public class RequestResponseTest {
         ApiVersionsRequest request = new ApiVersionsRequest.Builder().build();
         ApiVersionsResponse response = request.getErrorResponse(0, Errors.UNSUPPORTED_VERSION.exception());
 
-        assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.data.errorCode());
+        assertEquals(Errors.UNSUPPORTED_VERSION, response.data.errorCode());
 
         ApiVersionsResponseKey apiVersion = response.data.apiKeys().find(ApiKeys.API_VERSIONS.id);
         assertNotNull(apiVersion);
@@ -843,7 +843,7 @@ public class RequestResponseTest {
         ApiVersionsRequest request = new ApiVersionsRequest.Builder().build();
         ApiVersionsResponse response = request.getErrorResponse(0, Errors.INVALID_REQUEST.exception());
 
-        assertEquals(response.data.errorCode(), Errors.INVALID_REQUEST.code());
+        assertEquals(response.data.errorCode(), Errors.INVALID_REQUEST);
         assertTrue(response.data.apiKeys().isEmpty());
     }
 
@@ -853,7 +853,7 @@ public class RequestResponseTest {
         ApiVersionsResponse response = ApiVersionsResponse.
             fromStruct(struct, ApiKeys.API_VERSIONS.latestVersion());
 
-        assertEquals(Errors.NONE.code(), response.data.errorCode());
+        assertEquals(Errors.NONE, response.data.errorCode());
     }
 
     @Test(expected = SchemaException.class)
@@ -868,7 +868,7 @@ public class RequestResponseTest {
         ApiVersionsResponse response = ApiVersionsResponse.
             fromStruct(struct, ApiKeys.API_VERSIONS.latestVersion());
 
-        assertEquals(Errors.NONE.code(), response.data.errorCode());
+        assertEquals(Errors.NONE, response.data.errorCode());
     }
 
     @Test
@@ -1464,7 +1464,7 @@ public class RequestResponseTest {
             .setMaxVersion((short) 2));
 
         return new ApiVersionsResponse(new ApiVersionsResponseData()
-            .setErrorCode(Errors.NONE.code())
+            .setErrorCode(Errors.NONE)
             .setThrottleTimeMs(0)
             .setApiKeys(apiVersions));
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -697,7 +697,7 @@ public class SaslAuthenticatorTest {
         ByteBuffer responseBuffer = waitForResponse();
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion((short) 0));
         ApiVersionsResponse response = ApiVersionsResponse.parse(responseBuffer, (short) 0);
-        assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.data.errorCode());
+        assertEquals(Errors.UNSUPPORTED_VERSION, response.data.errorCode());
 
         ApiVersionsResponseKey apiVersion = response.data.apiKeys().find(ApiKeys.API_VERSIONS.id);
         assertNotNull(apiVersion);
@@ -737,7 +737,7 @@ public class SaslAuthenticatorTest {
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion(version));
         ApiVersionsResponse response =
             ApiVersionsResponse.parse(responseBuffer, version);
-        assertEquals(Errors.INVALID_REQUEST.code(), response.data.errorCode());
+        assertEquals(Errors.INVALID_REQUEST, response.data.errorCode());
 
         // Send ApiVersionsRequest with a supported version. This should succeed.
         sendVersionRequestReceiveResponse(node);
@@ -768,7 +768,7 @@ public class SaslAuthenticatorTest {
         ByteBuffer responseBuffer = waitForResponse();
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion(version));
         ApiVersionsResponse response = ApiVersionsResponse.parse(responseBuffer, version);
-        assertEquals(Errors.NONE.code(), response.data.errorCode());
+        assertEquals(Errors.NONE, response.data.errorCode());
 
         // Test that client can authenticate successfully
         sendHandshakeRequestReceiveResponse(node, handshakeVersion);
@@ -1770,7 +1770,7 @@ public class SaslAuthenticatorTest {
 
                         }
                         ApiVersionsResponseData data = new ApiVersionsResponseData()
-                            .setErrorCode(Errors.NONE.code())
+                            .setErrorCode(Errors.NONE)
                             .setThrottleTimeMs(0)
                             .setApiKeys(apiVersions);
                         return new ApiVersionsResponse(data);
@@ -2036,7 +2036,7 @@ public class SaslAuthenticatorTest {
     private ApiVersionsResponse sendVersionRequestReceiveResponse(String node) throws Exception {
         ApiVersionsRequest handshakeRequest = createApiVersionsRequestV0();
         ApiVersionsResponse response =  (ApiVersionsResponse) sendKafkaRequestReceiveResponse(node, ApiKeys.API_VERSIONS, handshakeRequest);
-        assertEquals(Errors.NONE.code(), response.data.errorCode());
+        assertEquals(Errors.NONE, response.data.errorCode());
         return response;
     }
 

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -162,7 +162,7 @@ object BrokerApiVersionsCommand {
 
     private def getApiVersions(node: Node): ApiVersionsResponseKeyCollection = {
       val response = send(node, ApiKeys.API_VERSIONS, new ApiVersionsRequest.Builder()).asInstanceOf[ApiVersionsResponse]
-      Errors.forCode(response.data.errorCode).maybeThrow()
+      response.data.errorCode.maybeThrow()
       response.data.apiKeys
     }
 

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
@@ -38,7 +38,7 @@ class ApiVersionsRequestTest extends AbstractApiVersionsRequestTest {
   def testApiVersionsRequestWithUnsupportedVersion(): Unit = {
     val apiVersionsRequest = new ApiVersionsRequest.Builder().build()
     val apiVersionsResponse = sendUnsupportedApiVersionRequest(apiVersionsRequest)
-    assertEquals(Errors.UNSUPPORTED_VERSION.code(), apiVersionsResponse.data.errorCode())
+    assertEquals(Errors.UNSUPPORTED_VERSION, apiVersionsResponse.data.errorCode())
     assertFalse(apiVersionsResponse.data.apiKeys().isEmpty)
     val apiVersion = apiVersionsResponse.data.apiKeys().find(ApiKeys.API_VERSIONS.id)
     assertEquals(ApiKeys.API_VERSIONS.id, apiVersion.apiKey())
@@ -58,7 +58,7 @@ class ApiVersionsRequestTest extends AbstractApiVersionsRequestTest {
     // Invalid request because Name and Version are empty by default
     val apiVersionsRequest = new ApiVersionsRequest(new ApiVersionsRequestData(), 3.asInstanceOf[Short])
     val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest)
-    assertEquals(Errors.INVALID_REQUEST.code(), apiVersionsResponse.data.errorCode())
+    assertEquals(Errors.INVALID_REQUEST, apiVersionsResponse.data.errorCode())
   }
 
   private def sendApiVersionsRequest(request: ApiVersionsRequest): ApiVersionsResponse = {

--- a/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
@@ -68,7 +68,7 @@ class SaslApiVersionsRequestTest extends AbstractApiVersionsRequestTest with Sas
       sendSaslHandshakeRequestValidateResponse(socket)
       val response = sendAndReceive[ApiVersionsResponse](
         new ApiVersionsRequest.Builder().build(0), socket)
-      assertEquals(Errors.ILLEGAL_SASL_STATE.code, response.data.errorCode)
+      assertEquals(Errors.ILLEGAL_SASL_STATE, response.data.errorCode)
     } finally {
       socket.close()
     }
@@ -80,7 +80,7 @@ class SaslApiVersionsRequestTest extends AbstractApiVersionsRequestTest with Sas
     try {
       val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0)
       val apiVersionsResponse = sendUnsupportedApiVersionRequest(apiVersionsRequest)
-      assertEquals(Errors.UNSUPPORTED_VERSION.code, apiVersionsResponse.data.errorCode)
+      assertEquals(Errors.UNSUPPORTED_VERSION, apiVersionsResponse.data.errorCode)
       val apiVersionsResponse2 = sendAndReceive[ApiVersionsResponse](
         new ApiVersionsRequest.Builder().build(0), socket)
       validateApiVersionsResponse(apiVersionsResponse2)

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -97,6 +97,21 @@ public interface FieldType {
         }
     }
 
+    final class ErrorFieldType implements FieldType {
+        static final ErrorFieldType INSTANCE = new ErrorFieldType();
+        private static final String NAME = "error";
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(2);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
     final class UUIDFieldType implements FieldType {
         static final UUIDFieldType INSTANCE = new UUIDFieldType();
         private static final String NAME = "uuid";
@@ -239,6 +254,8 @@ public interface FieldType {
                 return Int32FieldType.INSTANCE;
             case Int64FieldType.NAME:
                 return Int64FieldType.INSTANCE;
+            case ErrorFieldType.NAME:
+                return ErrorFieldType.INSTANCE;
             case UUIDFieldType.NAME:
                 return UUIDFieldType.INSTANCE;
             case StringFieldType.NAME:

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -86,6 +86,8 @@ public final class MessageGenerator {
 
     static final String BYTES_CLASS = "org.apache.kafka.common.utils.Bytes";
 
+    static final String ERRORS_CLASS = "org.apache.kafka.common.protocol.Errors";
+
     static final String UUID_CLASS = "java.util.UUID";
 
     static final String REQUEST_SUFFIX = "Request";

--- a/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
@@ -254,6 +254,12 @@ final class SchemaGenerator {
                 throw new RuntimeException("Type " + type + " cannot be nullable.");
             }
             return "Type.INT64";
+        } else if (type instanceof FieldType.ErrorFieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.ERRORS";
         } else if (type instanceof FieldType.UUIDFieldType) {
             headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
             if (nullable) {

--- a/generator/src/test/java/org/apache/kafka/message/MessageDataGeneratorTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/MessageDataGeneratorTest.java
@@ -74,6 +74,23 @@ public class MessageDataGeneratorTest {
     }
 
     @Test
+    public void testInvalidNullDefaultForError() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+            "{",
+            "  \"type\": \"request\",",
+            "  \"name\": \"FooBar\",",
+            "  \"validVersions\": \"0-2\",",
+            "  \"fields\": [",
+            "    { \"name\": \"field1\", \"type\": \"error\", \"versions\": \"0+\", \"default\": \"null\" }",
+            "  ]",
+            "}")), MessageSpec.class);
+        assertStringContains("Invalid default for error",
+            assertThrows(RuntimeException.class, () -> {
+                new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec);
+            }).getMessage());
+    }
+
+    @Test
     public void testInvalidNullDefaultForPotentiallyNonNullableArray() throws Exception {
         MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
                 "{",


### PR DESCRIPTION
Introduces a new `error` type in the generated protocol's specs which maps to the `Errors` enum in Java/Scala. The `error` type does not change the wire format which remains an `int16`.

As a first example, the `ApiVersionsResponse` has been updated to use the new type. Tests in the `generator` are limited but the unit and integration tests around the `ApiVersionsResponse` cover the new `error` type.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
