### PR TITLE
KAFKA-8988. Replace CreatePartitions Request/Response with automated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -71,6 +71,10 @@ import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData.Re
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData.CreatableRenewers;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsAssignment;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCollection;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicConfigs;
@@ -127,7 +131,6 @@ import org.apache.kafka.common.requests.CreateAclsResponse.AclCreationResponse;
 import org.apache.kafka.common.requests.CreateDelegationTokenRequest;
 import org.apache.kafka.common.requests.CreateDelegationTokenResponse;
 import org.apache.kafka.common.requests.CreatePartitionsRequest;
-import org.apache.kafka.common.requests.CreatePartitionsRequest.PartitionDetails;
 import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
@@ -2313,8 +2316,21 @@ public class KafkaAdminClient extends AdminClient {
         for (String topic : newPartitions.keySet()) {
             futures.put(topic, new KafkaFutureImpl<>());
         }
-        final Map<String, PartitionDetails> requestMap = newPartitions.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> partitionDetails(e.getValue())));
+
+        final List<CreatePartitionsTopic> topics = newPartitions.entrySet().stream()
+                .map(partitionsEntry -> {
+                    NewPartitions newPartition = partitionsEntry.getValue();
+                    List<List<Integer>> newAssignments = newPartition.assignments();
+                    List<CreatePartitionsAssignment> assignments = newAssignments == null ? null :
+                            newAssignments.stream()
+                            .map(integers -> new CreatePartitionsAssignment().setBrokerIds(integers))
+                            .collect(Collectors.toList());
+                    return new CreatePartitionsTopic()
+                            .setName(partitionsEntry.getKey())
+                            .setCount(newPartition.totalCount())
+                            .setAssignments(assignments);
+                })
+                .collect(Collectors.toList());
 
         final long now = time.milliseconds();
         runnable.call(new Call("createPartitions", calcDeadlineMs(now, options.timeoutMs()),
@@ -2322,26 +2338,33 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public CreatePartitionsRequest.Builder createRequest(int timeoutMs) {
-                return new CreatePartitionsRequest.Builder(requestMap, timeoutMs, options.validateOnly());
+                CreatePartitionsRequestData requestData = new CreatePartitionsRequestData()
+                        .setTopics(topics)
+                        .setValidateOnly(options.validateOnly())
+                        .setTimeoutMs(timeoutMs);
+
+                return new CreatePartitionsRequest.Builder(requestData);
             }
 
             @Override
             public void handleResponse(AbstractResponse abstractResponse) {
                 CreatePartitionsResponse response = (CreatePartitionsResponse) abstractResponse;
                 // Check for controller change
-                for (ApiError error : response.errors().values()) {
-                    if (error.error() == Errors.NOT_CONTROLLER) {
+                for (CreatePartitionsTopicResult topicResult: response.data().results()) {
+                    Errors error = Errors.forCode(topicResult.errorCode());
+                    if (error == Errors.NOT_CONTROLLER) {
                         metadataManager.clearController();
                         metadataManager.requestUpdate();
                         throw error.exception();
                     }
                 }
-                for (Map.Entry<String, ApiError> result : response.errors().entrySet()) {
-                    KafkaFutureImpl<Void> future = futures.get(result.getKey());
-                    if (result.getValue().isSuccess()) {
+                for (CreatePartitionsTopicResult topicResult: response.data().results()) {
+                    Errors error = Errors.forCode(topicResult.errorCode());
+                    KafkaFutureImpl<Void> future = futures.get(topicResult.name());
+                    if (error == Errors.NONE) {
                         future.complete(null);
                     } else {
-                        future.completeExceptionally(result.getValue().exception());
+                        future.completeExceptionally(error.exception(topicResult.errorMessage()));
                     }
                 }
             }
@@ -2849,10 +2872,6 @@ public class KafkaAdminClient extends AdminClient {
             return true;
         }
         return false;
-    }
-
-    private PartitionDetails partitionDetails(NewPartitions newPartitions) {
-        return new PartitionDetails(newPartitions.totalCount(), newPartitions.assignments());
     }
 
     private final static class ListConsumerGroupsResults {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2323,7 +2323,7 @@ public class KafkaAdminClient extends AdminClient {
                     List<List<Integer>> newAssignments = newPartition.assignments();
                     List<CreatePartitionsAssignment> assignments = newAssignments == null ? null :
                             newAssignments.stream()
-                            .map(integers -> new CreatePartitionsAssignment().setBrokerIds(integers))
+                            .map(brokerIds -> new CreatePartitionsAssignment().setBrokerIds(brokerIds))
                             .collect(Collectors.toList());
                     return new CreatePartitionsTopic()
                             .setName(partitionsEntry.getKey())

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.message.ControlledShutdownRequestData;
 import org.apache.kafka.common.message.ControlledShutdownResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
@@ -94,8 +96,6 @@ import org.apache.kafka.common.requests.AlterReplicaLogDirsRequest;
 import org.apache.kafka.common.requests.AlterReplicaLogDirsResponse;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreateAclsResponse;
-import org.apache.kafka.common.requests.CreatePartitionsRequest;
-import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
 import org.apache.kafka.common.requests.DeleteAclsResponse;
 import org.apache.kafka.common.requests.DeleteRecordsRequest;
@@ -191,8 +191,8 @@ public enum ApiKeys {
             DescribeLogDirsResponse.schemaVersions()),
     SASL_AUTHENTICATE(36, "SaslAuthenticate", SaslAuthenticateRequestData.SCHEMAS,
             SaslAuthenticateResponseData.SCHEMAS),
-    CREATE_PARTITIONS(37, "CreatePartitions", CreatePartitionsRequest.schemaVersions(),
-            CreatePartitionsResponse.schemaVersions()),
+    CREATE_PARTITIONS(37, "CreatePartitions", CreatePartitionsRequestData.SCHEMAS,
+            CreatePartitionsResponseData.SCHEMAS),
     CREATE_DELEGATION_TOKEN(38, "CreateDelegationToken", CreateDelegationTokenRequestData.SCHEMAS, CreateDelegationTokenResponseData.SCHEMAS),
     RENEW_DELEGATION_TOKEN(39, "RenewDelegationToken", RenewDelegationTokenRequestData.SCHEMAS, RenewDelegationTokenResponseData.SCHEMAS),
     EXPIRE_DELEGATION_TOKEN(40, "ExpireDelegationToken", ExpireDelegationTokenRequestData.SCHEMAS, ExpireDelegationTokenResponseData.SCHEMAS),

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -155,7 +155,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case SASL_AUTHENTICATE:
                 return new SaslAuthenticateResponse(struct, version);
             case CREATE_PARTITIONS:
-                return new CreatePartitionsResponse(struct);
+                return new CreatePartitionsResponse(struct, version);
             case CREATE_DELEGATION_TOKEN:
                 return new CreateDelegationTokenResponse(struct, version);
             case RENEW_DELEGATION_TOKEN:

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
@@ -17,6 +17,10 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsResponseData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.types.ArrayOf;
 import org.apache.kafka.common.protocol.types.Field;
@@ -24,13 +28,6 @@ import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
@@ -68,170 +65,65 @@ public class CreatePartitionsRequest extends AbstractRequest {
         return new Schema[]{CREATE_PARTITIONS_REQUEST_V0, CREATE_PARTITIONS_REQUEST_V1};
     }
 
-    // It is an error for duplicate topics to be present in the request,
-    // so track duplicates here to allow KafkaApis to report per-topic errors.
-    private final Set<String> duplicates;
-    private final Map<String, PartitionDetails> newPartitions;
-    private final int timeout;
-    private final boolean validateOnly;
-
-    public static class PartitionDetails {
-
-        private final int totalCount;
-
-        private final List<List<Integer>> newAssignments;
-
-        public PartitionDetails(int totalCount) {
-            this(totalCount, null);
-        }
-
-        public PartitionDetails(int totalCount, List<List<Integer>> newAssignments) {
-            this.totalCount = totalCount;
-            this.newAssignments = newAssignments;
-        }
-
-        public int totalCount() {
-            return totalCount;
-        }
-
-        public List<List<Integer>> newAssignments() {
-            return newAssignments;
-        }
-
-        @Override
-        public String toString() {
-            return "(totalCount=" + totalCount() + ", newAssignments=" + newAssignments() + ")";
-        }
-
-    }
+    private final CreatePartitionsRequestData data;
+    private final short version;
 
     public static class Builder extends AbstractRequest.Builder<CreatePartitionsRequest> {
 
-        private final Map<String, PartitionDetails> newPartitions;
-        private final int timeout;
-        private final boolean validateOnly;
+        private final CreatePartitionsRequestData data;
 
-        public Builder(Map<String, PartitionDetails> newPartitions, int timeout, boolean validateOnly) {
+        public Builder(CreatePartitionsRequestData data) {
             super(ApiKeys.CREATE_PARTITIONS);
-            this.newPartitions = newPartitions;
-            this.timeout = timeout;
-            this.validateOnly = validateOnly;
+            this.data = data;
         }
 
         @Override
         public CreatePartitionsRequest build(short version) {
-            return new CreatePartitionsRequest(newPartitions, timeout, validateOnly, version);
+            return new CreatePartitionsRequest(data, version);
         }
 
         @Override
         public String toString() {
-            StringBuilder bld = new StringBuilder();
-            bld.append("(type=CreatePartitionsRequest").
-                    append(", newPartitions=").append(newPartitions).
-                    append(", timeout=").append(timeout).
-                    append(", validateOnly=").append(validateOnly).
-                    append(")");
-            return bld.toString();
+            return data.toString();
         }
     }
 
-    CreatePartitionsRequest(Map<String, PartitionDetails> newPartitions, int timeout, boolean validateOnly, short apiVersion) {
+    CreatePartitionsRequest(CreatePartitionsRequestData data, short apiVersion) {
         super(ApiKeys.CREATE_PARTITIONS, apiVersion);
-        this.newPartitions = newPartitions;
-        this.duplicates = Collections.emptySet();
-        this.timeout = timeout;
-        this.validateOnly = validateOnly;
+        this.data = data;
+        this.version = apiVersion;
     }
 
     public CreatePartitionsRequest(Struct struct, short apiVersion) {
         super(ApiKeys.CREATE_PARTITIONS, apiVersion);
-        Object[] topicCountArray = struct.getArray(TOPIC_PARTITIONS_KEY_NAME);
-        Map<String, PartitionDetails> counts = new HashMap<>(topicCountArray.length);
-        Set<String> dupes = new HashSet<>();
-        for (Object topicPartitionCountObj : topicCountArray) {
-            Struct topicPartitionCountStruct = (Struct) topicPartitionCountObj;
-            String topic = topicPartitionCountStruct.get(TOPIC_NAME);
-            Struct partitionCountStruct = topicPartitionCountStruct.getStruct(NEW_PARTITIONS_KEY_NAME);
-            int count = partitionCountStruct.getInt(COUNT_KEY_NAME);
-            Object[] assignmentsArray = partitionCountStruct.getArray(ASSIGNMENT_KEY_NAME);
-            PartitionDetails newPartition;
-            if (assignmentsArray != null) {
-                List<List<Integer>> assignments = new ArrayList<>(assignmentsArray.length);
-                for (Object replicas : assignmentsArray) {
-                    Object[] replicasArray = (Object[]) replicas;
-                    List<Integer> replicasList = new ArrayList<>(replicasArray.length);
-                    assignments.add(replicasList);
-                    for (Object broker : replicasArray) {
-                        replicasList.add((Integer) broker);
-                    }
-                }
-                newPartition = new PartitionDetails(count, assignments);
-            } else {
-                newPartition = new PartitionDetails(count);
-            }
-            PartitionDetails dupe = counts.put(topic, newPartition);
-            if (dupe != null) {
-                dupes.add(topic);
-            }
-        }
-        this.newPartitions = counts;
-        this.duplicates = dupes;
-        this.timeout = struct.getInt(TIMEOUT_KEY_NAME);
-        this.validateOnly = struct.getBoolean(VALIDATE_ONLY_KEY_NAME);
-    }
 
-    public Set<String> duplicates() {
-        return duplicates;
-    }
-
-    public Map<String, PartitionDetails> newPartitions() {
-        return newPartitions;
-    }
-
-    public int timeout() {
-        return timeout;
-    }
-
-    public boolean validateOnly() {
-        return validateOnly;
+        this.data = new CreatePartitionsRequestData(struct, apiVersion);
+        this.version = apiVersion;
     }
 
     @Override
     protected Struct toStruct() {
-        Struct struct = new Struct(ApiKeys.CREATE_PARTITIONS.requestSchema(version()));
-        List<Struct> topicPartitionsList = new ArrayList<>();
-        for (Map.Entry<String, PartitionDetails> topicPartitionCount : this.newPartitions.entrySet()) {
-            Struct topicPartitionCountStruct = struct.instance(TOPIC_PARTITIONS_KEY_NAME);
-            topicPartitionCountStruct.set(TOPIC_NAME, topicPartitionCount.getKey());
-            PartitionDetails partitionDetails = topicPartitionCount.getValue();
-            Struct partitionCountStruct = topicPartitionCountStruct.instance(NEW_PARTITIONS_KEY_NAME);
-            partitionCountStruct.set(COUNT_KEY_NAME, partitionDetails.totalCount());
-            Object[][] assignments = null;
-            if (partitionDetails.newAssignments() != null) {
-                assignments = new Object[partitionDetails.newAssignments().size()][];
-                int i = 0;
-                for (List<Integer> partitionAssignment : partitionDetails.newAssignments()) {
-                    assignments[i] = partitionAssignment.toArray(new Object[0]);
-                    i++;
-                }
-            }
-            partitionCountStruct.set(ASSIGNMENT_KEY_NAME, assignments);
-            topicPartitionCountStruct.set(NEW_PARTITIONS_KEY_NAME, partitionCountStruct);
-            topicPartitionsList.add(topicPartitionCountStruct);
-        }
-        struct.set(TOPIC_PARTITIONS_KEY_NAME, topicPartitionsList.toArray(new Object[0]));
-        struct.set(TIMEOUT_KEY_NAME, this.timeout);
-        struct.set(VALIDATE_ONLY_KEY_NAME, this.validateOnly);
-        return struct;
+        return data.toStruct(version);
+    }
+
+    public CreatePartitionsRequestData data() {
+        return data;
     }
 
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        Map<String, ApiError> topicErrors = new HashMap<>();
-        for (String topic : newPartitions.keySet()) {
-            topicErrors.put(topic, ApiError.fromThrowable(e));
+        CreatePartitionsResponseData response = new CreatePartitionsResponseData();
+        response.setThrottleTimeMs(throttleTimeMs);
+
+        ApiError apiError = ApiError.fromThrowable(e);
+        for (CreatePartitionsTopic topic : data.topics()) {
+            response.results().add(new CreatePartitionsTopicResult()
+                    .setName(topic.name())
+                    .setErrorCode(apiError.error().code())
+                    .setErrorMessage(apiError.message())
+            );
         }
-        return new CreatePartitionsResponse(throttleTimeMs, topicErrors);
+        return new CreatePartitionsResponse(response);
     }
 
     public static CreatePartitionsRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
@@ -22,51 +22,13 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.types.ArrayOf;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
 
-import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
-import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
-import static org.apache.kafka.common.protocol.types.Type.INT32;
-
 public class CreatePartitionsRequest extends AbstractRequest {
 
-    private static final String TOPIC_PARTITIONS_KEY_NAME = "topic_partitions";
-    private static final String NEW_PARTITIONS_KEY_NAME = "new_partitions";
-    private static final String COUNT_KEY_NAME = "count";
-    private static final String ASSIGNMENT_KEY_NAME = "assignment";
-    private static final String TIMEOUT_KEY_NAME = "timeout";
-    private static final String VALIDATE_ONLY_KEY_NAME = "validate_only";
-
-    private static final Schema CREATE_PARTITIONS_REQUEST_V0 = new Schema(
-            new Field(TOPIC_PARTITIONS_KEY_NAME, new ArrayOf(
-                    new Schema(
-                            TOPIC_NAME,
-                            new Field(NEW_PARTITIONS_KEY_NAME, new Schema(
-                                    new Field(COUNT_KEY_NAME, INT32, "The new partition count."),
-                                    new Field(ASSIGNMENT_KEY_NAME, ArrayOf.nullable(new ArrayOf(INT32)),
-                                            "The assigned brokers.")
-                            )))),
-                    "List of topic and the corresponding new partitions."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for the partitions to be created."),
-            new Field(VALIDATE_ONLY_KEY_NAME, BOOLEAN,
-                    "If true then validate the request, but don't actually increase the number of partitions."));
-
-    /**
-     * The version number is bumped to indicate that on quota violation brokers send out responses before throttling.
-     */
-    private static final Schema CREATE_PARTITIONS_REQUEST_V1 = CREATE_PARTITIONS_REQUEST_V0;
-
-    public static Schema[] schemaVersions() {
-        return new Schema[]{CREATE_PARTITIONS_REQUEST_V0, CREATE_PARTITIONS_REQUEST_V1};
-    }
-
     private final CreatePartitionsRequestData data;
-    private final short version;
 
     public static class Builder extends AbstractRequest.Builder<CreatePartitionsRequest> {
 
@@ -91,19 +53,15 @@ public class CreatePartitionsRequest extends AbstractRequest {
     CreatePartitionsRequest(CreatePartitionsRequestData data, short apiVersion) {
         super(ApiKeys.CREATE_PARTITIONS, apiVersion);
         this.data = data;
-        this.version = apiVersion;
     }
 
     public CreatePartitionsRequest(Struct struct, short apiVersion) {
-        super(ApiKeys.CREATE_PARTITIONS, apiVersion);
-
-        this.data = new CreatePartitionsRequestData(struct, apiVersion);
-        this.version = apiVersion;
+        this(new CreatePartitionsRequestData(struct, apiVersion), apiVersion);
     }
 
     @Override
     protected Struct toStruct() {
-        return data.toStruct(version);
+        return data.toStruct(version());
     }
 
     public CreatePartitionsRequestData data() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -17,105 +17,59 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.message.CreatePartitionsResponseData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.ArrayOf;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
-import static org.apache.kafka.common.protocol.CommonFields.ERROR_MESSAGE;
-import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
-import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 
 
 public class CreatePartitionsResponse extends AbstractResponse {
 
-    private static final String TOPIC_ERRORS_KEY_NAME = "topic_errors";
+    private final CreatePartitionsResponseData data;
 
-    private static final Schema CREATE_PARTITIONS_RESPONSE_V0 = new Schema(
-            THROTTLE_TIME_MS,
-            new Field(TOPIC_ERRORS_KEY_NAME, new ArrayOf(
-                    new Schema(
-                            TOPIC_NAME,
-                            ERROR_CODE,
-                            ERROR_MESSAGE
-                    )), "Per topic results for the create partitions request")
-    );
-
-    /**
-     * The version number is bumped to indicate that on quota violation brokers send out responses before throttling.
-     */
-    private static final Schema CREATE_PARTITIONS_RESPONSE_V1 = CREATE_PARTITIONS_RESPONSE_V0;
-
-    public static Schema[] schemaVersions() {
-        return new Schema[]{CREATE_PARTITIONS_RESPONSE_V0, CREATE_PARTITIONS_RESPONSE_V1};
+    public CreatePartitionsResponse(CreatePartitionsResponseData data) {
+        this.data = data;
     }
 
-    private final int throttleTimeMs;
-    private final Map<String, ApiError> errors;
-
-    public CreatePartitionsResponse(int throttleTimeMs, Map<String, ApiError> errors) {
-        this.throttleTimeMs = throttleTimeMs;
-        this.errors = errors;
+    public CreatePartitionsResponse(Struct struct, short version) {
+        this.data = new CreatePartitionsResponseData(struct, version);
     }
 
-    public CreatePartitionsResponse(Struct struct) {
-        super();
-        Object[] topicErrorsArray = struct.getArray(TOPIC_ERRORS_KEY_NAME);
-        Map<String, ApiError> errors = new HashMap<>(topicErrorsArray.length);
-        for (Object topicErrorObj : topicErrorsArray) {
-            Struct topicErrorStruct = (Struct) topicErrorObj;
-            String topic = topicErrorStruct.get(TOPIC_NAME);
-            ApiError error = new ApiError(topicErrorStruct);
-            errors.put(topic, error);
-        }
-        this.throttleTimeMs = struct.get(THROTTLE_TIME_MS);
-        this.errors = errors;
+    public CreatePartitionsResponseData data() {
+        return data;
     }
 
     @Override
     protected Struct toStruct(short version) {
-        Struct struct = new Struct(ApiKeys.CREATE_PARTITIONS.responseSchema(version));
-        List<Struct> topicErrors = new ArrayList<>(errors.size());
-        for (Map.Entry<String, ApiError> error : errors.entrySet()) {
-            Struct errorStruct = struct.instance(TOPIC_ERRORS_KEY_NAME);
-            errorStruct.set(TOPIC_NAME, error.getKey());
-            error.getValue().write(errorStruct);
-            topicErrors.add(errorStruct);
-        }
-        struct.set(THROTTLE_TIME_MS, throttleTimeMs);
-        struct.set(TOPIC_ERRORS_KEY_NAME, topicErrors.toArray(new Object[topicErrors.size()]));
-        return struct;
-    }
-
-    public Map<String, ApiError> errors() {
-        return errors;
+        return data.toStruct(version);
     }
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return apiErrorCounts(errors);
-    }
-
-    @Override
-    public int throttleTimeMs() {
-        return throttleTimeMs;
+        HashMap<Errors, Integer> counts = new HashMap<>();
+        for (CreatePartitionsTopicResult result : data.results()) {
+            Errors error = Errors.forCode(result.errorCode());
+            counts.put(error, counts.getOrDefault(error, 0) + 1);
+        }
+        return counts;
     }
 
     public static CreatePartitionsResponse parse(ByteBuffer buffer, short version) {
-        return new CreatePartitionsResponse(ApiKeys.CREATE_PARTITIONS.parseResponse(version, buffer));
+        return new CreatePartitionsResponse(ApiKeys.CREATE_PARTITIONS.parseResponse(version, buffer), version);
     }
 
     @Override
     public boolean shouldClientThrottle(short version) {
         return version >= 1;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -51,7 +51,7 @@ public class CreatePartitionsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        HashMap<Errors, Integer> counts = new HashMap<>();
+        Map<Errors, Integer> counts = new HashMap<>();
         for (CreatePartitionsTopicResult result : data.results()) {
             Errors error = Errors.forCode(result.errorCode());
             counts.put(error, counts.getOrDefault(error, 0) + 1);

--- a/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+++ b/clients/src/main/resources/common/message/CreatePartitionsResponse.json
@@ -30,7 +30,7 @@
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The result error, or zero if there was no error."},
       { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
-        "about": "The result message, or null if there was no error."}
+        "default": "null", "about": "The result message, or null if there was no error."}
     ]}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -58,8 +58,10 @@ import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
-import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResult;
 import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResultCollection;
@@ -138,6 +140,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -889,12 +892,20 @@ public class KafkaAdminClientTest {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
 
-            Map<String, ApiError> m = new HashMap<>();
-            m.put("my_topic", ApiError.NONE);
-            m.put("other_topic", ApiError.fromThrowable(new InvalidTopicException("some detailed reason")));
+            List<CreatePartitionsTopicResult> createPartitionsResult = new LinkedList<>();
+            createPartitionsResult.add(new CreatePartitionsTopicResult()
+                    .setName("my_topic")
+                    .setErrorCode(Errors.NONE.code()));
+            createPartitionsResult.add(new CreatePartitionsTopicResult()
+                    .setName("other_topic")
+                    .setErrorCode(Errors.INVALID_TOPIC_EXCEPTION.code())
+                    .setErrorMessage("some detailed reason"));
+            CreatePartitionsResponseData data = new CreatePartitionsResponseData()
+                    .setThrottleTimeMs(42)
+                    .setResults(createPartitionsResult);
 
             // Test a call where one filter has an error.
-            env.kafkaClient().prepareResponse(new CreatePartitionsResponse(0, m));
+            env.kafkaClient().prepareResponse(new CreatePartitionsResponse(data));
 
             Map<String, NewPartitions> counts = new HashMap<>();
             counts.put("my_topic", NewPartitions.increaseTo(3));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
@@ -48,6 +47,11 @@ import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData.CreatableRenewers;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsAssignment;
+import org.apache.kafka.common.message.CreatePartitionsResponseData;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreateableTopicConfig;
@@ -123,7 +127,6 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.CreateAclsRequest.AclCreation;
 import org.apache.kafka.common.requests.CreateAclsResponse.AclCreationResponse;
-import org.apache.kafka.common.requests.CreatePartitionsRequest.PartitionDetails;
 import org.apache.kafka.common.requests.CreateTopicsRequest.Builder;
 import org.apache.kafka.common.requests.DeleteAclsResponse.AclDeletionResult;
 import org.apache.kafka.common.requests.DeleteAclsResponse.AclFilterResponse;
@@ -1760,25 +1763,61 @@ public class RequestResponseTest {
     }
 
     private CreatePartitionsRequest createCreatePartitionsRequest() {
-        Map<String, PartitionDetails> assignments = new HashMap<>();
-        assignments.put("my_topic", new PartitionDetails(3));
-        assignments.put("my_other_topic", new PartitionDetails(3));
-        return new CreatePartitionsRequest(assignments, 0, false, (short) 0);
+        List<CreatePartitionsTopic> topics = new LinkedList<>();
+        topics.add(new CreatePartitionsTopic()
+                .setName("my_topic")
+                .setCount(3)
+        );
+        topics.add(new CreatePartitionsTopic()
+                .setName("my_other_topic")
+                .setCount(3)
+        );
+
+        CreatePartitionsRequestData data = new CreatePartitionsRequestData()
+                .setTimeoutMs(0)
+                .setValidateOnly(false)
+                .setTopics(topics);
+        return new CreatePartitionsRequest(data, (short) 0);
     }
 
     private CreatePartitionsRequest createCreatePartitionsRequestWithAssignments() {
-        Map<String, PartitionDetails> assignments = new HashMap<>();
-        assignments.put("my_topic", new PartitionDetails(3, asList(asList(2))));
-        assignments.put("my_other_topic", new PartitionDetails(3, asList(asList(2, 3), asList(3, 1))));
-        return new CreatePartitionsRequest(assignments, 0, false, (short) 0);
+        List<CreatePartitionsTopic> topics = new LinkedList<>();
+        CreatePartitionsAssignment myTopicAssignment = new CreatePartitionsAssignment()
+                .setBrokerIds(Collections.singletonList(2));
+        topics.add(new CreatePartitionsTopic()
+                .setName("my_topic")
+                .setCount(3)
+                .setAssignments(Collections.singletonList(myTopicAssignment))
+        );
+
+        topics.add(new CreatePartitionsTopic()
+                .setName("my_other_topic")
+                .setCount(3)
+                .setAssignments(asList(
+                    new CreatePartitionsAssignment().setBrokerIds(asList(2, 3)),
+                    new CreatePartitionsAssignment().setBrokerIds(asList(3, 1))
+                ))
+        );
+
+        CreatePartitionsRequestData data = new CreatePartitionsRequestData()
+                .setTimeoutMs(0)
+                .setValidateOnly(false)
+                .setTopics(topics);
+        return new CreatePartitionsRequest(data, (short) 0);
     }
 
     private CreatePartitionsResponse createCreatePartitionsResponse() {
-        Map<String, ApiError> results = new HashMap<>();
-        results.put("my_topic", ApiError.fromThrowable(
-                new InvalidReplicaAssignmentException("The assigned brokers included an unknown broker")));
-        results.put("my_topic", ApiError.NONE);
-        return new CreatePartitionsResponse(42, results);
+        List<CreatePartitionsTopicResult> results = new LinkedList<>();
+        results.add(new CreatePartitionsTopicResult()
+                .setName("my_topic")
+                .setErrorCode(Errors.INVALID_REPLICA_ASSIGNMENT.code()));
+        results.add(new CreatePartitionsTopicResult()
+                .setName("my_topic")
+                .setErrorCode(Errors.NONE.code()));
+        CreatePartitionsResponseData data = new CreatePartitionsResponseData()
+                .setThrottleTimeMs(42)
+                .setResults(results);
+        return new CreatePartitionsResponse(data);
     }
 
     private CreateDelegationTokenRequest createCreateTokenRequest() {

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -291,7 +291,7 @@ class AdminManager(val config: KafkaConfig,
           throw new InvalidPartitionsException(s"Topic already has $oldNumPartitions partitions.")
         }
 
-        val newPartitionsAssignment = Option(newPartition.assignments).filterNot(_.isEmpty)
+        val newPartitionsAssignment = Option(newPartition.assignments)
           .map { assignmentMap =>
             val assignments = assignmentMap.asScala.map {
               createPartitionAssignment => createPartitionAssignment.brokerIds.asScala.map(_.toInt)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -208,11 +208,11 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     authorizeClusterOperation(request, CLUSTER_ACTION)
-    if (isBrokerEpochStale(leaderAndIsrRequest.brokerEpoch())) {
+    if (isBrokerEpochStale(leaderAndIsrRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
       // for its previous generation so the broker should skip the stale request.
       info("Received LeaderAndIsr request with broker epoch " +
-        s"${leaderAndIsrRequest.brokerEpoch()} smaller than the current broker epoch ${controller.brokerEpoch}")
+        s"${leaderAndIsrRequest.brokerEpoch} smaller than the current broker epoch ${controller.brokerEpoch}")
       sendResponseExemptThrottle(request, leaderAndIsrRequest.getErrorResponse(0, Errors.STALE_BROKER_EPOCH.exception))
     } else {
       val response = replicaManager.becomeLeaderOrFollower(correlationId, leaderAndIsrRequest, onLeadershipChange)
@@ -226,11 +226,11 @@ class KafkaApis(val requestChannel: RequestChannel,
     // stop serving data to clients for the topic being deleted
     val stopReplicaRequest = request.body[StopReplicaRequest]
     authorizeClusterOperation(request, CLUSTER_ACTION)
-    if (isBrokerEpochStale(stopReplicaRequest.brokerEpoch())) {
+    if (isBrokerEpochStale(stopReplicaRequest.brokerEpoch)) {
       // When the broker restarts very quickly, it is possible for this broker to receive request intended
       // for its previous generation so the broker should skip the stale request.
       info("Received stop replica request with broker epoch " +
-        s"${stopReplicaRequest.brokerEpoch()} smaller than the current broker epoch ${controller.brokerEpoch}")
+        s"${stopReplicaRequest.brokerEpoch} smaller than the current broker epoch ${controller.brokerEpoch}")
       sendResponseExemptThrottle(request, new StopReplicaResponse(new StopReplicaResponseData().setErrorCode(Errors.STALE_BROKER_EPOCH.code)))
     } else {
       val (result, error) = replicaManager.stopReplicas(stopReplicaRequest)
@@ -344,10 +344,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     // reject the request if not authorized to the group
-    if (!authorize(request, READ, GROUP, offsetCommitRequest.data().groupId)) {
+    if (!authorize(request, READ, GROUP, offsetCommitRequest.data.groupId)) {
       val error = Errors.GROUP_AUTHORIZATION_FAILED
       val responseTopicList = OffsetCommitRequest.getErrorResponseTopics(
-        offsetCommitRequest.data().topics(),
+        offsetCommitRequest.data.topics,
         error)
 
       sendResponseMaybeThrottle(request, requestThrottleMs => new OffsetCommitResponse(
@@ -360,9 +360,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       // until we are sure that all brokers support it. If static group being loaded by an older coordinator, it will discard
       // the group.instance.id field, so static members could accidentally become "dynamic", which leads to wrong states.
       val errorMap = new mutable.HashMap[TopicPartition, Errors]
-      for (topicData <- offsetCommitRequest.data().topics().asScala) {
-        for (partitionData <- topicData.partitions().asScala) {
-          val topicPartition = new TopicPartition(topicData.name(), partitionData.partitionIndex())
+      for (topicData <- offsetCommitRequest.data.topics.asScala) {
+        for (partitionData <- topicData.partitions.asScala) {
+          val topicPartition = new TopicPartition(topicData.name, partitionData.partitionIndex)
           errorMap += topicPartition -> Errors.UNSUPPORTED_VERSION
         }
       }
@@ -371,10 +371,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       val authorizedTopicRequestInfoBldr = immutable.Map.newBuilder[TopicPartition, OffsetCommitRequestData.OffsetCommitRequestPartition]
 
       val authorizedTopics = filterAuthorized(request, READ, TOPIC, offsetCommitRequest.data.topics.asScala.map(_.name))
-      for (topicData <- offsetCommitRequest.data().topics().asScala) {
-        for (partitionData <- topicData.partitions().asScala) {
-          val topicPartition = new TopicPartition(topicData.name(), partitionData.partitionIndex())
-          if (!authorizedTopics.contains(topicData.name()))
+      for (topicData <- offsetCommitRequest.data.topics.asScala) {
+        for (partitionData <- topicData.partitions.asScala) {
+          val topicPartition = new TopicPartition(topicData.name, partitionData.partitionIndex)
+          if (!authorizedTopics.contains(topicData.name))
             unauthorizedTopicErrors += (topicPartition -> Errors.TOPIC_AUTHORIZATION_FAILED)
           else if (!metadataCache.contains(topicPartition))
             nonExistingTopicErrors += (topicPartition -> Errors.UNKNOWN_TOPIC_OR_PARTITION)
@@ -397,9 +397,9 @@ class KafkaApis(val requestChannel: RequestChannel,
                 (topicPartition, Errors.OFFSET_METADATA_TOO_LARGE)
               else {
                 zkClient.setOrCreateConsumerOffset(
-                  offsetCommitRequest.data().groupId(),
+                  offsetCommitRequest.data.groupId,
                   topicPartition,
-                  partitionData.committedOffset())
+                  partitionData.committedOffset)
                 (topicPartition, Errors.NONE)
               }
             } catch {
@@ -418,7 +418,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         //   - For v5 and beyond there is no per partition expiration timestamp, so this field is no longer in effect
         val currentTimestamp = time.milliseconds
         val partitionData = authorizedTopicRequestInfo.map { case (k, partitionData) =>
-          val metadata = if (partitionData.committedMetadata() == null)
+          val metadata = if (partitionData.committedMetadata == null)
             OffsetAndMetadata.NoMetadata
           else
             partitionData.committedMetadata
@@ -429,14 +429,14 @@ class KafkaApis(val requestChannel: RequestChannel,
             Optional.of[Integer](partitionData.committedLeaderEpoch)
 
           k -> new OffsetAndMetadata(
-            offset = partitionData.committedOffset(),
+            offset = partitionData.committedOffset,
             leaderEpoch = leaderEpochOpt,
             metadata = metadata,
-            commitTimestamp = partitionData.commitTimestamp() match {
+            commitTimestamp = partitionData.commitTimestamp match {
               case OffsetCommitRequest.DEFAULT_TIMESTAMP => currentTimestamp
               case customTimestamp => customTimestamp
             },
-            expireTimestamp = offsetCommitRequest.data().retentionTimeMs() match {
+            expireTimestamp = offsetCommitRequest.data.retentionTimeMs match {
               case OffsetCommitRequest.DEFAULT_RETENTION_TIME => None
               case retentionTime => Some(currentTimestamp + retentionTime)
             }
@@ -490,7 +490,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         nonExistingTopicResponses += topicPartition -> new PartitionResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION)
       else
         try {
-          ProduceRequest.validateRecords(request.header.apiVersion(), memoryRecords)
+          ProduceRequest.validateRecords(request.header.apiVersion, memoryRecords)
           authorizedRequestInfo += (topicPartition -> memoryRecords)
         } catch {
           case e: ApiException =>
@@ -520,7 +520,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       // Record both bandwidth and request quota-specific values and throttle by muting the channel if any of the quotas
       // have been violated. If both quotas have been violated, use the max throttle time between the two quotas. Note
       // that the request quota is not enforced if acks == 0.
-      val bandwidthThrottleTimeMs = quotas.produce.maybeRecordAndGetThrottleTimeMs(request, numBytesAppended, time.milliseconds())
+      val bandwidthThrottleTimeMs = quotas.produce.maybeRecordAndGetThrottleTimeMs(request, numBytesAppended, time.milliseconds)
       val requestThrottleTimeMs = if (produceRequest.acks == 0) 0 else quotas.request.maybeRecordAndGetThrottleTimeMs(request)
       val maxThrottleTimeMs = Math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
       if (maxThrottleTimeMs > 0) {
@@ -725,7 +725,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       def createResponse(throttleTimeMs: Int): FetchResponse[BaseRecords] = {
         // Down-convert messages for each partition if required
         val convertedData = new util.LinkedHashMap[TopicPartition, FetchResponse.PartitionData[BaseRecords]]
-        unconvertedFetchResponse.responseData().asScala.foreach { case (tp, unconvertedPartitionData) =>
+        unconvertedFetchResponse.responseData.asScala.foreach { case (tp, unconvertedPartitionData) =>
           if (unconvertedPartitionData.error != Errors.NONE)
             debug(s"Fetch request with correlation id ${request.header.correlationId} from client $clientId " +
               s"on partition $tp failed due to ${unconvertedPartitionData.error.exceptionName}")
@@ -733,8 +733,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
 
         // Prepare fetch response from converted data
-        val response = new FetchResponse(unconvertedFetchResponse.error(), convertedData, throttleTimeMs,
-          unconvertedFetchResponse.sessionId())
+        val response = new FetchResponse(unconvertedFetchResponse.error, convertedData, throttleTimeMs,
+          unconvertedFetchResponse.sessionId)
         // record the bytes out metrics only when the response is being sent
         response.responseData.asScala.foreach { case (tp, data) =>
           brokerTopicStats.updateBytesOut(tp.topic, fetchRequest.isFromFollower, reassigningPartitions.contains(tp), data.records.sizeInBytes)
@@ -757,8 +757,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         unconvertedFetchResponse = fetchContext.updateAndGenerateResponseData(partitions)
         val responseSize = sizeOfThrottledPartitions(versionId, unconvertedFetchResponse, quotas.leader)
         quotas.leader.record(responseSize)
-        trace(s"Sending Fetch response with partitions.size=${unconvertedFetchResponse.responseData().size()}, " +
-          s"metadata=${unconvertedFetchResponse.sessionId()}")
+        trace(s"Sending Fetch response with partitions.size=${unconvertedFetchResponse.responseData.size}, " +
+          s"metadata=${unconvertedFetchResponse.sessionId}")
         sendResponseExemptThrottle(request, createResponse(0), Some(updateConversionStats))
       } else {
         // Fetch size used to determine throttle time is calculated before any down conversions.
@@ -769,7 +769,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // quotas have been violated. If both quotas have been violated, use the max throttle time between the two
         // quotas. When throttled, we unrecord the recorded bandwidth quota value
         val responseSize = fetchContext.getResponseSize(partitions, versionId)
-        val timeMs = time.milliseconds()
+        val timeMs = time.milliseconds
         val requestThrottleTimeMs = quotas.request.maybeRecordAndGetThrottleTimeMs(request)
         val bandwidthThrottleTimeMs = quotas.fetch.maybeRecordAndGetThrottleTimeMs(request, responseSize, timeMs)
 
@@ -848,7 +848,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   private def sizeOfThrottledPartitions(versionId: Short,
                                         unconvertedResponse: FetchResponse[Records],
                                         quota: ReplicationQuotaManager): Int = {
-    val iter = new SelectingIterator(unconvertedResponse.responseData(), quota)
+    val iter = new SelectingIterator(unconvertedResponse.responseData, quota)
     FetchResponse.sizeOf(versionId, iter)
   }
 
@@ -856,7 +856,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (fetchRequest.isFromFollower) quotas.leader else UnboundedQuota
 
   def handleListOffsetRequest(request: RequestChannel.Request): Unit = {
-    val version = request.header.apiVersion()
+    val version = request.header.apiVersion
 
     val mergedResponseMap = if (version == 0)
       handleListOffsetRequestV0(request)
@@ -1318,9 +1318,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val describeRequest = request.body[DescribeGroupsRequest]
     val describeGroupsResponseData = new DescribeGroupsResponseData()
 
-    describeRequest.data().groups().asScala.foreach { groupId =>
+    describeRequest.data.groups.asScala.foreach { groupId =>
       if (!authorize(request, DESCRIBE, GROUP, groupId)) {
-        describeGroupsResponseData.groups().add(DescribeGroupsResponse.forError(groupId, Errors.GROUP_AUTHORIZATION_FAILED))
+        describeGroupsResponseData.groups.add(DescribeGroupsResponse.forError(groupId, Errors.GROUP_AUTHORIZATION_FAILED))
       } else {
         val (error, summary) = groupCoordinator.handleDescribeGroup(groupId)
         val members = summary.members.map { member =>
@@ -1334,7 +1334,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
 
         val describedGroup = new DescribeGroupsResponseData.DescribedGroup()
-          .setErrorCode(error.code())
+          .setErrorCode(error.code)
           .setGroupId(groupId)
           .setGroupState(summary.state)
           .setProtocolType(summary.protocolType)
@@ -1347,7 +1347,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           }
         }
 
-        describeGroupsResponseData.groups().add(describedGroup)
+        describeGroupsResponseData.groups.add(describedGroup)
       }
     }
 
@@ -1360,7 +1360,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       // With describe cluster access all groups are returned. We keep this alternative for backward compatibility.
       sendResponseMaybeThrottle(request, requestThrottleMs =>
         new ListGroupsResponse(new ListGroupsResponseData()
-            .setErrorCode(error.code())
+            .setErrorCode(error.code)
             .setGroups(groups.map { group => new ListGroupsResponseData.ListedGroup()
               .setGroupId(group.groupId)
               .setProtocolType(group.protocolType)}.asJava
@@ -1371,7 +1371,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       val filteredGroups = groups.filter(group => authorize(request, DESCRIBE, GROUP, group.groupId))
       sendResponseMaybeThrottle(request, requestThrottleMs =>
         new ListGroupsResponse(new ListGroupsResponseData()
-          .setErrorCode(error.code())
+          .setErrorCode(error.code)
           .setGroups(filteredGroups.map { group => new ListGroupsResponseData.ListedGroup()
             .setGroupId(group.groupId)
             .setProtocolType(group.protocolType)}.asJava
@@ -1390,7 +1390,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         val responseBody = new JoinGroupResponse(
           new JoinGroupResponseData()
             .setThrottleTimeMs(requestThrottleMs)
-            .setErrorCode(joinResult.error.code())
+            .setErrorCode(joinResult.error.code)
             .setGenerationId(joinResult.generationId)
             .setProtocolName(joinResult.subProtocol)
             .setLeader(joinResult.leaderId)
@@ -1417,7 +1417,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         JoinGroupResponse.UNKNOWN_MEMBER_ID,
         Errors.UNSUPPORTED_VERSION
       ))
-    } else if (!authorize(request, READ, GROUP, joinGroupRequest.data().groupId())) {
+    } else if (!authorize(request, READ, GROUP, joinGroupRequest.data.groupId)) {
       sendResponseMaybeThrottle(request, requestThrottleMs =>
         new JoinGroupResponse(
           new JoinGroupResponseData()
@@ -1561,9 +1561,9 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleLeaveGroupRequest(request: RequestChannel.Request): Unit = {
     val leaveGroupRequest = request.body[LeaveGroupRequest]
 
-    val members = leaveGroupRequest.members().asScala.toList
+    val members = leaveGroupRequest.members.asScala.toList
 
-    if (!authorize(request, READ, GROUP, leaveGroupRequest.data().groupId())) {
+    if (!authorize(request, READ, GROUP, leaveGroupRequest.data.groupId)) {
       sendResponseMaybeThrottle(request, requestThrottleMs => {
         new LeaveGroupResponse(new LeaveGroupResponseData()
           .setThrottleTimeMs(requestThrottleMs)
@@ -1643,16 +1643,16 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     val createTopicsRequest = request.body[CreateTopicsRequest]
-    val results = new CreatableTopicResultCollection(createTopicsRequest.data().topics().size())
+    val results = new CreatableTopicResultCollection(createTopicsRequest.data.topics.size)
     if (!controller.isActive) {
       createTopicsRequest.data.topics.asScala.foreach { topic =>
-        results.add(new CreatableTopicResult().setName(topic.name()).
-          setErrorCode(Errors.NOT_CONTROLLER.code()))
+        results.add(new CreatableTopicResult().setName(topic.name).
+          setErrorCode(Errors.NOT_CONTROLLER.code))
       }
       sendResponseCallback(results)
     } else {
       createTopicsRequest.data.topics.asScala.foreach { topic =>
-        results.add(new CreatableTopicResult().setName(topic.name()))
+        results.add(new CreatableTopicResult().setName(topic.name))
       }
       val hasClusterAuthorization = authorize(request, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false)
       val topics = createTopicsRequest.data.topics.asScala.map(_.name)
@@ -1661,11 +1661,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         .map(name => name -> results.find(name)).toMap
 
       results.asScala.foreach(topic => {
-        if (results.findAll(topic.name()).size() > 1) {
-          topic.setErrorCode(Errors.INVALID_REQUEST.code())
+        if (results.findAll(topic.name).size > 1) {
+          topic.setErrorCode(Errors.INVALID_REQUEST.code)
           topic.setErrorMessage("Found multiple entries for this topic.")
         } else if (!authorizedTopics.contains(topic.name)) {
-          topic.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())
+          topic.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
           topic.setErrorMessage("Authorization failed.")
         }
         if (!authorizedForDescribeConfigs.contains(topic.name)) {
@@ -1724,7 +1724,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (!controller.isActive) {
       val result = createPartitionsRequest.data.topics.asScala.map { topic =>
-        (topic.name(), new ApiError(Errors.NOT_CONTROLLER, null))
+        (topic.name, new ApiError(Errors.NOT_CONTROLLER, null))
       }.toMap
       sendResponseCallback(result)
     } else {
@@ -1742,8 +1742,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
 
       val errors = dupes.map(_ -> new ApiError(Errors.INVALID_REQUEST, "Duplicate topic in request.")) ++
-        unauthorized.map(_.name() -> new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, "The topic authorization is failed.")) ++
-        queuedForDeletion.map(_.name() -> new ApiError(Errors.INVALID_TOPIC_EXCEPTION, "The topic is queued for deletion."))
+        unauthorized.map(_.name -> new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, "The topic authorization is failed.")) ++
+        queuedForDeletion.map(_.name -> new ApiError(Errors.INVALID_TOPIC_EXCEPTION, "The topic is queued for deletion."))
 
       adminManager.createPartitions(createPartitionsRequest.data.timeoutMs,
         valid,
@@ -2034,7 +2034,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     // No log appends were written as all partitions had incorrect log format
     // so we need to send the error response
-    if (skippedMarkers == markers.size())
+    if (skippedMarkers == markers.size)
       sendResponseExemptThrottle(request, new WriteTxnMarkersResponse(errors))
   }
 
@@ -2342,15 +2342,15 @@ class KafkaApis(val requestChannel: RequestChannel,
     def sendResponseCallback(result: Either[Map[TopicPartition, ApiError], ApiError]): Unit = {
       val responseData = result match {
         case Right(topLevelError) =>
-          new AlterPartitionReassignmentsResponseData().setErrorMessage(topLevelError.message()).setErrorCode(topLevelError.error().code())
+          new AlterPartitionReassignmentsResponseData().setErrorMessage(topLevelError.message).setErrorCode(topLevelError.error.code)
 
         case Left(assignments) =>
-          val topicResponses = assignments.groupBy(_._1.topic()).map {
+          val topicResponses = assignments.groupBy(_._1.topic).map {
             case (topic, reassignmentsByTp) =>
               val partitionResponses = reassignmentsByTp.map {
                 case (topicPartition, error) =>
-                  new ReassignablePartitionResponse().setPartitionIndex(topicPartition.partition())
-                    .setErrorCode(error.error().code()).setErrorMessage(error.message())
+                  new ReassignablePartitionResponse().setPartitionIndex(topicPartition.partition)
+                    .setErrorCode(error.error.code).setErrorMessage(error.message)
               }
               new ReassignableTopicResponse().setName(topic).setPartitions(partitionResponses.toList.asJava)
           }
@@ -2362,14 +2362,14 @@ class KafkaApis(val requestChannel: RequestChannel,
       )
     }
 
-    val reassignments = alterPartitionReassignmentsRequest.data().topics().asScala.flatMap {
-      reassignableTopic => reassignableTopic.partitions().asScala.map {
+    val reassignments = alterPartitionReassignmentsRequest.data.topics.asScala.flatMap {
+      reassignableTopic => reassignableTopic.partitions.asScala.map {
         reassignablePartition =>
-          val tp = new TopicPartition(reassignableTopic.name(), reassignablePartition.partitionIndex())
-          if (reassignablePartition.replicas() == null)
+          val tp = new TopicPartition(reassignableTopic.name, reassignablePartition.partitionIndex)
+          if (reassignablePartition.replicas == null)
             tp -> None // revert call
           else
-            tp -> Some(reassignablePartition.replicas().asScala.map(_.toInt))
+            tp -> Some(reassignablePartition.replicas.asScala.map(_.toInt))
       }
     }.toMap
 
@@ -2382,15 +2382,15 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     def sendResponseCallback(result: Either[Map[TopicPartition, ReplicaAssignment], ApiError]): Unit = {
       val responseData = result match {
-        case Right(error) => new ListPartitionReassignmentsResponseData().setErrorMessage(error.message()).setErrorCode(error.error().code())
+        case Right(error) => new ListPartitionReassignmentsResponseData().setErrorMessage(error.message).setErrorCode(error.error.code)
 
         case Left(assignments) =>
-          val topicReassignments = assignments.groupBy(_._1.topic()).map {
+          val topicReassignments = assignments.groupBy(_._1.topic).map {
             case (topic, reassignmentsByTp) =>
               val partitionReassignments = reassignmentsByTp.map {
                 case (topicPartition, assignment) =>
                   new ListPartitionReassignmentsResponseData.OngoingPartitionReassignment()
-                    .setPartitionIndex(topicPartition.partition())
+                    .setPartitionIndex(topicPartition.partition)
                     .setAddingReplicas(assignment.addingReplicas.toList.asJava.asInstanceOf[java.util.List[java.lang.Integer]])
                     .setRemovingReplicas(assignment.removingReplicas.toList.asJava.asInstanceOf[java.util.List[java.lang.Integer]])
                     .setReplicas(assignment.replicas.toList.asJava.asInstanceOf[java.util.List[java.lang.Integer]])
@@ -2408,10 +2408,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       )
     }
 
-    val partitionsOpt = listPartitionReassignmentsRequest.data().topics() match {
+    val partitionsOpt = listPartitionReassignmentsRequest.data.topics match {
       case topics: Any =>
         Some(topics.iterator().asScala.flatMap { topic =>
-          topic.partitionIndexes().iterator().asScala
+          topic.partitionIndexes.iterator().asScala
             .map { tp => new TopicPartition(topic.name(), tp) }
         }.toSet)
       case _ => None
@@ -2432,10 +2432,10 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleIncrementalAlterConfigsRequest(request: RequestChannel.Request): Unit = {
     val alterConfigsRequest = request.body[IncrementalAlterConfigsRequest]
 
-    val configs = alterConfigsRequest.data().resources().iterator().asScala.map { alterConfigResource =>
-      val configResource = new ConfigResource(ConfigResource.Type.forId(alterConfigResource.resourceType()), alterConfigResource.resourceName())
+    val configs = alterConfigsRequest.data.resources.iterator().asScala.map { alterConfigResource =>
+      val configResource = new ConfigResource(ConfigResource.Type.forId(alterConfigResource.resourceType), alterConfigResource.resourceName)
       configResource -> alterConfigResource.configs().iterator().asScala.map {
-        alterConfig => new AlterConfigOp(new ConfigEntry(alterConfig.name(), alterConfig.value()), OpType.forId(alterConfig.configOperation())) }.toList
+        alterConfig => new AlterConfigOp(new ConfigEntry(alterConfig.name, alterConfig.value), OpType.forId(alterConfig.configOperation)) }.toList
     }.toMap
 
     val (authorizedResources, unauthorizedResources) = configs.partition { case (resource, _) =>
@@ -2448,7 +2448,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
 
-    val authorizedResult = adminManager.incrementalAlterConfigs(authorizedResources, alterConfigsRequest.data().validateOnly())
+    val authorizedResult = adminManager.incrementalAlterConfigs(authorizedResources, alterConfigsRequest.data.validateOnly)
     val unauthorizedResult = unauthorizedResources.keys.map { resource =>
       resource -> configsAuthorizationApiError(resource)
     }
@@ -2499,7 +2499,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           if (describeLogDirsDirRequest.isAllTopicPartitions)
             replicaManager.logManager.allLogs.map(_.topicPartition).toSet
           else
-            describeLogDirsDirRequest.topicPartitions().asScala
+            describeLogDirsDirRequest.topicPartitions.asScala
 
         replicaManager.describeLogDirs(partitions)
       } else {
@@ -2622,7 +2622,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         val owners = if (describeTokenRequest.data.owners == null)
           None
         else
-          Some(describeTokenRequest.data.owners.asScala.map(p => new KafkaPrincipal(p.principalType(), p.principalName())).toList)
+          Some(describeTokenRequest.data.owners.asScala.map(p => new KafkaPrincipal(p.principalType(), p.principalName)).toList)
         def authorizeToken(tokenId: String) = authorize(request, DESCRIBE, DELEGATION_TOKEN, tokenId)
         def eligible(token: TokenInformation) = DelegationTokenManager.filterToken(requestPrincipal, owners, token, authorizeToken)
         val tokens =  tokenManager.getTokens(eligible)
@@ -2652,7 +2652,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       results: Map[TopicPartition, ApiError]
     ): Unit = {
       sendResponseMaybeThrottle(request, requestThrottleMs => {
-        val adjustedResults = if (electionRequest.data().topicPartitions() == null) {
+        val adjustedResults = if (electionRequest.data.topicPartitions == null) {
           /* When performing elections across all of the partitions we should only return
            * partitions for which there was an eleciton or resulted in an error. In other
            * words, partitions that didn't need election because they ready have the correct
@@ -2697,7 +2697,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       sendResponseCallback(error)(partitionErrors)
     } else {
-      val partitions = if (electionRequest.data().topicPartitions() == null) {
+      val partitions = if (electionRequest.data.topicPartitions == null) {
         metadataCache.getAllPartitions()
       } else {
         electionRequest.topicPartitions
@@ -2708,7 +2708,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         partitions,
         electionRequest.electionType,
         sendResponseCallback(ApiError.NONE),
-        electionRequest.data().timeoutMs()
+        electionRequest.data.timeoutMs
       )
     }
   }
@@ -2825,7 +2825,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       case None =>
         supportedOps.toSet
     }
-    Utils.to32BitField(authorizedOps.map(operation => operation.code().asInstanceOf[JByte]).asJava)
+    Utils.to32BitField(authorizedOps.map(operation => operation.code.asInstanceOf[JByte]).asJava)
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -24,6 +24,7 @@ import kafka.security.authorizer.AclAuthorizer
 import kafka.utils.TestUtils
 import org.apache.kafka.common.acl._
 import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreatableTopicCollection}
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
@@ -438,9 +439,11 @@ class RequestQuotaTest extends BaseRequestTest {
           new DescribeLogDirsRequest.Builder(Collections.singleton(tp))
 
         case ApiKeys.CREATE_PARTITIONS =>
-          new CreatePartitionsRequest.Builder(
-            Collections.singletonMap("topic-2", new CreatePartitionsRequest.PartitionDetails(1)), 0, false
-          )
+          val data = new CreatePartitionsRequestData()
+            .setTimeoutMs(0)
+            .setValidateOnly(false)
+            .setTopics(Collections.singletonList(new CreatePartitionsTopic().setName("topic-2").setCount(1)))
+          new CreatePartitionsRequest.Builder(data)
 
         case ApiKeys.CREATE_DELEGATION_TOKEN =>
           new CreateDelegationTokenRequest.Builder(


### PR DESCRIPTION
This change update the CreatePartitions request and response api objects
to use automated protocol. The change involved updating all client code
to use the newly updated CreatePartitionsRequest and
CreatePartitionsResponse classes.

Updated relevant tests. All tests pass.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
