### PR TITLE
KAFKA-7204: Avoid clearing records for paused partitions on poll of MockConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -188,6 +188,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
         // update the consumed offset
         final Map<TopicPartition, List<ConsumerRecord<K, V>>> results = new HashMap<>();
+        final List<TopicPartition> toClear = new ArrayList<>();
 
         for (Map.Entry<TopicPartition, List<ConsumerRecord<K, V>>> entry : this.records.entrySet()) {
             if (!subscriptions.isPaused(entry.getKey())) {
@@ -206,9 +207,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
                         subscriptions.position(entry.getKey(), newPosition);
                     }
                 }
+                toClear.add(entry.getKey());
             }
         }
-        this.records.clear();
+
+        toClear.forEach(p -> this.records.remove(p));
         return new ConsumerRecords<>(results);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -98,6 +99,22 @@ public class MockConsumerTest {
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1));
         assertThat(records.count(), is(0));
         assertThat(records.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldNotClearRecordsForPausedPartitions() {
+        TopicPartition partition0 = new TopicPartition("test", 0);
+        Collection<TopicPartition> testPartitionList = Collections.singletonList(partition0);
+        consumer.assign(testPartitionList);
+        consumer.addRecord(new ConsumerRecord<>("test", 0, 0, null, null));
+        consumer.updateBeginningOffsets(Collections.singletonMap(partition0, 0L));
+        consumer.seekToBeginning(testPartitionList);
+
+        consumer.pause(testPartitionList);
+        consumer.poll(Duration.ofMillis(1));
+        consumer.resume(testPartitionList);
+        ConsumerRecords<String, String> recordsSecondPoll = consumer.poll(Duration.ofMillis(1));
+        assertThat(recordsSecondPoll.count(), is(1));
     }
 
 }


### PR DESCRIPTION
The previous version of MockConsumer does not allow the clients to test consecutive calls to poll while consuming only from a partial set of partitions due to the fact that it clears all the records after each call. This change makes MockConsumer clearing the records only for the partitions that are not paused (whose records are actually returned by the poll). The remaining paused partitions will retain the records.

Unit test added accordingly.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
