### PR TITLE
MINOR Fixed LogCleanerIntegrationTest.testIsThreadFailed by removing the metric if it exists.

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -213,8 +213,8 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest with K
   }
 
   private def removeMetric(name: String): Unit = {
-    val metricName = Metrics.defaultRegistry().allMetrics()
-      .asScala.find(p => p._1.getName.endsWith(name)).get._1
-    Metrics.defaultRegistry().removeMetric(metricName)
+    Metrics.defaultRegistry().allMetrics()
+      .asScala.find(p => p._1.getName.endsWith(name))
+      .foreach(metricName => Metrics.defaultRegistry().removeMetric(metricName._1))
   }
 }


### PR DESCRIPTION
LogCleanerIntegrationTest.testIsThreadFailed is failed if it is run as the first test or it is run alone as the metric may not exist already and causes java.util.NoSuchElementException. It is fixed by removing only if it exists. 
```
kafka.log.LogCleanerIntegrationTest > testIsThreadFailed FAILED
    java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:529)
        at scala.None$.get(Option.scala:527)
        at kafka.log.LogCleanerIntegrationTest.removeMetric(LogCleanerIntegrationTest.scala:217)
        at kafka.log.LogCleanerIntegrationTest.testIsThreadFailed(LogCleanerIntegrationTest.scala:199)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
