### PR TITLE
MINOR: log reason for fatal error in locking state dir

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -190,8 +190,9 @@ public abstract class AbstractTask implements Task {
             }
         } catch (final IOException e) {
             throw new StreamsException(
-                String.format("%sFatal error while trying to lock the state directory for task %s",
-                logPrefix, id));
+                String.format("%sFatal error while trying to lock the state directory for task %s", logPrefix, id),
+                e
+            );
         }
         log.trace("Initializing state stores");
 


### PR DESCRIPTION
Log the reason for fatal errors while locking the state directory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
