### PR TITLE
KAFKA-9029: Flaky Test CooperativeStickyAssignorTest.testReassignmentWithRandomSubscriptionsAndChanges

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -68,7 +68,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
             assignments.putAll(assignor.assign(partitionsPerTopic, subscriptions));
             ++rebalances;
 
-            assertTrue(rebalances <= 2);
+            assertTrue(rebalances <= 4);
         }
 
         // Check the validity and balance of the final assignment


### PR DESCRIPTION
One of the sticky assignor tests involves a random change in subscriptions that the current assignor algorithm struggles to react to and in cooperative mode ends up requiring more than one followup rebalance. 

Apparently, in rare cases it can also require more than 2. Bumping the "allowed subsequent rebalances" to 4 (increase of 2) to allow some breathing room and reduce flakiness (technically any number is "correct", but if it turns out to ever require more than 4 we should revisit and improve the algorithm because that would be excessive (see [KAFKA-8767](https://issues.apache.org/jira/browse/KAFKA-8767))