### PR TITLE
KAFKA-9010: Add PartitionGrower, Support partition requery in ProduceBench test.

### DIFF
--- a/trogdor/src/main/java/org/apache/kafka/trogdor/common/JsonUtil.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/common/JsonUtil.java
@@ -39,7 +39,7 @@ public class JsonUtil {
         JSON_SERDE.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         JSON_SERDE.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         JSON_SERDE.registerModule(new Jdk8Module());
-        JSON_SERDE.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        JSON_SERDE.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
     }
 
     public static String toJsonString(Object object) {


### PR DESCRIPTION
This creates a test in trogdor to grow a topic at a specified interval by a specified number of partitions.

This test also introduces the ability for the ProduceBench test workload to requery the partitions of the active topics at an interval, if so desired.  If no query interval is specified, the default behaviour of ProduceBenchWorker remains unchanged.