### PR TITLE
MINOR: unify calls to get committed offsets and metadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -17,10 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.AuthorizationException;
-import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
@@ -34,9 +31,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public abstract class AbstractTask implements Task {
 
@@ -62,7 +57,7 @@ public abstract class AbstractTask implements Task {
      * @throws ProcessorStateException if the state manager cannot be created
      */
     AbstractTask(final TaskId id,
-                 final Collection<TopicPartition> partitions,
+                 final Set<TopicPartition> partitions,
                  final ProcessorTopology topology,
                  final Consumer<byte[], byte[]> consumer,
                  final ChangelogReader changelogReader,
@@ -249,26 +244,6 @@ public abstract class AbstractTask implements Task {
 
     public Collection<TopicPartition> changelogPartitions() {
         return stateMgr.changelogPartitions();
-    }
-
-    Map<TopicPartition, Long> committedOffsetForPartitions(final Set<TopicPartition> partitions) {
-        try {
-            final Map<TopicPartition, Long> results = consumer.committed(partitions)
-                .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
-
-            // those do not have a committed offset would default to 0
-            for (final TopicPartition tp : partitions) {
-                results.putIfAbsent(tp, 0L);
-            }
-
-            return results;
-        } catch (final AuthorizationException e) {
-            throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partitions), e);
-        } catch (final WakeupException e) {
-            throw e;
-        } catch (final KafkaException e) {
-            throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partitions), e);
-        }
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -31,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements RestoringTasks {
     private final Map<TaskId, StreamTask> suspended = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -68,6 +68,7 @@ abstract class AssignedTasks<T extends Task> {
             final Map.Entry<TaskId, T> entry = it.next();
             try {
                 final T task = entry.getValue();
+                task.initializeMetadata();
                 if (!task.initializeStateStores()) {
                     log.debug("Transitioning {} {} to restoring", taskTypeName, entry.getKey());
                     ((AssignedStreamsTasks) this).addToRestoring((StreamTask) task);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -67,11 +67,12 @@ abstract class AssignedTasks<T extends Task> {
         for (final Iterator<Map.Entry<TaskId, T>> it = created.entrySet().iterator(); it.hasNext(); ) {
             final Map.Entry<TaskId, T> entry = it.next();
             try {
-                if (!entry.getValue().initializeStateStores()) {
+                final T task = entry.getValue();
+                if (!task.initializeStateStores()) {
                     log.debug("Transitioning {} {} to restoring", taskTypeName, entry.getKey());
-                    ((AssignedStreamsTasks) this).addToRestoring((StreamTask) entry.getValue());
+                    ((AssignedStreamsTasks) this).addToRestoring((StreamTask) task);
                 } else {
-                    transitionToRunning(entry.getValue());
+                    transitionToRunning(task);
                 }
                 it.remove();
             } catch (final LockException e) {
@@ -110,7 +111,6 @@ abstract class AssignedTasks<T extends Task> {
     void transitionToRunning(final T task) {
         log.debug("Transitioning {} {} to running", taskTypeName, task.id());
         running.put(task.id(), task);
-        task.initializeTaskTime();
         task.initializeTopology();
         for (final TopicPartition topicPartition : task.partitions()) {
             runningByPartition.put(topicPartition, task);
@@ -251,7 +251,7 @@ abstract class AssignedTasks<T extends Task> {
         task.close(clean, false);
     }
 
-    private boolean closeUnclean(final T task) {
+    private void closeUnclean(final T task) {
         log.info("Try to close {} {} unclean.", task.getClass().getSimpleName(), task.id());
         try {
             task.close(false, false);
@@ -260,10 +260,7 @@ abstract class AssignedTasks<T extends Task> {
                 task.getClass().getSimpleName(),
                 task.id(),
                 fatalException);
-            return false;
         }
-
-        return true;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -16,22 +16,27 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsMetrics;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import java.util.stream.Collectors;
 
 /**
  * A StandbyTask
@@ -54,7 +59,7 @@ public class StandbyTask extends AbstractTask {
      * @param stateDirectory the {@link StateDirectory} created by the thread
      */
     StandbyTask(final TaskId id,
-                final Collection<TopicPartition> partitions,
+                final Set<TopicPartition> partitions,
                 final ProcessorTopology topology,
                 final Consumer<byte[], byte[]> consumer,
                 final ChangelogReader changelogReader,
@@ -85,14 +90,7 @@ public class StandbyTask extends AbstractTask {
     }
 
     @Override
-    public void initializeTopology() {
-        //no-op
-    }
-
-    @Override
-    public void initializeTaskTime() {
-        //no-op
-    }
+    public void initializeTopology() {}
 
     /**
      * <pre>
@@ -217,6 +215,26 @@ public class StandbyTask extends AbstractTask {
         updateOffsetLimits = false;
 
         return offsetLimits.get(partition);
+    }
+
+    private Map<TopicPartition, Long> committedOffsetForPartitions(final Set<TopicPartition> partitions) {
+        try {
+            final Map<TopicPartition, Long> results = consumer.committed(partitions)
+                .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+
+            // those do not have a committed offset would default to 0
+            for (final TopicPartition tp : partitions) {
+                results.putIfAbsent(tp, 0L);
+            }
+
+            return results;
+        } catch (final AuthorizationException e) {
+            throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partitions), e);
+        } catch (final WakeupException e) {
+            throw e;
+        } catch (final KafkaException e) {
+            throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partitions), e);
+        }
     }
 
     void allowUpdateOfOffsetLimit() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -80,6 +80,9 @@ public class StandbyTask extends AbstractTask {
     }
 
     @Override
+    public void initializeMetadata() {}
+
+    @Override
     public boolean initializeStateStores() {
         log.trace("Initializing state stores");
         registerStateStores();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -252,7 +252,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         if (eosEnabled) {
             initializeTransactions();
         }
+    }
 
+    @Override
+    public void initializeMetadata() {
         try {
             final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = consumer.committed(partitions);
             initializeCommittedOffsets(offsetsAndMetadata);
@@ -303,7 +306,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             }
         }
 
-        final Set<TopicPartition> nonCommitted = new HashSet<>(partitionGroup.partitions());
+        final Set<TopicPartition> nonCommitted = new HashSet<>(partitions);
         nonCommitted.removeAll(offsetsAndMetadata.keySet());
         for (final TopicPartition partition : nonCommitted) {
             log.debug("No committed offset for partition {}, therefore no timestamp can be found for this partition", partition);
@@ -369,6 +372,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 throw new ProcessorStateException(format("%sError while deleting the checkpoint file", logPrefix), e);
             }
         }
+        initializeMetadata();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -16,23 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import static java.lang.String.format;
-import static java.util.Collections.singleton;
-import static org.apache.kafka.streams.kstream.internals.metrics.Sensors.recordLatenessSensor;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.nio.ByteBuffer;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -41,8 +24,10 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeCount;
@@ -64,6 +49,22 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static org.apache.kafka.streams.kstream.internals.metrics.Sensors.recordLatenessSensor;
 
 /**
  * A StreamTask is associated with a {@link PartitionGroup}, and is assigned to a StreamThread for processing.
@@ -161,7 +162,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     }
 
     public StreamTask(final TaskId id,
-                      final Collection<TopicPartition> partitions,
+                      final Set<TopicPartition> partitions,
                       final ProcessorTopology topology,
                       final Consumer<byte[], byte[]> consumer,
                       final ChangelogReader changelogReader,
@@ -175,7 +176,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     }
 
     public StreamTask(final TaskId id,
-                      final Collection<TopicPartition> partitions,
+                      final Set<TopicPartition> partitions,
                       final ProcessorTopology topology,
                       final Consumer<byte[], byte[]> consumer,
                       final ChangelogReader changelogReader,
@@ -251,12 +252,21 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         if (eosEnabled) {
             initializeTransactions();
         }
+
+        try {
+            final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = consumer.committed(partitions);
+            initializeCommittedOffsets(offsetsAndMetadata);
+            initializeTaskTime(offsetsAndMetadata);
+        } catch (final AuthorizationException e) {
+            throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partitions), e);
+        } catch (final WakeupException e) {
+            throw e;
+        } catch (final KafkaException e) {
+            throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partitions), e);
+        }
     }
 
-    @Override
-    public boolean initializeStateStores() {
-        log.debug("Initializing state stores");
-
+    private void initializeCommittedOffsets(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {
         // Currently there is no easy way to tell the ProcessorStateManager to only restore up to
         // a specific offset. In most cases this is fine. However, in optimized topologies we can
         // have a source topic that also serves as a changelog, and in this case we want our active
@@ -264,13 +274,47 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         // partitions of topics that are both sources and changelogs and set the consumer committed
         // offset via stateMgr as there is not a more direct route.
         final Set<String> changelogTopicNames = new HashSet<>(topology.storeToChangelogTopic().values());
-        final Set<TopicPartition> sourcePartitionsAsChangelog = new HashSet<>(partitions)
-            .stream().filter(tp -> changelogTopicNames.contains(tp.topic())).collect(Collectors.toSet());
-        final Map<TopicPartition, Long> committedOffsets = committedOffsetForPartitions(sourcePartitionsAsChangelog);
-        stateMgr.putOffsetLimits(committedOffsets);
+        final Map<TopicPartition, Long> committedOffsetsForChangelogs = offsetsAndMetadata
+            .entrySet()
+            .stream()
+            .filter(e -> changelogTopicNames.contains(e.getKey().topic()))
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
 
+        // those do not have a committed offset would default to 0
+        for (final TopicPartition tp : partitions) {
+            committedOffsetsForChangelogs.putIfAbsent(tp, 0L);
+        }
+
+        stateMgr.putOffsetLimits(committedOffsetsForChangelogs);
+    }
+
+    private void initializeTaskTime(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {
+        for (final Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsetsAndMetadata.entrySet()) {
+            final TopicPartition partition = entry.getKey();
+            final OffsetAndMetadata metadata = entry.getValue();
+
+            if (metadata != null) {
+                final long committedTimestamp = decodeTimestamp(metadata.metadata());
+                partitionGroup.setPartitionTime(partition, committedTimestamp);
+                log.debug("A committed timestamp was detected: setting the partition time of partition {}"
+                    + " to {} in stream task {}", partition, committedTimestamp, this);
+            } else {
+                log.debug("No committed timestamp was found in metadata for partition {}", partition);
+            }
+        }
+
+        final Set<TopicPartition> nonCommitted = new HashSet<>(partitionGroup.partitions());
+        nonCommitted.removeAll(offsetsAndMetadata.keySet());
+        for (final TopicPartition partition : nonCommitted) {
+            log.debug("No committed offset for partition {}, therefore no timestamp can be found for this partition", partition);
+        }
+    }
+
+
+    @Override
+    public boolean initializeStateStores() {
+        log.debug("Initializing state stores");
         registerStateStores();
-
         return changelogPartitions().isEmpty();
     }
 
@@ -741,33 +785,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         closeSuspended(clean, firstException);
 
         taskClosed = true;
-    }
-
-    /**
-     * Retrieves formerly committed timestamps and updates the local queue's partition time.
-     */
-    public void initializeTaskTime() {
-        final Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(partitionGroup.partitions());
-
-        for (final Map.Entry<TopicPartition, OffsetAndMetadata> entry : committed.entrySet()) {
-            final TopicPartition partition = entry.getKey();
-            final OffsetAndMetadata metadata = entry.getValue();
-
-            if (metadata != null) {
-                final long committedTimestamp = decodeTimestamp(metadata.metadata());
-                partitionGroup.setPartitionTime(partition, committedTimestamp);
-                log.debug("A committed timestamp was detected: setting the partition time of partition {}"
-                    + " to {} in stream task {}", partition, committedTimestamp, this);
-            } else {
-                log.debug("No committed timestamp was found in metadata for partition {}", partition);
-            }
-        }
-
-        final Set<TopicPartition> nonCommitted = new HashSet<>(partitionGroup.partitions());
-        nonCommitted.removeAll(committed.keySet());
-        for (final TopicPartition partition : nonCommitted) {
-            log.debug("No committed offset for partition {}, therefore no timestamp can be found for this partition", partition);
-        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1243,9 +1243,7 @@ public class StreamThread extends Thread {
 
     public Map<MetricName, Metric> adminClientMetrics() {
         final Map<MetricName, ? extends Metric> adminClientMetrics = taskManager.adminClient().metrics();
-        final LinkedHashMap<MetricName, Metric> result = new LinkedHashMap<>();
-        result.putAll(adminClientMetrics);
-        return result;
+        return new LinkedHashMap<>(adminClientMetrics);
     }
 
     // the following are for testing only

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Set;
 
 public interface Task {
+
     /**
      * Initialize the task and return {@code true} if the task is ready to run, i.e, it has no state stores
      * @return true if this task has no state stores that may need restoring.
@@ -65,6 +66,4 @@ public interface Task {
     boolean hasStateStores();
 
     String toString(final String indent);
-
-    void initializeTaskTime();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 public interface Task {
 
+    void initializeMetadata();
+
     /**
      * Initialize the task and return {@code true} if the task is ready to run, i.e, it has no state stores
      * @return true if this task has no state stores that may need restoring.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -16,21 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import static org.apache.kafka.streams.processor.internals.ProcessorTopologyFactories.withLocalStores;
-import static org.easymock.EasyMock.expect;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -48,6 +33,22 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.kafka.streams.processor.internals.ProcessorTopologyFactories.withLocalStores;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class AbstractTaskTest {
 
     private final TaskId id = new TaskId(0, 0);
@@ -56,7 +57,7 @@ public class AbstractTaskTest {
     private final TopicPartition storeTopicPartition2 = new TopicPartition("t2", 0);
     private final TopicPartition storeTopicPartition3 = new TopicPartition("t3", 0);
     private final TopicPartition storeTopicPartition4 = new TopicPartition("t4", 0);
-    private final Collection<TopicPartition> storeTopicPartitions =
+    private final Set<TopicPartition> storeTopicPartitions =
         Utils.mkSet(storeTopicPartition1, storeTopicPartition2, storeTopicPartition3, storeTopicPartition4);
 
     @Before
@@ -216,9 +217,6 @@ public class AbstractTaskTest {
                                 false,
                                 stateDirectory,
                                 config) {
-
-            @Override
-            public void initializeTaskTime() {}
 
             @Override
             public void resume() {}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -219,6 +219,9 @@ public class AbstractTaskTest {
                                 config) {
 
             @Override
+            public void initializeMetadata() {}
+
+            @Override
             public void resume() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
@@ -78,6 +78,7 @@ public class AssignedStreamsTasksTest {
 
     @Test
     public void shouldInitializeNewTasks() {
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
         EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet());
@@ -90,11 +91,13 @@ public class AssignedStreamsTasksTest {
 
     @Test
     public void shouldMoveInitializedTasksNeedingRestoreToRestoring() {
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
         EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet());
+        t2.initializeMetadata();
         EasyMock.expect(t2.initializeStateStores()).andReturn(true);
         t2.initializeTopology();
         EasyMock.expectLastCall().once();
@@ -116,6 +119,7 @@ public class AssignedStreamsTasksTest {
 
     @Test
     public void shouldMoveInitializedTasksThatDontNeedRestoringToRunning() {
+        t2.initializeMetadata();
         EasyMock.expect(t2.initializeStateStores()).andReturn(true);
         t2.initializeTopology();
         EasyMock.expectLastCall().once();
@@ -133,6 +137,7 @@ public class AssignedStreamsTasksTest {
     @Test
     public void shouldTransitionFullyRestoredTasksToRunning() {
         final Set<TopicPartition> task1Partitions = Utils.mkSet(tp1);
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
         EasyMock.expect(t1.partitions()).andReturn(task1Partitions).anyTimes();
         EasyMock.expect(t1.changelogPartitions()).andReturn(Utils.mkSet(changeLog1, changeLog2)).anyTimes();
@@ -162,6 +167,7 @@ public class AssignedStreamsTasksTest {
 
     @Test
     public void shouldCloseRestoringTasks() {
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1)).times(2);
         EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet()).times(2);
@@ -274,6 +280,7 @@ public class AssignedStreamsTasksTest {
     }
 
     private void mockTaskInitialization() {
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(true);
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
@@ -553,6 +560,7 @@ public class AssignedStreamsTasksTest {
     }
 
     private void mockRunningTaskSuspension() {
+        t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(true);
         t1.initializeTopology();
         EasyMock.expectLastCall().once();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
@@ -17,20 +17,6 @@
 
 package org.apache.kafka.streams.processor.internals;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
@@ -51,6 +37,21 @@ import org.apache.kafka.test.MockSourceNode;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AssignedStreamsTasksTest {
 
@@ -90,20 +91,16 @@ public class AssignedStreamsTasksTest {
     @Test
     public void shouldMoveInitializedTasksNeedingRestoreToRestoring() {
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
         EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet());
         EasyMock.expect(t2.initializeStateStores()).andReturn(true);
-        t1.initializeTaskTime();
         t2.initializeTopology();
         EasyMock.expectLastCall().once();
         final Set<TopicPartition> t2partitions = Collections.singleton(tp2);
         EasyMock.expect(t2.partitions()).andReturn(t2partitions);
         EasyMock.expect(t2.changelogPartitions()).andReturn(Collections.emptyList());
-        t1.initializeTaskTime();
-        t2.initializeTaskTime();
 
         EasyMock.replay(t1, t2);
 
@@ -120,7 +117,6 @@ public class AssignedStreamsTasksTest {
     @Test
     public void shouldMoveInitializedTasksThatDontNeedRestoringToRunning() {
         EasyMock.expect(t2.initializeStateStores()).andReturn(true);
-        t2.initializeTaskTime();
         t2.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
@@ -141,7 +137,6 @@ public class AssignedStreamsTasksTest {
         EasyMock.expect(t1.partitions()).andReturn(task1Partitions).anyTimes();
         EasyMock.expect(t1.changelogPartitions()).andReturn(Utils.mkSet(changeLog1, changeLog2)).anyTimes();
         EasyMock.expect(t1.hasStateStores()).andReturn(true).anyTimes();
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.replay(t1);
@@ -246,7 +241,6 @@ public class AssignedStreamsTasksTest {
         mockRunningTaskSuspension();
         t1.resume();
         EasyMock.expectLastCall();
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.replay(t1);
@@ -262,7 +256,6 @@ public class AssignedStreamsTasksTest {
     public void shouldCloseTaskOnResumeSuspendedIfTaskMigratedException() {
         mockRunningTaskSuspension();
         t1.resume();
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().andThrow(new TaskMigratedException());
         t1.close(false, true);
@@ -282,7 +275,6 @@ public class AssignedStreamsTasksTest {
 
     private void mockTaskInitialization() {
         EasyMock.expect(t1.initializeStateStores()).andReturn(true);
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
@@ -562,7 +554,6 @@ public class AssignedStreamsTasksTest {
 
     private void mockRunningTaskSuspension() {
         EasyMock.expect(t1.initializeStateStores()).andReturn(true);
-        t1.initializeTaskTime();
         t1.initializeTopology();
         EasyMock.expectLastCall().once();
         EasyMock.expect(t1.hasStateStores()).andReturn(false).anyTimes();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -79,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
@@ -309,7 +309,7 @@ public class StandbyTaskTest {
 
         final TopicPartition topicPartition = new TopicPartition(changelogName, 1);
 
-        final List<TopicPartition> partitions = Collections.singletonList(topicPartition);
+        final Set<TopicPartition> partitions = Collections.singleton(topicPartition);
 
         consumer.assign(partitions);
 
@@ -410,7 +410,7 @@ public class StandbyTaskTest {
         final String changelogName = applicationId + "-" + storeName + "-changelog";
 
         final TopicPartition topicPartition = new TopicPartition(changelogName, 1);
-        final List<TopicPartition> partitions = Collections.singletonList(topicPartition);
+        final Set<TopicPartition> partitions = Collections.singleton(topicPartition);
 
         final InternalTopologyBuilder internalTopologyBuilder = new InternalTopologyBuilder().setApplicationId(applicationId);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -669,7 +669,6 @@ public class StreamTaskTest {
         // reset times here by creating a new task
         task = createStatelessTask(createConfig(false));
 
-        task.initializeTaskTime();
         assertEquals(DEFAULT_TIMESTAMP, task.partitionTime(partition1));
         assertEquals(DEFAULT_TIMESTAMP, task.streamTime());
     }
@@ -695,7 +694,6 @@ public class StreamTaskTest {
         // reset times here by creating a new task
         task = createStatelessTask(createConfig(true));
 
-        task.initializeTaskTime();
         assertEquals(DEFAULT_TIMESTAMP, task.partitionTime(partition1));
         assertEquals(DEFAULT_TIMESTAMP, task.streamTime());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -164,9 +164,9 @@ public class StreamTaskTest {
         }
     };
 
-    static ProcessorTopology withRepartitionTopics(final List<ProcessorNode> processorNodes,
-                                                   final Map<String, SourceNode> sourcesByTopic,
-                                                   final Set<String> repartitionTopics) {
+    private static ProcessorTopology withRepartitionTopics(final List<ProcessorNode> processorNodes,
+                                                           final Map<String, SourceNode> sourcesByTopic,
+                                                           final Set<String> repartitionTopics) {
         return new ProcessorTopology(processorNodes,
                                      sourcesByTopic,
                                      Collections.emptyMap(),
@@ -176,8 +176,8 @@ public class StreamTaskTest {
                                      repartitionTopics);
     }
 
-    static ProcessorTopology withSources(final List<ProcessorNode> processorNodes,
-                                         final Map<String, SourceNode> sourcesByTopic) {
+    private static ProcessorTopology withSources(final List<ProcessorNode> processorNodes,
+                                                 final Map<String, SourceNode> sourcesByTopic) {
         return new ProcessorTopology(processorNodes,
                                      sourcesByTopic,
                                      Collections.emptyMap(),
@@ -233,7 +233,7 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = withSources(
             asList(source1, source2, processorStreamTime, processorSystemTime),
-            mkMap(mkEntry(topic1, (SourceNode) source1), mkEntry(topic2, (SourceNode) source2))
+            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2))
         );
 
         source1.addChild(processorStreamTime);
@@ -282,7 +282,7 @@ public class StreamTaskTest {
 
         final ProcessorTopology topology = withSources(
             asList(source1, source2, processorStreamTime, processorSystemTime),
-            mkMap(mkEntry(topic1, (SourceNode) source1), mkEntry(topic2, (SourceNode) source2))
+            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2))
         );
 
         source1.addChild(processorStreamTime);
@@ -353,7 +353,6 @@ public class StreamTaskTest {
         assertThat(expectedError, is(singletonList("ERROR")));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testProcessOrder() {
         task = createStatelessTask(createConfig(false));
@@ -437,7 +436,6 @@ public class StreamTaskTest {
         ));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testPauseResume() {
         task = createStatelessTask(createConfig(false));
@@ -492,7 +490,6 @@ public class StreamTaskTest {
         assertEquals(0, consumer.paused().size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldPunctuateOnceStreamTimeAfterGap() {
         task = createStatelessTask(createConfig(false));
@@ -669,6 +666,7 @@ public class StreamTaskTest {
         // reset times here by creating a new task
         task = createStatelessTask(createConfig(false));
 
+        task.initializeMetadata();
         assertEquals(DEFAULT_TIMESTAMP, task.partitionTime(partition1));
         assertEquals(DEFAULT_TIMESTAMP, task.streamTime());
     }
@@ -677,23 +675,12 @@ public class StreamTaskTest {
     public void shouldRestorePartitionTimeAfterRestartWithEosEnabled() {
         createTaskWithProcessAndCommit(true);
 
-        // extract the committed metadata from MockProducer
-        final List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> metadataList = 
-            producer.consumerGroupOffsetsHistory();
-        final String storedMetadata = metadataList.get(0).get(APPLICATION_ID).get(partition1).metadata();
-        final long partitionTime = task.decodeTimestamp(storedMetadata);
-        assertEquals(DEFAULT_TIMESTAMP, partitionTime);
-
-        // since producer and consumer is mocked, we need to "connect" producer and consumer
-        // so we should manually commit offsets here to simulate this "connection"
-        final Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
-        final String encryptedMetadata = task.encodeTimestamp(partitionTime);
-        offsetMap.put(partition1, new OffsetAndMetadata(partitionTime, encryptedMetadata));
-        consumer.commitSync(offsetMap);
+        moveCommittedOffsetsFromProducerToConsumer(DEFAULT_TIMESTAMP);
 
         // reset times here by creating a new task
         task = createStatelessTask(createConfig(true));
 
+        task.initializeMetadata();
         assertEquals(DEFAULT_TIMESTAMP, task.partitionTime(partition1));
         assertEquals(DEFAULT_TIMESTAMP, task.streamTime());
     }
@@ -888,11 +875,8 @@ public class StreamTaskTest {
         task.initializeTopology();
 
         try {
-            task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, new Punctuator() {
-                @Override
-                public void punctuate(final long timestamp) {
-                    throw new KafkaException("KABOOM!");
-                }
+            task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, timestamp -> {
+                throw new KafkaException("KABOOM!");
             });
             fail("Should've thrown StreamsException");
         } catch (final StreamsException e) {
@@ -909,11 +893,8 @@ public class StreamTaskTest {
         task.initializeTopology();
 
         try {
-            task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, new Punctuator() {
-                @Override
-                public void punctuate(final long timestamp) {
-                    throw new KafkaException("KABOOM!");
-                }
+            task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
+                throw new KafkaException("KABOOM!");
             });
             fail("Should've thrown StreamsException");
         } catch (final StreamsException e) {
@@ -1013,24 +994,14 @@ public class StreamTaskTest {
     @Test(expected = IllegalStateException.class)
     public void shouldThrowIllegalStateExceptionOnScheduleIfCurrentNodeIsNull() {
         task = createStatelessTask(createConfig(false));
-        task.schedule(1, PunctuationType.STREAM_TIME, new Punctuator() {
-            @Override
-            public void punctuate(final long timestamp) {
-                // no-op
-            }
-        });
+        task.schedule(1, PunctuationType.STREAM_TIME, timestamp -> { });
     }
 
     @Test
     public void shouldNotThrowExceptionOnScheduleIfCurrentNodeIsNotNull() {
         task = createStatelessTask(createConfig(false));
         task.processorContext.setCurrentNode(processorStreamTime);
-        task.schedule(1, PunctuationType.STREAM_TIME, new Punctuator() {
-            @Override
-            public void punctuate(final long timestamp) {
-                // no-op
-            }
-        });
+        task.schedule(1, PunctuationType.STREAM_TIME, timestamp -> { });
     }
 
     @Test
@@ -1332,6 +1303,41 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldInitTaskTimeOnResumeWithEosDisabled() {
+        shouldInitTaskTimeOnResume(false);
+    }
+
+    @Test
+    public void shouldInitTaskTimeOnResumeWithEosEnabled() {
+        shouldInitTaskTimeOnResume(true);
+    }
+
+    private void shouldInitTaskTimeOnResume(final boolean eosEnabled) {
+        task = createStatelessTask(createConfig(eosEnabled));
+        task.initializeTopology();
+
+        assertThat(task.partitionTime(partition1), is(RecordQueue.UNKNOWN));
+        assertThat(task.streamTime(), is(RecordQueue.UNKNOWN));
+
+        task.addRecords(partition1, singletonList(getConsumerRecord(partition1, 0)));
+        task.process();
+        assertThat(task.partitionTime(partition1), is(0L));
+        assertThat(task.streamTime(), is(0L));
+
+        task.suspend();
+        assertThat(task.partitionTime(partition1), is(RecordQueue.UNKNOWN));
+        assertThat(task.streamTime(), is(RecordQueue.UNKNOWN));
+
+        if (eosEnabled) {
+            moveCommittedOffsetsFromProducerToConsumer(0L);
+        }
+
+        task.resume();
+        assertThat(task.partitionTime(partition1), is(0L));
+        assertThat(task.streamTime(), is(0L));
+    }
+
+    @Test
     public void shouldStartNewTransactionOnResumeIfEosEnabled() {
         task = createStatelessTask(createConfig(true));
         task.initializeTopology();
@@ -1560,13 +1566,8 @@ public class StreamTaskTest {
 
         task.initializeStateStores();
         task.initializeTopology();
-        task.punctuate(processorSystemTime, 5, PunctuationType.WALL_CLOCK_TIME, new Punctuator() {
-            @Override
-            public void punctuate(final long timestamp) {
-                recordCollector.send("result-topic1", 3, 5, null, 0, time.milliseconds(),
-                        new IntegerSerializer(),  new IntegerSerializer());
-            }
-        });
+        task.punctuate(processorSystemTime, 5, PunctuationType.WALL_CLOCK_TIME, timestamp -> recordCollector.send("result-topic1", 3, 5, null, 0, time.milliseconds(),
+                new IntegerSerializer(),  new IntegerSerializer()));
         task.commit();
         assertEquals(1, producer.history().size());
     }
@@ -1575,6 +1576,7 @@ public class StreamTaskTest {
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenAuthorizationException() {
         final Consumer<byte[], byte[]> consumer = mockConsumerWithCommittedException(new AuthorizationException("message"));
         final StreamTask task = createOptimizedStatefulTask(createConfig(false), consumer);
+        task.initializeMetadata();
         task.initializeStateStores();
     }
 
@@ -1582,6 +1584,7 @@ public class StreamTaskTest {
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenKafkaException() {
         final Consumer<byte[], byte[]> consumer = mockConsumerWithCommittedException(new KafkaException("message"));
         final AbstractTask task = createOptimizedStatefulTask(createConfig(false), consumer);
+        task.initializeMetadata();
         task.initializeStateStores();
     }
 
@@ -1589,6 +1592,7 @@ public class StreamTaskTest {
     public void shouldThrowWakeupExceptionOnInitializeOffsetsWhenWakeupException() {
         final Consumer<byte[], byte[]> consumer = mockConsumerWithCommittedException(new WakeupException());
         final AbstractTask task = createOptimizedStatefulTask(createConfig(false), consumer);
+        task.initializeMetadata();
         task.initializeStateStores();
     }
 
@@ -1601,11 +1605,27 @@ public class StreamTaskTest {
         };
     }
 
+    private void moveCommittedOffsetsFromProducerToConsumer(final long expectedPartitionTime) {
+        // extract the committed metadata from MockProducer
+        final List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> metadataList =
+            producer.consumerGroupOffsetsHistory();
+        final String storedMetadata = metadataList.get(0).get(APPLICATION_ID).get(partition1).metadata();
+        final long partitionTime = task.decodeTimestamp(storedMetadata);
+        assertThat(partitionTime, is(expectedPartitionTime));
+
+        // since producer and consumer is mocked, we need to "connect" producer and consumer
+        // so we should manually commit offsets here to simulate this "connection"
+        final Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
+        final String encryptedMetadata = task.encodeTimestamp(partitionTime);
+        offsetMap.put(partition1, new OffsetAndMetadata(partitionTime, encryptedMetadata));
+        consumer.commitSync(offsetMap);
+    }
+
     private StreamTask createOptimizedStatefulTask(final StreamsConfig config, final Consumer<byte[], byte[]> consumer) {
         final StateStore stateStore = new MockKeyValueStore(storeName, true);
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
-            asList(source1),
+            singletonList(source1),
             mkMap(mkEntry(topic1, source1)),
             singletonList(stateStore),
             Collections.singletonMap(storeName, topic1));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -304,7 +304,7 @@ public class StreamThreadStateStoreProviderTest {
         final Metrics metrics = new Metrics();
         return new StreamTask(
             taskId,
-            Collections.singletonList(new TopicPartition(topicName, taskId.partition)),
+            Collections.singleton(new TopicPartition(topicName, taskId.partition)),
             topology,
             clientSupplier.consumer,
             new StoreChangelogReader(

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -388,7 +388,7 @@ public class TopologyTestDriver implements Closeable {
         if (!partitionsByTopic.isEmpty()) {
             task = new StreamTask(
                 TASK_ID,
-                partitionsByTopic.values(),
+                new HashSet<>(partitionsByTopic.values()),
                 processorTopology,
                 consumer,
                 new StoreChangelogReader(


### PR DESCRIPTION
This is a follow up to #7304 and #6694 to unify the calls to `consumer.committed()` further and only call it once during startup instead of twice.