### PR TITLE
KAFKA-9038: Allow creating partitions while partition reassignment is in progress 

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -268,7 +268,7 @@ class AdminManager(val config: KafkaConfig,
         val existingAssignment = zkClient.getFullReplicaAssignmentForTopics(immutable.Set(topic)).map {
           case (topicPartition, assignment) =>
             if (assignment.isBeingReassigned) {
-              // We prevent adding partitions while topic reassignment is in progress, to protect from race condition
+              // We prevent adding partitions while topic reassignment is in progress, to protect from a race condition
               // between the controller thread processing reassignment update and createPartitions(this) request.
               throw new ReassignmentInProgressException(s"A partition reassignment is in progress for the topic '$topic'.")
             }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -259,20 +259,20 @@ class AdminManager(val config: KafkaConfig,
                        listenerName: ListenerName,
                        callback: Map[String, ApiError] => Unit): Unit = {
 
-    val reassignPartitionsInProgress = zkClient.reassignPartitionsInProgress
     val allBrokers = adminZkClient.getBrokerMetadatas()
     val allBrokerIds = allBrokers.map(_.id)
 
     // 1. map over topics creating assignment and calling AdminUtils
     val metadata = newPartitions.map { case (topic, newPartition) =>
       try {
-        // We prevent addition partitions while a reassignment is in progress, since
-        // during reassignment there is no meaningful notion of replication factor
-        if (reassignPartitionsInProgress)
-          throw new ReassignmentInProgressException("A partition reassignment is in progress.")
-
         val existingAssignment = zkClient.getFullReplicaAssignmentForTopics(immutable.Set(topic)).map {
-          case (topicPartition, assignment) => topicPartition.partition -> assignment
+          case (topicPartition, assignment) =>
+            if (assignment.isBeingReassigned) {
+              // We prevent adding partitions while topic reassignment is in progress, to protect from race condition
+              // between the controller thread processing reassignment update and createPartitions(this) request.
+              throw new ReassignmentInProgressException(s"A partition reassignment is in progress for the topic '$topic'.")
+            }
+            topicPartition.partition -> assignment
         }
         if (existingAssignment.isEmpty)
           throw new UnknownTopicOrPartitionException(s"The topic '$topic' does not exist.")

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -1147,9 +1147,13 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       try {
         adminClient.createPartitions(Map(topicName -> NewPartitions.increaseTo(4)).asJava).values.get(topicName).get()
       } catch {
-        case e: ExecutionException =>
+        case e: Exception =>
           doesThrowException = true
-          assertEquals(classOf[ReassignmentInProgressException], e.getCause().getClass  ())
+          if (shouldThrowException) {
+            assertEquals(classOf[ReassignmentInProgressException], e.getCause().getClass())
+          } else {
+            Assert.fail("createPartitions call did not expect an exception" + e.toString)
+          }
         case e: Exception =>
           Assert.fail("createPartitions call did not expect an exception" + e.toString)
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -1102,8 +1102,8 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   /**
-   * Validates that partitions can be created for topics not in reassignment and for the topics that are in reassignment
-   * an ReassignmentInProgressException should be thrown.cThe test creates two topics `topicName` and `otherTopicName`,
+   * Verifies that partitions can be created for topics not in reassignment and for the topics that are in reassignment
+   * an ReassignmentInProgressException should be thrown. The test creates two topics `topicName` and `otherTopicName`,
    * the `topicName` topic undergoes partition reassignment and the test validates that during reassignment createPartitions
    * call throws ReassignmentInProgressException `topicName` topic and for topic `otherTopicName` which is not being reassigned
    * successfully creates partitions. Further validates that after the reassignment is complete for topic `topicName`

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -12,16 +12,15 @@
   */
 package kafka.admin
 
-import java.util.{Collections, Properties}
-
 import kafka.admin.ReassignPartitionsCommand._
 import kafka.common.AdminCommandFailedException
+import kafka.controller.PartitionReplicaAssignment
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils._
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ReassignPartitionsZNode, ZkVersion, ZooKeeperTestHarness}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
-import org.junit.{After, Assert, Before, Test}
+import org.junit.{After, Before, Test}
 import kafka.admin.ReplicationQuotaUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewPartitionReassignment, NewPartitions, PartitionReassignment, AdminClient => JAdminClient}
 import org.apache.kafka.common.{TopicPartition, TopicPartitionReplica}
@@ -30,10 +29,9 @@ import scala.collection.JavaConverters._
 import scala.collection.{Map, Seq}
 import scala.util.Random
 import java.io.File
-import java.util
+import java.util.{Collections, Properties}
 import java.util.concurrent.ExecutionException
 
-import kafka.controller.PartitionReplicaAssignment
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.errors.{NoReassignmentInProgressException, ReassignmentInProgressException}
 
@@ -1152,10 +1150,10 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
           if (shouldThrowException) {
             assertEquals(classOf[ReassignmentInProgressException], e.getCause().getClass())
           } else {
-            Assert.fail("createPartitions call did not expect an exception" + e.toString)
+            org.junit.Assert.fail("createPartitions call did not expect an exception" + e.toString)
           }
         case e: Exception =>
-          Assert.fail("createPartitions call did not expect an exception" + e.toString)
+          org.junit.Assert.fail("createPartitions call did not expect an exception" + e.toString)
       }
       if (shouldThrowException) {
         assertTrue("createPartitions for topic under reassignment should throw an exception", doesThrowException)

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -1147,7 +1147,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       try {
         adminClient.createPartitions(Map(topicName -> NewPartitions.increaseTo(4)).asJava).values.get(topicName).get()
       } catch {
-        case e: Exception =>
+        case e: ExecutionException =>
           doesThrowException = true
           if (shouldThrowException) {
             assertEquals(classOf[ReassignmentInProgressException], e.getCause().getClass())


### PR DESCRIPTION
The PR check reassignment in progress at topic level and remove zk node assignment check, note that the check cannot be removed completely to prevent further exposure to race condition between in progress reassignments and the createPartitions update.