### PR TITLE
KAFKA-9035: Improve logging on potential loop forwaring in Kafka Connect REST

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -91,7 +91,23 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     member.memberId(),
                     IncrementalCooperativeConnectProtocol.deserializeMetadata(ByteBuffer.wrap(member.metadata())));
         }
-        log.debug("Member configs: {}", memberConfigs);
+
+        Set<String> seenUrls = new HashSet<>();
+        boolean duplicateUrlsFound = false;
+        for (ExtendedWorkerState state : memberConfigs.values()) {
+            if (seenUrls.contains(state.url())) {
+                duplicateUrlsFound = true;
+                break;
+            } else {
+                seenUrls.add(state.url());
+            }
+        }
+        if (duplicateUrlsFound) {
+            log.warn("Member configs: {}", memberConfigs);
+            log.warn("Duplicate member URLs found. This can break REST API forwarding to leader.");
+        } else {
+            log.debug("Member configs: {}", memberConfigs);
+        }
 
         // The new config offset is the maximum seen by any member. We always perform assignment using this offset,
         // even if some members have fallen behind. The config offset used to generate the assignment is included in

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -226,7 +226,7 @@ public class RestServer {
         resourceConfig.register(new JacksonJsonProvider());
 
         resourceConfig.register(new RootResource(herder));
-        resourceConfig.register(new ConnectorsResource(herder, config));
+        resourceConfig.register(new ConnectorsResource(herder, config, advertisedUrl()));
         resourceConfig.register(new ConnectorPluginsResource(herder));
 
         resourceConfig.register(ConnectExceptionMapper.class);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -80,12 +80,14 @@ public class ConnectorsResource {
 
     private final Herder herder;
     private final WorkerConfig config;
+    private final URI advertisedUrl;
     @javax.ws.rs.core.Context
     private ServletContext context;
 
-    public ConnectorsResource(Herder herder, WorkerConfig config) {
+    public ConnectorsResource(Herder herder, WorkerConfig config, URI advertisedUrl) {
         this.herder = herder;
         this.config = config;
+        this.advertisedUrl = advertisedUrl;
     }
 
     @GET
@@ -306,6 +308,11 @@ public class ConnectorsResource {
                     // this gives two total hops to resolve the request before giving up.
                     boolean recursiveForward = forward == null;
                     RequestTargetException targetException = (RequestTargetException) cause;
+
+                    if (this.advertisedUrl.compareTo(URI.create(targetException.forwardUrl())) == 0) {
+                        log.warn("Request will be forwarded to URL {} same as this server's advertised URL (potential loop)",
+                                targetException.forwardUrl());
+                    }
                     String forwardUrl = UriBuilder.fromUri(targetException.forwardUrl())
                             .path(path)
                             .queryParam("forward", recursiveForward)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -139,7 +139,7 @@ public class ConnectorsResourceTest {
     public void setUp() throws NoSuchMethodException {
         PowerMock.mockStatic(RestClient.class,
                 RestClient.class.getMethod("httpRequest", String.class, String.class, HttpHeaders.class, Object.class, TypeReference.class, WorkerConfig.class));
-        connectorsResource = new ConnectorsResource(herder, null);
+        connectorsResource = new ConnectorsResource(herder, null, URI.create("http://localhost:8083"));
         forward = EasyMock.mock(UriInfo.class);
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.putSingle("forward", "true");


### PR DESCRIPTION
These two commits make Kafka Connect warn the user when there's a possibility of redirecting REST requests from a Connect worker to itself.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
