### PR TITLE
[KAFKA-8820] [WIP] Ongoing work for changing the ReassignPartitionsCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -866,7 +866,7 @@ class ReassignPartitionsCommand private (serviceClient : ReassignCommandService,
         if (proposedReplicaAssignment.nonEmpty)
           serviceClient.alterReplicaLogDirs(proposedReplicaAssignment, timeoutMs)
 
-        // Create reassignment znode so that controller will send LeaderAndIsrRequest to create replica in the broker
+        // Create reassignment so that controller will send LeaderAndIsrRequest to create replica in the broker
         serviceClient.alterPartitionAssignment(validPartitions.map({case (key, value) => (new TopicPartition(key.topic, key.partition), value)}).toMap,
           timeoutMs)
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -270,7 +270,7 @@ object ReassignPartitionsCommand extends Logging {
     new ReassignPartitionsCommand(new AdminClientReassignCommandService(adminClient), proposedPartitionAssignment, proposedReplicaAssignment)
 
   // Package-private constructor for testing
-  def apply(serviceClient: ReassignCommandService,
+  private[admin] def apply(serviceClient: ReassignCommandService,
             proposedPartitionAssignment: Map[TopicPartition, Seq[Int]],
             proposedReplicaAssignment: Map[TopicPartitionReplica, String]) : ReassignPartitionsCommand =
     new ReassignPartitionsCommand(serviceClient, proposedPartitionAssignment, proposedReplicaAssignment)
@@ -414,14 +414,16 @@ object ReassignPartitionsCommand extends Logging {
     (partitionsToBeReassigned, currentAssignment)
   }
 
-  def generateAssignment(zkClient: KafkaZkClient, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
+  // Package-private for testing
+  private[admin] def generateAssignment(zkClient: KafkaZkClient, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     generateAssignment(serviceClient, brokerListToReassign, topicsToMoveJsonString, disableRackAware)
 
   }
 
-  def generateAssignment(adminClient: Admin, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
+  // Kafka-private for testing
+  private[kafka] def generateAssignment(adminClient: Admin, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
     generateAssignment(serviceClient, brokerListToReassign, topicsToMoveJsonString, disableRackAware)
@@ -457,13 +459,13 @@ object ReassignPartitionsCommand extends Logging {
     }
   }
 
-  def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin],
+  private[admin] def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin],
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long = 10000L): Unit = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     executeAssignment(serviceClient, reassignmentJsonString, throttle, timeoutMs)
   }
 
-  def executeAssignment(adminClient: Admin,
+  private[kafka] def executeAssignment(adminClient: Admin,
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long): Unit = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
     executeAssignment(serviceClient, reassignmentJsonString, throttle, timeoutMs)
@@ -615,13 +617,14 @@ object ReassignPartitionsCommand extends Logging {
     }.toMap
   }
 
-  def checkIfPartitionReassignmentSucceeded(zkClient: KafkaZkClient, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
+  // Package-private for testing.
+  private[admin] def checkIfPartitionReassignmentSucceeded(zkClient: KafkaZkClient, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
   :Map[TopicPartition, ReassignmentStatus] = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     checkIfPartitionReassignmentSucceeded(serviceClient, partitionsToBeReassigned)
   }
 
-  def checkIfPartitionReassignmentSucceeded(adminClient: Admin, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
+  private[admin] def checkIfPartitionReassignmentSucceeded(adminClient: Admin, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
   :Map[TopicPartition, ReassignmentStatus] = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
     checkIfPartitionReassignmentSucceeded(serviceClient, partitionsToBeReassigned)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -290,7 +290,7 @@ object ReassignPartitionsCommand extends Logging {
       else if(opts.options.has(opts.generateOpt))
         generateAssignment(commandService, opts)
       else if (opts.options.has(opts.executeOpt))
-        executeAssignment(commandService, adminClientOpt, opts)
+        executeAssignment(commandService, opts)
     } catch {
       case e: Throwable =>
         println("Partitions reassignment failed due to " + e.getMessage)
@@ -435,7 +435,7 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   private[admin]
-  def executeAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
+  def executeAssignment(serviceClient : ReassignCommandService, opts: ReassignPartitionsCommandOptions): Unit = {
     val reassignmentJsonFile =  opts.options.valueOf(opts.reassignmentJsonFileOpt)
     val reassignmentJsonString = Utils.readFileAsString(reassignmentJsonFile)
     val interBrokerThrottle = opts.options.valueOf(opts.interBrokerThrottleOpt)
@@ -466,7 +466,7 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   private[admin]
-  def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin],
+  def executeAssignment(zkClient: KafkaZkClient,
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long = 10000L): Unit = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     executeAssignment(serviceClient, reassignmentJsonString, throttle, timeoutMs)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -286,7 +286,7 @@ object ReassignPartitionsCommand extends Logging {
 
     try {
       if(opts.options.has(opts.verifyOpt))
-        verifyAssignment(commandService, adminClientOpt, opts)
+        verifyAssignment(commandService, opts)
       else if(opts.options.has(opts.generateOpt))
         generateAssignment(commandService, opts)
       else if (opts.options.has(opts.executeOpt))
@@ -313,14 +313,14 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   private[admin]
-  def verifyAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
+  def verifyAssignment(serviceClient : ReassignCommandService, opts: ReassignPartitionsCommandOptions): Unit = {
     val jsonFile = opts.options.valueOf(opts.reassignmentJsonFileOpt)
     val jsonString = Utils.readFileAsString(jsonFile)
-    verifyAssignment(serviceClient, adminClientOpt, jsonString)
+    verifyAssignment(serviceClient, jsonString)
   }
 
   private[admin]
-  def verifyAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], jsonString: String): Unit = {
+  def verifyAssignment(serviceClient : ReassignCommandService, jsonString: String): Unit = {
     println("Status of partition reassignment: ")
     val (partitionsToBeReassigned, replicaAssignment) = parsePartitionReassignmentData(jsonString)
     val reassignedPartitionsStatus = checkIfPartitionReassignmentSucceeded(serviceClient, partitionsToBeReassigned.toMap)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -16,10 +16,8 @@
  */
 package kafka.admin
 
-import java.util.{Collections, Properties}
-import java.util.concurrent.{ExecutionException, TimeUnit}
-
-import kafka.admin.ConfigCommand.ConfigEntity
+import java.util.Properties
+import java.util.concurrent.ExecutionException
 import kafka.common.AdminCommandFailedException
 import kafka.log.LogConfig
 import kafka.log.LogConfig._
@@ -28,12 +26,12 @@ import kafka.utils._
 import kafka.utils.json.JsonValue
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo
-import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigOp, AlterReplicaLogDirsOptions, ConfigEntry, DescribeConfigsOptions, NewPartitionReassignment}
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigOp, AlterReplicaLogDirsOptions, ConfigEntry, NewPartitionReassignment}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.ReplicaNotAvailableException
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.utils.{Time, Utils}
-import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionReplica}
+import org.apache.kafka.common.{TopicPartition, TopicPartitionReplica}
 import org.apache.zookeeper.KeeperException.NodeExistsException
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -631,12 +631,6 @@ object ReassignPartitionsCommand extends Logging {
     checkIfPartitionReassignmentSucceeded(serviceClient, partitionsToBeReassigned)
   }
 
-  private[admin] def checkIfPartitionReassignmentSucceeded(adminClient: Admin, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
-  :Map[TopicPartition, ReassignmentStatus] = {
-    val serviceClient = AdminClientReassignCommandService(adminClient)
-    checkIfPartitionReassignmentSucceeded(serviceClient, partitionsToBeReassigned)
-  }
-
   private def checkIfReplicaReassignmentSucceeded(adminClientOpt: Option[Admin], replicaAssignment: Map[TopicPartitionReplica, String])
   :Map[TopicPartitionReplica, ReassignmentStatus] = {
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -277,12 +277,16 @@ object ReassignPartitionsCommand extends Logging {
 
   def main(args: Array[String]): Unit = {
     val opts = validateAndParseArgs(args)
-    val zkConnect = opts.options.valueOf(opts.zkConnectOpt)
     val time = Time.SYSTEM
-    val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 30000, 30000, Int.MaxValue, time)
-    val commandService = new ZkClientReassignCommandService(zkClient)
 
     val adminClientOpt = createAdminClient(opts)
+    val commandService = adminClientOpt match {
+      case Some(adminClient) => AdminClientReassignCommandService(adminClient)
+      case None =>
+        val zkConnect = opts.options.valueOf(opts.zkConnectOpt)
+        val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 30000, 30000, Int.MaxValue, time)
+        ZkClientReassignCommandService(zkClient)
+    }
 
     try {
       if(opts.options.has(opts.verifyOpt))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -312,12 +312,14 @@ object ReassignPartitionsCommand extends Logging {
     }
   }
 
+  private[admin]
   def verifyAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val jsonFile = opts.options.valueOf(opts.reassignmentJsonFileOpt)
     val jsonString = Utils.readFileAsString(jsonFile)
     verifyAssignment(serviceClient, adminClientOpt, jsonString)
   }
 
+  private[admin]
   def verifyAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], jsonString: String): Unit = {
     println("Status of partition reassignment: ")
     val (partitionsToBeReassigned, replicaAssignment) = parsePartitionReassignmentData(jsonString)
@@ -378,6 +380,7 @@ object ReassignPartitionsCommand extends Logging {
     }
   }
 
+  private[admin]
   def generateAssignment(serviceClient : ReassignCommandService, opts: ReassignPartitionsCommandOptions): Unit = {
     val topicsToMoveJsonFile = opts.options.valueOf(opts.topicsToMoveJsonFileOpt)
     val brokerListToReassign = opts.options.valueOf(opts.brokerListOpt).split(',').map(_.toInt)
@@ -391,6 +394,7 @@ object ReassignPartitionsCommand extends Logging {
     println("Proposed partition reassignment configuration\n%s".format(formatAsReassignmentJson(proposedAssignments, Map.empty)))
   }
 
+  private[admin]
   def generateAssignment(serviceClient : ReassignCommandService, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val topicsToReassign = parseTopicsData(topicsToMoveJsonString)
@@ -415,21 +419,22 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   // Package-private for testing
-  private[admin] def generateAssignment(zkClient: KafkaZkClient, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
+  private[admin]
+  def generateAssignment(zkClient: KafkaZkClient, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     generateAssignment(serviceClient, brokerListToReassign, topicsToMoveJsonString, disableRackAware)
 
   }
-
-  // Kafka-private for testing
-  private[kafka] def generateAssignment(adminClient: Admin, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
+  
+  def generateAssignment(adminClient: Admin, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
     generateAssignment(serviceClient, brokerListToReassign, topicsToMoveJsonString, disableRackAware)
 
   }
 
+  private[admin]
   def executeAssignment(serviceClient : ReassignCommandService, adminClientOpt: Option[Admin], opts: ReassignPartitionsCommandOptions): Unit = {
     val reassignmentJsonFile =  opts.options.valueOf(opts.reassignmentJsonFileOpt)
     val reassignmentJsonString = Utils.readFileAsString(reassignmentJsonFile)
@@ -439,6 +444,7 @@ object ReassignPartitionsCommand extends Logging {
     executeAssignment(serviceClient, reassignmentJsonString, Throttle(interBrokerThrottle, replicaAlterLogDirsThrottle), timeoutMs)
   }
 
+  private[admin]
   def executeAssignment(serviceClient : ReassignCommandService,
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long): Unit = {
     val (partitionAssignment, replicaAssignment) = parseAndValidate(serviceClient, reassignmentJsonString)
@@ -459,13 +465,14 @@ object ReassignPartitionsCommand extends Logging {
     }
   }
 
-  private[admin] def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin],
+  private[admin]
+  def executeAssignment(zkClient: KafkaZkClient, adminClientOpt: Option[Admin],
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long = 10000L): Unit = {
     val serviceClient = ZkClientReassignCommandService(zkClient)
     executeAssignment(serviceClient, reassignmentJsonString, throttle, timeoutMs)
   }
 
-  private[kafka] def executeAssignment(adminClient: Admin,
+  def executeAssignment(adminClient: Admin,
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long): Unit = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
     executeAssignment(serviceClient, reassignmentJsonString, throttle, timeoutMs)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -257,6 +257,7 @@ object ReassignPartitionsCommand extends Logging {
   val helpText = "This tool helps to moves topic partitions between replicas."
 
   // Two distinct public "constructors" one for ZK clients and one for AdminClient forms
+  @deprecated("Zookeeper direct access is deprecated", "Kafka 2.5" )
   def apply(zkClient: KafkaZkClient,
             adminClientOpt: Option[Admin],
             proposedPartitionAssignment: Map[TopicPartition, Seq[Int]],
@@ -423,6 +424,7 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   // Package-private for testing
+  @deprecated("Zookeeper direct access is deprecated", "Kafka 2.5" )
   private[admin]
   def generateAssignment(zkClient: KafkaZkClient, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
@@ -430,7 +432,7 @@ object ReassignPartitionsCommand extends Logging {
     generateAssignment(serviceClient, brokerListToReassign, topicsToMoveJsonString, disableRackAware)
 
   }
-  
+
   def generateAssignment(adminClient: Admin, brokerListToReassign: Seq[Int], topicsToMoveJsonString: String,
                          disableRackAware: Boolean): (Map[TopicPartition, Seq[Int]], Map[TopicPartition, Seq[Int]]) = {
     val serviceClient = AdminClientReassignCommandService(adminClient)
@@ -469,6 +471,7 @@ object ReassignPartitionsCommand extends Logging {
     }
   }
 
+  @deprecated("Zookeeper direct access is deprecated", "Kafka 2.5" )
   private[admin]
   def executeAssignment(zkClient: KafkaZkClient,
                         reassignmentJsonString: String, throttle: Throttle, timeoutMs: Long = 10000L): Unit = {
@@ -629,6 +632,7 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   // Package-private for testing.
+  @deprecated("Zookeeper direct access is deprecated", "Kafka 2.5" )
   private[admin] def checkIfPartitionReassignmentSucceeded(zkClient: KafkaZkClient, partitionsToBeReassigned: Map[TopicPartition, Seq[Int]])
   :Map[TopicPartition, ReassignmentStatus] = {
     val serviceClient = ZkClientReassignCommandService(zkClient)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -54,7 +54,7 @@ trait ReassignCommandService extends AutoCloseable {
   def getOngoingReassignments: Map[TopicPartition, Seq[Int]]
 }
 
-case class AdminClientReassignCommandService  (adminClient : Admin) extends ReassignCommandService {
+case class AdminClientReassignCommandService(adminClient : Admin) extends ReassignCommandService {
   override def getBrokerIdsInCluster: Seq[Int] = adminClient.describeCluster().nodes().get().asScala.map(_.id()).toArray
 
   override def getBrokerMetadatas(rackAwareMode: RackAwareMode, brokerList: Option[Seq[Int]]): Seq[BrokerMetadata] = {
@@ -96,8 +96,8 @@ case class AdminClientReassignCommandService  (adminClient : Admin) extends Reas
       v._2 match {
         case "" => AlterConfigOp.OpType.DELETE
         case _ => AlterConfigOp.OpType.SET
-    })
-  }.asJavaCollection
+      })
+    }.asJavaCollection
 
     val alterResult = adminClient.incrementalAlterConfigs(Map(
     configResource -> configUpdates
@@ -151,7 +151,7 @@ case class AdminClientReassignCommandService  (adminClient : Admin) extends Reas
     for (topicData <- topicDescriptions) {
       val topic = topicData._1
       for (partition <- topicData._2.partitions.asScala) {
-        replicaList(new TopicPartition(topic, partition.partition())) = partition.replicas.asScala.map(_.id())
+        replicaList += (new TopicPartition(topic, partition.partition()) -> partition.replicas.asScala.map(_.id()))
       }
     }
     replicaList

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -48,6 +48,7 @@ object ReassignPartitionsCommand extends Logging {
 
   val helpText = "This tool helps to moves topic partitions between replicas."
 
+  // Two distinct public "constructors" one for ZK clients and one for AdminClient forms
   def apply(zkClient: KafkaZkClient,
             adminClientOpt: Option[Admin],
             proposedPartitionAssignment: Map[TopicPartition, Seq[Int]],
@@ -55,6 +56,12 @@ object ReassignPartitionsCommand extends Logging {
             adminZkClient: AdminZkClient) : ReassignPartitionsCommand = {
     new ReassignPartitionsCommand(zkClient, adminClientOpt, proposedPartitionAssignment, proposedReplicaAssignment, adminZkClient)
   }
+
+  // Package-private constructor for testing
+  def apply(serviceClient: ReassignCommandService,
+            proposedPartitionAssignment: Map[TopicPartition, Seq[Int]],
+            proposedReplicaAssignment: Map[TopicPartitionReplica, String]) : ReassignPartitionsCommand =
+    new ReassignPartitionsCommand(serviceClient, proposedPartitionAssignment, proposedReplicaAssignment)
 
   def main(args: Array[String]): Unit = {
     val opts = validateAndParseArgs(args)

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -132,7 +132,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // reassign partition 0
     val oldAssignedReplicas = zkClient.getReplicasForPartition(new TopicPartition(topic, 0))
     val newReplicas = Seq(1, 2, 3)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None,
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None,
       Map(topicPartition -> newReplicas),  adminZkClient = adminZkClient)
     assertTrue("Partition reassignment should fail for [test,0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -133,7 +133,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     val oldAssignedReplicas = zkClient.getReplicasForPartition(new TopicPartition(topic, 0))
     val newReplicas = Seq(1, 2, 3)
     val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None,
-      Map(topicPartition -> newReplicas),  adminZkClient = adminZkClient)
+      Map(topicPartition -> newReplicas),  adminZkClientOpt = Some(adminZkClient))
     assertTrue("Partition reassignment should fail for [test,0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -444,7 +444,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     checkThrottleConfigAddedToZK(adminZkClient, initialThrottle, servers, topicName, Set("0:100","0:101"), Set("0:102"))
 
     //Ensure that running Verify, whilst the command is executing, should have no effect
-    verifyAssignment(serviceClient, None, ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Map.empty))
+    verifyAssignment(serviceClient, ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Map.empty))
 
     //Check throttle config again
     checkThrottleConfigAddedToZK(adminZkClient, initialThrottle, servers, topicName, Set("0:100","0:101"), Set("0:102"))
@@ -462,7 +462,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     waitForAdminReassignmentToComplete(serviceClient)
 
     //Verify should remove the throttle
-    verifyAssignment(serviceClient, None, ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Map.empty))
+    verifyAssignment(serviceClient, ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Map.empty))
 
     //Check removed
     checkThrottleConfigRemovedFromZK(adminZkClient, topicName, servers)

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -512,7 +512,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     )
 
     //When we run a throttled reassignment
-    ReassignPartitionsCommand(zkClient, None, move, adminZkClient = adminZkClient).reassignPartitions(throttle)
+    ReassignPartitionsCommand(zkClient, None, move, adminZkClientOpt = Some(adminZkClient)).reassignPartitions(throttle)
 
     waitForZkReassignmentToComplete()
 
@@ -552,7 +552,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2) //increase replication factor
     )
 
-    ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -577,7 +577,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2, 3) //increase replication factor
     )
 
-    ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -599,14 +599,14 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
 
     val thirdMove = Map(new TopicPartition("orders", 0) -> Seq(1, 2, 3))
 
-    ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
 
     val fourthMove = Map(new TopicPartition("payments", 1) -> Seq(2, 3))
 
     // Continuously attempt to set the reassignment znode with `fourthMove` until it succeeds. It will only succeed
     // after `thirdMove` completes.
     Iterator.continually {
-      try ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClient = adminZkClient).reassignPartitions()
+      try ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
       catch {
         case _: AdminCommandFailedException => false
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -512,7 +512,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     )
 
     //When we run a throttled reassignment
-    new ReassignPartitionsCommand(zkClient, None, move, adminZkClient = adminZkClient).reassignPartitions(throttle)
+    ReassignPartitionsCommand(zkClient, None, move, adminZkClient = adminZkClient).reassignPartitions(throttle)
 
     waitForZkReassignmentToComplete()
 
@@ -552,7 +552,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2) //increase replication factor
     )
 
-    new ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClient = adminZkClient).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -577,7 +577,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2, 3) //increase replication factor
     )
 
-    new ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClient = adminZkClient).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -599,14 +599,14 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
 
     val thirdMove = Map(new TopicPartition("orders", 0) -> Seq(1, 2, 3))
 
