### PR TITLE
MINOR: add missed curly brackets to the log.error

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -176,7 +176,7 @@ abstract class WorkerTask implements Runnable {
 
             execute();
         } catch (Throwable t) {
-            log.error("{} Task threw an uncaught and unrecoverable exception", this, t);
+            log.error("{} Task threw an uncaught and unrecoverable exception: {}", this, t);
             log.error("{} Task is being killed and will not recover until manually restarted", this);
             throw t;
         } finally {


### PR DESCRIPTION
I've added missed curly brackets to the log.error(...) in `WorkerTask` as it doesn't show the root cause of the exception if some appears in Kafka Connector.