### PR TITLE
MINOR: Upgrade zk to 3.5.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -114,7 +114,7 @@ versions += [
   spotbugs: "3.1.12",
   spotbugsPlugin: "1.6.9",
   spotlessPlugin: "3.23.1",
-  zookeeper: "3.5.5",
+  zookeeper: "3.5.6",
   zstd: "1.4.3-1"
 ]
 


### PR DESCRIPTION
It includes an important fix for people running on k8s:

* ZOOKEEPER-3320: Leader election port stop listen when
hostname unresolvable for some time

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
