### PR TITLE
MINOR: Added missed curly brackets to the log.error

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -557,7 +557,7 @@ class WorkerSinkTask extends WorkerTask {
             // Let this exit normally, the batch will be reprocessed on the next loop.
         } catch (Throwable t) {
             log.error("{} Task threw an uncaught and unrecoverable exception. Task is being killed and will not "
-                    + "recover until manually restarted.", this, t);
+                    + "recover until manually restarted. Error: {}", this, t.getMessage(), t);
             throw new ConnectException("Exiting WorkerSinkTask due to unrecoverable exception.", t);
         }
     }


### PR DESCRIPTION
When some particular connector throws exception, `WorkerSinkTask` doesn't show that message in log.
For example, when Snowflake connector for Kafka Connect throws some Exception related with Insufficient privileges, Kafka Connect prints such message in log:
   
`ERROR WorkerSinkTask{id=SnowflakeConnector-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted. (org.apache.kafka.connect.runtime.WorkerSinkTask:558)`

Which is not informative and it doesn't show the root message of the Exception.
So, I've added missed curly brackets to the log.error(...) in `WorkerSinkTask`.