### PR TITLE
KAFKA-8968: Refactor task-level metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -25,13 +25,12 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 
 class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
     private static final Logger LOG = LoggerFactory.getLogger(KStreamKStreamJoin.class);
@@ -60,15 +59,14 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
 
         private WindowStore<K, V2> otherWindow;
         private StreamsMetricsImpl metrics;
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
 
         @SuppressWarnings("unchecked")
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
-
+            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             otherWindow = (WindowStore<K, V2>) context.getStateStore(otherWindowName);
         }
 
@@ -86,7 +84,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
                     "Skipping record due to null key or value. key=[{}] value=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     key, value, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -22,12 +22,10 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1, V1> {
@@ -38,7 +36,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
     private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
     private final boolean leftJoin;
     private StreamsMetricsImpl metrics;
-    private Optional<Sensor> skippedRecordsSensor;
+    private Sensor droppedRecordsSensor;
 
     KStreamKTableJoinProcessor(final KTableValueGetter<K2, V2> valueGetter,
                                final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper,
@@ -54,8 +52,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
     public void init(final ProcessorContext context) {
         super.init(context);
         metrics = (StreamsMetricsImpl) context.metrics();
-        skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
-
+        droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
         valueGetter.init(context);
     }
 
@@ -74,7 +71,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
                 "Skipping record due to null key or value. key=[{}] value=[{}] topic=[{}] partition=[{}] offset=[{}]",
                 key, value, context().topic(), context().partition(), context().offset()
             );
-            skippedRecordsSensor.ifPresent(Sensor::record);
+            droppedRecordsSensor.record();
         } else {
             final K2 mappedKey = keyMapper.apply(key, value);
             final V2 value2 = mappedKey == null ? null : getValueOrNull(valueGetter.get(mappedKey));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -22,14 +22,12 @@ import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V, V> {
@@ -60,14 +58,14 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         private TimestampedKeyValueStore<K, V> store;
         private TimestampedTupleForwarder<K, V> tupleForwarder;
         private StreamsMetricsImpl metrics;
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
 
         @SuppressWarnings("unchecked")
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
+            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             store = (TimestampedKeyValueStore<K, V>) context.getStateStore(storeName);
             tupleForwarder = new TimestampedTupleForwarder<>(
                 store,
@@ -84,7 +82,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
                     "Skipping record due to null key or value. key=[{}] value=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     key, value, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -24,13 +24,11 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, V2> {
@@ -70,7 +68,7 @@ class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
 
         private final KTableValueGetter<K, V2> valueGetter;
         private StreamsMetricsImpl metrics;
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
 
         KTableKTableJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
             this.valueGetter = valueGetter;
@@ -80,7 +78,7 @@ class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
+            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             valueGetter.init(context);
         }
 
@@ -92,7 +90,7 @@ class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
                     "Skipping record due to null key. change=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     change, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -23,13 +23,11 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.RecordQueue.UNKNOWN;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
@@ -69,7 +67,7 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
 
         private final KTableValueGetter<K, V2> valueGetter;
         private StreamsMetricsImpl metrics;
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
 
         KTableKTableLeftJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
             this.valueGetter = valueGetter;
@@ -79,7 +77,7 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
+            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             valueGetter.init(context);
         }
 
@@ -91,7 +89,7 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
                     "Skipping record due to null key. change=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     change, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -23,13 +23,11 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.RecordQueue.UNKNOWN;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
@@ -68,7 +66,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
 
         private final KTableValueGetter<K, V2> valueGetter;
         private StreamsMetricsImpl metrics;
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
 
         KTableKTableOuterJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
             this.valueGetter = valueGetter;
@@ -78,7 +76,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            skippedRecordsSensor = ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), metrics);
+            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             valueGetter.init(context);
         }
 
@@ -90,7 +88,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
                     "Skipping record due to null key. change=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     change, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
+import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 public class ForeignJoinSubscriptionProcessorSupplier<K, KO, VO> implements ProcessorSupplier<KO, Change<VO>> {
     private static final Logger LOG = LoggerFactory.getLogger(ForeignJoinSubscriptionProcessorSupplier.class);
@@ -58,15 +57,18 @@ public class ForeignJoinSubscriptionProcessorSupplier<K, KO, VO> implements Proc
 
 
     private final class KTableKTableJoinProcessor extends AbstractProcessor<KO, Change<VO>> {
-        private Optional<Sensor> skippedRecordsSensor;
+        private Sensor droppedRecordsSensor;
         private TimestampedKeyValueStore<Bytes, SubscriptionWrapper<K>> store;
 
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
             final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
-            skippedRecordsSensor =
-                ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), internalProcessorContext.metrics());
+            droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(
+                Thread.currentThread().getName(),
+                internalProcessorContext.taskId().toString(),
+                internalProcessorContext.metrics()
+            );
             store = internalProcessorContext.getStateStore(storeBuilder);
         }
 
@@ -82,7 +84,7 @@ public class ForeignJoinSubscriptionProcessorSupplier<K, KO, VO> implements Proc
                     "Skipping record due to null key. value=[{}] topic=[{}] partition=[{}] offset=[{}]",
                     value, context().topic(), context().partition(), context().offset()
                 );
-                skippedRecordsSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/metrics/Sensors.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/metrics/Sensors.java
@@ -18,9 +18,7 @@ package org.apache.kafka.streams.kstream.internals.metrics;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
-import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -30,7 +28,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATE_RECORD_DROP;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_METRICS_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 
 public class Sensors {
     private Sensors() {}
@@ -48,43 +46,14 @@ public class Sensors {
         );
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             sensor,
-            PROCESSOR_NODE_METRICS_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             metrics.nodeLevelTagMap(threadId, context.taskId().toString(), context.currentNode().name()),
             LATE_RECORD_DROP
         );
         return sensor;
     }
 
