### PR TITLE
MINOR: Use replicas instead of brokers in the reassignment API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3277,7 +3277,7 @@ public class KafkaAdminClient extends AdminClient {
 
                         ReassignablePartition reassignablePartition = new ReassignablePartition()
                                 .setPartitionIndex(partitionIndex)
-                                .setReplicas(reassignment.map(NewPartitionReassignment::targetBrokers).orElse(null));
+                                .setReplicas(reassignment.map(NewPartitionReassignment::targetReplicas).orElse(null));
                         reassignablePartitions.add(reassignablePartition);
                     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -30,8 +30,8 @@ import java.util.Optional;
 public class NewPartitionReassignment {
     private final List<Integer> targetReplicas;
 
-    public static Optional<NewPartitionReassignment> of(Integer... replicas) {
-        return Optional.of(new NewPartitionReassignment(Arrays.asList(replicas)));
+    public static NewPartitionReassignment of(Integer... replicas) {
+        return new NewPartitionReassignment(Arrays.asList(replicas));
     }
 
     public NewPartitionReassignment(List<Integer> targetReplicas) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -30,10 +30,6 @@ import java.util.Optional;
 public class NewPartitionReassignment {
     private final List<Integer> targetReplicas;
 
-    public static NewPartitionReassignment of(Integer... replicas) {
-        return new NewPartitionReassignment(Arrays.asList(replicas));
-    }
-
     public NewPartitionReassignment(List<Integer> targetReplicas) {
         this.targetReplicas = Collections.unmodifiableList(new ArrayList<>(targetReplicas));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -17,12 +17,10 @@
 
 package org.apache.kafka.clients.admin;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A new partition reassignment, which can be applied via {@link AdminClient#alterPartitionReassignments(Map, AlterPartitionReassignmentsOptions)}.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -28,17 +28,17 @@ import java.util.Optional;
  * A new partition reassignment, which can be applied via {@link AdminClient#alterPartitionReassignments(Map, AlterPartitionReassignmentsOptions)}.
  */
 public class NewPartitionReassignment {
-    private final List<Integer> targetBrokers;
+    private final List<Integer> targetReplicas;
 
-    public static Optional<NewPartitionReassignment> of(Integer... brokers) {
-        return Optional.of(new NewPartitionReassignment(Arrays.asList(brokers)));
+    public static Optional<NewPartitionReassignment> of(Integer... replicas) {
+        return Optional.of(new NewPartitionReassignment(Arrays.asList(replicas)));
     }
 
-    public NewPartitionReassignment(List<Integer> targetBrokers) {
-        this.targetBrokers = Collections.unmodifiableList(new ArrayList<>(targetBrokers));
+    public NewPartitionReassignment(List<Integer> targetReplicas) {
+        this.targetReplicas = Collections.unmodifiableList(new ArrayList<>(targetReplicas));
     }
 
-    public List<Integer> targetBrokers() {
-        return targetBrokers;
+    public List<Integer> targetReplicas() {
+        return targetReplicas;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2051,7 +2051,7 @@ public class KafkaAdminClientTest {
             TopicPartition tp2 = new TopicPartition("B", 0);
             Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments = new HashMap<>();
             reassignments.put(tp1, Optional.empty());
-            reassignments.put(tp2, NewPartitionReassignment.of(1, 2, 3));
+            reassignments.put(tp2, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
 
             // 1. server returns less responses than number of partitions we sent
             AlterPartitionReassignmentsResponseData responseData1 = new AlterPartitionReassignmentsResponseData();
@@ -2142,9 +2142,9 @@ public class KafkaAdminClientTest {
             TopicPartition invalidTopicTP = new TopicPartition("", 0);
             TopicPartition invalidPartitionTP = new TopicPartition("ABC", -1);
             Map<TopicPartition, Optional<NewPartitionReassignment>> invalidTopicReassignments = new HashMap<>();
-            invalidTopicReassignments.put(invalidPartitionTP, NewPartitionReassignment.of(1, 2, 3));
-            invalidTopicReassignments.put(invalidTopicTP, NewPartitionReassignment.of(1, 2, 3));
-            invalidTopicReassignments.put(tp1, NewPartitionReassignment.of(1, 2, 3));
+            invalidTopicReassignments.put(invalidPartitionTP, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
+            invalidTopicReassignments.put(invalidTopicTP, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
+            invalidTopicReassignments.put(tp1, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
 
             AlterPartitionReassignmentsResponseData singlePartResponseData =
                     new AlterPartitionReassignmentsResponseData()

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2051,7 +2051,7 @@ public class KafkaAdminClientTest {
             TopicPartition tp2 = new TopicPartition("B", 0);
             Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments = new HashMap<>();
             reassignments.put(tp1, Optional.empty());
-            reassignments.put(tp2, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
+            reassignments.put(tp2, newPartitionReassignment(Arrays.asList(1, 2, 3)));
 
             // 1. server returns less responses than number of partitions we sent
             AlterPartitionReassignmentsResponseData responseData1 = new AlterPartitionReassignmentsResponseData();
@@ -2142,9 +2142,9 @@ public class KafkaAdminClientTest {
             TopicPartition invalidTopicTP = new TopicPartition("", 0);
             TopicPartition invalidPartitionTP = new TopicPartition("ABC", -1);
             Map<TopicPartition, Optional<NewPartitionReassignment>> invalidTopicReassignments = new HashMap<>();
-            invalidTopicReassignments.put(invalidPartitionTP, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
-            invalidTopicReassignments.put(invalidTopicTP, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
-            invalidTopicReassignments.put(tp1, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
+            invalidTopicReassignments.put(invalidPartitionTP, newPartitionReassignment(Arrays.asList(1, 2, 3)));
+            invalidTopicReassignments.put(invalidTopicTP, newPartitionReassignment(Arrays.asList(1, 2, 3)));
+            invalidTopicReassignments.put(tp1, newPartitionReassignment(Arrays.asList(1, 2, 3)));
 
             AlterPartitionReassignmentsResponseData singlePartResponseData =
                     new AlterPartitionReassignmentsResponseData()
@@ -2770,5 +2770,9 @@ public class KafkaAdminClientTest {
                 }
             }
         }
+    }
+
+    private static Optional<NewPartitionReassignment> newPartitionReassignment(List<Integer> targetReplicas) {
+        return Optional.of(new NewPartitionReassignment(targetReplicas));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2051,7 +2051,7 @@ public class KafkaAdminClientTest {
             TopicPartition tp2 = new TopicPartition("B", 0);
             Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments = new HashMap<>();
             reassignments.put(tp1, Optional.empty());
-            reassignments.put(tp2, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
+            reassignments.put(tp2, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
 
             // 1. server returns less responses than number of partitions we sent
             AlterPartitionReassignmentsResponseData responseData1 = new AlterPartitionReassignmentsResponseData();
@@ -2142,9 +2142,9 @@ public class KafkaAdminClientTest {
             TopicPartition invalidTopicTP = new TopicPartition("", 0);
             TopicPartition invalidPartitionTP = new TopicPartition("ABC", -1);
             Map<TopicPartition, Optional<NewPartitionReassignment>> invalidTopicReassignments = new HashMap<>();
-            invalidTopicReassignments.put(invalidPartitionTP, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
-            invalidTopicReassignments.put(invalidTopicTP, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
-            invalidTopicReassignments.put(tp1, Optional.of(NewPartitionReassignment.of(1, 2, 3)));
+            invalidTopicReassignments.put(invalidPartitionTP, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
+            invalidTopicReassignments.put(invalidTopicTP, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
+            invalidTopicReassignments.put(tp1, Optional.of(new NewPartitionReassignment(Arrays.asList(1, 2, 3))));
 
             AlterPartitionReassignmentsResponseData singlePartResponseData =
                     new AlterPartitionReassignmentsResponseData()


### PR DESCRIPTION
Brokers assigned to a topic partition are called replicas. Fix reassignment API to be consistent with other APIs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
