### PR TITLE
KAFKA-8943: Move SecurityProviderCreator to org.apache.kafka.common.security.auth package

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SecurityConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SecurityConfig.java
@@ -22,7 +22,8 @@ package org.apache.kafka.common.config;
 public class SecurityConfig {
 
     public static final String SECURITY_PROVIDERS_CONFIG = "security.providers";
-    public static final String SECURITY_PROVIDERS_DOC = "A list of configurable creators each returning a provider " +
-            "implementing security algorithms";
+    public static final String SECURITY_PROVIDERS_DOC = "A list of configurable creator classes each returning a provider" +
+        " implementing security algorithms. These classes should implement the" +
+        " <code>org.apache.kafka.common.security.auth.SecurityProviderCreator<code> interface.";
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/config/SecurityConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SecurityConfig.java
@@ -24,6 +24,6 @@ public class SecurityConfig {
     public static final String SECURITY_PROVIDERS_CONFIG = "security.providers";
     public static final String SECURITY_PROVIDERS_DOC = "A list of configurable creator classes each returning a provider" +
         " implementing security algorithms. These classes should implement the" +
-        " <code>org.apache.kafka.common.security.auth.SecurityProviderCreator<code> interface.";
+        " <code>org.apache.kafka.common.security.auth.SecurityProviderCreator</code> interface.";
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SecurityProviderCreator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SecurityProviderCreator.java
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.common.security;
+package org.apache.kafka.common.security.auth;
 
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.security.Provider;
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.Map;
 /**
  * An interface for generating security providers.
  */
+@InterfaceStability.Evolving
 public interface SecurityProviderCreator extends Configurable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.utils;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.resource.ResourceType;
-import org.apache.kafka.common.security.SecurityProviderCreator;
+import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestPlainSaslServerProviderCreator.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestPlainSaslServerProviderCreator.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.security.ssl.mock;
 
-import org.apache.kafka.common.security.SecurityProviderCreator;
+import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 
 import java.security.Provider;
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestProviderCreator.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestProviderCreator.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.security.ssl.mock;
 
-import org.apache.kafka.common.security.SecurityProviderCreator;
+import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 
 import java.security.Provider;
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestScramSaslServerProviderCreator.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/mock/TestScramSaslServerProviderCreator.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.security.ssl.mock;
 
-import org.apache.kafka.common.security.SecurityProviderCreator;
+import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 
 import java.security.Provider;
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/SecurityUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/SecurityUtilsTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.config.SecurityConfig;
-import org.apache.kafka.common.security.SecurityProviderCreator;
+import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.ssl.mock.TestPlainSaslServerProviderCreator;
 import org.apache.kafka.common.security.ssl.mock.TestScramSaslServerProviderCreator;


### PR DESCRIPTION


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
