### PR TITLE
MINOR: Add toString to PartitionReassignment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListPartitionReassignmentsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListPartitionReassignmentsResult.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class ListPartitionReassignmentsResult {
     private final KafkaFuture<Map<TopicPartition, PartitionReassignment>> future;
 
-    public ListPartitionReassignmentsResult(KafkaFuture<Map<TopicPartition, PartitionReassignment>> reassignments) {
+    ListPartitionReassignmentsResult(KafkaFuture<Map<TopicPartition, PartitionReassignment>> reassignments) {
         this.future = reassignments;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/PartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/PartitionReassignment.java
@@ -57,4 +57,13 @@ public class PartitionReassignment {
     public List<Integer> removingReplicas() {
         return removingReplicas;
     }
+
+    @Override
+    public String toString() {
+        return "PartitionReassignment(" +
+                "replicas=" + replicas +
+                ", addingReplicas=" + addingReplicas +
+                ", removingReplicas=" + removingReplicas +
+                ')';
+    }
 }


### PR DESCRIPTION
This patch adds a `toString()` implementation to `PartitionReassignment`. It also makes the `ListPartitionReassignmentsResult` constructor use default access, which is the standard for the admin client *Result classes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
