### PR TITLE
HOT FIX: fix checkstyle in Streams system test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -104,7 +104,7 @@ public class StreamsBrokerDownResilienceTest {
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), streamsProperties);
 
-        streams.setUncaughtExceptionHandler( (t,e) -> {
+        streams.setUncaughtExceptionHandler((t, e) -> {
                 System.err.println("FATAL: An unexpected exception " + e);
                 System.err.flush();
                 streams.close(Duration.ofSeconds(30));
@@ -114,11 +114,11 @@ public class StreamsBrokerDownResilienceTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread( () -> {
-                streams.close(Duration.ofSeconds(30));
-                System.out.println("Complete shutdown of streams resilience test app now");
-                System.out.flush();
-            }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            streams.close(Duration.ofSeconds(30));
+            System.out.println("Complete shutdown of streams resilience test app now");
+            System.out.flush();
+        }
         ));
     }
 


### PR DESCRIPTION
Checkstyle is broken on trunk due to replacing anonymous function with a lambda in one of the system tests, just formatting it so it won't complain.

Should be cherry-picked to 2.4