### PR TITLE
KAFKA-8700: Flaky Test QueryableStateIntegrationTest#queryOnRebalance

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/NoRetryException.java
+++ b/clients/src/test/java/org/apache/kafka/test/NoRetryException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+/**
+ * This class can be used in the callback given to {@link TestUtils#retryOnExceptionWithTimeout(long, long, ValuelessCallable)}
+ * to indicate that a particular exception should not be retried. Instead the retry operation will
+ * be aborted immediately and the exception will be rethrown.
+ */
+public class NoRetryException extends RuntimeException {
+    private final Throwable cause;
+
+    public NoRetryException(Throwable cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public Throwable getCause() {
+        return this.cause;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -416,6 +416,8 @@ public class TestUtils {
             try {
                 runnable.call();
                 return;
+            } catch (final NoRetryException e) {
+                throw e;
             } catch (final AssertionError t) {
                 if (expectedEnd <= System.currentTimeMillis()) {
                     throw t;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.kafka.streams.integration;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.time.Duration;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 import kafka.utils.MockTime;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -29,6 +36,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreamsTest;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -54,6 +62,7 @@ import org.apache.kafka.streams.state.StreamsMetadata;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockMapper;
+import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -86,6 +95,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static java.time.Instant.ofEpochMilli;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
+import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -97,6 +109,8 @@ import static org.apache.kafka.test.StreamsTestUtils.startKafkaStreamsAndWaitFor
 @Category({IntegrationTest.class})
 public class QueryableStateIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(QueryableStateIntegrationTest.class);
+
+    private static final long DEFAULT_TIMEOUT_MS = 120 * 1000;
 
     private static final int NUM_BROKERS = 1;
 
@@ -242,131 +256,152 @@ public class QueryableStateIntegrationTest {
         return new KafkaStreams(builder.build(), streamsConfiguration);
     }
 
-    private class StreamRunnable implements Runnable {
-        private final KafkaStreams myStream;
-        private boolean closed = false;
-        private final KafkaStreamsTest.StateListenerStub stateListener = new KafkaStreamsTest.StateListenerStub();
-
-        StreamRunnable(final String inputTopic,
-                       final String outputTopic,
-                       final String outputTopicWindowed,
-                       final String storeName,
-                       final String windowStoreName,
-                       final int queryPort) {
-            final Properties props = (Properties) streamsConfiguration.clone();
-            props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + queryPort);
-            myStream = createCountStream(inputTopic, outputTopic, outputTopicWindowed, storeName, windowStoreName, props);
-            myStream.setStateListener(stateListener);
-        }
-
-        @Override
-        public void run() {
-            myStream.start();
-
-            try {
-                TestUtils.waitForCondition(
-                    () -> stateListener.mapStates.containsKey(KafkaStreams.State.RUNNING),
-                    "Did not start successfully after " + TestUtils.DEFAULT_MAX_WAIT_MS + " ms"
-                );
-            } catch (final InterruptedException e) {
-                if (!stateListener.mapStates.containsKey(KafkaStreams.State.RUNNING))
-                    fail("Did not start successfully");
-            }
-        }
-
-        public void close() {
-            if (!closed) {
-                myStream.close();
-                closed = true;
-            }
-        }
-
-        public boolean isClosed() {
-            return closed;
-        }
-
-        public final KafkaStreams getStream() {
-            return myStream;
-        }
-
-        final KafkaStreamsTest.StateListenerStub getStateListener() {
-            return stateListener;
-        }
-    }
-
-    private void verifyAllKVKeys(final StreamRunnable[] streamRunnables,
+    private void verifyAllKVKeys(final List<KafkaStreams> streamsList,
                                  final KafkaStreams streams,
-                                 final KafkaStreamsTest.StateListenerStub stateListenerStub,
+                                 final KafkaStreamsTest.StateListenerStub stateListener,
                                  final Set<String> keys,
-                                 final String storeName) throws Exception {
-        for (final String key : keys) {
-            TestUtils.waitForCondition(
-                () -> {
-                    try {
-                        final StreamsMetadata metadata = streams.metadataForKey(storeName, key, new StringSerializer());
+                                 final String storeName,
+                                 final long timeout) throws Exception {
+        retryOnExceptionWithTimeout(timeout, () -> {
+            final List<String> noMetadataKeys = new ArrayList<>();
+            final List<String> nullStoreKeys = new ArrayList<>();
+            final List<String> nullValueKeys = new ArrayList<>();
+            final Map<String, Exception> exceptionalKeys = new TreeMap<>();
 
-                        if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
-                            return false;
-                        }
-                        final int index = metadata.hostInfo().port();
-                        final KafkaStreams streamsWithKey = streamRunnables[index].getStream();
-                        final ReadOnlyKeyValueStore<String, Long> store =
-                            streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore());
-
-                        return store != null && store.get(key) != null;
-                    } catch (final IllegalStateException e) {
-                        // Kafka Streams instance may have closed but rebalance hasn't happened
-                        return false;
-                    } catch (final InvalidStateStoreException e) {
-                        // there must have been at least one rebalance state
-                        assertTrue(stateListenerStub.mapStates.get(KafkaStreams.State.REBALANCING) >= 1);
-                        return false;
+            for (final String key: keys) {
+                try {
+                    final StreamsMetadata metadata = streams
+                        .metadataForKey(storeName, key, new StringSerializer());
+                    if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
+                        noMetadataKeys.add(key);
+                        continue;
                     }
-                },
-                120000,
-                "waiting for metadata, store and value to be non null");
-        }
+
+                    final int index = metadata.hostInfo().port();
+                    final KafkaStreams streamsWithKey = streamsList.get(index);
+                    final ReadOnlyKeyValueStore<String, Long> store =
+                        streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore());
+                    if (store == null) {
+                        nullStoreKeys.add(key);
+                        continue;
+                    }
+
+                    if (store.get(key) == null) {
+                        nullValueKeys.add(key);
+                        continue;
+                    }
+                } catch (final InvalidStateStoreException e) {
+                    if (stateListener.mapStates.get(KafkaStreams.State.REBALANCING) < 1) {
+                        throw new NoRetryException(new AssertionError(
+                            String.format("Received %s for key %s and expected at least one rebalancing state, but had none",
+                                e.getClass().getName(), key)));
+                    }
+                } catch (final Exception e) {
+                    exceptionalKeys.put(key, e);
+                }
+            }
+
+            assertNoKVKeyFailures(storeName, timeout, noMetadataKeys, nullStoreKeys, nullValueKeys, exceptionalKeys);
+        });
     }
 
-    private void verifyAllWindowedKeys(final StreamRunnable[] streamRunnables,
+    private void verifyAllWindowedKeys(final List<KafkaStreams> streamsList,
                                        final KafkaStreams streams,
                                        final KafkaStreamsTest.StateListenerStub stateListenerStub,
                                        final Set<String> keys,
                                        final String storeName,
                                        final Long from,
-                                       final Long to) throws Exception {
-        for (final String key : keys) {
-            TestUtils.waitForCondition(
-                () -> {
-                    try {
-                        final StreamsMetadata metadata = streams.metadataForKey(storeName, key, new StringSerializer());
-                        if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
-                            return false;
-                        }
-                        final int index = metadata.hostInfo().port();
-                        final KafkaStreams streamsWithKey = streamRunnables[index].getStream();
-                        final ReadOnlyWindowStore<String, Long> store =
-                            streamsWithKey.store(storeName, QueryableStoreTypes.windowStore());
-                        return store != null && store.fetch(key, ofEpochMilli(from), ofEpochMilli(to)) != null;
-                    } catch (final IllegalStateException e) {
-                        // Kafka Streams instance may have closed but rebalance hasn't happened
-                        return false;
-                    } catch (final InvalidStateStoreException e) {
-                        // there must have been at least one rebalance state
-                        assertTrue(stateListenerStub.mapStates.get(KafkaStreams.State.REBALANCING) >= 1);
-                        return false;
+                                       final Long to,
+                                       final long timeout) throws Exception {
+        retryOnExceptionWithTimeout(timeout, () -> {
+            final List<String> noMetadataKeys = new ArrayList<>();
+            final List<String> nullStoreKeys = new ArrayList<>();
+            final List<String> nullValueKeys = new ArrayList<>();
+            final Map<String, Exception> exceptionalKeys = new TreeMap<>();
+
+            for (final String key: keys) {
+                try {
+                    final StreamsMetadata metadata = streams
+                        .metadataForKey(storeName, key, new StringSerializer());
+                    if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
+                        noMetadataKeys.add(key);
+                        continue;
                     }
-                },
-                120000,
-                "waiting for metadata, store and value to be non null");
+
+                    final int index = metadata.hostInfo().port();
+                    final KafkaStreams streamsWithKey = streamsList.get(index);
+                    final ReadOnlyWindowStore<String, Long> store =
+                        streamsWithKey.store(storeName, QueryableStoreTypes.windowStore());
+                    if (store == null) {
+                        nullStoreKeys.add(key);
+                        continue;
+                    }
+
+                    if (store.fetch(key, ofEpochMilli(from), ofEpochMilli(to)) == null) {
+                        nullValueKeys.add(key);
+                        continue;
+                    }
+                } catch (final InvalidStateStoreException e) {
+                    // there must have been at least one rebalance state
+                    if (stateListenerStub.mapStates.get(KafkaStreams.State.REBALANCING) < 1) {
+                        throw new NoRetryException(new AssertionError(
+                            String.format("Received %s for key %s and expected at least one rebalancing state, but had none",
+                                e.getClass().getName(), key)));
+                    }
+                } catch (final Exception e) {
+                    exceptionalKeys.put(key, e);
+                }
+            }
+
+            assertNoKVKeyFailures(storeName, timeout, noMetadataKeys, nullStoreKeys, nullValueKeys, exceptionalKeys);
+        });
+    }
+
+    private void assertNoKVKeyFailures(final String storeName,
+                                       final long timeout,
+                                       final List<String> noMetadataKeys,
+                                       final List<String> nullStoreKeys,
+                                       final List<String> nullValueKeys,
+                                       final Map<String, Exception> exceptionalKeys) throws IOException {
+        final StringBuilder reason = new StringBuilder();
+        reason.append(String.format("Not all keys are available for store %s in %d ms", storeName, timeout));
+        if (!noMetadataKeys.isEmpty()) {
+            reason.append("\n    * No metadata is available for these keys: ").append(noMetadataKeys);
         }
+        if (!nullStoreKeys.isEmpty()) {
+            reason.append("\n    * No store is available for these keys: ").append(nullStoreKeys);
+        }
+        if (!nullValueKeys.isEmpty()) {
+            reason.append("\n    * No value is available for these keys: ").append(nullValueKeys);
+        }
+        if (!exceptionalKeys.isEmpty()) {
+            reason.append("\n    * Exceptions were raised for the following keys: ");
+            for (final Entry<String, Exception> entry : exceptionalKeys.entrySet()) {
+                reason.append(String.format("\n        %s:", entry.getKey()));
+
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final Exception exception = entry.getValue();
+
+                exception.printStackTrace(new PrintStream(baos));
+                try (final BufferedReader reader = new BufferedReader(new StringReader(baos.toString()))) {
+                    String line = reader.readLine();
+                    while (line != null) {
+                        reason.append("\n            ").append(line);
+                        line = reader.readLine();
+                    }
+                }
+            }
+        }
+
+        assertThat(reason.toString(),
+            noMetadataKeys.isEmpty() && nullStoreKeys.isEmpty() && nullValueKeys.isEmpty() && exceptionalKeys.isEmpty());
     }
 
     @Test
     public void queryOnRebalance() throws Exception {
         final int numThreads = STREAM_TWO_PARTITIONS;
-        final StreamRunnable[] streamRunnables = new StreamRunnable[numThreads];
-        final Thread[] streamThreads = new Thread[numThreads];
+        final List<KafkaStreams> streamsList = new ArrayList<>(numThreads);
+        final List<KafkaStreamsTest.StateListenerStub> listeners = new ArrayList<>(numThreads);
 
         final ProducerRunnable producerRunnable = new ProducerRunnable(streamThree, inputValues, 1);
         producerRunnable.run();
@@ -375,68 +410,77 @@ public class QueryableStateIntegrationTest {
         final String storeName = "word-count-store";
         final String windowStoreName = "windowed-word-count-store";
         for (int i = 0; i < numThreads; i++) {
-            streamRunnables[i] = new StreamRunnable(
-                streamThree,
-                outputTopicThree,
-                outputTopicConcurrentWindowed,
-                storeName,
-                windowStoreName,
-                i);
-            streamThreads[i] = new Thread(streamRunnables[i]);
-            streamThreads[i].start();
+            final Properties props = (Properties) streamsConfiguration.clone();
+            props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
+            props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
+            final KafkaStreams streams =
+                createCountStream(streamThree, outputTopicThree, outputTopicConcurrentWindowed, storeName, windowStoreName, props);
+            final KafkaStreamsTest.StateListenerStub listener = new KafkaStreamsTest.StateListenerStub();
+            streams.setStateListener(listener);
+            listeners.add(listener);
+            streamsList.add(streams);
         }
+        startApplicationAndWaitUntilRunning(streamsList, Duration.ofSeconds(60));
 
         try {
             waitUntilAtLeastNumRecordProcessed(outputTopicThree, 1);
 
-            for (int i = 0; i < numThreads; i++) {
+            for (int i = 0; i < streamsList.size(); i++) {
                 verifyAllKVKeys(
-                    streamRunnables,
-                    streamRunnables[i].getStream(),
-                    streamRunnables[i].getStateListener(),
+                    streamsList,
+                    streamsList.get(i),
+                    listeners.get(i),
                     inputValuesKeys,
-                    storeName + "-" + streamThree);
+                    storeName + "-" + streamThree,
+                    DEFAULT_TIMEOUT_MS);
                 verifyAllWindowedKeys(
-                    streamRunnables,
-                    streamRunnables[i].getStream(),
-                    streamRunnables[i].getStateListener(),
+                    streamsList,
+                    streamsList.get(i),
+                    listeners.get(i),
                     inputValuesKeys,
                     windowStoreName + "-" + streamThree,
                     0L,
-                    WINDOW_SIZE);
-                assertEquals(KafkaStreams.State.RUNNING, streamRunnables[i].getStream().state());
+                    WINDOW_SIZE,
+                    DEFAULT_TIMEOUT_MS);
             }
 
             // kill N-1 threads
-            for (int i = 1; i < numThreads; i++) {
-                streamRunnables[i].close();
-                streamThreads[i].interrupt();
-                streamThreads[i].join();
+            for (int i = 1; i < streamsList.size(); i++) {
+                final Duration closeTimeout = Duration.ofSeconds(60);
+                assertThat(String.format("Streams instance %s did not close in %d ms", i, closeTimeout.toMillis()),
+                    streamsList.get(i).close(closeTimeout));
             }
+
+            waitForApplicationState(streamsList.subList(1, numThreads), State.NOT_RUNNING, Duration.ofSeconds(60));
+
+            // Even though the closed instance(s) are now in NOT_RUNNING there is no guarantee that
+            // the running instance is aware of this, so we must run our follow up queries with
+            // enough time for the shutdown to be detected.
 
             // query from the remaining thread
             verifyAllKVKeys(
-                streamRunnables,
-                streamRunnables[0].getStream(),
-                streamRunnables[0].getStateListener(),
+                streamsList,
+                streamsList.get(0),
+                listeners.get(0),
                 inputValuesKeys,
-                storeName + "-" + streamThree);
+                storeName + "-" + streamThree,
+                DEFAULT_TIMEOUT_MS);
             verifyAllWindowedKeys(
-                streamRunnables,
-                streamRunnables[0].getStream(),
-                streamRunnables[0].getStateListener(),
+                streamsList,
+                streamsList.get(0),
+                listeners.get(0),
                 inputValuesKeys,
                 windowStoreName + "-" + streamThree,
                 0L,
-                WINDOW_SIZE);
-            assertEquals(KafkaStreams.State.RUNNING, streamRunnables[0].getStream().state());
+                WINDOW_SIZE,
+                DEFAULT_TIMEOUT_MS);
+
+            // It's not enough to assert that the first instance is RUNNING because it is possible
+            // for the above checks to succeed while the instance is in a REBALANCING state.
+            waitForApplicationState(streamsList.subList(0, 1), State.RUNNING, Duration.ofSeconds(60));
         } finally {
-            for (int i = 0; i < numThreads; i++) {
-                if (!streamRunnables[i].isClosed()) {
-                    streamRunnables[i].close();
-                    streamThreads[i].interrupt();
-                    streamThreads[i].join();
-                }
+            for (final KafkaStreams streams : streamsList) {
+                streams.close();
             }
         }
     }
@@ -1005,6 +1049,7 @@ public class QueryableStateIntegrationTest {
 
     private void waitUntilAtLeastNumRecordProcessed(final String topic,
                                                     final int numRecs) throws Exception {
+        final long timeout = DEFAULT_TIMEOUT_MS;
         final Properties config = new Properties();
         config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         config.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "queryable-state-consumer");
@@ -1015,7 +1060,7 @@ public class QueryableStateIntegrationTest {
             config,
             topic,
             numRecs,
-            120 * 1000);
+            timeout);
     }
 
     private Set<KeyValue<String, Long>> fetch(final ReadOnlyWindowStore<String, Long> store,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -453,6 +453,10 @@ public class QueryableStateIntegrationTest {
 
             waitForApplicationState(streamsList.subList(1, numThreads), State.NOT_RUNNING, Duration.ofSeconds(60));
 
+            // It's not enough to assert that the first instance is RUNNING because it is possible
+            // for the above checks to succeed while the instance is in a REBALANCING state.
+            waitForApplicationState(streamsList.subList(0, 1), State.RUNNING, Duration.ofSeconds(60));
+
             // Even though the closed instance(s) are now in NOT_RUNNING there is no guarantee that
             // the running instance is aware of this, so we must run our follow up queries with
             // enough time for the shutdown to be detected.
@@ -474,10 +478,6 @@ public class QueryableStateIntegrationTest {
                 0L,
                 WINDOW_SIZE,
                 DEFAULT_TIMEOUT_MS);
-
-            // It's not enough to assert that the first instance is RUNNING because it is possible
-            // for the above checks to succeed while the instance is in a REBALANCING state.
-            waitForApplicationState(streamsList.subList(0, 1), State.RUNNING, Duration.ofSeconds(60));
         } finally {
             for (final KafkaStreams streams : streamsList) {
                 streams.close();


### PR DESCRIPTION
This is not guaranteed to actually fix `queryOnRebalance`, since the
failure could never be reproduced locally. I did not bump timeouts
because it looks like that has been done in the past for this test
without success. Instead this change makes the following improvements:

1. It waits for the application to be in a RUNNING state before
proceeding with the test.

2. It waits for the remaining instance to return to RUNNING state
within a timeout after rebalance. I observed once that we were able to
do the KV queries but the instance was still in REBALANCING, so this
should reduce some opportunity for flakiness.

3. The meat of this change: we now iterate over all keys in one shot
(vs. one at a time with a timeout) and collect various failures, all of
which are reported at the end. This should help us to narrow down the
cause of flakiness if it shows up again.

Before:

```
java.lang.AssertionError: Condition not met within timeout 120000. waiting for metadata, store and value to be non null
    at org.apache.kafka.test.TestUtils.waitForCondition(TestUtils.java:376)
    ...
```

After:

```
java.lang.AssertionError: Not all keys are available for store word-count-store-stream-three-0 in 120000 ms
    * No value is available for these keys: [goodbye, foo, bar]
    * Exceptions were raised for the following keys:
        Sam:
            java.lang.IllegalArgumentException: Ooops
            	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.lambda$verifyAllKVKeys$6(QueryableStateIntegrationTest.java:289)
            	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:417)
            	at org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout(TestUtils.java:385)
            	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.verifyAllKVKeys(QueryableStateIntegrationTest.java:265)
            	at org.apache.kafka.streams.integration.QueryableStateIntegrationTest.queryOnRebalance(QueryableStateIntegrationTest.java:431)

	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:24)
        ...
```

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
