### PR TITLE
MINOR: don't require key serde in join materialized

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -712,7 +712,10 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final StoreBuilder<TimestampedKeyValueStore<K, VR>> storeBuilder;
 
         if (materializedInternal != null) {
-            keySerde = materializedInternal.keySerde() != null ? materializedInternal.keySerde() : this.keySerde;
+            if (materializedInternal.keySerde() == null) {
+                materializedInternal.withKeySerde(this.keySerde);
+            }
+            keySerde = materializedInternal.keySerde();
             valueSerde = materializedInternal.valueSerde();
             queryableStoreName = materializedInternal.storeName();
             storeBuilder = new TimestampedKeyValueStoreMaterializer<>(materializedInternal).materialize();


### PR DESCRIPTION
If the `Materialized` is missing a key serde, set it from the current scope. 

This was the intent of the prior code, but it didn't actually update the
`MaterializedInternal`, which is needed to correctly construct the store
builder later on.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
