### PR TITLE
KAFKA-6968: Adds calls to listener on rebalance of MockConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -90,9 +90,13 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     /** Simulate a rebalance event. */
     public synchronized void rebalance(Collection<TopicPartition> newAssignment) {
-        // TODO: Rebalance callbacks
+        if (newAssignment == null)
+            throw new IllegalArgumentException("newAssignment cannot be null");
+
+        this.subscriptions.rebalanceListener().onPartitionsRevoked(this.subscriptions.assignedPartitions());
         this.records.clear();
         this.subscriptions.assignFromSubscribed(newAssignment);
+        this.subscriptions.rebalanceListener().onPartitionsAssigned(newAssignment);
     }
 
     @Override


### PR DESCRIPTION
The MockConsumer has a rebalance operation which receives a new set of partitions to simulate the rebalance of a consumer group. However, the current version is not calling the listener provided on subscription to notify the client when partitions are revoked and assigned.

This MR calls both listeners on rebalance and adds a unit test to cover that.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
