### PR TITLE
KAFKA-8122: Fix Kafka Streams EOS integration test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -59,6 +58,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.kafka.test.StreamsTestUtils.startKafkaStreamsAndWaitForRunningState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -103,21 +103,21 @@ public abstract class AbstractJoinIntegrationTest {
     AtomicBoolean finalResultReached = new AtomicBoolean(false);
 
     private final List<Input<String>> input = Arrays.asList(
-            new Input<>(INPUT_TOPIC_LEFT, null),
-            new Input<>(INPUT_TOPIC_RIGHT, null),
-            new Input<>(INPUT_TOPIC_LEFT, "A"),
-            new Input<>(INPUT_TOPIC_RIGHT, "a"),
-            new Input<>(INPUT_TOPIC_LEFT, "B"),
-            new Input<>(INPUT_TOPIC_RIGHT, "b"),
-            new Input<>(INPUT_TOPIC_LEFT, null),
-            new Input<>(INPUT_TOPIC_RIGHT, null),
-            new Input<>(INPUT_TOPIC_LEFT, "C"),
-            new Input<>(INPUT_TOPIC_RIGHT, "c"),
-            new Input<>(INPUT_TOPIC_RIGHT, null),
-            new Input<>(INPUT_TOPIC_LEFT, null),
-            new Input<>(INPUT_TOPIC_RIGHT, null),
-            new Input<>(INPUT_TOPIC_RIGHT, "d"),
-            new Input<>(INPUT_TOPIC_LEFT, "D")
+        new Input<>(INPUT_TOPIC_LEFT, null),
+        new Input<>(INPUT_TOPIC_RIGHT, null),
+        new Input<>(INPUT_TOPIC_LEFT, "A"),
+        new Input<>(INPUT_TOPIC_RIGHT, "a"),
+        new Input<>(INPUT_TOPIC_LEFT, "B"),
+        new Input<>(INPUT_TOPIC_RIGHT, "b"),
+        new Input<>(INPUT_TOPIC_LEFT, null),
+        new Input<>(INPUT_TOPIC_RIGHT, null),
+        new Input<>(INPUT_TOPIC_LEFT, "C"),
+        new Input<>(INPUT_TOPIC_RIGHT, "c"),
+        new Input<>(INPUT_TOPIC_RIGHT, null),
+        new Input<>(INPUT_TOPIC_LEFT, null),
+        new Input<>(INPUT_TOPIC_RIGHT, null),
+        new Input<>(INPUT_TOPIC_RIGHT, "d"),
+        new Input<>(INPUT_TOPIC_LEFT, "D")
     );
 
     final ValueJoiner<String, String, String> valueJoiner = (value1, value2) -> value1 + "-" + value2;
@@ -201,11 +201,7 @@ public abstract class AbstractJoinIntegrationTest {
         KeyValueTimestamp<Long, String> expectedFinalResult = null;
 
         try {
-            streams.start();
-            TestUtils.waitForCondition(
-                () -> streams.state() == State.RUNNING,
-                TIMEOUT,
-                () -> "Kafka Streams application did not reach state RUNNING in " + TIMEOUT + " ms");
+            startKafkaStreamsAndWaitForRunningState(streams, TIMEOUT);
 
             final long firstTimestamp = System.currentTimeMillis();
             long ts = firstTimestamp;
@@ -238,23 +234,12 @@ public abstract class AbstractJoinIntegrationTest {
     /*
      * Runs the actual test. Checks the final result only after expected number of records have been consumed.
      */
-    void runTest(final KeyValueTimestamp<Long, String> expectedFinalResult) throws Exception {
-        runTest(expectedFinalResult, null);
-    }
-
-    /*
-     * Runs the actual test. Checks the final result only after expected number of records have been consumed.
-     */
     void runTest(final KeyValueTimestamp<Long, String> expectedFinalResult, final String storeName) throws Exception {
         IntegrationTestUtils.purgeLocalStreamsState(STREAMS_CONFIG);
         streams = new KafkaStreams(builder.build(), STREAMS_CONFIG);
 
         try {
-            streams.start();
-            TestUtils.waitForCondition(
-                () -> streams.state() == State.RUNNING,
-                TIMEOUT,
-                () -> "Kafka Streams application did not reach state RUNNING in " + TIMEOUT + " ms");
+            startKafkaStreamsAndWaitForRunningState(streams, TIMEOUT);
 
             final long firstTimestamp = System.currentTimeMillis();
             long ts = firstTimestamp;
@@ -299,7 +284,7 @@ public abstract class AbstractJoinIntegrationTest {
         }
     }
 
-    private final class Input<V> {
+    private static final class Input<V> {
         String topic;
         KeyValue<Long, V> record;
 

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -83,12 +83,12 @@ public final class StreamsTestUtils {
         return getStreamsConfig(UUID.randomUUID().toString());
     }
 
-    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams) {
+    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams) throws InterruptedException {
         startKafkaStreamsAndWaitForRunningState(kafkaStreams, DEFAULT_MAX_WAIT_MS);
     }
 
     public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams,
-                                                               final long timeoutMs) {
+                                                               final long timeoutMs) throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         kafkaStreams.setStateListener((newState, oldState) -> {
             if (newState == KafkaStreams.State.RUNNING) {
@@ -97,11 +97,9 @@ public final class StreamsTestUtils {
         });
 
         kafkaStreams.start();
-        try {
-            countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (final InterruptedException interruptedException) {
-            throw new AssertionError("KafkaStreams did not transit to RUNNING state within " + timeoutMs + " milli seconds.");
-        }
+        assertThat(
+            "KafkaStreams did not transit to RUNNING state within " + timeoutMs + " milli seconds.",
+            countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS), equalTo(true));
     }
 
     public static <K, V> List<KeyValue<K, V>> toList(final Iterator<KeyValue<K, V>> iterator) {

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -31,8 +32,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
+import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -77,6 +81,27 @@ public final class StreamsTestUtils {
 
     public static Properties getStreamsConfig() {
         return getStreamsConfig(UUID.randomUUID().toString());
+    }
+
+    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams) {
+        startKafkaStreamsAndWaitForRunningState(kafkaStreams, DEFAULT_MAX_WAIT_MS);
+    }
+
+    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams,
+                                                               final long timeoutMs) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        kafkaStreams.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                countDownLatch.countDown();
+            }
+        });
+
+        kafkaStreams.start();
+        try {
+            countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException interruptedException) {
+            throw new AssertionError("KafkaStreams did not transit to RUNNING state within " + timeoutMs + " milli seconds.");
+        }
     }
 
     public static <K, V> List<KeyValue<K, V>> toList(final Iterator<KeyValue<K, V>> iterator) {


### PR DESCRIPTION
We tried to use `commitRequested` to synchronize the test progress, however, this mechanism seems to be broken. Note that `context.commit();` is a request that KS should commit asap -- however, after `context.commit()` returned only an internal flag is set and the commit is not executed yet.

Hence, after the counter is increased to 2, there is no guarantee what happens next: either we commit, or we might actually `poll()` for new data and if `writeInputData(uncommittedDataBeforeFailure);` executed before KS `poll()` again, we might process more than 10 records per partition before we actually commit, and hence the test fails.

A better way seems to be, to read the committed output data before writing new data to make sure the new data is not part of the first transactions and stays uncommitted before we inject the error.

Call for review @guozhangwang @ableegoldman @abbccdda @cpettitt-confluent 