### PR TITLE
KAFKA-9078: Fix Connect system test after adding MM2 connector classes

### DIFF
--- a/tests/kafkatest/tests/connect/connect_rest_test.py
+++ b/tests/kafkatest/tests/connect/connect_rest_test.py
@@ -91,7 +91,10 @@ class ConnectRestApiTest(KafkaTest):
 
         assert self.cc.list_connectors() == []
 
-        assert set([connector_plugin['class'] for connector_plugin in self.cc.list_connector_plugins()]) == {self.FILE_SOURCE_CONNECTOR, self.FILE_SINK_CONNECTOR}
+        # After MM2 and the connector classes that it added, the assertion here checks that the registered
+        # Connect plugins are a superset of the connectors expected to be present.
+        assert set([connector_plugin['class'] for connector_plugin in self.cc.list_connector_plugins()]).issuperset(
+            {self.FILE_SOURCE_CONNECTOR, self.FILE_SINK_CONNECTOR})
 
         source_connector_props = self.render("connect-file-source.properties")
         sink_connector_props = self.render("connect-file-sink.properties")


### PR DESCRIPTION
MM2 added a few connector classes in Connect's classpath and given that the assertion in the Connect REST system tests need to be adjusted to account for these additions. 

This fix makes sure that the loaded Connect plugins are a superset of the expected by the test connectors. 

Testing: The change is straightforward. The fix was tested with local system test runs. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
