### PR TITLE
KAFKA-8940: Tighten up SmokeTestDriver

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -109,14 +109,18 @@ public class SmokeTestDriverIntegrationTest {
 
             // let the oldest client die of "natural causes"
             if (clients.size() >= 3) {
-                clients.remove(0).closeAsync();
+                SmokeTestClient client = clients.remove(0);
+
+                client.closeAsync();
+                while (!client.closed()) {
+                    Thread.sleep(100);
+                }
             }
         }
+
         try {
             // wait for verification to finish
             driver.join();
-
-
         } finally {
             // whether or not the assertions failed, tell all the streams instances to stop
             for (final SmokeTestClient client : clients) {
@@ -125,7 +129,9 @@ public class SmokeTestDriverIntegrationTest {
 
             // then, wait for them to stop
             for (final SmokeTestClient client : clients) {
-                client.close();
+                while (!client.closed()) {
+                    Thread.sleep(100);
+                }
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -109,7 +109,7 @@ public class SmokeTestDriverIntegrationTest {
 
             // let the oldest client die of "natural causes"
             if (clients.size() >= 3) {
-                SmokeTestClient client = clients.remove(0);
+                final SmokeTestClient client = clients.remove(0);
 
                 client.closeAsync();
                 while (!client.closed()) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -53,6 +53,7 @@ public class SmokeTestClient extends SmokeTestUtil {
     private KafkaStreams streams;
     private boolean uncaughtException = false;
     private boolean started;
+    private boolean closed;
 
     public SmokeTestClient(final String name) {
         super();
@@ -61,6 +62,10 @@ public class SmokeTestClient extends SmokeTestUtil {
 
     public boolean started() {
         return started;
+    }
+
+    public boolean closed() {
+        return closed;
     }
 
     public void start(final Properties streamsProperties) {
@@ -119,6 +124,10 @@ public class SmokeTestClient extends SmokeTestUtil {
             System.out.printf("%s %s: %s -> %s%n", name, Instant.now(), oldState, newState);
             if (oldState == KafkaStreams.State.REBALANCING && newState == KafkaStreams.State.RUNNING) {
                 started = true;
+            }
+
+            if (newState == KafkaStreams.State.NOT_RUNNING) {
+                closed = true;
             }
         });
         streamsClient.setUncaughtExceptionHandler((t, e) -> {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -56,7 +56,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 
@@ -332,7 +331,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
         int retry = 0;
         final long start = System.currentTimeMillis();
         while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
-            final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(1));
+            final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
             if (records.isEmpty() && recordsProcessed >= recordsGenerated) {
                 verificationResult = verifyAll(inputs, events, false);
                 if (verificationResult.passed()) {
@@ -341,9 +340,11 @@ public class SmokeTestDriver extends SmokeTestUtil {
                     System.out.println(Instant.now() + " Didn't get any more results, verification hasn't passed, and out of retries.");
                     break;
                 } else {
-                    System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying...");
+                    System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying..." + retry);
                 }
             } else {
+                System.out.println(Instant.now() + " Get some more results from " + records.partitions() + ", resetting retry.");
+
                 retry = 0;
                 for (final ConsumerRecord<String, Number> record : records) {
                     final String key = record.key();
@@ -441,13 +442,13 @@ public class SmokeTestDriver extends SmokeTestUtil {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         boolean pass;
         try (final PrintStream resultStream = new PrintStream(byteArrayOutputStream)) {
-            pass = verifyTAgg(resultStream, inputs, events.get("tagg"));
-            pass &= verifySuppressed(resultStream, "min-suppressed", events);
+            pass = verifyTAgg(resultStream, inputs, events.get("tagg"), printResults);
+            pass &= verifySuppressed(resultStream, "min-suppressed", events, printResults);
             pass &= verify(resultStream, "min-suppressed", inputs, events, windowedKey -> {
                 final String unwindowedKey = windowedKey.substring(1, windowedKey.length() - 1).replaceAll("@.*", "");
                 return getMin(unwindowedKey);
             }, printResults);
-            pass &= verifySuppressed(resultStream, "sws-suppressed", events);
+            pass &= verifySuppressed(resultStream, "sws-suppressed", events, printResults);
             pass &= verify(resultStream, "min", inputs, events, SmokeTestDriver::getMin, printResults);
             pass &= verify(resultStream, "max", inputs, events, SmokeTestDriver::getMax, printResults);
             pass &= verify(resultStream, "dif", inputs, events, key -> getMax(key).intValue() - getMin(key).intValue(), printResults);
@@ -482,13 +483,11 @@ public class SmokeTestDriver extends SmokeTestUtil {
                 final Number expected = keyToExpectation.apply(key);
                 final Number actual = entry.getValue().getLast().value();
                 if (!expected.equals(actual)) {
+                    resultStream.printf("%s fail: key=%s actual=%s expected=%s%n", topic, key, actual, expected);
+
                     if (printResults) {
-                        resultStream.printf("%s fail: key=%s actual=%s expected=%s%n\t inputEvents=%n%s%n\t" +
+                        resultStream.printf("\t inputEvents=%n%s%n\t" +
                                 "echoEvents=%n%s%n\tmaxEvents=%n%s%n\tminEvents=%n%s%n\tdifEvents=%n%s%n\tcntEvents=%n%s%n\ttaggEvents=%n%s%n",
-                            topic,
-                            key,
-                            actual,
-                            expected,
                             indent("\t\t", observedInputEvents.get(key)),
                             indent("\t\t", events.getOrDefault("echo", emptyMap()).getOrDefault(key, new LinkedList<>())),
                             indent("\t\t", events.getOrDefault("max", emptyMap()).getOrDefault(key, new LinkedList<>())),
@@ -511,7 +510,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
     private static boolean verifySuppressed(final PrintStream resultStream,
                                             @SuppressWarnings("SameParameterValue") final String topic,
-                                            final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events) {
+                                            final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events,
+                                            final boolean printResults) {
         resultStream.println("verifying suppressed " + topic);
         final Map<String, LinkedList<ConsumerRecord<String, Number>>> topicEvents = events.getOrDefault(topic, emptyMap());
         for (final Map.Entry<String, LinkedList<ConsumerRecord<String, Number>>> entry : topicEvents.entrySet()) {
@@ -519,12 +519,15 @@ public class SmokeTestDriver extends SmokeTestUtil {
                 final String unsuppressedTopic = topic.replace("-suppressed", "-raw");
                 final String key = entry.getKey();
                 final String unwindowedKey = key.substring(1, key.length() - 1).replaceAll("@.*", "");
-                resultStream.printf("fail: key=%s%n\tnon-unique result:%n%s%n\traw results:%n%s%n\tinput data:%n%s%n",
+                resultStream.printf("fail: key=%s%n\tnon-unique result:%n%s%n",
                                     key,
-                                    indent("\t\t", entry.getValue()),
-                                    indent("\t\t", events.get(unsuppressedTopic).get(key)),
-                                    indent("\t\t", events.get("data").get(unwindowedKey))
-                );
+                                    indent("\t\t", entry.getValue()));
+
+                if (printResults)
+                    resultStream.printf("\tresultEvents:%n%s%n\tinputEvents:%n%s%n",
+                        indent("\t\t", events.get(unsuppressedTopic).get(key)),
+                        indent("\t\t", events.get("data").get(unwindowedKey)));
+
                 return false;
             }
         }
@@ -555,7 +558,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
     private static boolean verifyTAgg(final PrintStream resultStream,
                                       final Map<String, Set<Integer>> allData,
-                                      final Map<String, LinkedList<ConsumerRecord<String, Number>>> taggEvents) {
+                                      final Map<String, LinkedList<ConsumerRecord<String, Number>>> taggEvents,
+                                      final boolean printResults) {
         if (taggEvents == null) {
             resultStream.println("tagg is missing");
             return false;
@@ -585,7 +589,9 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
                 if (entry.getValue().getLast().value().longValue() != expectedCount) {
                     resultStream.println("fail: key=" + key + " tagg=" + entry.getValue() + " expected=" + expectedCount);
-                    resultStream.println("\t outputEvents: " + entry.getValue());
+
+                    if (printResults)
+                        resultStream.println("\t taggEvents: " + entry.getValue());
                     return false;
                 }
             }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -37,7 +37,7 @@ public class StreamsSmokeTest {
      *
      * @param args
      */
-    public static void main(final String[] args) throws InterruptedException, IOException {
+    public static void main(final String[] args) throws IOException {
         if (args.length < 2) {
             System.err.println("StreamsSmokeTest are expecting two parameters: propFile, command; but only see " + args.length + " parameter");
             System.exit(1);


### PR DESCRIPTION
After many runs of reproducing the failure (on my local MP5 it takes about 100 - 200 run to get one) I think it is more likely a flaky one and not exposing a real bug in rebalance protocol.

What I've observed is that, when the verifying consumer is trying to fetch from the output topics (there are 11 of them), it `poll(1sec)` each time, and retries 30 times if there's no more data to fetch and stop. It means that if there are no data fetched from the output topics for 30 * 1 = 30 seconds then the verification would stop (potentially too early). And for the failure cases, we observe consistent rebalancing among the closing / newly created clients since the closing is async, i.e. while new clients are added it is possible that closing clients triggered rebalance are not completed yet (note that each instance is configured with 3 threads, and in the worst case there are 6 instances running / pending shutdown at the same time, so a group fo 3 * 6 = 18 members is possible).

However, there's still a possible bug that in KIP-429, somehow the rebalance can never stabilize and members keep re-rejoining and hence cause it to fail. We have another unit test that have bumped up to 3 rebalance by @ableegoldman and if that failed again then it may be a better confirmation such bug may exist.

So what I've done so far for this test:

1. When closing a client, wait for it to complete closure before moving on to the next iteration and starting a new instance to reduce the rebalance churns.

2. Poll for 5 seconds instead of 1 to wait for longer time: 5 * 30 = 150 seconds, and locally my laptop finished this test in about 50 seconds.

3. Minor debug logging improvement; in fact some of them is to reduce redundant debug logging since it is too long and sometimes hides the key information.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
