### PR TITLE
KAFKA-8932; Add tag for CreateTopicsResponse.TopicConfigErrorCode

### DIFF
--- a/clients/src/main/resources/common/message/CreateTopicsRequest.json
+++ b/clients/src/main/resources/common/message/CreateTopicsRequest.json
@@ -21,11 +21,10 @@
   //
   // Version 4 makes partitions/replicationFactor optional even when assignments are not present (KIP-464)
   //
-  // Version 5 returns topic configs in the response (KIP-525).
-  //
-  // Version 6 is the first flexible version.
-  "validVersions": "0-6",
-  "flexibleVersions": "6+",
+  // Version 5 is the first flexible version.
+  // Version 5 also returns topic configs in the response (KIP-525).
+  "validVersions": "0-5",
+  "flexibleVersions": "5+",
   "fields": [
     { "name": "Topics", "type": "[]CreatableTopic", "versions": "0+",
       "about": "The topics to create.", "fields": [

--- a/clients/src/main/resources/common/message/CreateTopicsResponse.json
+++ b/clients/src/main/resources/common/message/CreateTopicsResponse.json
@@ -25,11 +25,10 @@
   //
   // Version 4 makes partitions/replicationFactor optional even when assignments are not present (KIP-464).
   //
-  // Version 5 returns topic configs in the response (KIP-525).
-  //
-  // Version 6 is the first flexible version.
-  "validVersions": "0-6",
-  "flexibleVersions": "6+",
+  // Version 5 is the first flexible version.
+  // Version 5 also returns topic configs in the response (KIP-525).
+  "validVersions": "0-5",
+  "flexibleVersions": "5+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "2+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
@@ -41,7 +40,7 @@
         "about": "The error code, or 0 if there was no error." },
       { "name": "ErrorMessage", "type": "string", "versions": "1+", "nullableVersions": "0+", "ignorable": true,
         "about": "The error message, or null if there was no error." },
-      { "name": "TopicConfigErrorCode", "type": "int16", "versions": "5+", "default": "0",
+      { "name": "TopicConfigErrorCode", "type": "int16", "versions": "5+", "tag": 0, "taggedVersions": "5+",
         "about": "Optional topic config error returned if configs are not returned in the response." },
       { "name": "NumPartitions", "type": "int32", "versions": "5+", "default": "-1",
         "about": "Number of partitions of the topic." },
@@ -51,7 +50,7 @@
         "about": "Configuration of the topic.", "fields": [
         { "name": "Name", "type": "string", "versions": "5+",
           "about": "The configuration name." },
-        { "name": "Value", "type": "string", "versions": "5+", "nullableVersions": "0+",
+        { "name": "Value", "type": "string", "versions": "5+", "nullableVersions": "5+",
           "about": "The configuration value." },
         { "name": "ReadOnly", "type": "bool", "versions": "5+",
           "about": "True if the configuration is read-only." },

--- a/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
@@ -88,10 +88,10 @@ public class ApiMessageTypeTest {
         assertEquals((short) 1, ApiMessageType.CONTROLLED_SHUTDOWN.requestHeaderVersion((short) 1));
         assertEquals((short) 0, ApiMessageType.CONTROLLED_SHUTDOWN.responseHeaderVersion((short) 1));
 
-        assertEquals((short) 1, ApiMessageType.CREATE_TOPICS.requestHeaderVersion((short) 5));
-        assertEquals((short) 0, ApiMessageType.CREATE_TOPICS.responseHeaderVersion((short) 5));
+        assertEquals((short) 1, ApiMessageType.CREATE_TOPICS.requestHeaderVersion((short) 4));
+        assertEquals((short) 0, ApiMessageType.CREATE_TOPICS.responseHeaderVersion((short) 4));
 
-        assertEquals((short) 2, ApiMessageType.CREATE_TOPICS.requestHeaderVersion((short) 6));
-        assertEquals((short) 1, ApiMessageType.CREATE_TOPICS.responseHeaderVersion((short) 6));
+        assertEquals((short) 2, ApiMessageType.CREATE_TOPICS.requestHeaderVersion((short) 5));
+        assertEquals((short) 1, ApiMessageType.CREATE_TOPICS.responseHeaderVersion((short) 5));
     }
 }


### PR DESCRIPTION
This was discussed under KIP-525, but tag was not added in the original commit since the PR with flexible versions hadn't yet been merged. Sets CreateTopics version to 5 with both KIP-525 and flexible versions change so that tags can be used with v5.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
