### PR TITLE
MINOR: Make it possible to produce messages with a null body in kafka console producer

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -35,7 +35,8 @@ class ConsoleProducerTest {
     "--property",
     "parse.key=true",
     "--property",
-    "key.separator=#"
+    "key.separator=#",
+    "null.value=NULL"
   )
 
   val invalidArgs: Array[String] = Array(


### PR DESCRIPTION
Currently it is not possible to produce messages with a null body using the kafka-console-producer

Having this capability would be useful when dealing with compacted kafka topics

This patch adds a `null.value` argument that lets you specify a value that will be interpreted as NULL