-    public static Sensor recordLatenessSensor(final InternalProcessorContext context) {
-        final StreamsMetricsImpl metrics = context.metrics();
-        final String threadId = Thread.currentThread().getName();
 
-        final Sensor sensor = metrics.taskLevelSensor(
-            threadId,
-            context.taskId().toString(),
-            "record-lateness",
-            Sensor.RecordingLevel.DEBUG
-        );
-
-        final Map<String, String> tags = metrics.taskLevelTagMap(threadId, context.taskId().toString());
-        sensor.add(
-            new MetricName(
-                "record-lateness-avg",
-                "stream-task-metrics",
-                "The average observed lateness of records.",
-                tags),
-            new Avg()
-        );
-        sensor.add(
-            new MetricName(
-                "record-lateness-max",
-                "stream-task-metrics",
-                "The max observed lateness of records.",
-                tags),
-            new Max()
-        );
-        return sensor;
-    }
 
     public static Sensor suppressionEmitSensor(final InternalProcessorContext context) {
         final StreamsMetricsImpl metrics = context.metrics();
@@ -104,7 +73,7 @@ public class Sensors {
         sensor.add(
             new MetricName(
                 "suppression-emit-rate",
-                PROCESSOR_NODE_METRICS_GROUP,
+                PROCESSOR_NODE_LEVEL_GROUP,
                 "The average number of occurrence of suppression-emit operation per second.",
                 tags
             ),
@@ -113,7 +82,7 @@ public class Sensors {
         sensor.add(
             new MetricName(
                 "suppression-emit-total",
-                PROCESSOR_NODE_METRICS_GROUP,
+                PROCESSOR_NODE_LEVEL_GROUP,
                 "The total number of occurrence of suppression-emit operations.",
                 tags
             ),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -21,12 +21,13 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 
 /**
  * Updates the state for all Global State Stores.
@@ -70,7 +71,11 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
                     source,
                     deserializationExceptionHandler,
                     logContext,
-                    ThreadMetrics.skipRecordSensor(Thread.currentThread().getName(), processorContext.metrics())
+                    droppedRecordsSensorOrSkippedRecordsSensor(
+                        Thread.currentThread().getName(),
+                        processorContext.taskId().toString(),
+                        processorContext.metrics()
+                    )
                 )
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_METRICS_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxLatencyToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
@@ -260,8 +260,8 @@ public class ProcessorNode<K, V> {
                 operation,
                 Sensor.RecordingLevel.DEBUG
             );
-            addAvgAndMaxLatencyToSensor(parent, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
-            addInvocationRateAndCountToSensor(parent, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
+            addAvgAndMaxLatencyToSensor(parent, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
+            addInvocationRateAndCountToSensor(parent, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
 
             final Sensor sensor = metrics.nodeLevelSensor(
                 threadId,
@@ -271,8 +271,9 @@ public class ProcessorNode<K, V> {
                 Sensor.RecordingLevel.DEBUG,
                 parent
             );
-            addAvgAndMaxLatencyToSensor(sensor, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
-            addInvocationRateAndCountToSensor(sensor, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
+            addAvgAndMaxLatencyToSensor(sensor, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
+            addInvocationRateAndCountToSensor(sensor, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
+
 
             return sensor;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -47,12 +47,11 @@ import org.slf4j.Logger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class RecordCollectorImpl implements RecordCollector {
     private final Logger log;
     private final String logPrefix;
-    private final Optional<Sensor> skippedRecordsSensor;
+    private final Sensor droppedRecordsSensor;
     private Producer<byte[], byte[]> producer;
     private final Map<TopicPartition, Long> offsets;
     private final ProductionExceptionHandler productionExceptionHandler;
@@ -69,12 +68,12 @@ public class RecordCollectorImpl implements RecordCollector {
     public RecordCollectorImpl(final String streamTaskId,
                                final LogContext logContext,
                                final ProductionExceptionHandler productionExceptionHandler,
-                               final Optional<Sensor> skippedRecordsSensor) {
+                               final Sensor droppedRecordsSensor) {
         this.offsets = new HashMap<>();
         this.logPrefix = String.format("task [%s] ", streamTaskId);
         this.log = logContext.logger(getClass());
         this.productionExceptionHandler = productionExceptionHandler;
-        this.skippedRecordsSensor = skippedRecordsSensor;
+        this.droppedRecordsSensor = droppedRecordsSensor;
     }
 
     @Override
@@ -212,7 +211,7 @@ public class RecordCollectorImpl implements RecordCollector {
                                     // KAFKA-7510 put message key and value in TRACE level log so we don't leak data by default
                                     log.trace("Failed message: (key {} value {} timestamp {}) topic=[{}] partition=[{}]", key, value, timestamp, topic, partition);
 
-                                    skippedRecordsSensor.ifPresent(Sensor::record);
+                                    droppedRecordsSensor.record();
                                 }
                             }
                         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -25,24 +25,22 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.slf4j.Logger;
 
-import java.util.Optional;
-
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG;
 
 class RecordDeserializer {
     private final SourceNode sourceNode;
     private final DeserializationExceptionHandler deserializationExceptionHandler;
     private final Logger log;
-    private final Optional<Sensor> skippedRecordSensor;
+    private final Sensor droppedRecordsSensor;
 
     RecordDeserializer(final SourceNode sourceNode,
                        final DeserializationExceptionHandler deserializationExceptionHandler,
                        final LogContext logContext,
-                       final Optional<Sensor> skippedRecordsSensor) {
+                       final Sensor droppedRecordsSensor) {
         this.sourceNode = sourceNode;
         this.deserializationExceptionHandler = deserializationExceptionHandler;
         this.log = logContext.logger(RecordDeserializer.class);
-        this.skippedRecordSensor = skippedRecordsSensor;
+        this.droppedRecordsSensor = droppedRecordsSensor;
     }
 
     /**
@@ -92,7 +90,7 @@ class RecordDeserializer {
                     rawRecord.offset(),
                     deserializationException
                 );
-                skippedRecordSensor.ifPresent(Sensor::record);
+                droppedRecordsSensor.record();
                 return null;
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -22,18 +22,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.CumulativeCount;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
@@ -41,6 +35,7 @@ import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -54,19 +49,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.singleton;
-import static org.apache.kafka.streams.kstream.internals.metrics.Sensors.recordLatenessSensor;
 
 /**
  * A StreamTask is associated with a {@link PartitionGroup}, and is assigned to a StreamThread for processing.
@@ -80,7 +71,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     private final Time time;
     private final long maxTaskIdleMs;
     private final int maxBufferedSize;
-    private final TaskMetrics taskMetrics;
+    private final StreamsMetricsImpl streamsMetrics;
     private final PartitionGroup partitionGroup;
     private final RecordCollector recordCollector;
     private final PartitionGroup.RecordInfo recordInfo;
@@ -89,75 +80,19 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     private final PunctuationQueue systemTimePunctuationQueue;
     private final ProducerSupplier producerSupplier;
 
-    private Sensor closeTaskSensor;
+    private final Sensor closeTaskSensor;
+    private final Sensor processLatencySensor;
+    private final Sensor punctuateLatencySensor;
+    private final Sensor commitSensor;
+    private final Sensor enforcedProcessingSensor;
+    private final Sensor recordLatenessSensor;
+
     private long idleStartTime;
     private Producer<byte[], byte[]> producer;
     private boolean commitRequested = false;
     private boolean transactionInFlight = false;
 
-    protected static final class TaskMetrics {
-        final StreamsMetricsImpl metrics;
-        final Sensor taskCommitTimeSensor;
-        final Sensor taskEnforcedProcessSensor;
-        private final String threadId;
-        private final String taskName;
-
-        TaskMetrics(final String threadId,
-                    final TaskId taskId,
-                    final StreamsMetricsImpl metrics) {
-            this.threadId = threadId;
-            taskName = taskId.toString();
-            this.metrics = metrics;
-            final String group = "stream-task-metrics";
-
-            // first add the global operation metrics if not yet, with the global tags only
-            final Sensor[] parent = ThreadMetrics.commitOverTasksSensor(threadId, metrics)
-                .map(Arrays::asList).orElse(Collections.emptyList()).toArray(new Sensor[0]);
-
-            // add the operation metrics with additional tags
-            final Map<String, String> tagMap = metrics.taskLevelTagMap(threadId, taskName);
-            taskCommitTimeSensor =
-                metrics.taskLevelSensor(threadId, taskName, "commit", Sensor.RecordingLevel.DEBUG, parent);
-            taskCommitTimeSensor.add(
-                new MetricName("commit-latency-avg", group, "The average latency of commit operation.", tagMap),
-                new Avg()
-            );
-            taskCommitTimeSensor.add(
-                new MetricName("commit-latency-max", group, "The max latency of commit operation.", tagMap),
-                new Max()
-            );
-            taskCommitTimeSensor.add(
-                new MetricName("commit-rate", group, "The average number of occurrence of commit operation per second.", tagMap),
-                new Rate(TimeUnit.SECONDS, new WindowedCount())
-            );
-            taskCommitTimeSensor.add(
-                new MetricName("commit-total", group, "The total number of occurrence of commit operations.", tagMap),
-                new CumulativeCount()
-            );
-
-            // add the metrics for enforced processing
-            taskEnforcedProcessSensor = metrics.taskLevelSensor(
-                threadId,
-                taskName,
-                "enforced-processing",
-                Sensor.RecordingLevel.DEBUG,
-                parent
-            );
-            taskEnforcedProcessSensor.add(
-                    new MetricName("enforced-processing-rate", group, "The average number of occurrence of enforced-processing operation per second.", tagMap),
-                    new Rate(TimeUnit.SECONDS, new WindowedCount())
-            );
-            taskEnforcedProcessSensor.add(
-                    new MetricName("enforced-processing-total", group, "The total number of occurrence of enforced-processing operations.", tagMap),
-                    new CumulativeCount()
-            );
-
-        }
-
-        void removeAllSensors() {
-            metrics.removeAllTaskLevelSensors(threadId, taskName);
-        }
-    }
+    private final String threadId;
 
     public interface ProducerSupplier {
         Producer<byte[], byte[]> get();
@@ -194,19 +129,28 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         this.time = time;
         this.producerSupplier = producerSupplier;
         this.producer = producerSupplier.get();
-        final String threadId = Thread.currentThread().getName();
-        this.taskMetrics = new TaskMetrics(threadId, id, streamsMetrics);
+        this.streamsMetrics = streamsMetrics;
 
+        threadId = Thread.currentThread().getName();
+        final String taskId = id.toString();
         closeTaskSensor = ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
+        final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
+        commitSensor = TaskMetrics.commitSensor(threadId, taskId, streamsMetrics, parent);
+        enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics, parent);
+        processLatencySensor = TaskMetrics.processLatencySensor(threadId, taskId, streamsMetrics);
+        punctuateLatencySensor = TaskMetrics.punctuateSensor(threadId, taskId, streamsMetrics);
+        recordLatenessSensor = TaskMetrics.recordLatenessSensor(threadId, taskId, streamsMetrics);
+        TaskMetrics.droppedRecordsSensor(threadId, taskId, streamsMetrics);
 
         final ProductionExceptionHandler productionExceptionHandler = config.defaultProductionExceptionHandler();
 
         if (recordCollector == null) {
             this.recordCollector = new RecordCollectorImpl(
-                id.toString(),
+                taskId,
                 logContext,
                 productionExceptionHandler,
-                ThreadMetrics.skipRecordSensor(threadId, streamsMetrics));
+                TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId, streamsMetrics)
+            );
         } else {
             this.recordCollector = recordCollector;
         }
@@ -245,7 +189,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         recordInfo = new PartitionGroup.RecordInfo();
-        partitionGroup = new PartitionGroup(partitionQueues, recordLatenessSensor(processorContextImpl));
+        partitionGroup = new PartitionGroup(partitionQueues, recordLatenessSensor);
 
         stateMgr.registerGlobalStateStores(topology.globalStateStores());
 
@@ -391,7 +335,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             }
 
             if (now - idleStartTime >= maxTaskIdleMs) {
-                taskMetrics.taskEnforcedProcessSensor.record();
+                enforcedProcessingSensor.record();
                 return true;
             } else {
                 return false;
@@ -425,7 +369,14 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             log.trace("Start processing one record [{}]", record);
 
             updateProcessorContext(record, currNode);
-            currNode.process(record.key(), record.value());
+            StreamsMetricsImpl.maybeMeasureLatency(
+                () -> {
+                    currNode.process(record.key(), record.value());
+                    return null;
+                },
+                time,
+                processLatencySensor
+            );
 
             log.trace("Completed processing one record [{}]", record);
 
@@ -487,7 +438,14 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         try {
-            node.punctuate(timestamp, punctuator);
+            StreamsMetricsImpl.maybeMeasureLatency(
+                () -> {
+                    node.punctuate(timestamp, punctuator);
+                    return null;
+                },
+                time,
+                punctuateLatencySensor
+            );
         } catch (final ProducerFencedException fatal) {
             throw new TaskMigratedException(this, fatal);
         } catch (final KafkaException e) {
@@ -564,7 +522,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
         commitNeeded = false;
         commitRequested = false;
-        taskMetrics.taskCommitTimeSensor.record(time.nanoseconds() - startNs);
+        commitSensor.record(time.nanoseconds() - startNs);
     }
 
     private Map<TopicPartition, Long> activeTaskCheckpointableOffsets() {
@@ -747,7 +705,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         partitionGroup.close();
-        taskMetrics.removeAllSensors();
+        streamsMetrics.removeAllTaskLevelSensors(threadId, id.toString());
 
         closeTaskSensor.record();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -372,7 +372,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             StreamsMetricsImpl.maybeMeasureLatency(
                 () -> {
                     currNode.process(record.key(), record.value());
-                    return null;
                 },
                 time,
                 processLatencySensor
@@ -441,7 +440,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             StreamsMetricsImpl.maybeMeasureLatency(
                 () -> {
                     node.punctuate(timestamp, punctuator);
-                    return null;
                 },
                 time,
                 punctuateLatencySensor

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -46,7 +46,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 public class StreamsMetricsImpl implements StreamsMetrics {
 
@@ -763,18 +762,18 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         );
     }
 
-    public static <R> R maybeMeasureLatency(final Supplier<R> action,
-                                            final Time time,
-                                            final Sensor sensor) {
+    public static void maybeMeasureLatency(final Runnable actionToMeasure,
+                                           final Time time,
+                                           final Sensor sensor) {
         if (sensor.shouldRecord()) {
             final long startNs = time.nanoseconds();
             try {
-                return action.get();
+                actionToMeasure.run();
             } finally {
                 sensor.record(time.nanoseconds() - startNs);
             }
         } else {
-            return action.get();
+            actionToMeasure.run();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.metrics.stats.WindowedSum;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
@@ -45,6 +46,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public class StreamsMetricsImpl implements StreamsMetrics {
 
@@ -111,6 +113,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String THREAD_ID_TAG = "thread-id";
     public static final String THREAD_ID_TAG_0100_TO_24 = "client-id";
     public static final String TASK_ID_TAG = "task-id";
+    public static final String PROCESSOR_NODE_ID_TAG = "processor-node-id";
     public static final String STORE_ID_TAG = "state-id";
     public static final String BUFFER_ID_TAG = "buffer-id";
     public static final String RECORD_CACHE_ID_TAG = "record-cache-id";
@@ -137,15 +140,13 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String THREAD_LEVEL_GROUP = GROUP_PREFIX + "thread" + GROUP_SUFFIX;
     public static final String THREAD_LEVEL_GROUP_0100_TO_24 = GROUP_PREFIX_WO_DELIMITER + GROUP_SUFFIX;
     public static final String TASK_LEVEL_GROUP = GROUP_PREFIX + "task" + GROUP_SUFFIX;
+    public static final String PROCESSOR_NODE_LEVEL_GROUP = GROUP_PREFIX + "processor-node" + GROUP_SUFFIX;
     public static final String STATE_LEVEL_GROUP_SUFFIX = "-state" + GROUP_SUFFIX;
     public static final String STATE_LEVEL_GROUP = GROUP_PREFIX + "state" + GROUP_SUFFIX;
     public static final String CACHE_LEVEL_GROUP = GROUP_PREFIX + "record-cache" + GROUP_SUFFIX;
 
     public static final String TOTAL_DESCRIPTION = "The total number of ";
     public static final String RATE_DESCRIPTION = "The average per-second number of ";
-
-    public static final String PROCESSOR_NODE_METRICS_GROUP = "stream-processor-node-metrics";
-    public static final String PROCESSOR_NODE_ID_TAG = "processor-node-id";
 
     public static final String EXPIRED_WINDOW_RECORD_DROP = "expired-window-record-drop";
     public static final String LATE_RECORD_DROP = "late-record-drop";
@@ -580,11 +581,11 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     public static void addAvgAndMaxToSensor(final Sensor sensor,
-                                             final String group,
-                                             final Map<String, String> tags,
-                                             final String operation,
-                                             final String descriptionOfAvg,
-                                             final String descriptionOfMax) {
+                                            final String group,
+                                            final Map<String, String> tags,
+                                            final String operation,
+                                            final String descriptionOfAvg,
+                                            final String descriptionOfMax) {
         sensor.add(
             new MetricName(
                 operation + AVG_SUFFIX,
@@ -760,6 +761,21 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             new MetricName(metricNamePrefix + TOTAL_SUFFIX, group, descriptionOfTotal, tags),
             new CumulativeSum()
         );
+    }
+
+    public static <R> R maybeMeasureLatency(final Supplier<R> action,
+                                            final Time time,
+                                            final Sensor sensor) {
+        if (sensor.shouldRecord()) {
+            final long startNs = time.nanoseconds();
+            try {
+                return action.get();
+            } finally {
+                sensor.record(time.nanoseconds() - startNs);
+            }
+        } else {
+            return action.get();
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.V
 import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
@@ -32,46 +31,52 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 public class TaskMetrics {
     private TaskMetrics() {}
 
-    private static final String COMMIT = "commit";
-    private static final String PROCESS = "process";
-    private static final String PROCESS_LATENCY = PROCESS + LATENCY_SUFFIX;
-    private static final String PUNCTUATE = "punctuate";
-    private static final String ENFORCED_PROCESSING = "enforced-processing";
-    private static final String RECORD_LATENESS = "record-lateness";
-    private static final String DROPPED_RECORDS = "dropped-records";
+    private static final String AVG_LATENCY_DESCRIPTION = "The average latency of ";
+    private static final String MAX_LATENCY_DESCRIPTION = "The maximum latency of ";
+    private static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
+    private static final String RATE_DESCRIPTION_SUFFIX = " per second";
 
-    private static final String LATENCY_DESCRIPTION_SUFFIX = " latency";
-    private static final String AVG_LATENCY_DESCRIPTION_PREFIX = "The average ";
-    private static final String MAX_LATENCY_DESCRIPTION_PREFIX = "The maximum ";
-    private static final String COMMIT_DESCRIPTION = "commit calls";
+    private static final String COMMIT = "commit";
+    private static final String COMMIT_DESCRIPTION = "calls to commit";
     private static final String COMMIT_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + COMMIT_DESCRIPTION;
-    private static final String COMMIT_RATE_DESCRIPTION = RATE_DESCRIPTION + COMMIT_DESCRIPTION;
-    private static final String COMMIT_AVG_LATENCY_DESCRIPTION =
-        AVG_LATENCY_DESCRIPTION_PREFIX + COMMIT + LATENCY_DESCRIPTION_SUFFIX;
-    private static final String COMMIT_MAX_LATENCY_DESCRIPTION =
-        MAX_LATENCY_DESCRIPTION_PREFIX + COMMIT + LATENCY_DESCRIPTION_SUFFIX;
-    private static final String PUNCTUATE_DESCRIPTION = "punctuate calls";
+    private static final String COMMIT_RATE_DESCRIPTION =
+        RATE_DESCRIPTION_PREFIX + COMMIT_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
+    private static final String COMMIT_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION + COMMIT_DESCRIPTION;
+    private static final String COMMIT_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION + COMMIT_DESCRIPTION;
+
+    private static final String PUNCTUATE = "punctuate";
+    private static final String PUNCTUATE_DESCRIPTION = "calls to punctuate";
     private static final String PUNCTUATE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUNCTUATE_DESCRIPTION;
-    private static final String PUNCTUATE_RATE_DESCRIPTION = RATE_DESCRIPTION + PUNCTUATE_DESCRIPTION;
-    private static final String PUNCTUATE_AVG_LATENCY_DESCRIPTION =
-        AVG_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE + LATENCY_DESCRIPTION_SUFFIX;
-    private static final String PUNCTUATE_MAX_LATENCY_DESCRIPTION =
-        MAX_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String PUNCTUATE_RATE_DESCRIPTION =
+        RATE_DESCRIPTION_PREFIX + PUNCTUATE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
+    private static final String PUNCTUATE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION + PUNCTUATE_DESCRIPTION;
+    private static final String PUNCTUATE_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION + PUNCTUATE_DESCRIPTION;
+
+    private static final String ENFORCED_PROCESSING = "enforced-processing";
     private static final String ENFORCED_PROCESSING_TOTAL_DESCRIPTION =
         "The total number of occurrences of enforced-processing operations";
     private static final String ENFORCED_PROCESSING_RATE_DESCRIPTION =
         "The average number of occurrences of enforced-processing operations per second";
-    private static final String RECORD_LATENESS_MAX_DESCRIPTION = "The observed maximum lateness of records";
-    private static final String RECORD_LATENESS_AVG_DESCRIPTION = "The observed average lateness of records";
+
+    private static final String RECORD_LATENESS = "record-lateness";
+    private static final String RECORD_LATENESS_MAX_DESCRIPTION =
+        "The observed maximum lateness of records in milliseconds, measured by comparing the record timestamp with the "
+            + "current stream time";
+    private static final String RECORD_LATENESS_AVG_DESCRIPTION =
+        "The observed average lateness of records in milliseconds, measured by comparing the record timestamp with the "
+            + "current stream time";
+
+    private static final String DROPPED_RECORDS = "dropped-records";
     private static final String DROPPED_RECORDS_DESCRIPTION = "dropped records";
     private static final String DROPPED_RECORDS_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + DROPPED_RECORDS_DESCRIPTION;
-    private static final String DROPPED_RECORDS_RATE_DESCRIPTION = RATE_DESCRIPTION + DROPPED_RECORDS_DESCRIPTION;
-    private static final String PROCESS_DESCRIPTION = "processing";
-    private static final String PROCESS_AVG_LATENCY_DESCRIPTION =
-        AVG_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION + LATENCY_DESCRIPTION_SUFFIX;
-    private static final String PROCESS_MAX_LATENCY_DESCRIPTION =
-        MAX_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String DROPPED_RECORDS_RATE_DESCRIPTION =
+        RATE_DESCRIPTION_PREFIX + DROPPED_RECORDS_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
 
+    private static final String PROCESS = "process";
+    private static final String PROCESS_LATENCY = PROCESS + LATENCY_SUFFIX;
+    private static final String PROCESS_DESCRIPTION = "processing";
+    private static final String PROCESS_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION + PROCESS_DESCRIPTION;
+    private static final String PROCESS_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION + PROCESS_DESCRIPTION;
 
     public static Sensor processLatencySensor(final String threadId,
                                               final String taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.metrics;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
+
+import java.util.Map;
+
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
+
+public class TaskMetrics {
+    private TaskMetrics() {}
+
+    private static final String COMMIT = "commit";
+    private static final String PROCESS = "process";
+    private static final String PROCESS_LATENCY = PROCESS + LATENCY_SUFFIX;
+    private static final String PUNCTUATE = "punctuate";
+    private static final String ENFORCED_PROCESSING = "enforced-processing";
+    private static final String RECORD_LATENESS = "record-lateness";
+    private static final String DROPPED_RECORDS = "dropped-records";
+
+    private static final String LATENCY_DESCRIPTION_SUFFIX = " latency";
+    private static final String AVG_LATENCY_DESCRIPTION_PREFIX = "The average ";
+    private static final String MAX_LATENCY_DESCRIPTION_PREFIX = "The maximum ";
+    private static final String COMMIT_DESCRIPTION = "commit calls";
+    private static final String COMMIT_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + COMMIT_DESCRIPTION;
+    private static final String COMMIT_RATE_DESCRIPTION = RATE_DESCRIPTION + COMMIT_DESCRIPTION;
+    private static final String COMMIT_AVG_LATENCY_DESCRIPTION =
+        AVG_LATENCY_DESCRIPTION_PREFIX + COMMIT + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String COMMIT_MAX_LATENCY_DESCRIPTION =
+        MAX_LATENCY_DESCRIPTION_PREFIX + COMMIT + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String PUNCTUATE_DESCRIPTION = "punctuate calls";
+    private static final String PUNCTUATE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUNCTUATE_DESCRIPTION;
+    private static final String PUNCTUATE_RATE_DESCRIPTION = RATE_DESCRIPTION + PUNCTUATE_DESCRIPTION;
+    private static final String PUNCTUATE_AVG_LATENCY_DESCRIPTION =
+        AVG_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String PUNCTUATE_MAX_LATENCY_DESCRIPTION =
+        MAX_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String ENFORCED_PROCESSING_TOTAL_DESCRIPTION =
+        "The total number of occurrences of enforced-processing operations";
+    private static final String ENFORCED_PROCESSING_RATE_DESCRIPTION =
+        "The average number of occurrences of enforced-processing operations per second";
+    private static final String RECORD_LATENESS_MAX_DESCRIPTION = "The observed maximum lateness of records";
+    private static final String RECORD_LATENESS_AVG_DESCRIPTION = "The observed average lateness of records";
+    private static final String DROPPED_RECORDS_DESCRIPTION = "dropped records";
+    private static final String DROPPED_RECORDS_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + DROPPED_RECORDS_DESCRIPTION;
+    private static final String DROPPED_RECORDS_RATE_DESCRIPTION = RATE_DESCRIPTION + DROPPED_RECORDS_DESCRIPTION;
+    private static final String PROCESS_DESCRIPTION = "processing";
+    private static final String PROCESS_AVG_LATENCY_DESCRIPTION =
+        AVG_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION + LATENCY_DESCRIPTION_SUFFIX;
+    private static final String PROCESS_MAX_LATENCY_DESCRIPTION =
+        MAX_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION + LATENCY_DESCRIPTION_SUFFIX;
+
+
+    public static Sensor processLatencySensor(final String threadId,
+                                              final String taskId,
+                                              final StreamsMetricsImpl streamsMetrics) {
+        if (streamsMetrics.version() == Version.LATEST) {
+            return avgAndMaxSensor(
+                threadId,
+                taskId,
+                PROCESS_LATENCY,
+                PROCESS_AVG_LATENCY_DESCRIPTION,
+                PROCESS_MAX_LATENCY_DESCRIPTION,
+                RecordingLevel.DEBUG,
+                streamsMetrics
+            );
+        }
+        return emptySensor(threadId, taskId, PROCESS_LATENCY, RecordingLevel.DEBUG, streamsMetrics);
+    }
+
+    public static Sensor punctuateSensor(final String threadId,
+                                         final String taskId,
+                                         final StreamsMetricsImpl streamsMetrics) {
+        if (streamsMetrics.version() == Version.LATEST) {
+            return invocationRateAndCountAndAvgAndMaxLatencySensor(
+                threadId,
+                taskId,
+                PUNCTUATE,
+                PUNCTUATE_RATE_DESCRIPTION,
+                PUNCTUATE_TOTAL_DESCRIPTION,
+                PUNCTUATE_AVG_LATENCY_DESCRIPTION,
+                PUNCTUATE_MAX_LATENCY_DESCRIPTION,
+                Sensor.RecordingLevel.DEBUG,
+                streamsMetrics
+            );
+        }
+        return emptySensor(threadId, taskId, PUNCTUATE, RecordingLevel.DEBUG, streamsMetrics);
+    }
+
+    public static Sensor commitSensor(final String threadId,
+                                      final String taskId,
+                                      final StreamsMetricsImpl streamsMetrics,
+                                      final Sensor... parentSensor) {
+        return invocationRateAndCountAndAvgAndMaxLatencySensor(
+            threadId,
+            taskId,
+            COMMIT,
+            COMMIT_RATE_DESCRIPTION,
+            COMMIT_TOTAL_DESCRIPTION,
+            COMMIT_AVG_LATENCY_DESCRIPTION,
+            COMMIT_MAX_LATENCY_DESCRIPTION,
+            Sensor.RecordingLevel.DEBUG,
+            streamsMetrics,
+            parentSensor
+        );
+    }
+
+    public static Sensor enforcedProcessingSensor(final String threadId,
+                                                  final String taskId,
+                                                  final StreamsMetricsImpl streamsMetrics,
+                                                  final Sensor... parentSensors) {
+        return invocationRateAndCountSensor(
+            threadId,
+            taskId,
+            ENFORCED_PROCESSING,
+            ENFORCED_PROCESSING_RATE_DESCRIPTION,
+            ENFORCED_PROCESSING_TOTAL_DESCRIPTION,
+            RecordingLevel.DEBUG,
+            streamsMetrics,
+            parentSensors
+        );
+    }
+
+    public static Sensor recordLatenessSensor(final String threadId,
+                                              final String taskId,
+                                              final StreamsMetricsImpl streamsMetrics) {
+        return avgAndMaxSensor(
+            threadId,
+            taskId,
+            RECORD_LATENESS,
+            RECORD_LATENESS_AVG_DESCRIPTION,
+            RECORD_LATENESS_MAX_DESCRIPTION,
+            RecordingLevel.DEBUG,
+            streamsMetrics
+        );
+    }
+
+    public static Sensor droppedRecordsSensor(final String threadId,
+                                              final String taskId,
+                                              final StreamsMetricsImpl streamsMetrics) {
+        return invocationRateAndCountSensor(
+            threadId,
+            taskId,
+            DROPPED_RECORDS,
+            DROPPED_RECORDS_RATE_DESCRIPTION,
+            DROPPED_RECORDS_TOTAL_DESCRIPTION,
+            RecordingLevel.INFO,
+            streamsMetrics
+        );
+    }
+
+    public static Sensor droppedRecordsSensorOrSkippedRecordsSensor(final String threadId,
+                                                                    final String taskId,
+                                                                    final StreamsMetricsImpl streamsMetrics) {
+        if (streamsMetrics.version() == Version.FROM_100_TO_24) {
+            return ThreadMetrics.skipRecordSensor(threadId, streamsMetrics);
+        }
+        return droppedRecordsSensor(threadId, taskId, streamsMetrics);
+    }
+
+    private static Sensor invocationRateAndCountSensor(final String threadId,
+                                                       final String taskId,
+                                                       final String metricName,
+                                                       final String descriptionOfRate,
+                                                       final String descriptionOfCount,
+                                                       final RecordingLevel recordingLevel,
+                                                       final StreamsMetricsImpl streamsMetrics,
+                                                       final Sensor... parentSensors) {
+        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel, parentSensors);
+        addInvocationRateAndCountToSensor(
+            sensor,
+            TASK_LEVEL_GROUP,
+            streamsMetrics.taskLevelTagMap(threadId, taskId),
+            metricName,
+            descriptionOfRate,
+            descriptionOfCount
+        );
+        return sensor;
+    }
+
+    private static Sensor avgAndMaxSensor(final String threadId,
+                                          final String taskId,
+                                          final String metricName,
+                                          final String descriptionOfAvg,
+                                          final String descriptionOfMax,
+                                          final RecordingLevel recordingLevel,
+                                          final StreamsMetricsImpl streamsMetrics,
+                                          final Sensor... parentSensors) {
+        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel, parentSensors);
+        final Map<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        addAvgAndMaxToSensor(
+            sensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            metricName,
+            descriptionOfAvg,
+            descriptionOfMax
+        );
+        return sensor;
+    }
+
+    private static Sensor invocationRateAndCountAndAvgAndMaxLatencySensor(final String threadId,
+                                                                          final String taskId,
+                                                                          final String metricName,
+                                                                          final String descriptionOfRate,
+                                                                          final String descriptionOfCount,
+                                                                          final String descriptionOfAvg,
+                                                                          final String descriptionOfMax,
+                                                                          final RecordingLevel recordingLevel,
+                                                                          final StreamsMetricsImpl streamsMetrics,
+                                                                          final Sensor... parentSensors) {
+        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel, parentSensors);
+        final Map<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        addAvgAndMaxToSensor(
+            sensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            metricName + LATENCY_SUFFIX,
+            descriptionOfAvg,
+            descriptionOfMax
+        );
+        addInvocationRateAndCountToSensor(
+            sensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            metricName,
+            descriptionOfRate,
+            descriptionOfCount
+        );
+        return sensor;
+    }
+
+    private static Sensor emptySensor(final String threadId,
+                                      final String taskId,
+                                      final String metricName,
+                                      final RecordingLevel recordingLevel,
+                                      final StreamsMetricsImpl streamsMetrics,
+                                      final Sensor... parentSensors) {
+        return streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel, parentSensors);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
@@ -107,19 +106,19 @@ public class ThreadMetrics {
         );
     }
 
-    public static Optional<Sensor> skipRecordSensor(final String threadId,
-                                                    final StreamsMetricsImpl streamsMetrics) {
+    public static Sensor skipRecordSensor(final String threadId,
+                                          final StreamsMetricsImpl streamsMetrics) {
         if (streamsMetrics.version() == Version.FROM_100_TO_24) {
-            return Optional.of(invocationRateAndCountSensor(
+            return invocationRateAndCountSensor(
                 threadId,
                 SKIP_RECORD,
                 SKIP_RECORD_RATE_DESCRIPTION,
                 SKIP_RECORD_TOTAL_DESCRIPTION,
                 RecordingLevel.INFO,
                 streamsMetrics
-            ));
+            );
         }
-        return Optional.empty();
+        return emptySensor(threadId, SKIP_RECORD, RecordingLevel.INFO, streamsMetrics);
     }
 
     public static Sensor commitSensor(final String threadId,
@@ -178,7 +177,7 @@ public class ThreadMetrics {
         );
     }
 
-    public static Optional<Sensor> commitOverTasksSensor(final String threadId,
+    public static Sensor commitOverTasksSensor(final String threadId,
                                                          final StreamsMetricsImpl streamsMetrics) {
         if (streamsMetrics.version() == Version.FROM_100_TO_24) {
             final Sensor commitOverTasksSensor =
@@ -200,9 +199,9 @@ public class ThreadMetrics {
                 COMMIT_OVER_TASKS_RATE_DESCRIPTION,
                 COMMIT_OVER_TASKS_TOTAL_DESCRIPTION
             );
-            return Optional.of(commitOverTasksSensor);
+            return commitOverTasksSensor;
         }
-        return Optional.empty();
+        return emptySensor(threadId, COMMIT, RecordingLevel.DEBUG, streamsMetrics);
     }
 
     private static Sensor invocationRateAndCountSensor(final String threadId,
@@ -251,6 +250,14 @@ public class ThreadMetrics {
             descriptionOfCount
         );
         return sensor;
+    }
+
+    private static Sensor emptySensor(final String threadId,
+                                      final String metricName,
+                                      final RecordingLevel recordingLevel,
+                                      final StreamsMetricsImpl streamsMetrics,
+                                      final Sensor... parentSensors) {
+        return streamsMetrics.threadLevelSensor(threadId, metricName, recordingLevel, parentSensors);
     }
 
     private static String threadLevelGroup(final StreamsMetricsImpl streamsMetrics) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -150,6 +150,8 @@ public class MetricsIntegrationTest {
     private static final String POLL_LATENCY_MAX = "poll-latency-max";
     private static final String COMMIT_RATE = "commit-rate";
     private static final String COMMIT_TOTAL = "commit-total";
+    private static final String ENFORCED_PROCESSING_RATE = "enforced-processing-rate";
+    private static final String ENFORCED_PROCESSING_TOTAL = "enforced-processing-total";
     private static final String POLL_RATE = "poll-rate";
     private static final String POLL_TOTAL = "poll-total";
     private static final String TASK_CREATED_RATE = "task-created-rate";
@@ -522,8 +524,24 @@ public class MetricsIntegrationTest {
             COMMIT_TOTAL,
             StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? 4 : 5
         );
+        checkMetricByName(listMetricTask, ENFORCED_PROCESSING_RATE, 4);
+        checkMetricByName(listMetricTask, ENFORCED_PROCESSING_TOTAL, 4);
         checkMetricByName(listMetricTask, RECORD_LATENESS_AVG, 4);
         checkMetricByName(listMetricTask, RECORD_LATENESS_MAX, 4);
+        checkTaskLevelMetricsForBuiltInMetricsVersionLatest(
+            listMetricTask,
+            StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? 4 : 0
+        );
+    }
+
+    private void checkTaskLevelMetricsForBuiltInMetricsVersionLatest(final List<Metric> metrics,
+                                                                     final int count) {
+        checkMetricByName(metrics, PROCESS_LATENCY_AVG, count);
+        checkMetricByName(metrics, PROCESS_LATENCY_MAX, count);
+        checkMetricByName(metrics, PUNCTUATE_LATENCY_AVG, count);
+        checkMetricByName(metrics, PUNCTUATE_LATENCY_MAX, count);
+        checkMetricByName(metrics, PUNCTUATE_RATE, count);
+        checkMetricByName(metrics, PUNCTUATE_TOTAL, count);
     }
 
     private void checkProcessorLevelMetrics() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
@@ -81,8 +81,8 @@ public class TaskMetricsTest {
         expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG))
             .andReturn(expectedSensor);
         if (builtInMetricsVersion == Version.LATEST) {
-            final String avgLatencyDescription = "The average processing latency";
-            final String maxLatencyDescription = "The maximum processing latency";
+            final String avgLatencyDescription = "The average latency of processing";
+            final String maxLatencyDescription = "The maximum latency of processing";
             expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
             StreamsMetricsImpl.addAvgAndMaxToSensor(
                 expectedSensor,
@@ -108,10 +108,10 @@ public class TaskMetricsTest {
             .andReturn(expectedSensor);
         if (builtInMetricsVersion == Version.LATEST) {
             final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
-            final String totalDescription = "The total number of punctuate calls";
-            final String rateDescription = "The average per-second number of punctuate calls";
-            final String avgLatencyDescription = "The average punctuate latency";
-            final String maxLatencyDescription = "The maximum punctuate latency";
+            final String totalDescription = "The total number of calls to punctuate";
+            final String rateDescription = "The average number of calls to punctuate per second";
+            final String avgLatencyDescription = "The average latency of calls to punctuate";
+            final String maxLatencyDescription = "The maximum latency of calls to punctuate";
             expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
             StreamsMetricsImpl.addInvocationRateAndCountToSensor(
                 expectedSensor,
@@ -142,10 +142,10 @@ public class TaskMetricsTest {
     public void shouldGetCommitSensor() {
         final String operation = "commit";
         final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
-        final String totalDescription = "The total number of commit calls";
-        final String rateDescription = "The average per-second number of commit calls";
-        final String avgLatencyDescription = "The average commit latency";
-        final String maxLatencyDescription = "The maximum commit latency";
+        final String totalDescription = "The total number of calls to commit";
+        final String rateDescription = "The average number of calls to commit per second";
+        final String avgLatencyDescription = "The average latency of calls to commit";
+        final String maxLatencyDescription = "The maximum latency of calls to commit";
         expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
@@ -198,8 +198,12 @@ public class TaskMetricsTest {
     @Test
     public void shouldGetRecordLatenessSensor() {
         final String operation = "record-lateness";
-        final String avgDescription = "The observed average lateness of records";
-        final String maxDescription = "The observed maximum lateness of records";
+        final String avgDescription =
+            "The observed average lateness of records in milliseconds, measured by comparing the record timestamp with "
+                + "the current stream time";
+        final String maxDescription =
+            "The observed maximum lateness of records in milliseconds, measured by comparing the record timestamp with "
+                + "the current stream time";
         expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
@@ -222,7 +226,7 @@ public class TaskMetricsTest {
     public void shouldGetDroppedRecordsSensor() {
         final String operation = "dropped-records";
         final String totalDescription = "The total number of dropped records";
-        final String rateDescription = "The average per-second number of dropped records";
+        final String rateDescription = "The average number of dropped records per second";
         expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.metrics;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
+import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
+import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
+import static org.easymock.EasyMock.expect;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({StreamsMetricsImpl.class, Sensor.class, ThreadMetrics.class})
+public class TaskMetricsTest {
+
+    private final static String THREAD_ID = "test-thread";
+    private final static String TASK_ID = "test-task";
+
+    private final StreamsMetricsImpl streamsMetrics = createMock(StreamsMetricsImpl.class);
+    private final Sensor expectedSensor = createMock(Sensor.class);
+    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {Version.LATEST},
+            {Version.FROM_100_TO_24}
+        });
+    }
+
+    @Parameter
+    public Version builtInMetricsVersion;
+
+    @Before
+    public void setUp() {
+        expect(streamsMetrics.version()).andReturn(builtInMetricsVersion).anyTimes();
+        mockStatic(StreamsMetricsImpl.class);
+    }
+
+    @Test
+    public void shouldGetProcessLatencySensor() {
+        final String operation = "process-latency";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG))
+            .andReturn(expectedSensor);
+        if (builtInMetricsVersion == Version.LATEST) {
+            final String avgLatencyDescription = "The average processing latency";
+            final String maxLatencyDescription = "The maximum processing latency";
+            expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+            StreamsMetricsImpl.addAvgAndMaxToSensor(
+                expectedSensor,
+                TASK_LEVEL_GROUP,
+                tagMap,
+                operation,
+                avgLatencyDescription,
+                maxLatencyDescription
+            );
+        }
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.processLatencySensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetPunctuateSensor() {
+        final String operation = "punctuate";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG))
+            .andReturn(expectedSensor);
+        if (builtInMetricsVersion == Version.LATEST) {
+            final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
+            final String totalDescription = "The total number of punctuate calls";
+            final String rateDescription = "The average per-second number of punctuate calls";
+            final String avgLatencyDescription = "The average punctuate latency";
+            final String maxLatencyDescription = "The maximum punctuate latency";
+            expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+            StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+                expectedSensor,
+                TASK_LEVEL_GROUP,
+                tagMap,
+                operation,
+                rateDescription,
+                totalDescription
+            );
+            StreamsMetricsImpl.addAvgAndMaxToSensor(
+                expectedSensor,
+                TASK_LEVEL_GROUP,
+                tagMap,
+                operationLatency,
+                avgLatencyDescription,
+                maxLatencyDescription
+            );
+        }
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.punctuateSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetCommitSensor() {
+        final String operation = "commit";
+        final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
+        final String totalDescription = "The total number of commit calls";
+        final String rateDescription = "The average per-second number of commit calls";
+        final String avgLatencyDescription = "The average commit latency";
+        final String maxLatencyDescription = "The maximum commit latency";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
+        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operation,
+            rateDescription,
+            totalDescription
+        );
+        StreamsMetricsImpl.addAvgAndMaxToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operationLatency,
+            avgLatencyDescription,
+            maxLatencyDescription
+        );
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.commitSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetEnforcedProcessingSensor() {
+        final String operation = "enforced-processing";
+        final String totalDescription = "The total number of occurrences of enforced-processing operations";
+        final String rateDescription = "The average number of occurrences of enforced-processing operations per second";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
+        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operation,
+            rateDescription,
+            totalDescription
+        );
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.enforcedProcessingSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetRecordLatenessSensor() {
+        final String operation = "record-lateness";
+        final String avgDescription = "The observed average lateness of records";
+        final String maxDescription = "The observed maximum lateness of records";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
+        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+        StreamsMetricsImpl.addAvgAndMaxToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operation,
+            avgDescription,
+            maxDescription
+        );
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.recordLatenessSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetDroppedRecordsSensor() {
+        final String operation = "dropped-records";
+        final String totalDescription = "The total number of dropped records";
+        final String rateDescription = "The average per-second number of dropped records";
+        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
+        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
+        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operation,
+            rateDescription,
+            totalDescription
+        );
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = TaskMetrics.droppedRecordsSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
+
+    @Test
+    public void shouldGetDroppedOrSkippedRecordsSensor() {
+        mockStatic(ThreadMetrics.class);
+        if (builtInMetricsVersion == Version.FROM_100_TO_24) {
+            expect(ThreadMetrics.skipRecordSensor(THREAD_ID, streamsMetrics)).andReturn(expectedSensor);
+            replay(ThreadMetrics.class, StreamsMetricsImpl.class, streamsMetrics);
+
+            final Sensor sensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(THREAD_ID, TASK_ID, streamsMetrics);
+
+            verify(ThreadMetrics.class);
+            assertThat(sensor, is(expectedSensor));
+        } else {
+            shouldGetDroppedRecordsSensor();
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -110,7 +109,7 @@ public class ProcessorNodeTest {
                 null,
                 new LogContext("processnode-test "),
                 new DefaultProductionExceptionHandler(),
-                Optional.of(metrics.sensor("skipped-records"))
+                metrics.sensor("dropped-records")
             ),
             metrics
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -48,7 +48,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Future;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -86,7 +85,7 @@ public class RecordCollectorTest {
             "RecordCollectorTest-TestSpecificPartition",
             new LogContext("RecordCollectorTest-TestSpecificPartition "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer));
 
@@ -124,7 +123,7 @@ public class RecordCollectorTest {
             "RecordCollectorTest-TestStreamPartitioner",
             new LogContext("RecordCollectorTest-TestStreamPartitioner "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer));
 
@@ -158,7 +157,7 @@ public class RecordCollectorTest {
             "RecordCollectorTest-TestSpecificPartition",
             new LogContext("RecordCollectorTest-TestSpecificPartition "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer));
 
@@ -181,7 +180,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -200,7 +199,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -225,7 +224,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new AlwaysContinueProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -244,7 +243,7 @@ public class RecordCollectorTest {
     @Test
     public void shouldRecordSkippedMetricAndLogWarningIfSendFailsWithContinueExceptionHandler() {
         final Metrics metrics = new Metrics();
-        final Sensor sensor = metrics.sensor("skipped-records");
+        final Sensor sensor = metrics.sensor("dropped-records");
         final LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister();
         final MetricName metricName = new MetricName("name", "group", "description", Collections.emptyMap());
         sensor.add(metricName, new WindowedSum());
@@ -252,7 +251,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new AlwaysContinueProductionExceptionHandler(),
-            Optional.of(sensor)
+            metrics.sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -274,7 +273,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -299,7 +298,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new AlwaysContinueProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -321,7 +320,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -346,7 +345,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new AlwaysContinueProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -368,7 +367,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -387,7 +386,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new AlwaysContinueProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
             @Override
@@ -409,7 +408,7 @@ public class RecordCollectorTest {
             "test",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         final MockProducer<byte[], byte[]> mockProducer = new MockProducer<>(cluster, true, new DefaultPartitioner(),
                 byteArraySerializer, byteArraySerializer);
@@ -432,7 +431,7 @@ public class RecordCollectorTest {
             "NoNPE",
             logContext,
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
 
         collector.close();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -57,7 +56,7 @@ public class RecordDeserializerTest {
             ),
             null,
             new LogContext(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(null, rawRecord);
         assertEquals(rawRecord.topic(), record.topic());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -46,7 +46,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +56,7 @@ public class RecordQueueTest {
     private final TimestampExtractor timestampExtractor = new MockTimestampExtractor();
     private final String[] topics = {"topic"};
 
-    private final Optional<Sensor> skippedRecordsSensor = Optional.of(new Metrics().sensor("skipped-records"));
+    private final Sensor droppedRecordsSensor = new Metrics().sensor("skipped-records");
 
     final InternalMockProcessorContext context = new InternalMockProcessorContext(
         StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class),
@@ -65,7 +64,7 @@ public class RecordQueueTest {
             null,
             new LogContext("record-queue-test "),
             new DefaultProductionExceptionHandler(),
-            skippedRecordsSensor
+            droppedRecordsSensor
         )
     );
     private final MockSourceNode mockSourceNodeWithMetrics = new MockSourceNode<>(topics, intDeserializer, intDeserializer);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -29,8 +29,6 @@ import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +41,7 @@ public class SinkNodeTest {
         null,
         new LogContext("sinknode-test "),
         new DefaultProductionExceptionHandler(),
-        Optional.of(new Metrics().sensor("skipped-records"))
+        new Metrics().sensor("dropped-records")
     );
 
     private final InternalMockProcessorContext context = new InternalMockProcessorContext(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -75,7 +75,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -404,7 +403,6 @@ public class StreamTaskTest {
         assertEquals(3, source2.numReceived);
     }
 
-
     @Test
     public void testMetricsWithBuiltInMetricsVersion0100To24() {
         testMetrics(StreamsConfig.METRICS_0100_TO_24);
@@ -419,62 +417,60 @@ public class StreamTaskTest {
         task = createStatelessTask(createConfig(false), builtInMetricsVersion);
 
         assertNotNull(getMetric(
+            "commit",
             "%s-latency-avg",
-            "The average latency of %s operation.",
             task.id().toString(),
             builtInMetricsVersion
         ));
         assertNotNull(getMetric(
+            "commit",
             "%s-latency-max",
-            "The max latency of %s operation.",
             task.id().toString(),
             builtInMetricsVersion
         ));
         assertNotNull(getMetric(
+            "commit",
             "%s-rate",
-            "The average number of occurrence of %s operation per second.",
+            task.id().toString(),
+            builtInMetricsVersion
+        ));
+        assertNotNull(getMetric(
+            "commit",
+            "%s-total",
+            task.id().toString(),
+            builtInMetricsVersion
+        ));
+
+        assertNotNull(getMetric(
+            "enforced-processing",
+            "%s-rate",
+            task.id().toString(),
+            builtInMetricsVersion
+        ));
+        assertNotNull(getMetric(
+            "enforced-processing",
+            "%s-total",
+            task.id().toString(),
+            builtInMetricsVersion
+        ));
+
+        assertNotNull(getMetric(
+            "record-lateness",
+            "%s-avg",
+            task.id().toString(),
+            builtInMetricsVersion
+        ));
+        assertNotNull(getMetric(
+            "record-lateness",
+            "%s-max",
             task.id().toString(),
             builtInMetricsVersion
         ));
 
         if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertNotNull(getMetric(
-                "%s-latency-avg",
-                "The average latency of %s operation.",
-                "all",
-                builtInMetricsVersion
-            ));
-            assertNotNull(getMetric(
-                "%s-latency-max",
-                "The max latency of %s operation.",
-                "all",
-                builtInMetricsVersion
-            ));
-            assertNotNull(getMetric(
-                "%s-rate",
-                "The average number of occurrence of %s operation per second.",
-                "all",
-                builtInMetricsVersion
-            ));
+            testMetricsForBuiltInMetricsVersion0100To24();
         } else {
-            assertNull(getMetric(
-                "%s-latency-avg",
-                "The average latency of %s operation.",
-                "all",
-                builtInMetricsVersion
-            ));
-            assertNull(getMetric(
-                "%s-latency-max",
-                "The max latency of %s operation.",
-                "all",
-                builtInMetricsVersion
-            ));
-            assertNull(getMetric(
-                "%s-rate",
-                "The average number of occurrence of %s operation per second.",
-                "all",
-                builtInMetricsVersion
-            ));
+            testMetricsForBuiltInMetricsVersionLatest();
         }
 
         final String threadId = Thread.currentThread().getName();
@@ -497,14 +493,46 @@ public class StreamTaskTest {
         }
     }
 
-    private KafkaMetric getMetric(final String nameFormat,
-                                  final String descriptionFormat,
+    private void testMetricsForBuiltInMetricsVersionLatest() {
+        final String builtInMetricsVersion = StreamsConfig.METRICS_LATEST;
+        assertNull(getMetric("commit", "%s-latency-avg", "all", builtInMetricsVersion));
+        assertNull(getMetric("commit", "%s-latency-max", "all", builtInMetricsVersion));
+        assertNull(getMetric("commit", "%s-rate", "all", builtInMetricsVersion));
+        assertNull(getMetric("commit", "%s-total", "all", builtInMetricsVersion));
+
+        assertNotNull(getMetric("process", "%s-latency-avg", task.id().toString(), builtInMetricsVersion));
+        assertNotNull(getMetric("process", "%s-latency-max", task.id().toString(), builtInMetricsVersion));
+
+        assertNotNull(getMetric("punctuate", "%s-latency-avg", task.id().toString(), builtInMetricsVersion));
+        assertNotNull(getMetric("punctuate", "%s-latency-max", task.id().toString(), builtInMetricsVersion));
+        assertNotNull(getMetric("punctuate", "%s-rate", task.id().toString(), builtInMetricsVersion));
+        assertNotNull(getMetric("punctuate", "%s-total", task.id().toString(), builtInMetricsVersion));
+    }
+
+    private void testMetricsForBuiltInMetricsVersion0100To24() {
+        final String builtInMetricsVersion = StreamsConfig.METRICS_0100_TO_24;
+        assertNotNull(getMetric("commit", "%s-latency-avg", "all", builtInMetricsVersion));
+        assertNotNull(getMetric("commit", "%s-latency-max", "all", builtInMetricsVersion));
+        assertNotNull(getMetric("commit", "%s-rate", "all", builtInMetricsVersion));
+
+        assertNull(getMetric("process", "%s-latency-avg", task.id().toString(), builtInMetricsVersion));
+        assertNull(getMetric("process", "%s-latency-max", task.id().toString(), builtInMetricsVersion));
+
+        assertNull(getMetric("punctuate", "%s-latency-avg", task.id().toString(), builtInMetricsVersion));
+        assertNull(getMetric("punctuate", "%s-latency-max", task.id().toString(), builtInMetricsVersion));
+        assertNull(getMetric("punctuate", "%s-rate", task.id().toString(), builtInMetricsVersion));
+        assertNull(getMetric("punctuate", "%s-total", task.id().toString(), builtInMetricsVersion));
+    }
+
+    private KafkaMetric getMetric(final String operation,
+                                  final String nameFormat,
                                   final String taskId,
                                   final String builtInMetricsVersion) {
+        final String descriptionIsNotVerified = "";
         return metrics.metrics().get(metrics.metricName(
-            String.format(nameFormat, "commit"),
+            String.format(nameFormat, operation),
             "stream-task-metrics",
-            String.format(descriptionFormat, "commit"),
+            descriptionIsNotVerified,
             mkMap(
                 mkEntry("task-id", taskId),
                 mkEntry(
@@ -1644,7 +1672,7 @@ public class StreamTaskTest {
             "StreamTask",
             new LogContext("StreamTaskTest "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         );
         recordCollector.init(producer);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1852,6 +1852,7 @@ public class StreamThreadTest {
         adminClient.setMockMetrics(testMetricName, testMetric);
         final Map<MetricName, Metric> adminClientMetrics = thread.adminClientMetrics();
         assertEquals(testMetricName, adminClientMetrics.get(testMetricName).metricName());
+
     }
 
     private void addRecord(final MockConsumer<byte[], byte[]> mockConsumer,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -639,7 +639,7 @@ public class StreamsMetricsImplTest {
         expect(time.nanoseconds()).andReturn(endTime);
         replay(sensor, time);
 
-        StreamsMetricsImpl.maybeMeasureLatency(() -> null, time, sensor);
+        StreamsMetricsImpl.maybeMeasureLatency(() -> { }, time, sensor);
 
         verify(sensor, time);
     }
@@ -651,7 +651,7 @@ public class StreamsMetricsImplTest {
         final Time time = mock(Time.class);
         replay(sensor);
 
-        StreamsMetricsImpl.maybeMeasureLatency(() -> null, time, sensor);
+        StreamsMetricsImpl.maybeMeasureLatency(() -> { }, time, sensor);
 
         verify(sensor);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -24,13 +24,16 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ImmutableMetricValue;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockSupport;
 import org.easymock.IArgumentMatcher;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -40,16 +43,17 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CLIENT_LEVEL_GROUP;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_METRICS_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxLatencyToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.resetToDefault;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.verify;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.resetToDefault;
 import static org.hamcrest.CoreMatchers.equalToObject;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -57,8 +61,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.replay;
 
-public class StreamsMetricsImplTest extends EasyMockSupport {
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
+public class StreamsMetricsImplTest {
 
     private final static String SENSOR_PREFIX_DELIMITER = ".";
     private final static String SENSOR_NAME_DELIMITER = ".s.";
@@ -202,7 +210,7 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
         final Gauge<String> valueProvider = (config, now) -> "mutable-value";
         expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
             .andReturn(metricName1);
-        metrics.addMetric(eq(metricName1), eqMetricConfig(metricConfig), eq(valueProvider));
+        metrics.addMetric(EasyMock.eq(metricName1), eqMetricConfig(metricConfig), eq(valueProvider));
         replay(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION);
 
@@ -228,7 +236,6 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
                                         final String level,
                                         final RecordingLevel recordingLevel) {
         final String fullSensorNamePrefix = INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER;
-        final Sensor[] parents = {};
         resetToDefault(metrics);
         metrics.removeSensor(fullSensorNamePrefix + sensorName1);
         metrics.removeSensor(fullSensorNamePrefix + sensorName2);
@@ -310,14 +317,14 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
         final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
 
         final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
-        addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
-        addInvocationRateAndCountToSensor(parent1, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation, "", "");
+        addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
+        addInvocationRateAndCountToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         final int numberOfTaskMetrics = registry.metrics().size();
 
         final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent1);
-        addAvgAndMaxLatencyToSensor(sensor1, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
-        addInvocationRateAndCountToSensor(sensor1, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation, "", "");
+        addAvgAndMaxLatencyToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
+        addInvocationRateAndCountToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
@@ -326,14 +333,14 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
         final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
-        addAvgAndMaxLatencyToSensor(parent2, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation);
-        addInvocationRateAndCountToSensor(parent2, PROCESSOR_NODE_METRICS_GROUP, taskTags, operation, "", "");
+        addAvgAndMaxLatencyToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
+        addInvocationRateAndCountToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
         final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent2);
-        addAvgAndMaxLatencyToSensor(sensor2, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation);
-        addInvocationRateAndCountToSensor(sensor2, PROCESSOR_NODE_METRICS_GROUP, nodeTags, operation, "", "");
+        addAvgAndMaxLatencyToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
+        addInvocationRateAndCountToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
@@ -618,5 +625,34 @@ public class StreamsMetricsImplTest extends EasyMockSupport {
             metric.measurable().measure(new MetricConfig(), time.milliseconds()),
             equalTo(expectedMetricValue)
         );
+    }
+
+    @Test
+    public void shouldMeasureLatency() {
+        final long startTime = 6;
+        final long endTime = 10;
+        final Sensor sensor = createMock(Sensor.class);
+        expect(sensor.shouldRecord()).andReturn(true);
+        sensor.record(endTime - startTime);
+        final Time time = mock(Time.class);
+        expect(time.nanoseconds()).andReturn(startTime);
+        expect(time.nanoseconds()).andReturn(endTime);
+        replay(sensor, time);
+
+        StreamsMetricsImpl.maybeMeasureLatency(() -> null, time, sensor);
+
+        verify(sensor, time);
+    }
+
+    @Test
+    public void shouldNotMeasureLatency() {
+        final Sensor sensor = createMock(Sensor.class);
+        expect(sensor.shouldRecord()).andReturn(false);
+        final Time time = mock(Time.class);
+        replay(sensor);
+
+        StreamsMetricsImpl.maybeMeasureLatency(() -> null, time, sensor);
+
+        verify(sensor);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -33,14 +33,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
 import static org.powermock.api.easymock.PowerMock.createMock;
 import static org.powermock.api.easymock.PowerMock.mockStatic;
 import static org.powermock.api.easymock.PowerMock.replay;
@@ -262,37 +260,35 @@ public class ThreadMetricsTest {
 
     @Test
     public void shouldGetSkipRecordSensor() {
+        final String operation = "skipped-records";
+        final String totalDescription = "The total number of skipped records";
+        final String rateDescription = "The average per-second number of skipped records";
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO))
+            .andReturn(expectedSensor);
         if (builtInMetricsVersion == Version.FROM_100_TO_24) {
-            final String operation = "skipped-records";
-            final String totalDescription = "The total number of skipped records";
-            final String rateDescription = "The average per-second number of skipped records";
-            expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
             expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
             StreamsMetricsImpl.addInvocationRateAndCountToSensor(
                 expectedSensor,
                 threadLevelGroup,
                 tagMap,
                 operation,
-                rateDescription, totalDescription
+                rateDescription,
+                totalDescription
             );
         }
         replay(StreamsMetricsImpl.class, streamsMetrics);
 
-        final Optional<Sensor> sensor = ThreadMetrics.skipRecordSensor(THREAD_ID, streamsMetrics);
+        final Sensor sensor = ThreadMetrics.skipRecordSensor(THREAD_ID, streamsMetrics);
 
         verify(StreamsMetricsImpl.class, streamsMetrics);
-
-        if (builtInMetricsVersion == Version.FROM_100_TO_24) {
-            assertThat(sensor.orElse(null), is(expectedSensor));
-        } else {
-            assertFalse(sensor.isPresent());
-        }
+        assertThat(sensor, is(expectedSensor));
     }
 
     @Test
     public void shouldGetCommitOverTasksSensor() {
+        final String operation = "commit";
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         if (builtInMetricsVersion == Version.FROM_100_TO_24) {
-            final String operation = "commit";
             final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
             final String totalDescription =
                 "The total number of calls to commit over all tasks assigned to one stream thread";
@@ -302,14 +298,14 @@ public class ThreadMetricsTest {
                 "The average commit latency over all tasks assigned to one stream thread";
             final String maxLatencyDescription =
                 "The maximum commit latency over all tasks assigned to one stream thread";
-            expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG))
-                .andReturn(expectedSensor);
             expect(streamsMetrics.taskLevelTagMap(THREAD_ID, ROLLUP_VALUE)).andReturn(tagMap);
             StreamsMetricsImpl.addInvocationRateAndCountToSensor(
-                expectedSensor, TASK_LEVEL_GROUP,
+                expectedSensor,
+                TASK_LEVEL_GROUP,
                 tagMap,
                 operation,
-                rateDescription, totalDescription
+                rateDescription,
+                totalDescription
             );
             StreamsMetricsImpl.addAvgAndMaxToSensor(
                 expectedSensor,
@@ -322,13 +318,9 @@ public class ThreadMetricsTest {
         }
         replay(StreamsMetricsImpl.class, streamsMetrics);
 
-        final Optional<Sensor> sensor = ThreadMetrics.commitOverTasksSensor(THREAD_ID, streamsMetrics);
+        final Sensor sensor = ThreadMetrics.commitOverTasksSensor(THREAD_ID, streamsMetrics);
 
         verify(StreamsMetricsImpl.class, streamsMetrics);
-        if (builtInMetricsVersion == Version.FROM_100_TO_24) {
-            assertThat(sensor.orElse(null), is(expectedSensor));
-        } else {
-            assertFalse(sensor.isPresent());
-        }
+        assertThat(sensor, is(expectedSensor));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -48,7 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -194,7 +193,7 @@ public class KeyValueStoreTestDriver<K, V> {
             "KeyValueStoreTestDriver",
             new LogContext("KeyValueStoreTestDriver "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         ) {
             @Override
             public <K1, V1> void send(final String topic,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -90,7 +89,7 @@ public abstract class SessionBytesStoreTest {
         return new RecordCollectorImpl(name,
             new LogContext(name),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         ) {
             @Override
             public <K1, V1> void send(final String topic,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -50,7 +49,7 @@ public class StoreChangeLoggerTest {
             "StoreChangeLoggerTest",
             new LogContext("StoreChangeLoggerTest "),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         ) {
             @Override
             public <K1, V1> void send(final String topic,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
@@ -37,7 +37,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -102,7 +101,7 @@ public abstract class WindowBytesStoreTest {
         return new RecordCollectorImpl(name,
             new LogContext(name),
             new DefaultProductionExceptionHandler(),
-            Optional.of(new Metrics().sensor("skipped-records"))
+            new Metrics().sensor("dropped-records")
         ) {
             @Override
             public <K1, V1> void send(final String topic,

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -43,6 +43,7 @@ import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.internals.KeyValueStoreFacade;
 import org.apache.kafka.streams.internals.QuietStreamsConfig;
 import org.apache.kafka.streams.internals.WindowStoreFacade;
+import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -62,7 +63,6 @@ import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StoreChangelogReader;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
@@ -307,7 +307,7 @@ public class TopologyTestDriver implements Closeable {
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
         );
         streamsMetrics.setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
-        ThreadMetrics.skipRecordSensor(threadId, streamsMetrics);
+        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, TASK_ID.toString(), streamsMetrics);
         final ThreadCache cache = new ThreadCache(
             new LogContext("topology-test-driver "),
             Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -30,9 +30,9 @@ import org.apache.kafka.streams.internals.ApiUtils;
 import org.apache.kafka.streams.internals.QuietStreamsConfig;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
 
 import java.io.File;
@@ -228,7 +228,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
             threadId,
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
         );
-        ThreadMetrics.skipRecordSensor(threadId, metrics);
+        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId.toString(), metrics);
     }
 
     @Override


### PR DESCRIPTION
- Introduces TaskMetrics class
- Introduces dropped-records
- Replaces skipped-records with dropped-records with latest built-in
  metrics version
- Does not add standby-process-ratio and active-process-ratio
- Does not refactor parent sensors for processor node metrics

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
