### PR TITLE
MINOR: fix compatibility-breaking bug in RequestHeader

### DIFF
--- a/clients/src/main/resources/common/message/RequestHeader.json
+++ b/clients/src/main/resources/common/message/RequestHeader.json
@@ -30,8 +30,12 @@
       "about": "The API version of this request." },
     { "name": "CorrelationId", "type": "int32", "versions": "0+",
       "about": "The correlation ID of this request." },
-    // Due to the way we handle compatibility for ApiVersionsRequest, the
-    // ClientId string needs to use the old-style string serialization.
+
+    // The ClientId string must be serialized with the old-style two-byte length prefix.
+    // The reason is that older brokers must be able to read the request header for any
+    // ApiVersionsRequest, even if it is from a newer version.
+    // Since the client is sending the ApiVersionsRequest in order to discover what
+    // versions are supported, the client does not know the best version to use.
     { "name": "ClientId", "type": "string", "versions": "1+", "nullableVersions": "1+", "ignorable": true,
       "flexibleVersions": "none", "about": "The client ID string." }
   ]

--- a/clients/src/main/resources/common/message/RequestHeader.json
+++ b/clients/src/main/resources/common/message/RequestHeader.json
@@ -30,7 +30,9 @@
       "about": "The API version of this request." },
     { "name": "CorrelationId", "type": "int32", "versions": "0+",
       "about": "The correlation ID of this request." },
+    // Due to the way we handle compatibility for ApiVersionsRequest, the
+    // ClientId string needs to use the old-style string serialization.
     { "name": "ClientId", "type": "string", "versions": "1+", "nullableVersions": "1+", "ignorable": true,
-      "about": "The client ID string." }
+      "flexibleVersions": "none", "about": "The client ID string." }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
@@ -69,7 +69,7 @@ public class RequestHeaderTest {
         RequestHeader header = new RequestHeader(ApiKeys.CREATE_DELEGATION_TOKEN, (short) 2, "", 10);
         assertEquals(2, header.headerVersion());
         ByteBuffer buffer = toBuffer(header.toStruct());
-        assertEquals(10, buffer.remaining());
+        assertEquals(11, buffer.remaining());
         RequestHeader deserialized = RequestHeader.parse(buffer);
         assertEquals(header, deserialized);
     }


### PR DESCRIPTION
Fix a compatibility break in trunk introduced by the work on KIP-511 and KIP-482.

Older brokers must be able to read the first part of any version of ApiVersionsRequest that they get sent without encountering an error. Therefore, the first part of any new version of the RequestHeader must match the first part in the old header version used alongside the original ApiVersionsRequest.