### PR TITLE
 Add bounded flush API to Producer.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1059,11 +1059,23 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      */
     @Override
     public void flush() {
-        log.trace("Flushing accumulated records in producer.");
-        this.accumulator.beginFlush();
-        this.sender.wakeup();
+        flush(Duration.ofMillis(Integer.MAX_VALUE));
+    }
+
+    /**
+     * This method waits up to <code>timeout</code> for the producer to send out all the buffered records.
+     *
+     * @param timeout The maximum time to wait for producer to complete.
+     * @throws TimeoutException If producer fail to finish in time
+     * @throws InterruptException If the thread is interrupted while blocked
+     */
+    @Override
+    public void flush(Duration timeout) {
+        long timeoutMs = timeout.toMillis();
         try {
-            this.accumulator.awaitFlushCompletion();
+            this.accumulator.beginFlush();
+            this.sender.wakeup();
+            this.accumulator.awaitFlushCompletion(timeoutMs);
         } catch (InterruptedException e) {
             throw new InterruptException("Flush interrupted.", e);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1071,6 +1071,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      */
     @Override
     public void flush(Duration timeout) {
+        log.trace("Flushing accumulated records in producer.");
         long timeoutMs = timeout.toMillis();
         try {
             this.accumulator.beginFlush();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -229,7 +229,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     /**
      * Adds the record to the list of sent records. The {@link RecordMetadata} returned will be immediately satisfied.
-     * 
+     *
      * @see #history()
      */
     @Override
@@ -289,10 +289,14 @@ public class MockProducer<K, V> implements Producer<K, V> {
         }
     }
 
-    public synchronized void flush() {
+    public synchronized void flush(Duration timeout) {
         verifyProducerState();
         while (!this.completions.isEmpty())
             completeNext();
+    }
+
+    public synchronized void flush() {
+        flush(Duration.ofMillis(Long.MAX_VALUE));
     }
 
     public List<PartitionInfo> partitionsFor(String topic) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -79,6 +79,11 @@ public interface Producer<K, V> extends Closeable {
     void flush();
 
     /**
+     * See {@link KafkaProducer#flush(Duration)}
+     */
+    void flush(Duration timeout);
+
+     /**
      * See {@link KafkaProducer#partitionsFor(String)}
      */
     List<PartitionInfo> partitionsFor(String topic);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -728,7 +728,7 @@ public final class RecordAccumulator {
                     throw new TimeoutException(String.format("Failed to flush accumulated records within %d milliseconds,"
                         + " successfully completed %d batches.", timeoutMs, numBatchesFlushed));
                 }
-                numBatchesFlushed ++;
+                numBatchesFlushed++;
             }
         } finally {
             this.flushesInProgress.decrementAndGet();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
@@ -38,6 +39,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.metrics.Measurable;
@@ -709,12 +711,21 @@ public final class RecordAccumulator {
     }
 
     /**
-     * Mark all partitions as ready to send and block until the send is complete
+     * Mark all partitions as ready to send and block until the send is complete or time expires
      */
-    public void awaitFlushCompletion() throws InterruptedException {
+    public void awaitFlushCompletion(long timeoutMs) throws InterruptedException {
         try {
-            for (ProducerBatch batch : this.incomplete.copyAll())
-                batch.produceFuture.await();
+            Long expireMs = System.currentTimeMillis() + timeoutMs;
+            for (ProducerBatch batch : this.incomplete.copyAll()) {
+                Long currentMs = System.currentTimeMillis();
+                if (currentMs > expireMs) {
+                    throw new TimeoutException("Failed to flush accumulated records within" + timeoutMs + "milliseconds.");
+                }
+                boolean completed = batch.produceFuture.await(Math.max(expireMs - currentMs, 0), TimeUnit.MILLISECONDS);
+                if (!completed) {
+                    throw new TimeoutException("Failed to flush accumulated records within" + timeoutMs + "milliseconds.");
+                }
+            }
         } finally {
             this.flushesInProgress.decrementAndGet();
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -398,7 +399,7 @@ public class RecordAccumulatorTest {
                 accum.deallocate(batch);
 
         // should be complete with no unsent records.
-        accum.awaitFlushCompletion();
+        accum.awaitFlushCompletion(Integer.MAX_VALUE);
         assertFalse(accum.hasUndrained());
         assertFalse(accum.hasIncomplete());
     }
@@ -424,10 +425,26 @@ public class RecordAccumulatorTest {
         assertTrue(accum.flushInProgress());
         delayedInterrupt(Thread.currentThread(), 1000L);
         try {
-            accum.awaitFlushCompletion();
+            accum.awaitFlushCompletion(Integer.MAX_VALUE);
             fail("awaitFlushCompletion should throw InterruptException");
         } catch (InterruptedException e) {
             assertFalse("flushInProgress count should be decremented even if thread is interrupted", accum.flushInProgress());
+        }
+    }
+
+    @Test
+    public void testAwaitFlushTimeout() throws Exception {
+        RecordAccumulator accum = createTestRecordAccumulator(
+             4 * 1024 + DefaultRecordBatch.RECORD_BATCH_OVERHEAD, 64 * 1024, CompressionType.NONE, Integer.MAX_VALUE);
+        accum.append(new TopicPartition(topic, 0), 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
+
+        accum.beginFlush();
+        assertTrue(accum.flushInProgress());
+        try {
+            accum.awaitFlushCompletion(100);
+            fail("testAwaitFlushTimeout should throw TimeoutException");
+        } catch (TimeoutException e) {
+            assertFalse("flushInProgress count should be decremented even if flush timeout expires", accum.flushInProgress());
         }
     }
 


### PR DESCRIPTION
*More detailed description of your change,
This is the patch for [KIP-514](https://cwiki.apache.org/confluence/display/KAFKA/KIP-514%3A+Add+a+bounded+flush%28%29+API+to+Kafka+Producer)

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Add a unit test to verify RecordAccumulator will throw TimeoutException if flush can not be finished in time.
Add an integration test to verify KafkaProducer will throw TimeoutException if flush can not be finished in time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
