### PR TITLE
MINOR: Increase spotBugs max heap to 2 GB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -483,6 +483,7 @@ subprojects {
       xml.enabled(project.hasProperty('xmlSpotBugsReport') || project.hasProperty('xmlFindBugsReport'))
       html.enabled(!project.hasProperty('xmlSpotBugsReport') && !project.hasProperty('xmlFindBugsReport'))
     }
+    maxHeapSize = "2g"
   }
 
   // Ignore core since its a scala project


### PR DESCRIPTION
Gradle 5.0 has reduced the heap size for
workers and there have been reports of
`GC overhead limit exceeded` errors.

Also see:
https://discuss.gradle.org/t/spotbugsplugin-with-gradle-5-0-fails-gc-overhead-limit-exceeded/30461

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
