### PR TITLE
Provide better messages when waiting for a condition in test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1257,6 +1257,7 @@ project(':streams:streams-scala') {
     testCompile libs.junit
     testCompile libs.scalatest
     testCompile libs.easymock
+    testCompile libs.hamcrest
 
     testRuntime libs.slf4jlog4j
   }

--- a/clients/src/test/java/org/apache/kafka/test/ValuelessCallable.java
+++ b/clients/src/test/java/org/apache/kafka/test/ValuelessCallable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+/**
+ * Like a {@link Runnable} that allows exceptions to be thrown or a {@link java.util.concurrent.Callable}
+ * that does not return a value.
+ */
+public interface ValuelessCallable {
+    void call() throws Exception;
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -189,7 +189,7 @@ public class OptimizedKTableIntegrationTest {
 
         final ReadOnlyKeyValueStore<Integer, Integer> newActiveStore =
             kafkaStreams1WasFirstActive ? store2 : store1;
-        retryOnExceptionWithTimeout(100, 60 * 1000, TimeUnit.MILLISECONDS, () -> {
+        TestUtils.retryOnExceptionWithTimeout(100, 60 * 1000, () -> {
             // Assert that after failover we have recovered to the last store write
             assertThat(newActiveStore.get(key), is(equalTo(batch1NumMessages - 1)));
         });
@@ -224,25 +224,6 @@ public class OptimizedKTableIntegrationTest {
                 .collect(Collectors.toList()),
             producerProps,
             mockTime);
-    }
-
-    private void retryOnExceptionWithTimeout(final long pollInterval,
-                                             final long timeout,
-                                             final TimeUnit timeUnit,
-                                             final Runnable runnable) throws InterruptedException {
-        final long expectedEnd = System.currentTimeMillis() + timeUnit.toMillis(timeout);
-
-        while (true) {
-            try {
-                runnable.run();
-                return;
-            } catch (final Throwable t) {
-                if (expectedEnd <= System.currentTimeMillis()) {
-                    throw new AssertionError(t);
-                }
-                Thread.sleep(timeUnit.toMillis(pollInterval));
-            }
-        }
     }
 
     private void waitForKafkaStreamssToEnterRunningState(final Collection<KafkaStreams> kafkaStreamss,


### PR DESCRIPTION
This change lifts `retryOnExceptionWithTimeout` from `OptimizedKTableIntegrationTest` into `TestUtils` and uses it for some of the pre-canned condition wait functions. `retryOnExceptionWithTimeout` differs from `waitForCondition` in that it allows you to use regular assertions, with more descriptive messages and more details context when a test fails.

Some examples:

* `IntegrationTestUtils.waitUntilMinValuesRecordsReceived`

Before:

```
java.lang.AssertionError: Condition not met within timeout 1000. Did not receive all 51 records from topic output-three-0

	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:377)
	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:354)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinValuesRecordsReceived(IntegrationTestUtils.java:682)
	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.waitUntilAtLeastNumRecordProcessed(QueryableStateIntegrationTest.java:1000)
	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.queryOnRebalance(QueryableStateIntegrationTest.java:379)
```

After:

```
java.lang.AssertionError: Did not receive all 51 records from topic output-three-0 within 1000 ms
Expected: is a value equal to or greater than <51>
     but: <38> was less than <51>

	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.lambda$waitUntilMinValuesRecordsReceived$6(IntegrationTestUtils.java:674)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:417)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:385)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinValuesRecordsReceived(IntegrationTestUtils.java:670)
	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.waitUntilAtLeastNumRecordProcessed(QueryableStateIntegrationTest.java:1000)
	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.queryOnRebalance(QueryableStateIntegrationTest.java:379)
```

* `IntegrationTestUtils.waitUntilMinRecordsReceived`

Before:

```
java.lang.AssertionError: Condition not met within timeout 60000. Did not receive all 1 records from topic outputTopic

	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:377)
	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:354)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinRecordsReceived(IntegrationTestUtils.java:460)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinRecordsReceived(IntegrationTestUtils.java:432)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.verifyKeyValueTimestamps(IntegrationTestUtils.java:729)
	at org.apache.kafka.streams.integration.AbstractJoinIntegrationTest.checkResult(AbstractJoinIntegrationTest.java:170)
	at org.apache.kafka.streams.integration.AbstractJoinIntegrationTest.runTest(AbstractJoinIntegrationTest.java:218)
	at org.apache.kafka.streams.integration.TableTableJoinIntegrationTest.testInner(TableTableJoinIntegrationTest.java:121)
```

After:

```
java.lang.AssertionError: Did not receive all 51 records from topic outputTopic within 60000 ms
Expected: is a value equal to or greater than <51>
     but: <1> was less than <51>

	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.lambda$waitUntilMinRecordsReceived$0(IntegrationTestUtils.java:458)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:417)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:385)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinRecordsReceived(IntegrationTestUtils.java:454)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinRecordsReceived(IntegrationTestUtils.java:432)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.verifyKeyValueTimestamps(IntegrationTestUtils.java:734)
	at org.apache.kafka.streams.integration.AbstractJoinIntegrationTest.checkResult(AbstractJoinIntegrationTest.java:170)
	at org.apache.kafka.streams.integration.AbstractJoinIntegrationTest.runTest(AbstractJoinIntegrationTest.java:218)
	at org.apache.kafka.streams.integration.TableTableJoinIntegrationTest.testInner(TableTableJoinIntegrationTest.java:121)
```

* And my favorite: `IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived`

Before:

```
java.lang.AssertionError: Condition not met within timeout 60000. Did not receive all [KeyValueTimestamp{key=A, value=A:A, timestamp=1570731458595}, KeyValueTimestamp{key=B, value=B:B, timestamp=1570731458595}, KeyValueTimestamp{key=C, value=C:C, timestamp=1570731458595}, KeyValueTimestamp{key=D, value=D:D, timestamp=1570731458595}, KeyValueTimestamp{key=F, value=F:F, timestamp=1570731458595}, KeyValueTimestamp{key=E, value=E:E, timestamp=1570731458595}] records from topic output-0

	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:377)
	at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:354)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived(IntegrationTestUtils.java:638)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilFinalKeyValueTimestampRecordsReceived(IntegrationTestUtils.java:569)
	at org.apache.kafka.streams.integration.KStreamAggregationDedupIntegrationTest.validateReceivedMessages(KStreamAggregationDedupIntegrationTest.java:246)
	at org.apache.kafka.streams.integration.KStreamAggregationDedupIntegrationTest.shouldReduce(KStreamAggregationDedupIntegrationTest.java:125)
```

After:

```
java.lang.AssertionError: Received records from topic output-0 did not match expected within 60000 ms
Expected: is <{A=[KeyValueTimestamp{key=A, value=A:A, timestamp=1570731302494}], B=[KeyValueTimestamp{key=B, value=B:B, timestamp=1570731302494}], C=[KeyValueTimestamp{key=C, value=C:C, timestamp=1570731302494}], D=[KeyValueTimestamp{key=D, value=D:D, timestamp=1570731302494}], E=[KeyValueTimestamp{key=E, value=E:E, timestamp=1570731302494}], F=[KeyValueTimestamp{key=F, value=F:F, timestamp=1570731302494}]}>
     but: was <{A=[KeyValueTimestamp{key=A, value=A:A, timestamp=1570731302494}], B=[KeyValueTimestamp{key=B, value=B:B, timestamp=1570731302494}], C=[KeyValueTimestamp{key=C, value=C:C, timestamp=1570731302494}], D=[KeyValueTimestamp{key=D, value=D:D, timestamp=1570731302494}], E=[KeyValueTimestamp{key=E, value=E:E, timestamp=1570731302494}]}>

	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.lambda$waitUntilFinalKeyValueRecordsReceived$5(IntegrationTestUtils.java:631)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:417)
	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:385)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilFinalKeyValueRecordsReceived(IntegrationTestUtils.java:603)
	at org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilFinalKeyValueTimestampRecordsReceived(IntegrationTestUtils.java:566)
	at org.apache.kafka.streams.integration.KStreamAggregationDedupIntegrationTest.validateReceivedMessages(KStreamAggregationDedupIntegrationTest.java:246)
	at org.apache.kafka.streams.integration.KStreamAggregationDedupIntegrationTest.shouldReduce(KStreamAggregationDedupIntegrationTest.java:125)
```

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
