### PR TITLE
MINOR: ListPartitionReassignmentsResponse should not be entirely failed when a topic-partition does not exist 

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1821,10 +1821,7 @@ class KafkaController(val config: KafkaConfig,
 
       partitionsToList.foreach { tp =>
         val assignment = controllerContext.partitionFullReplicaAssignment(tp)
-        if (assignment.replicas.isEmpty) {
-          callback(Right(new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION)))
-          return
-        } else if (assignment.isBeingReassigned) {
+        if (assignment.isBeingReassigned) {
           results += tp -> assignment
         }
       }

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1822,10 +1822,8 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
   @Test
   def testListReassignmentsDoesNotShowDeletedPartitions(): Unit = {
     client = AdminClient.create(createConfig())
-
-    // Create topics
+    
     val topic = "list-reassignments-no-reassignments"
-    //createTopic(topic, numPartitions = 1, replicationFactor = 3)
     val tp = new TopicPartition(topic, 0)
 
     val reassignmentsMap = client.listPartitionReassignments(Set(tp).asJava).reassignments().get()

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1820,6 +1820,22 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
   }
 
   @Test
+  def testListReassignmentsDoesNotShowDeletedPartitions(): Unit = {
+    client = AdminClient.create(createConfig())
+
+    // Create topics
+    val topic = "list-reassignments-no-reassignments"
+    //createTopic(topic, numPartitions = 1, replicationFactor = 3)
+    val tp = new TopicPartition(topic, 0)
+
+    val reassignmentsMap = client.listPartitionReassignments(Set(tp).asJava).reassignments().get()
+    assertEquals(0, reassignmentsMap.size())
+
+    val allReassignmentsMap = client.listPartitionReassignments().reassignments().get()
+    assertEquals(0, allReassignmentsMap.size())
+  }
+
+  @Test
   def testValidIncrementalAlterConfigs(): Unit = {
     client = AdminClient.create(createConfig)
 


### PR DESCRIPTION
When a ListPartitionReassignmentsRequest containing a non-existing topic-partition is sent to the controller, the controller returns a ListPartitionReassignmentsResponse with the top level error code set to UNKNOWN_TOPIC_OR_PARTITION. If multiple topic-partitions are passed in the same request, the caller has no way to know which ones do not exist any more. It has to use another admin call to figure it out and then retries the former.

Instead, the controller should ignore any non-existing topic-partitions. It is fine because they don't have any reassignments by definition so the contract of the API remains valid.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
