### PR TITLE
KAFKA-9056; Inbound/outbound byte metrics should reflect partial sends/receives

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -301,18 +301,6 @@ public final class Sensor {
     }
 
     /**
-     * Find a metric attached to this sensor by name.
-     */
-    public synchronized KafkaMetric findByName(String name) {
-        for (Map.Entry<MetricName, KafkaMetric> metricEntry : metrics.entrySet()) {
-            if (name.equals(metricEntry.getKey().name())) {
-                return metricEntry.getValue();
-            }
-        }
-        return null;
-    }
-
-    /**
      * KafkaMetrics of sensors which use SampledStat should be synchronized on the same lock
      * for sensor record and metric value read to allow concurrent reads and updates. For simplicity,
      * all sensors are synchronized on this object.

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -301,6 +301,18 @@ public final class Sensor {
     }
 
     /**
+     * Find a metric attached to this sensor by name.
+     */
+    public synchronized KafkaMetric findByName(String name) {
+        for (Map.Entry<MetricName, KafkaMetric> metricEntry : metrics.entrySet()) {
+            if (name.equals(metricEntry.getKey().name())) {
+                return metricEntry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
      * KafkaMetrics of sensors which use SampledStat should be synchronized on the same lock
      * for sensor record and metric value read to allow concurrent reads and updates. For simplicity,
      * all sensors are synchronized on this object.

--- a/clients/src/main/java/org/apache/kafka/common/network/ByteBufferSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ByteBufferSend.java
@@ -64,4 +64,8 @@ public class ByteBufferSend implements Send {
         pending = TransportLayers.hasPendingWrites(channel);
         return written;
     }
+
+    public long remaining() {
+        return remaining;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-import java.net.SocketAddress;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -25,6 +24,7 @@ import org.apache.kafka.common.utils.Utils;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.List;
@@ -328,7 +328,7 @@ public class KafkaChannel implements AutoCloseable {
     /**
      * Returns true if this channel has been explicitly muted using {@link KafkaChannel#mute()}
      */
-    public boolean isMute() {
+    public boolean isMuted() {
         return muteState != ChannelMuteState.NOT_MUTED;
     }
 
@@ -375,32 +375,51 @@ public class KafkaChannel implements AutoCloseable {
         this.transportLayer.addInterestOps(SelectionKey.OP_WRITE);
     }
 
-    public NetworkReceive read() throws IOException {
-        NetworkReceive result = null;
+    public Send maybeCompleteSend() {
+        if (send != null && send.completed()) {
+            midWrite = false;
+            transportLayer.removeInterestOps(SelectionKey.OP_WRITE);
+            Send result = send;
+            send = null;
+            return result;
+        }
+        return null;
+    }
 
+    public long read() throws IOException {
         if (receive == null) {
             receive = new NetworkReceive(maxReceiveSize, id, memoryPool);
         }
 
-        receive(receive);
-        if (receive.complete()) {
-            receive.payload().rewind();
-            result = receive;
-            receive = null;
-        } else if (receive.requiredMemoryAmountKnown() && !receive.memoryAllocated() && isInMutableState()) {
+        long bytesReceived = receive(this.receive);
+
+        if (this.receive.requiredMemoryAmountKnown() && !this.receive.memoryAllocated() && isInMutableState()) {
             //pool must be out of memory, mute ourselves.
             mute();
         }
-        return result;
+        return bytesReceived;
     }
 
-    public Send write() throws IOException {
-        Send result = null;
-        if (send != null && send(send)) {
-            result = send;
-            send = null;
+    public NetworkReceive currentReceive() {
+        return receive;
+    }
+
+    public NetworkReceive maybeCompleteReceive() {
+        if (receive != null && receive.complete()) {
+            receive.payload().rewind();
+            NetworkReceive result = receive;
+            receive = null;
+            return result;
         }
-        return result;
+        return null;
+    }
+
+    public long write() throws IOException {
+        if (send == null)
+            return 0;
+
+        midWrite = true;
+        return send.writeTo(transportLayer);
     }
 
     /**
@@ -422,16 +441,6 @@ public class KafkaChannel implements AutoCloseable {
 
     private long receive(NetworkReceive receive) throws IOException {
         return receive.readFrom(transportLayer);
-    }
-
-    private boolean send(Send send) throws IOException {
-        midWrite = true;
-        send.writeTo(transportLayer);
-        if (send.completed()) {
-            midWrite = false;
-            transportLayer.removeInterestOps(SelectionKey.OP_WRITE);
-        }
-        return send.completed();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -529,7 +529,7 @@ public class KafkaChannel implements AutoCloseable {
          * We've delayed getting the time as long as possible in case we don't need it,
          * but at this point we need it -- so get it now.
          */
-        long nowNanos = nowNanosSupplier.get().longValue();
+        long nowNanos = nowNanosSupplier.get();
         /*
          * Cannot re-authenticate more than once every second; an attempt to do so will
          * result in the SASL handshake network receive being processed normally, which

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -16,13 +16,14 @@
  */
 package org.apache.kafka.common.network;
 
+import org.apache.kafka.common.memory.MemoryPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
-import org.apache.kafka.common.memory.MemoryPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A size delimited Receive that consists of a 4 byte network-ordered size N followed by N bytes of content

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -146,6 +146,12 @@ public class NetworkReceive implements Receive {
         return this.buffer;
     }
 
+    public int bytesRead() {
+        if (buffer == null)
+            return size.position();
+        return payload().position() + size.position();
+    }
+
     /**
      * Returns the total size of the receive including payload and size buffer
      * for use in metrics. This is consistent with {@link NetworkSend#size()}

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -150,7 +150,7 @@ public class NetworkReceive implements Receive {
     public int bytesRead() {
         if (buffer == null)
             return size.position();
-        return payload().position() + size.position();
+        return buffer.position() + size.position();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -234,10 +234,6 @@ public class Selector implements Selectable, AutoCloseable {
         this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, Collections.<String, String>emptyMap(), true, channelBuilder, logContext);
     }
 
-    SelectorMetrics sensors() {
-        return sensors;
-    }
-
     /**
      * Begin connecting to the given address and add the connection to this nioSelector associated with the given id
      * number.

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -202,28 +202,27 @@ public class Selector implements Selectable, AutoCloseable {
     }
 
     public Selector(int maxReceiveSize,
-                long connectionMaxIdleMs,
-                int failedAuthenticationDelayMs,
-                Metrics metrics,
-                Time time,
-                String metricGrpPrefix,
-                Map<String, String> metricTags,
-                boolean metricsPerConnection,
-                ChannelBuilder channelBuilder,
-                LogContext logContext) {
+                    long connectionMaxIdleMs,
+                    int failedAuthenticationDelayMs,
+                    Metrics metrics,
+                    Time time,
+                    String metricGrpPrefix,
+                    Map<String, String> metricTags,
+                    boolean metricsPerConnection,
+                    ChannelBuilder channelBuilder,
+                    LogContext logContext) {
         this(maxReceiveSize, connectionMaxIdleMs, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, metricTags, metricsPerConnection, false, channelBuilder, MemoryPool.NONE, logContext);
     }
 
-
     public Selector(int maxReceiveSize,
-            long connectionMaxIdleMs,
-            Metrics metrics,
-            Time time,
-            String metricGrpPrefix,
-            Map<String, String> metricTags,
-            boolean metricsPerConnection,
-            ChannelBuilder channelBuilder,
-            LogContext logContext) {
+                    long connectionMaxIdleMs,
+                    Metrics metrics,
+                    Time time,
+                    String metricGrpPrefix,
+                    Map<String, String> metricTags,
+                    boolean metricsPerConnection,
+                    ChannelBuilder channelBuilder,
+                    LogContext logContext) {
         this(maxReceiveSize, connectionMaxIdleMs, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, metricTags, metricsPerConnection, channelBuilder, logContext);
     }
 
@@ -233,6 +232,10 @@ public class Selector implements Selectable, AutoCloseable {
 
     public Selector(long connectionMaxIdleMS, int failedAuthenticationDelayMs, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
         this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, Collections.<String, String>emptyMap(), true, channelBuilder, logContext);
+    }
+
+    SelectorMetrics sensors() {
+        return sensors;
     }
 
     /**
@@ -519,24 +522,25 @@ public class Selector implements Selectable, AutoCloseable {
             KafkaChannel channel = channel(key);
             long channelStartTimeNanos = recordTimePerConnection ? time.nanoseconds() : 0;
             boolean sendFailed = false;
+            String nodeId = channel.id();
 
             // register all per-connection metrics at once
-            sensors.maybeRegisterConnectionMetrics(channel.id());
+            sensors.maybeRegisterConnectionMetrics(nodeId);
             if (idleExpiryManager != null)
-                idleExpiryManager.update(channel.id(), currentTimeNanos);
+                idleExpiryManager.update(nodeId, currentTimeNanos);
 
             try {
                 /* complete any connections that have finished their handshake (either normally or immediately) */
                 if (isImmediatelyConnected || key.isConnectable()) {
                     if (channel.finishConnect()) {
-                        this.connected.add(channel.id());
+                        this.connected.add(nodeId);
                         this.sensors.connectionCreated.record();
                         SocketChannel socketChannel = (SocketChannel) key.channel();
                         log.debug("Created socket with SO_RCVBUF = {}, SO_SNDBUF = {}, SO_TIMEOUT = {} to node {}",
                                 socketChannel.socket().getReceiveBufferSize(),
                                 socketChannel.socket().getSendBufferSize(),
                                 socketChannel.socket().getSoTimeout(),
-                                channel.id());
+                                nodeId);
                     } else {
                         continue;
                     }
@@ -582,18 +586,27 @@ public class Selector implements Selectable, AutoCloseable {
                 }
 
                 /* if channel is ready write to any sockets that have space in their buffer and for which we have data */
-                if (channel.ready() && key.isWritable() && !channel.maybeBeginClientReauthentication(
-                    () -> channelStartTimeNanos != 0 ? channelStartTimeNanos : currentTimeNanos)) {
-                    Send send;
+
+                long nowNanos = channelStartTimeNanos != 0 ? channelStartTimeNanos : currentTimeNanos;
+                if (channel.hasSend()
+                        && channel.ready()
+                        && key.isWritable()
+                        && !channel.maybeBeginClientReauthentication(() -> nowNanos)) {
                     try {
-                        send = channel.write();
+                        long bytesSent = channel.write();
+                        if (bytesSent > 0) {
+                            long currentTimeMs = time.milliseconds();
+                            this.sensors.recordPartialSend(nodeId, bytesSent, currentTimeMs);
+
+                            Send send = channel.maybeCompleteSend();
+                            if (send != null) {
+                                this.completedSends.add(send);
+                                this.sensors.recordCompletedSend(nodeId, send.size(), currentTimeMs);
+                            }
+                        }
                     } catch (Exception e) {
                         sendFailed = true;
                         throw e;
-                    }
-                    if (send != null) {
-                        this.completedSends.add(send);
-                        this.sensors.recordBytesSent(channel.id(), send.size());
                     }
                 }
 
@@ -647,12 +660,27 @@ public class Selector implements Selectable, AutoCloseable {
         //previous receive(s) already staged or otherwise in progress then read from it
         if (channel.ready() && (key.isReadable() || channel.hasBytesBuffered()) && !hasStagedReceive(channel)
             && !explicitlyMutedChannels.contains(channel)) {
-            NetworkReceive networkReceive;
-            while ((networkReceive = channel.read()) != null) {
+
+            String nodeId = channel.id();
+
+            while (true) {
+                long bytesReceived = channel.read();
+                if (bytesReceived == 0)
+                    break;
+
+                long currentTimeMs = time.milliseconds();
+                sensors.recordPartialReceive(nodeId, bytesReceived, currentTimeMs);
                 madeReadProgressLastPoll = true;
-                addToStagedReceives(channel, networkReceive);
+
+                NetworkReceive receive = channel.maybeCompleteReceive();
+                if (receive == null)
+                    break;
+
+                sensors.recordCompletedReceive(nodeId, receive.size(), currentTimeMs);
+                addToStagedReceives(channel, receive);
             }
-            if (channel.isMute()) {
+
+            if (channel.isMuted()) {
                 outOfMemory = true; //channel has muted itself due to memory pressure.
             } else {
                 madeReadProgressLastPoll = true;
@@ -971,7 +999,7 @@ public class Selector implements Selectable, AutoCloseable {
      */
     private boolean hasStagedReceives() {
         for (KafkaChannel channel : this.stagedReceives.keySet()) {
-            if (!channel.isMute())
+            if (!channel.isMuted())
                 return true;
         }
         return false;
@@ -1011,7 +1039,6 @@ public class Selector implements Selectable, AutoCloseable {
     private void addToCompletedReceives(KafkaChannel channel, Deque<NetworkReceive> stagedDeque) {
         NetworkReceive networkReceive = stagedDeque.poll();
         this.completedReceives.add(networkReceive);
-        this.sensors.recordBytesReceived(channel.id(), networkReceive.size());
     }
 
     // only for testing
@@ -1025,7 +1052,7 @@ public class Selector implements Selectable, AutoCloseable {
         return deque == null ? 0 : deque.size();
     }
 
-    private class SelectorMetrics implements AutoCloseable {
+    class SelectorMetrics implements AutoCloseable {
         private final Metrics metrics;
         private final String metricGrpPrefix;
         private final Map<String, String> metricTags;
@@ -1041,7 +1068,9 @@ public class Selector implements Selectable, AutoCloseable {
         public final Sensor failedReauthentication;
         public final Sensor bytesTransferred;
         public final Sensor bytesSent;
+        public final Sensor requestsSent;
         public final Sensor bytesReceived;
+        public final Sensor responsesReceived;
         public final Sensor selectTime;
         public final Sensor ioTime;
 
@@ -1111,17 +1140,21 @@ public class Selector implements Selectable, AutoCloseable {
             this.bytesSent = sensor("bytes-sent:" + tagsSuffix, bytesTransferred);
             this.bytesSent.add(createMeter(metrics, metricGrpName, metricTags,
                     "outgoing-byte", "outgoing bytes sent to all servers"));
-            this.bytesSent.add(createMeter(metrics, metricGrpName, metricTags, new WindowedCount(),
+
+            this.requestsSent = sensor("requests-sent:" + tagsSuffix);
+            this.requestsSent.add(createMeter(metrics, metricGrpName, metricTags, new WindowedCount(),
                     "request", "requests sent"));
             MetricName metricName = metrics.metricName("request-size-avg", metricGrpName, "The average size of requests sent.", metricTags);
-            this.bytesSent.add(metricName, new Avg());
+            this.requestsSent.add(metricName, new Avg());
             metricName = metrics.metricName("request-size-max", metricGrpName, "The maximum size of any request sent.", metricTags);
-            this.bytesSent.add(metricName, new Max());
+            this.requestsSent.add(metricName, new Max());
 
             this.bytesReceived = sensor("bytes-received:" + tagsSuffix, bytesTransferred);
             this.bytesReceived.add(createMeter(metrics, metricGrpName, metricTags,
                     "incoming-byte", "bytes read off all sockets"));
-            this.bytesReceived.add(createMeter(metrics, metricGrpName, metricTags,
+
+            this.responsesReceived = sensor("responses-received:" + tagsSuffix);
+            this.responsesReceived.add(createMeter(metrics, metricGrpName, metricTags,
                     new WindowedCount(), "response", "responses received"));
 
             this.selectTime = sensor("select-time:" + tagsSuffix);
@@ -1177,26 +1210,31 @@ public class Selector implements Selectable, AutoCloseable {
             if (!connectionId.isEmpty() && metricsPerConnection) {
                 // if one sensor of the metrics has been registered for the connection,
                 // then all other sensors should have been registered; and vice versa
-                String nodeRequestName = "node-" + connectionId + ".bytes-sent";
+                String nodeRequestName = "node-" + connectionId + ".requests-sent";
                 Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
                 if (nodeRequest == null) {
                     String metricGrpName = metricGrpPrefix + "-node-metrics";
-
                     Map<String, String> tags = new LinkedHashMap<>(metricTags);
                     tags.put("node-id", "node-" + connectionId);
 
                     nodeRequest = sensor(nodeRequestName);
-                    nodeRequest.add(createMeter(metrics, metricGrpName, tags, "outgoing-byte", "outgoing bytes"));
                     nodeRequest.add(createMeter(metrics, metricGrpName, tags, new WindowedCount(), "request", "requests sent"));
                     MetricName metricName = metrics.metricName("request-size-avg", metricGrpName, "The average size of requests sent.", tags);
                     nodeRequest.add(metricName, new Avg());
                     metricName = metrics.metricName("request-size-max", metricGrpName, "The maximum size of any request sent.", tags);
                     nodeRequest.add(metricName, new Max());
 
-                    String nodeResponseName = "node-" + connectionId + ".bytes-received";
+                    String bytesSentName = "node-" + connectionId + ".bytes-sent";
+                    Sensor bytesSent = sensor(bytesSentName);
+                    bytesSent.add(createMeter(metrics, metricGrpName, tags, "outgoing-byte", "outgoing bytes"));
+
+                    String nodeResponseName = "node-" + connectionId + ".responses-received";
                     Sensor nodeResponse = sensor(nodeResponseName);
-                    nodeResponse.add(createMeter(metrics, metricGrpName, tags, "incoming-byte", "incoming bytes"));
                     nodeResponse.add(createMeter(metrics, metricGrpName, tags, new WindowedCount(), "response", "responses received"));
+
+                    String bytesReceivedName = "node-" + connectionId + ".bytes-received";
+                    Sensor bytesReceive = sensor(bytesReceivedName);
+                    bytesReceive.add(createMeter(metrics, metricGrpName, tags, "incoming-byte", "incoming bytes"));
 
                     String nodeTimeName = "node-" + connectionId + ".latency";
                     Sensor nodeRequestTime = sensor(nodeTimeName);
@@ -1208,25 +1246,43 @@ public class Selector implements Selectable, AutoCloseable {
             }
         }
 
-        public void recordBytesSent(String connectionId, long bytes) {
-            long now = time.milliseconds();
-            this.bytesSent.record(bytes, now);
+        public void recordPartialSend(String connectionId, long bytes, long currentTimeMs) {
+            this.bytesSent.record(bytes, currentTimeMs);
             if (!connectionId.isEmpty()) {
-                String nodeRequestName = "node-" + connectionId + ".bytes-sent";
-                Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
-                if (nodeRequest != null)
-                    nodeRequest.record(bytes, now);
+                String bytesSentName = "node-" + connectionId + ".bytes-sent";
+                Sensor bytesSent = this.metrics.getSensor(bytesSentName);
+                if (bytesSent != null)
+                    bytesSent.record(bytes, currentTimeMs);
             }
         }
 
-        public void recordBytesReceived(String connection, int bytes) {
-            long now = time.milliseconds();
-            this.bytesReceived.record(bytes, now);
-            if (!connection.isEmpty()) {
-                String nodeRequestName = "node-" + connection + ".bytes-received";
+        public void recordCompletedSend(String connectionId, long totalBytes, long currentTimeMs) {
+            requestsSent.record(totalBytes, currentTimeMs);
+            if (!connectionId.isEmpty()) {
+                String nodeRequestName = "node-" + connectionId + ".requests-sent";
                 Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
                 if (nodeRequest != null)
-                    nodeRequest.record(bytes, now);
+                    nodeRequest.record(totalBytes, currentTimeMs);
+            }
+        }
+
+        public void recordPartialReceive(String connectionId, long bytes, long currentTimeMs) {
+            this.bytesReceived.record(bytes, currentTimeMs);
+            if (!connectionId.isEmpty()) {
+                String bytesReceivedName = "node-" + connectionId + ".bytes-received";
+                Sensor bytesReceived = this.metrics.getSensor(bytesReceivedName);
+                if (bytesReceived != null)
+                    bytesReceived.record(bytes, currentTimeMs);
+            }
+        }
+
+        public void recordCompletedReceive(String connectionId, long totalBytes, long currentTimeMs) {
+            responsesReceived.record(totalBytes, currentTimeMs);
+            if (!connectionId.isEmpty()) {
+                String nodeRequestName = "node-" + connectionId + ".responses-received";
+                Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
+                if (nodeRequest != null)
+                    nodeRequest.record(totalBytes, currentTimeMs);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -592,7 +592,7 @@ public class Selector implements Selectable, AutoCloseable {
                         long bytesSent = channel.write();
                         if (bytesSent > 0) {
                             long currentTimeMs = time.milliseconds();
-                            this.sensors.recordPartialSend(nodeId, bytesSent, currentTimeMs);
+                            this.sensors.recordBytesSent(nodeId, bytesSent, currentTimeMs);
 
                             Send send = channel.maybeCompleteSend();
                             if (send != null) {
@@ -665,7 +665,7 @@ public class Selector implements Selectable, AutoCloseable {
                     break;
 
                 long currentTimeMs = time.milliseconds();
-                sensors.recordPartialReceive(nodeId, bytesReceived, currentTimeMs);
+                sensors.recordBytesReceived(nodeId, bytesReceived, currentTimeMs);
                 madeReadProgressLastPoll = true;
 
                 NetworkReceive receive = channel.maybeCompleteReceive();
@@ -1242,7 +1242,7 @@ public class Selector implements Selectable, AutoCloseable {
             }
         }
 
-        public void recordPartialSend(String connectionId, long bytes, long currentTimeMs) {
+        public void recordBytesSent(String connectionId, long bytes, long currentTimeMs) {
             this.bytesSent.record(bytes, currentTimeMs);
             if (!connectionId.isEmpty()) {
                 String bytesSentName = "node-" + connectionId + ".bytes-sent";
@@ -1262,7 +1262,7 @@ public class Selector implements Selectable, AutoCloseable {
             }
         }
 
-        public void recordPartialReceive(String connectionId, long bytes, long currentTimeMs) {
+        public void recordBytesReceived(String connectionId, long bytes, long currentTimeMs) {
             this.bytesReceived.record(bytes, currentTimeMs);
             if (!connectionId.isEmpty()) {
                 String bytesReceivedName = "node-" + connectionId + ".bytes-received";

--- a/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class KafkaChannelTest {
+
+    @Test
+    public void testSending() throws IOException {
+        Authenticator authenticator = Mockito.mock(Authenticator.class);
+        TransportLayer transport = Mockito.mock(TransportLayer.class);
+        MemoryPool pool = Mockito.mock(MemoryPool.class);
+
+        KafkaChannel channel = new KafkaChannel("0", transport, () -> authenticator, 1024, pool);
+        NetworkSend send = new NetworkSend("0", ByteBuffer.wrap(TestUtils.randomBytes(128)));
+
+        channel.setSend(send);
+        assertTrue(channel.hasSend());
+        assertThrows(IllegalStateException.class, () -> channel.setSend(send));
+
+        Mockito.when(transport.write(Mockito.any(ByteBuffer[].class))).thenReturn(4L);
+        assertEquals(4L, channel.write());
+        assertEquals(128, send.remaining());
+        assertNull(channel.maybeCompleteSend());
+
+        Mockito.when(transport.write(Mockito.any(ByteBuffer[].class))).thenReturn(64L);
+        assertEquals(64, channel.write());
+        assertEquals(64, send.remaining());
+        assertNull(channel.maybeCompleteSend());
+
+        Mockito.when(transport.write(Mockito.any(ByteBuffer[].class))).thenReturn(64L);
+        assertEquals(64, channel.write());
+        assertEquals(0, send.remaining());
+        assertEquals(send, channel.maybeCompleteSend());
+    }
+
+    @Test
+    public void testReceiving() throws IOException {
+        Authenticator authenticator = Mockito.mock(Authenticator.class);
+        TransportLayer transport = Mockito.mock(TransportLayer.class);
+        MemoryPool pool = Mockito.mock(MemoryPool.class);
+
+        ArgumentCaptor<Integer> sizeCaptor = ArgumentCaptor.forClass(Integer.class);
+        Mockito.when(pool.tryAllocate(sizeCaptor.capture())).thenAnswer(invocation -> {
+            return ByteBuffer.allocate(sizeCaptor.getValue());
+        });
+
+        KafkaChannel channel = new KafkaChannel("0", transport, () -> authenticator, 1024, pool);
+
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().putInt(128);
+            return 4;
+        }).thenReturn(0);
+        assertEquals(4, channel.read());
+        assertEquals(4, channel.currentReceive().bytesRead());
+        assertNull(channel.maybeCompleteReceive());
+
+        Mockito.reset(transport);
+        Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
+            return 64;
+        });
+        assertEquals(64, channel.read());
+        assertEquals(68, channel.currentReceive().bytesRead());
+        assertNull(channel.maybeCompleteReceive());
+
+        Mockito.reset(transport);
+        Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
+            return 64;
+        });
+        assertEquals(64, channel.read());
+        assertEquals(132, channel.currentReceive().bytesRead());
+        assertNotNull(channel.maybeCompleteReceive());
+        assertNull(channel.currentReceive());
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ScatteringByteChannel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NetworkReceiveTest {
+
+    @Test
+    public void testBytesRead() throws IOException {
+        NetworkReceive receive = new NetworkReceive(128, "0");
+        assertEquals(0, receive.bytesRead());
+
+        ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
+
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().putInt(128);
+            return 4;
+        }).thenReturn(0);
+
+        assertEquals(4, receive.readFrom(channel));
+        assertEquals(4, receive.bytesRead());
+        assertFalse(receive.complete());
+
+        Mockito.reset(channel);
+        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
+            return 64;
+        });
+
+        assertEquals(64, receive.readFrom(channel));
+        assertEquals(68, receive.bytesRead());
+        assertFalse(receive.complete());
+
+        Mockito.reset(channel);
+        Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
+            return 64;
+        });
+
+        assertEquals(64, receive.readFrom(channel));
+        assertEquals(132, receive.bytesRead());
+        assertTrue(receive.complete());
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -265,7 +265,7 @@ public class SelectorTest {
     @Test
     public void testPartialSendAndReceiveReflectedInMetrics() throws Exception {
         // We use a large payload to attempt to trigger the partial send and receive logic.
-        int payloadSize = 200 * BUFFER_SIZE;
+        int payloadSize = 20 * BUFFER_SIZE;
         String payload = TestUtils.randomString(payloadSize);
         String nodeId = "0";
         blockingConnect(nodeId);

--- a/clients/src/test/java/org/apache/kafka/test/TestCondition.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestCondition.java
@@ -23,5 +23,5 @@ package org.apache.kafka.test;
 @FunctionalInterface
 public interface TestCondition {
 
-    boolean conditionMet() throws InterruptedException;
+    boolean conditionMet() throws Exception;
 }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -510,7 +510,7 @@ class SocketServerTest {
     assertEquals(serializedBytes.toSeq, receiveResponse(socket).toSeq)
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.MUTED_AND_THROTTLED), "fail")
     // Channel should still be muted.
-    assertTrue(openOrClosingChannel(request).exists(c => c.isMute()))
+    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted()))
   }
 
   @Test
@@ -525,7 +525,7 @@ class SocketServerTest {
     // Since throttling is already done, the channel can be unmuted after sending out the response.
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.NOT_MUTED), "fail")
     // Channel is now unmuted.
-    assertFalse(openOrClosingChannel(request).exists(c => c.isMute()))
+    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted()))
   }
 
   @Test
@@ -537,7 +537,7 @@ class SocketServerTest {
 
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.MUTED_AND_THROTTLED), "fail")
     // Channel should still be muted.
-    assertTrue(openOrClosingChannel(request).exists(c => c.isMute()))
+    assertTrue(openOrClosingChannel(request).exists(c => c.isMuted()))
   }
 
   @Test
@@ -550,7 +550,7 @@ class SocketServerTest {
     // Since throttling is already done, the channel can be unmuted.
     TestUtils.waitUntilTrue(() => openOrClosingChannel(request).exists(c => c.muteState() == ChannelMuteState.NOT_MUTED), "fail")
     // Channel is now unmuted.
-    assertFalse(openOrClosingChannel(request).exists(c => c.isMute()))
+    assertFalse(openOrClosingChannel(request).exists(c => c.isMuted()))
   }
 
   @Test


### PR DESCRIPTION
Currently we only record completed sends and receives in the selector metrics. If there is a disconnect in the middle of the respective operation, then it is not counted. The metrics will be more accurate if we take into account partial sends and receives.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