-    new ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClient = adminZkClient).reassignPartitions()
 
     val fourthMove = Map(new TopicPartition("payments", 1) -> Seq(2, 3))
 
     // Continuously attempt to set the reassignment znode with `fourthMove` until it succeeds. It will only succeed
     // after `thirdMove` completes.
     Iterator.continually {
-      try new ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClient = adminZkClient).reassignPartitions()
+      try ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClient = adminZkClient).reassignPartitions()
       catch {
         case _: AdminCommandFailedException => false
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -512,7 +512,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     )
 
     //When we run a throttled reassignment
-    ReassignPartitionsCommand(zkClient, None, move, adminZkClientOpt = Some(adminZkClient)).reassignPartitions(throttle)
+    ReassignPartitionsCommand(zkClient, move, adminZkClientOpt = Some(adminZkClient)).reassignPartitions(throttle)
 
     waitForZkReassignmentToComplete()
 
@@ -552,7 +552,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2) //increase replication factor
     )
 
-    ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, firstMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -577,7 +577,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2, 3) //increase replication factor
     )
 
-    ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, secondMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -599,14 +599,14 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
 
     val thirdMove = Map(new TopicPartition("orders", 0) -> Seq(1, 2, 3))
 
-    ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, thirdMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
 
     val fourthMove = Map(new TopicPartition("payments", 1) -> Seq(2, 3))
 
     // Continuously attempt to set the reassignment znode with `fourthMove` until it succeeds. It will only succeed
     // after `thirdMove` completes.
     Iterator.continually {
-      try ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
+      try ReassignPartitionsCommand(zkClient, fourthMove, adminZkClientOpt = Some(adminZkClient)).reassignPartitions()
       catch {
         case _: AdminCommandFailedException => false
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -571,7 +571,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
                    brokers: Seq[Int] = Seq[Int]()): KafkaZkClient = {
     val zkClient: KafkaZkClient = createMock(classOf[KafkaZkClient])
     expect(zkClient.getReplicaAssignmentForTopics(anyObject().asInstanceOf[Set[String]])).andStubReturn(existingAssignment)
-    expect(zkClient.getAllBrokersInCluster).andStubReturn(brokers.map(TestUtils.createBroker(_, "", 1)))
+    expect(zkClient.getSortedBrokerList).andStubReturn(brokers.sorted)
     replay(zkClient)
     zkClient
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -52,7 +52,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicas(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partition 0 moves from broker 100 -> 102. Partition 1 does not move.
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
@@ -74,7 +74,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasWhenProposedIsSubsetOfExisting(): Unit = {
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given we have more existing partitions than we are proposing
     val existingSuperset = Map(
@@ -110,7 +110,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicasMultiplePartitions(): Unit = {
     val control = new TopicPartition("topic1", 2) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partitions 0 & 1 moves from broker 100 -> 102. Partition 2 does not move.
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic1", 1) -> Seq(100, 101), control)
@@ -135,7 +135,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicasMultipleTopics(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given topics 1 -> move from broker 100 -> 102, topics 2 -> move from broker 101 -> 100
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic2", 0) -> Seq(101, 102), control)
@@ -166,7 +166,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasMultipleTopicsAndPartitions(): Unit = {
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given
     val existing = Map(
@@ -210,7 +210,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindTwoMovingReplicasInSamePartition(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partition 0 has 2 moves from broker 102 -> 104 & 103 -> 105
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101, 102, 103), control)
@@ -236,7 +236,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldNotOverwriteEntityConfigsWhenUpdatingThrottledReplicas(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
     val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
 
@@ -272,7 +272,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.fetchEntityConfig(anyString(), anyString())).andStubReturn(new Properties)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
     replay(admin)
@@ -298,7 +298,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Expect the existing broker config to be changed from 10/100 to 1000
@@ -332,7 +332,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Given there is some existing config
@@ -437,7 +437,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(0, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertTrue("Partition reassignment attempt failed for [test, 0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -466,7 +466,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(1, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -494,7 +494,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas),  adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas),  adminZkClient = adminZkClient)
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -519,7 +519,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertFalse("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     val reassignedPartitions = zkClient.getPartitionReassignment
     assertFalse("Partition should not be reassigned", reassignedPartitions.contains(topicAndPartition))
@@ -536,7 +536,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(0, 1)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     reassignPartitionsCommand.reassignPartitions()
     // create brokers
     servers = TestUtils.createBrokerConfigs(2, zkConnect, false).map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -48,6 +48,8 @@ import scala.util.Try
 class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   var servers: Seq[KafkaServer] = Seq()
   var calls = 0
+  val TestTopicName = "topic1"
+  val TestTopicAlternateName = "topic2"
 
   @Before
   def setup(): Unit = {
@@ -99,15 +101,15 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicas(): Unit = {
-    val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
+    val control = new TopicPartition(TestTopicName, 1) -> Seq(100, 102)
 
     //Given partition 0 moves from broker 100 -> 102. Partition 1 does not move.
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
-    val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101), control)
+    val proposed = Map(new TopicPartition(TestTopicName, 0) -> Seq(101, 102), control)
 
     class TestServiceClient() extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
-        assertEquals("topic1", topic)
+        assertEquals(TestTopicName, topic)
         assertEquals(Set("0:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
 
@@ -128,21 +130,21 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
     //Given we have more existing partitions than we are proposing
     val existingSuperset = Map(
-      new TopicPartition("topic1", 0) -> Seq(100, 101),
-      new TopicPartition("topic1", 1) -> Seq(100, 102),
-      new TopicPartition("topic1", 2) -> Seq(100, 101),
-      new TopicPartition("topic2", 0) -> Seq(100, 101, 102),
+      new TopicPartition(TestTopicName, 0) -> Seq(100, 101),
+      new TopicPartition(TestTopicName, 1) -> Seq(100, 102),
+      new TopicPartition(TestTopicName, 2) -> Seq(100, 101),
+      new TopicPartition(TestTopicAlternateName, 0) -> Seq(100, 101, 102),
       new TopicPartition("topic3", 0) -> Seq(100, 101, 102)
     )
     val proposedSubset = Map(
-      new TopicPartition("topic1", 0) -> Seq(101, 102),
-      new TopicPartition("topic1", 1) -> Seq(102),
-      new TopicPartition("topic1", 2) -> Seq(100, 101, 102)
+      new TopicPartition(TestTopicName, 0) -> Seq(101, 102),
+      new TopicPartition(TestTopicName, 1) -> Seq(102),
+      new TopicPartition(TestTopicName, 2) -> Seq(100, 101, 102)
     )
 
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
-        assertEquals("topic1", topic)
+        assertEquals(TestTopicName, topic)
         assertEquals(Set("0:102","2:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101","2:100","2:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
 
@@ -160,15 +162,15 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasMultiplePartitions(): Unit = {
-    val control = new TopicPartition("topic1", 2) -> Seq(100, 102)
+    val control = new TopicPartition(TestTopicName, 2) -> Seq(100, 102)
 
     //Given partitions 0 & 1 moves from broker 100 -> 102. Partition 2 does not move.
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic1", 1) -> Seq(100, 101), control)
-    val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), new TopicPartition("topic1", 1) -> Seq(101, 102), control)
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101), new TopicPartition(TestTopicName, 1) -> Seq(100, 101), control)
+    val proposed = Map(new TopicPartition(TestTopicName, 0) -> Seq(101, 102), new TopicPartition(TestTopicName, 1) -> Seq(101, 102), control)
 
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
-        assertEquals("topic1", topic)
+        assertEquals(TestTopicName, topic)
         assertEquals(Set("0:102","1:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101","1:100","1:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
 
@@ -186,20 +188,20 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasMultipleTopics(): Unit = {
-    val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
+    val control = new TopicPartition(TestTopicName, 1) -> Seq(100, 102)
 
     //Given topics 1 -> move from broker 100 -> 102, topics 2 -> move from broker 101 -> 100
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic2", 0) -> Seq(101, 102), control)
-    val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), new TopicPartition("topic2", 0) -> Seq(100, 102), control)
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101), new TopicPartition(TestTopicAlternateName, 0) -> Seq(101, 102), control)
+    val proposed = Map(new TopicPartition(TestTopicName, 0) -> Seq(101, 102), new TopicPartition(TestTopicAlternateName, 0) -> Seq(100, 102), control)
 
     //Then
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         topic match {
-          case "topic1" =>
+          case TestTopicName =>
             assertEquals(Set("0:100", "0:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get))
             assertEquals(Set("0:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get))
-          case "topic2" =>
+          case TestTopicAlternateName =>
             assertEquals(Set("0:101", "0:102"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get))
             assertEquals(Set("0:100"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get))
           case _ => fail(s"Unexpected topic $topic")
@@ -221,26 +223,26 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   def shouldFindMovingReplicasMultipleTopicsAndPartitions(): Unit = {
     //Given
     val existing = Map(
-      new TopicPartition("topic1", 0) -> Seq(100, 101),
-      new TopicPartition("topic1", 1) -> Seq(100, 101),
-      new TopicPartition("topic2", 0) -> Seq(101, 102),
-      new TopicPartition("topic2", 1) -> Seq(101, 102)
+      new TopicPartition(TestTopicName, 0) -> Seq(100, 101),
+      new TopicPartition(TestTopicName, 1) -> Seq(100, 101),
+      new TopicPartition(TestTopicAlternateName, 0) -> Seq(101, 102),
+      new TopicPartition(TestTopicAlternateName, 1) -> Seq(101, 102)
     )
     val proposed = Map(
-      new TopicPartition("topic1", 0) -> Seq(101, 102), //moves to 102
-      new TopicPartition("topic1", 1) -> Seq(101, 102), //moves to 102
-      new TopicPartition("topic2", 0) -> Seq(100, 102), //moves to 100
-      new TopicPartition("topic2", 1) -> Seq(101, 100)  //moves to 100
+      new TopicPartition(TestTopicName, 0) -> Seq(101, 102), //moves to 102
+      new TopicPartition(TestTopicName, 1) -> Seq(101, 102), //moves to 102
+      new TopicPartition(TestTopicAlternateName, 0) -> Seq(100, 102), //moves to 100
+      new TopicPartition(TestTopicAlternateName, 1) -> Seq(101, 100)  //moves to 100
     )
 
     //Then
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         topic match {
-          case "topic1" =>
+          case TestTopicName =>
             assertEquals(Set("0:102","1:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get))
             assertEquals(Set("0:100","0:101","1:100","1:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get))
-          case "topic2" =>
+          case TestTopicAlternateName =>
             assertEquals(Set("0:100","1:100"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get))
             assertEquals(Set("0:101","0:102","1:101","1:102"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get))
           case _ => fail(s"Unexpected topic $topic")
@@ -259,16 +261,16 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindTwoMovingReplicasInSamePartition(): Unit = {
-    val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
+    val control = new TopicPartition(TestTopicName, 1) -> Seq(100, 102)
 
     //Given partition 0 has 2 moves from broker 102 -> 104 & 103 -> 105
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101, 102, 103), control)
-    val proposed = Map(new TopicPartition("topic1", 0) -> Seq(100, 101, 104, 105), control)
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101, 102, 103), control)
+    val proposed = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101, 104, 105), control)
 
     // Then
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
-        assertEquals("topic1", topic)
+        assertEquals(TestTopicName, topic)
         assertEquals(Set("0:104","0:105"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replicas
         assertEquals(Set("0:100","0:101","0:102","0:103"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
         calls += 1
@@ -287,14 +289,14 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldNotOverwriteEntityConfigsWhenUpdatingThrottledReplicas(): Unit = {
-    val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
-    val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
+    val control = new TopicPartition(TestTopicName, 1) -> Seq(100, 102)
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101), control)
+    val proposed = Map(new TopicPartition(TestTopicName, 0) -> Seq(101, 102), control)
     
     //Then the dummy property should still be there
     class TestServiceClient extends TestServiceClientBase {
       override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
-        assertEquals("topic1", topic)
+        assertEquals(TestTopicName, topic)
         assertFalse(configChange.contains("some-key"))
         assert(configChange.contains(FollowerReplicationThrottledReplicasProp)) //Should only be follower-throttle the moving replicas
         assert(configChange.contains(LeaderReplicationThrottledReplicasProp)) //Should leader-throttle all existing (pre move) replicas
@@ -315,8 +317,8 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldSetQuotaLimit(): Unit = {
     //Given
-    val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101))
-    val proposed = mutable.Map(new TopicPartition("topic1", 0) -> Seq(101, 102))
+    val existing = Map(new TopicPartition(TestTopicName, 0) -> Seq(100, 101))
+    val proposed = mutable.Map(new TopicPartition(TestTopicName, 0) -> Seq(101, 102))
 
     //Setup
     val service: ReassignCommandService = createMock(classOf[ReassignCommandService])
@@ -344,7 +346,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   def shouldRemoveThrottleLimitFromAllBrokers(): Unit = {
     //Given 3 brokers, but with assignment only covering 2 of them
     val brokers = Seq(100, 101, 102)
-    val status = mutable.Map(new TopicPartition("topic1", 0) -> ReassignmentCompleted)
+    val status = mutable.Map(new TopicPartition(TestTopicName, 0) -> ReassignmentCompleted)
 
     //Setup
     val service: ReassignCommandService = createMock(classOf[ReassignCommandService])
@@ -352,7 +354,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val topicPropsCapture: Capture[Map[String, String]] = newCapture(CaptureType.ALL)
     expect(service.getBrokerIdsInCluster).andStubReturn(brokers)
     expect(service.updateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
-    expect(service.updateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is(TestTopicName), capture(topicPropsCapture))).andReturn(true).anyTimes()
     replay(service)
 
     //When
@@ -382,8 +384,8 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val brokers = Seq(100, 101)
 
     //Given two topics being reassigned
-    val status = mutable.Map(new TopicPartition("topic1", 0) -> ReassignmentCompleted,
-                             new TopicPartition("topic2", 0) -> ReassignmentCompleted)
+    val status = mutable.Map(new TopicPartition(TestTopicName, 0) -> ReassignmentCompleted,
+                             new TopicPartition(TestTopicAlternateName, 0) -> ReassignmentCompleted)
 
     //Setup
     val service: ReassignCommandService = createMock(classOf[ReassignCommandService])
@@ -393,8 +395,8 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     expect(service.updateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
 
     // Should change configs of both topics
-    expect(service.updateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
-    expect(service.updateTopicConfigs(is("topic2"), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is(TestTopicName), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is(TestTopicAlternateName), capture(topicPropsCapture))).andReturn(true).anyTimes()
 
     replay(service)
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -70,10 +70,10 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     override def getBrokerMetadatas(rackAwareMode: RackAwareMode, brokerList: Option[Seq[Int]]): Seq[BrokerMetadata] =
       throw new UnimplementedException()
 
-    override def UpdateBrokerConfigs(broker: Int, configs: collection.Map[String, String]): Boolean =
+    override def updateBrokerConfigs(broker: Int, configs: collection.Map[String, String]): Boolean =
       throw new UnimplementedException()
 
-    override def UpdateTopicConfigs(topic: String, configs: collection.Map[String, String]): Boolean =
+    override def updateTopicConfigs(topic: String, configs: collection.Map[String, String]): Boolean =
       throw new UnimplementedException()
 
     override def getPartitionsForTopics(topics: Set[String]): collection.Map[String, Seq[Int]] =
@@ -108,7 +108,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
 
     class TestServiceClient() extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         assertEquals("topic1", topic)
         assertEquals(Set("0:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
@@ -143,7 +143,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     )
 
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         assertEquals("topic1", topic)
         assertEquals(Set("0:102","2:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101","2:100","2:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
@@ -169,7 +169,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), new TopicPartition("topic1", 1) -> Seq(101, 102), control)
 
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         assertEquals("topic1", topic)
         assertEquals(Set("0:102","1:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replica
         assertEquals(Set("0:100","0:101","1:100","1:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
@@ -196,7 +196,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
     //Then
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         topic match {
           case "topic1" =>
             assertEquals(Set("0:100", "0:101"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get))
@@ -237,7 +237,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
     //Then
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         topic match {
           case "topic1" =>
             assertEquals(Set("0:102","1:102"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get))
@@ -269,7 +269,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
     // Then
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         assertEquals("topic1", topic)
         assertEquals(Set("0:104","0:105"), toReplicaSet(configChange.get(FollowerReplicationThrottledReplicasProp).get)) //Should only be follower-throttle the moving replicas
         assertEquals(Set("0:100","0:101","0:102","0:103"), toReplicaSet(configChange.get(LeaderReplicationThrottledReplicasProp).get)) //Should leader-throttle all existing (pre move) replicas
@@ -295,7 +295,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     
     //Then the dummy property should still be there
     class TestServiceClient extends TestServiceClientBase {
-      override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
+      override def updateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {
         assertEquals("topic1", topic)
         assertFalse(configChange.contains("some-key"))
         assert(configChange.contains(FollowerReplicationThrottledReplicasProp)) //Should only be follower-throttle the moving replicas
@@ -325,7 +325,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val propsCapture: Capture[mutable.Map[String, String]] = newCapture(CaptureType.ALL)
     val assigner = ReassignPartitionsCommand(service,  proposed, Map.empty[TopicPartitionReplica, String])
     expect(service.getReplicaAssignmentForTopics(anyObject.asInstanceOf[Set[String]])).andStubReturn(existing)
-    expect(service.UpdateBrokerConfigs(anyObject().asInstanceOf[Int], capture(propsCapture))).andReturn(true).anyTimes()
+    expect(service.updateBrokerConfigs(anyObject().asInstanceOf[Int], capture(propsCapture))).andReturn(true).anyTimes()
 
     replay(service)
 
@@ -353,8 +353,8 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val brokerPropsCapture: Capture[Map[String, String]] = newCapture(CaptureType.ALL)
     val topicPropsCapture: Capture[Map[String, String]] = newCapture(CaptureType.ALL)
     expect(service.getBrokerIdsInCluster).andStubReturn(brokers)
-    expect(service.UpdateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
-    expect(service.UpdateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
     replay(service)
 
     //When
@@ -392,11 +392,11 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val brokerPropsCapture: Capture[Map[String, String]] = newCapture(CaptureType.ALL)
     val topicPropsCapture: Capture[Map[String, String]] = newCapture(CaptureType.ALL)
     expect(service.getBrokerIdsInCluster).andStubReturn(brokers)
-    expect(service.UpdateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateBrokerConfigs(anyObject().asInstanceOf[Int], capture(brokerPropsCapture))).andReturn(true).anyTimes()
 
     // Should change configs of both topics
-    expect(service.UpdateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
-    expect(service.UpdateTopicConfigs(is("topic2"), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is("topic1"), capture(topicPropsCapture))).andReturn(true).anyTimes()
+    expect(service.updateTopicConfigs(is("topic2"), capture(topicPropsCapture))).andReturn(true).anyTimes()
 
     replay(service)
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -67,7 +67,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, adminZkClientOpt = Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, adminZkClientOpt = Some(admin))
 
     assigner.assignThrottledReplicas(existing, proposed)
     assertEquals(1, calls)
@@ -102,7 +102,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, adminZkClientOpt = Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, adminZkClientOpt = Some(admin))
     //Then replicas should assign correctly (based on the proposed map)
     assigner.assignThrottledReplicas(existingSuperset, proposedSubset)
     assertEquals(1, calls)
@@ -127,7 +127,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, Some(admin))
     //When
     assigner.assignThrottledReplicas(existing, proposed)
     assertEquals(1, calls)
@@ -159,7 +159,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, Some(admin))
     //When
     assigner.assignThrottledReplicas(existing, proposed)
     assertEquals(2, calls)
@@ -200,7 +200,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, Some(admin))
     //When
     assigner.assignThrottledReplicas(existing, proposed)
     assertEquals(2, calls)
@@ -226,7 +226,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, Some(admin))
 
     //When
     assigner.assignThrottledReplicas(existing, proposed)
@@ -255,7 +255,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     val admin = new TestAdminZkClient(zkClient)
-    val assigner = ReassignPartitionsCommand(null, null, null, null, Some(admin))
+    val assigner = ReassignPartitionsCommand(null, null, null, Some(admin))
 
     //When
     assigner.assignThrottledReplicas(existing, proposed)
@@ -272,7 +272,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, Some(admin))
+    val assigner = ReassignPartitionsCommand(zk,  proposed, Map.empty, Some(admin))
     // Return a fresh set of Properties for each broker
     expect(admin.fetchEntityConfig(is(ConfigType.Broker), is("100"))).andStubReturn(new Properties)
     expect(admin.fetchEntityConfig(is(ConfigType.Broker), is("101"))).andStubReturn(new Properties)
@@ -304,7 +304,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, Some(admin))
+    val assigner = ReassignPartitionsCommand(zk,  proposed, Map.empty, Some(admin))
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Expect the existing broker config to be changed from 10/100 to 1000
@@ -338,7 +338,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, Some(admin))
+    val assigner = ReassignPartitionsCommand(zk, proposed, Map.empty, Some(admin))
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Given there is some existing config
@@ -449,7 +449,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(0, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient,  Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
     assertTrue("Partition reassignment attempt failed for [test, 0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -478,7 +478,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(1, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient,  Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -506,7 +506,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas),  adminZkClientOpt = Some(adminZkClient))
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient,  Map(topicAndPartition -> newReplicas),  adminZkClientOpt = Some(adminZkClient))
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -531,7 +531,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient,  Map(topicAndPartition -> newReplicas), adminZkClientOpt = Some(adminZkClient))
     assertFalse("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     val reassignedPartitions = zkClient.getPartitionReassignment
     assertFalse("Partition should not be reassigned", reassignedPartitions.contains(topicAndPartition))

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -23,7 +23,6 @@ import kafka.admin.ReassignPartitionsCommand.Throttle
 import kafka.log.LogConfig
 import kafka.log.LogConfig._
 import kafka.server.{DynamicConfig, KafkaConfig, KafkaServer}
-import kafka.utils.CoreUtils._
 import kafka.utils.TestUtils._
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{KafkaZkClient, ZooKeeperTestHarness}
@@ -39,7 +38,6 @@ import org.scalatest.Assertions.fail
 
 import scala.collection.JavaConverters._
 import org.apache.kafka.common.{TopicPartition, TopicPartitionReplica}
-import org.apache.zookeeper.KeeperException.UnimplementedException
 
 import scala.collection.mutable
 import scala.collection.Seq
@@ -65,36 +63,36 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   // Base Test Service Client with minimal functionality, just enough for our tests to
   // override
   class TestServiceClientBase extends ReassignCommandService {
-    override def getBrokerIdsInCluster: Seq[Int] = throw new UnimplementedException()
+    override def getBrokerIdsInCluster: Seq[Int] = throw new UnsupportedOperationException()
 
     override def getBrokerMetadatas(rackAwareMode: RackAwareMode, brokerList: Option[Seq[Int]]): Seq[BrokerMetadata] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def updateBrokerConfigs(broker: Int, configs: collection.Map[String, String]): Boolean =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def updateTopicConfigs(topic: String, configs: collection.Map[String, String]): Boolean =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def getPartitionsForTopics(topics: Set[String]): collection.Map[String, Seq[Int]] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def getReplicaLogDirsForTopics(topics: collection.Set[TopicPartitionReplica]): collection.Map[TopicPartitionReplica, DescribeReplicaLogDirsResult.ReplicaLogDirInfo] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def alterPartitionAssignment(topics: collection.Map[TopicPartition, Seq[Int]], timeoutMs: Long): Unit =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def alterReplicaLogDirs(topics: collection.Map[TopicPartitionReplica, String], timeoutMs: Long): collection.Set[TopicPartitionReplica] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def getReplicaAssignmentForTopics(topics: Set[String]): collection.Map[TopicPartition, Seq[Int]] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
-    override def reassignInProgress: Boolean = throw new UnimplementedException()
+    override def reassignInProgress: Boolean = throw new UnsupportedOperationException()
 
     override def getOngoingReassignments: collection.Map[TopicPartition, Seq[Int]] =
-      throw new UnimplementedException()
+      throw new UnsupportedOperationException()
 
     override def close(): Unit = Unit
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -292,10 +292,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
     val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
-
-    //Given partition there are existing properties
-    val existingProperties = propsWith("some-key", "some-value")
-
+    
     //Then the dummy property should still be there
     class TestServiceClient extends TestServiceClientBase {
       override def UpdateTopicConfigs(topic: String, configChange: collection.Map[String, String]): Boolean = {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -22,11 +22,11 @@ import java.util.Properties
 import kafka.admin.ReassignPartitionsCommand.Throttle
 import kafka.log.LogConfig
 import kafka.log.LogConfig._
-import kafka.server.{ConfigType, DynamicConfig, KafkaConfig, KafkaServer}
+import kafka.server.{DynamicConfig, KafkaConfig, KafkaServer}
 import kafka.utils.CoreUtils._
 import kafka.utils.TestUtils._
-import kafka.utils.{CoreUtils, Logging, TestUtils}
-import kafka.zk.{AdminZkClient, KafkaZkClient, ZooKeeperTestHarness}
+import kafka.utils.{Logging, TestUtils}
+import kafka.zk.{KafkaZkClient, ZooKeeperTestHarness}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{AdminClient, DescribeReplicaLogDirsResult}
 import org.apache.kafka.common.network.ListenerName
@@ -34,7 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.easymock.EasyMock._
 import org.easymock.{Capture, CaptureType, EasyMock}
 import org.junit.{After, Before, Test}
-import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.scalatest.Assertions.fail
 
 import scala.collection.JavaConverters._

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package unit.kafka.admin
+
+import java.util.concurrent.ExecutionException
+import java.util.{Collections, Properties}
+
+import kafka.admin.{AdminClientReassignCommandService, AdminOperationException, BrokerMetadata, RackAwareMode, ZkClientReassignCommandService}
+import kafka.log.LogConfig.{FollowerReplicationThrottledReplicasProp, LeaderReplicationThrottledReplicasProp}
+import kafka.server.{ConfigType, KafkaServer}
+import kafka.utils.{Logging, TestUtils}
+import kafka.zk.{AdminZkClient, KafkaZkClient, ZooKeeperTestHarness}
+import org.apache.kafka.clients.admin.{Admin, MockAdminClient}
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo}
+import org.easymock.EasyMock.{replay, _}
+import org.easymock.{Capture, CaptureType, EasyMock}
+import org.junit.{After, Test}
+import org.junit.Assert.{assertEquals, assertFalse}
+
+import scala.collection.Seq
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+/*
+ * Validate methods of the ZkServiceClient used by the ReassignPartitionsCommand.
+ * Many methods are just passthroughs, and are not tested (presumed to be tested elsewhere).
+ * Any method with "real" logic should be validated.
+ */
+class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Logging {
+  var servers: Seq[KafkaServer] = Seq()
+  var calls = 0
+
+  @After
+  override def tearDown(): Unit = {
+    TestUtils.shutdownServers(servers)
+    super.tearDown()
+  }
+
+  // Test update topic configs and broker configs
+  @Test
+  def testShouldOverrideTopicConfigs() : Unit = {
+    val testTopicName = "TOPIC0"
+    val configUpdatesMap = Map("property1" -> "0", "property2" -> "1")
+
+    // Test 1: Have empty properties, this should just set the ones we expect.
+    val test1Properties = new Properties()
+    configUpdatesMap.foreach({ case (k,v) => test1Properties.setProperty(k : String, v : String)})
+    val mockZkClient : KafkaZkClient = createMock(classOf[KafkaZkClient])
+    val mockAdminZkClient : AdminZkClient= createMock(classOf[AdminZkClient])
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Topic, testTopicName)).andReturn(new Properties)
+    expect(mockAdminZkClient.changeTopicConfig(testTopicName, test1Properties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val service = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    service.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+
+    // Test 2: Hove other Properties that are completely disjoint from the ones we're updating.
+    reset(mockZkClient)
+    reset(mockAdminZkClient)
+    var test2Properties = new Properties
+    val test2XtraPropertiesMap = Map("otherProp1" -> "otherVal1", "otherProp2" -> "otherVal2")
+    for ((k,v) <- test2XtraPropertiesMap) {
+      test2Properties.setProperty(k, v)
+    }
+    val test2ExpectedPropertiesMap = configUpdatesMap ++ test2XtraPropertiesMap
+    var test2ExpectedProperties = new Properties
+    for ((k,v) <- test2ExpectedPropertiesMap) {
+      test2ExpectedProperties.setProperty(k, v)
+    }
+
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Topic, testTopicName)).andReturn(test2Properties)
+    expect(mockAdminZkClient.changeTopicConfig(testTopicName, test2ExpectedProperties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val serviceTest2 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    serviceTest2.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+
+    // Test 3. Overwrite some properties.
+    reset(mockZkClient)
+    reset(mockAdminZkClient)
+    var test3Properties = new Properties
+    val test3PropertiesMap = Map("otherProp1" -> "otherVal1", "property2" -> "origVal2")
+    var test3ExpectedProperties = new Properties()
+    for ((k,v) <- test3PropertiesMap) {
+      test3Properties.setProperty(k, v)
+      test3ExpectedProperties.setProperty(k, v)
+    }
+    for ((k,v) <- configUpdatesMap) {
+      test3ExpectedProperties.setProperty(k, v)
+    }
+
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Topic, testTopicName)).andReturn(test3Properties)
+    expect(mockAdminZkClient.changeTopicConfig(testTopicName, test3ExpectedProperties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val serviceTest3 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    serviceTest3.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+  }
+
+  // Test update broker configs. This behaves similarly to the topic test but the
+  // interface is slightly different.
+  @Test
+  def testShouldOverrideBrokerConfigs() : Unit = {
+    val testBrokerId = 17
+    val configUpdatesMap = Map("property1" -> "0", "property2" -> "1")
+
+    // Test 1: Have empty properties, this should just set the ones we expect.
+    val test1Properties = new Properties()
+    configUpdatesMap.foreach({ case (k,v) => test1Properties.setProperty(k : String, v : String)})
+    val mockZkClient : KafkaZkClient = createMock(classOf[KafkaZkClient])
+    val mockAdminZkClient : AdminZkClient= createMock(classOf[AdminZkClient])
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Broker, testBrokerId.toString)).andReturn(new Properties)
+    expect(mockAdminZkClient.changeBrokerConfig(Seq(testBrokerId), test1Properties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val service = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    service.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+
+    // Test 2: Hove other Properties that are completely disjoint from the ones we're updating.
+    reset(mockZkClient)
+    reset(mockAdminZkClient)
+    var test2Properties = new Properties
+    val test2XtraPropertiesMap = Map("otherProp1" -> "otherVal1", "otherProp2" -> "otherVal2")
+    for ((k,v) <- test2XtraPropertiesMap) {
+      test2Properties.setProperty(k, v)
+    }
+    val test2ExpectedPropertiesMap = configUpdatesMap ++ test2XtraPropertiesMap
+    var test2ExpectedProperties = new Properties
+    for ((k,v) <- test2ExpectedPropertiesMap) {
+      test2ExpectedProperties.setProperty(k, v)
+    }
+
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Broker, testBrokerId.toString)).andReturn(test2Properties)
+    expect(mockAdminZkClient.changeBrokerConfig(Seq(testBrokerId), test2ExpectedProperties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val serviceTest2 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    serviceTest2.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+
+    // Test 3. Overwrite some properties.
+    reset(mockZkClient)
+    reset(mockAdminZkClient)
+    var test3Properties = new Properties
+    val test3PropertiesMap = Map("otherProp1" -> "otherVal1", "property2" -> "origVal2")
+    var test3ExpectedProperties = new Properties()
+    for ((k,v) <- test3PropertiesMap) {
+      test3Properties.setProperty(k, v)
+      test3ExpectedProperties.setProperty(k, v)
+    }
+    for ((k,v) <- configUpdatesMap) {
+      test3ExpectedProperties.setProperty(k, v)
+    }
+
+    expect(mockAdminZkClient.fetchEntityConfig(ConfigType.Broker, testBrokerId.toString)).andReturn(test3Properties)
+    expect(mockAdminZkClient.changeBrokerConfig(Seq(testBrokerId), test3ExpectedProperties))
+    replay(mockZkClient)
+    replay(mockAdminZkClient)
+
+    val serviceTest3 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
+
+    serviceTest3.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+  }
+
+}
+
+/**
+ * Validate the AdminServiceClient used by the ReassignPartitionsCommand.
+ */
+class ReassignPartitionsServiceClientAdminTest {
+  // Define a standardized test cluster
+  val brokerIds = List(1, 4, 6, 7)
+  val portBase = 9000
+  // Try with a set of brokers where some have rack info and some don't
+  val brokerList = brokerIds.map { id => new Node(id, s"broker-$id", portBase, if (id % 2 == 0) { "" } else { s"rack-$id" }) }
+  // Topic test 1 has 2 partitions, 3RF, one partition is UR
+  // XXX: MockAdminClient doesn't allow partitions with different replica sets
+  val test1Partitions = List(new TopicPartitionInfo(1, brokerList(0), List(brokerList(0), brokerList(1), brokerList(2)).asJava,
+    List(brokerList(0), brokerList(1)).asJava),
+    new TopicPartitionInfo(2, brokerList(1), List(brokerList(0), brokerList(1), brokerList(2)).asJava,
+      List(brokerList(0), brokerList(1), brokerList(2)).asJava)).asJava
+
+  // Topic test2 has just 1 partition, RF 3, 1 UR partition
+  val test2Partitions = List(new TopicPartitionInfo(1, brokerList(3), List(brokerList(2), brokerList(3), brokerList(0)).asJava,
+    List(brokerList(3), brokerList(0)).asJava)).asJava
+
+  // Topic test3 has 3 partitions, RF3
+  val test3Partitions =  List(new TopicPartitionInfo(1, brokerList(0), List(brokerList(0), brokerList(1), brokerList(2)).asJava,
+    List(brokerList(0), brokerList(1)).asJava),
+    new TopicPartitionInfo(2, brokerList(1), List(brokerList(0), brokerList(1), brokerList(2)).asJava,
+      List(brokerList(0), brokerList(1), brokerList(2)).asJava),
+    new TopicPartitionInfo(3, brokerList(1), List(brokerList(0), brokerList(1), brokerList(2)).asJava,
+      List(brokerList(0), brokerList(1), brokerList(2)).asJava)).asJava
+
+
+  /**
+   * Set up the standardized test cluster.
+   */
+  def setUpTestCluster() : Admin = {
+    // Note the non-sequential, non-zero-based IDs.
+    val mockAdmin = new MockAdminClient(brokerList.asJava, brokerList(2))
+
+    mockAdmin.addTopic(false, "test1", test1Partitions, Collections.emptyMap())
+    mockAdmin.addTopic(false, "test2", test2Partitions, Collections.emptyMap())
+    mockAdmin.addTopic(false, "test3", test3Partitions, Collections.emptyMap())
+
+    mockAdmin
+  }
+
+  @Test
+  def testGetBrokerList() : Unit = {
+    val mockAdmin = setUpTestCluster()
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+
+    val brokerResults = serviceClient.getBrokerIdsInCluster
+    assertEquals(brokerIds, brokerResults)
+  }
+
+  @Test
+  def testGetBrokerMetadatasRackedBrokers() : Unit = {
+    // Don't use the standard Test Cluster but one that's all got rack data
+    val brokerIds = List(0, 1, 2, 3)
+    val portBase = 9000
+    val brokerList = brokerIds.map { id => new Node(id, s"broker-$id", portBase, s"rack-$id"); }
+    val mockAdmin = new MockAdminClient(brokerList.asJava, brokerList(2))
+
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+
+    // Test the flavors of rack-aware with valid rack info
+    val brokerMetadataRackDisabled = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Disabled, None)
+    assertEquals(brokerIds.map(id => new BrokerMetadata(id, None)), brokerMetadataRackDisabled)
+
+    val brokerMetadataRackAware = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Enforced, None)
+    assertEquals(brokerIds.map(id => new BrokerMetadata(id, Some(s"rack-$id"))), brokerMetadataRackAware)
+
+    // RackAwareMode Safe should return rack info for this example
+    val brokerMetadataRackSafe = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Safe, None)
+    assertEquals(brokerIds.map(id => new BrokerMetadata(id, Some(s"rack-$id"))), brokerMetadataRackSafe)
+  }
+
+  @Test
+  def testGetBrokerMetadatasMixedRackData() : Unit = {
+    val mockAdmin = setUpTestCluster()
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+
+    // Test the flavors of rack-aware with not-all-valid rack info
+    val brokerMetadataRackDisabled = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Disabled, None)
+    assertEquals(brokerIds.map(id => new BrokerMetadata(id, None)), brokerMetadataRackDisabled)
+
+    // Enforced rack mode should throw here
+    val badRackResult = Try(serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Enforced, None))
+    assert(badRackResult.isFailure)
+    badRackResult match {
+        // Shouldn't succeed
+      case Success(v) => false
+        // Expect an AdminOperationException
+      case Failure(e: kafka.admin.AdminOperationException) => true
+      case Failure(e) => false
+    }
+
+    // RackAwareMode Safe should return *no* rack info for this example.
+    val brokerMetadataRackSafe = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Safe, None)
+    assertEquals(brokerIds.map(id => new BrokerMetadata(id, None)), brokerMetadataRackSafe)
+  }
+
+  @Test
+  def testGetBrokerMetadatasLimitedSet() : Unit = {
+    val mockAdmin = setUpTestCluster()
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+    val interestingBrokers = Array(4, 6)
+
+    // Test limiting
+    val brokerMetadataLimited = serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Disabled, Some(interestingBrokers))
+    assert(brokerMetadataLimited.forall{ n => interestingBrokers.contains(n.id) })
+
+    val brokerMetadataFullList =  serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Disabled, Some(List.empty[Int]))
+    assertEquals(brokerIds, brokerMetadataFullList.collect ({ case m: BrokerMetadata  => m.id}))
+
+    val brokerMetadataFullNone =  serviceClient.getBrokerMetadatas(kafka.admin.RackAwareMode.Disabled, None)
+    assertEquals(brokerIds, brokerMetadataFullNone.collect ({ case m: BrokerMetadata => m.id}))
+  }
+
+
+  def testUpdateBrokerConfigs() : Unit = ???
+
+  def testUpdateTopicConfigs() : Unit = ???
+
+  @Test
+  def testGetPartitionsForTopics() : Unit = {
+    val mockAdmin = setUpTestCluster()
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+
+    // Test 1: Fetch all known topics
+    val topicQuery1 = Set("test1", "test2", "test3")
+    val topicResult1 = serviceClient.getPartitionsForTopics(topicQuery1)
+    assertEquals(topicResult1("test1"), Seq(1,2))
+    assertEquals(topicResult1("test2"), Seq(1))
+    assertEquals(topicResult1("test3"), Seq(1,2,3))
+
+    // Test 2: Fetch not all topics
+    val topicQuery2 = Set("test2", "test3")
+    val topicResult2 = serviceClient.getPartitionsForTopics(topicQuery2)
+    assertEquals(topicResult2("test2"), Seq(1))
+    assertEquals(topicResult2("test3"), Seq(1,2,3))
+    assertFalse(topicResult2.contains("test1"))
+
+    // Test 3: Attempt to fetch an invalid topic
+    val topicQuery3 = Set("test1", "test4")
+    val topicResult3 = Try(serviceClient.getPartitionsForTopics(topicQuery3))
+    assert(topicResult3.isFailure)
+    assert(topicResult3 match {
+      case Failure(e: ExecutionException) => e.getCause match {
+        case t : UnknownTopicOrPartitionException => true
+        case _ => throw e.getCause
+      }
+      case _ => false
+    })
+  }
+
+  @Test
+  def testGetReplicaAssignmentForTopics() : Unit = {
+    val mockAdmin = setUpTestCluster()
+    val serviceClient = new AdminClientReassignCommandService(mockAdmin)
+
+    // Test 1: Fetch partitions for all known topics
+    val topicQuery1 = Set("test1", "test2", "test3")
+    val topicResult1 = serviceClient.getReplicaAssignmentForTopics(topicQuery1)
+    assertEquals(topicResult1(new TopicPartition("test1", 1)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test1", 2)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test2", 1)), Seq(6, 7, 1))
+    assertEquals(topicResult1(new TopicPartition("test3", 1)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test3", 2)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test3", 3)), Seq(1, 4, 6))
+
+    // Test 2: Fetch not all topics
+    val topicQuery2 = Set("test2", "test3")
+    val topicResult2 = serviceClient.getReplicaAssignmentForTopics(topicQuery2)
+    assertEquals(topicResult1(new TopicPartition("test2", 1)), Seq(6, 7, 1))
+    assertEquals(topicResult1(new TopicPartition("test3", 1)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test3", 2)), Seq(1, 4, 6))
+    assertEquals(topicResult1(new TopicPartition("test3", 3)), Seq(1, 4, 6))
+    assertFalse(topicResult2.contains(new TopicPartition("test1", 1)))
+
+    // Test 3: Attempt to fetch an invalid topic
+    val topicQuery3 = Set("test1", "test4")
+    val topicResult3 = Try(serviceClient.getReplicaAssignmentForTopics(topicQuery3))
+    assert(topicResult3.isFailure)
+    assert(topicResult3 match {
+      case Failure(e: ExecutionException) => e.getCause match {
+        case t : UnknownTopicOrPartitionException => true
+        case _ => throw e.getCause
+      }
+      case _ => false
+    })
+
+  }
+
+  def testGetReplicaLogDirsForTopics() : Unit = ???
+
+  def testAlterPartitionAssignment() : Unit = ???
+
+  def testAlterPartitionLogDirs() : Unit = ???
+
+  def testGetReassignmentInProgress() : Unit = ???
+
+  def testGetOngoingReassignments() : Unit = ???
+
+}

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
@@ -28,7 +28,7 @@ import kafka.zk.{AdminZkClient, KafkaZkClient, ZooKeeperTestHarness}
 import org.apache.kafka.clients.admin.{Admin, MockAdminClient}
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo}
-import org.easymock.EasyMock.{replay, _}
+import org.easymock.EasyMock._
 import org.junit.{After, Test}
 import org.junit.Assert.{assertEquals, assertFalse}
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsServiceClientTest.scala
@@ -69,7 +69,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val service = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    service.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+    service.updateTopicConfigs("TOPIC0", configUpdatesMap)
   }
 
   @Test
@@ -98,7 +98,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val serviceTest2 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    serviceTest2.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+    serviceTest2.updateTopicConfigs("TOPIC0", configUpdatesMap)
   }
 
   @Test
@@ -128,7 +128,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val serviceTest3 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    serviceTest3.UpdateTopicConfigs("TOPIC0", configUpdatesMap)
+    serviceTest3.updateTopicConfigs("TOPIC0", configUpdatesMap)
   }
 
   // Test update broker configs. This behaves similarly to the topic test but the
@@ -150,7 +150,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val service = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    service.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+    service.updateBrokerConfigs(testBrokerId, configUpdatesMap)
   }
 
   @Test
@@ -180,7 +180,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val serviceTest2 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    serviceTest2.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+    serviceTest2.updateBrokerConfigs(testBrokerId, configUpdatesMap)
   }
 
   @Test
@@ -209,7 +209,7 @@ class ReassignPartitionsServiceClientZkTest extends ZooKeeperTestHarness with Lo
 
     val serviceTest3 = new ZkClientReassignCommandService(mockZkClient, Some(mockAdminZkClient))
 
-    serviceTest3.UpdateBrokerConfigs(testBrokerId, configUpdatesMap)
+    serviceTest3.updateBrokerConfigs(testBrokerId, configUpdatesMap)
   }
 
 }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -164,12 +164,19 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <Match>
         <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
-        <Source name="AdminZkClient.scala"/>
-        <Package name="kafka.zk"/>
+        <Source name="ReassignPartitionsCommand.scala"/>
+        <Package name="kafka.admin"/>
         <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
     </Match>
 
     <Match>
+        <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
+        <Source name="AdminZkClient.scala"/>
+        <Package name="kafka.zk"/>
+        <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
+      </Match>
+
+<Match>
         <!-- Suppress a warning about some static initializers in Schema using instances of a
              subclass. -->
         <Or>


### PR DESCRIPTION
A work-in-progress collection of changes to implement KIP-455 for the ReassignPartitionsCommand.

These changes are intended to remove the dependence of the ReassignPartitionsCommand on the ZK client and utilize the new AdminClient interfaces for doing partition reassignments. Eventually the command will support incremental changes to ongoing reassignments, including cancellation.

This is being done in the background and will be updated irregularly (hence the WIP designation).

The changes are significant, but the commits are ordered to be relatively small and easy to understand and build on each other; it is strongly recommended that the review be done a commit at a time rather than all at once.

The first several commits are "infrastructure" work that gets things ready. Then a service abstraction which can be used with either ZK or Admin clients is provided and implemented, so that the command can (eventually) run entirely with just the Admin client. Unit tests are provided for the Service client (XXX: not all tests are implemented yet but those that exist should be fine.)
