### PR TITLE
KAFKA-8986: Allow null as a valid default for tagged fields.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -12,9 +12,11 @@
     <suppress checks="CyclomaticComplexity|BooleanExpressionComplexity"
               files="(SchemaGenerator|MessageDataGenerator|FieldSpec).java"/>
     <suppress checks="NPathComplexity"
-              files="(FieldSpec).java"/>
+              files="(MessageDataGenerator|FieldSpec).java"/>
     <suppress checks="JavaNCSS"
               files="(ApiMessageType).java|MessageDataGenerator.java"/>
+    <suppress checks="MethodLength"
+              files="MessageDataGenerator.java"/>
 
     <!-- Clients -->
     <suppress checks="ClassFanOutComplexity"

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.message;
 
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
-import org.apache.kafka.common.protocol.MessageTestUtil;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteUtils;
@@ -25,10 +24,14 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
+import java.util.function.Consumer;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SimpleExampleMessageTest {
 
@@ -149,7 +152,7 @@ public class SimpleExampleMessageTest {
     }
 
     @Test
-    public void shouldImplementJVMMethods() {
+    public void shouldImplementEqualsAndHashCode() {
         final UUID uuid = UUID.randomUUID();
         final ByteBuffer buf = ByteBuffer.wrap(new byte[] {1, 2, 3});
         final SimpleExampleMessageData a = new SimpleExampleMessageData();
@@ -182,14 +185,105 @@ public class SimpleExampleMessageTest {
 
     @Test
     public void testMyTaggedIntArray() {
-        final SimpleExampleMessageData data = new SimpleExampleMessageData();
-        data.setMyTaggedIntArray(Arrays.asList(1, 2, 3));
+        // Verify that the tagged int array reads as empty when not set.
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertEquals(Collections.emptyList(), message.myTaggedIntArray()));
+
+        // Verify that we can set a tagged array of ints.
+        testRoundTrip(new SimpleExampleMessageData().
+                setMyTaggedIntArray(Arrays.asList(1, 2, 3)),
+            message -> assertEquals(Arrays.asList(1, 2, 3), message.myTaggedIntArray()));
+    }
+
+    @Test
+    public void testMyNullableString() {
+        // Verify that the tagged field reads as null when not set.
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertTrue(message.myNullableString() == null));
+
+        // Verify that we can set and retrieve a string for the tagged field.
+        testRoundTrip(new SimpleExampleMessageData().setMyNullableString("foobar"),
+            message -> assertEquals("foobar", message.myNullableString()));
+    }
+
+    @Test
+    public void testMyInt16() {
+        // Verify that the tagged field reads as 123 when not set.
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertEquals((short) 123, message.myInt16()));
+
+        testRoundTrip(new SimpleExampleMessageData().setMyInt16((short) 456),
+            message -> assertEquals((short) 456, message.myInt16()));
+    }
+
+    @Test
+    public void testMyString() {
+        // Verify that the tagged field reads as empty when not set.
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertEquals("", message.myString()));
+
+        testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
+            message -> assertEquals("abc", message.myString()));
+    }
+
+    @Test
+    public void testMyBytes() {
+        // Verify that the tagged field reads as empty when not set.
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertArrayEquals(new byte[0], message.myBytes()));
+
+        testRoundTrip(new SimpleExampleMessageData().
+                setMyBytes(new byte[] {0x43, 0x66}),
+            message -> assertArrayEquals(new byte[] {0x43, 0x66},
+                message.myBytes()));
+
+        testRoundTrip(new SimpleExampleMessageData().setMyBytes(null),
+            message -> assertTrue(message.myBytes() == null));
+    }
+
+    @Test
+    public void testTaggedUuid() {
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertEquals(
+                UUID.fromString("212d5494-4a8b-4fdf-94b3-88b470beb367"),
+                message.taggedUuid()));
+
+        testRoundTrip(new SimpleExampleMessageData().
+                setTaggedUuid(UUID.fromString("01234567-89ab-cdef-0123-456789abcdef")),
+            message -> assertEquals(
+                UUID.fromString("01234567-89ab-cdef-0123-456789abcdef"),
+                message.taggedUuid()));
+    }
+
+    @Test
+    public void testTaggedLong() {
+        testRoundTrip(new SimpleExampleMessageData(),
+            message -> assertEquals(0xcafcacafcacafcaL,
+                message.taggedLong()));
+
+        testRoundTrip(new SimpleExampleMessageData().
+                setMyString("blah").
+                setMyTaggedIntArray(Arrays.asList(4)).
+                setTaggedLong(0x123443211234432L),
+            message -> assertEquals(0x123443211234432L,
+                message.taggedLong()));
+    }
+
+    private void testRoundTrip(SimpleExampleMessageData message,
+                               Consumer<SimpleExampleMessageData> validator) {
+        validator.accept(message);
         short version = 1;
-        ByteBuffer buf = MessageTestUtil.messageToByteBuffer(data, version);
-        final SimpleExampleMessageData data2 = new SimpleExampleMessageData();
-        data2.read(new ByteBufferAccessor(buf.duplicate()), version);
-        assertEquals(Arrays.asList(1, 2, 3), data.myTaggedIntArray());
-        assertEquals(Arrays.asList(1, 2, 3), data2.myTaggedIntArray());
-        assertEquals(data, data2);
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        int size = message.size(cache, version);
+        ByteBuffer buf = ByteBuffer.allocate(size);
+        message.write(new ByteBufferAccessor(buf), cache, version);
+        buf.flip();
+        assertEquals(size, buf.remaining());
+
+        SimpleExampleMessageData message2 = new SimpleExampleMessageData();
+        message2.read(new ByteBufferAccessor(buf.duplicate()), version);
+        validator.accept(message2);
+        assertEquals(message, message2);
+        assertEquals(message.hashCode(), message2.hashCode());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/MessageTestUtil.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/MessageTestUtil.java
@@ -36,4 +36,15 @@ public final class MessageTestUtil {
     public static void messageFromByteBuffer(ByteBuffer bytes, Message message, short version) {
         message.read(new ByteBufferAccessor(bytes.duplicate()), version);
     }
+
+    public static String byteBufferToString(ByteBuffer buf) {
+        ByteBuffer buf2 = buf.duplicate();
+        StringBuilder bld = new StringBuilder();
+        String prefix = "";
+        while (buf2.hasRemaining()) {
+            bld.append(String.format("%s%02x", prefix, (int) buf2.get()));
+            prefix = " ";
+        }
+        return bld.toString();
+    }
 }

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -20,22 +20,20 @@
   "fields": [
     { "name": "processId", "versions": "1+", "type": "uuid" },
     { "name": "myTaggedIntArray", "type": "[]int32",
-        "versions": "1+", "taggedVersions": "1+", "tag": 0 },
-
-    {
-      "name": "zeroCopyByteBuffer",
-      "type": "bytes",
-      "zeroCopy": true,
-      "versions": "1",
-      "about": "Byte buffer field."
-    },
-    {
-      "name": "nullableZeroCopyByteBuffer",
-      "type": "bytes",
-      "zeroCopy": true,
-      "nullableVersions": "0+",
-      "versions": "1",
-      "about": "Nullable byte buffer field."
-    }
+        "taggedVersions": "1+", "tag": 0 },
+    { "name": "myNullableString", "type": "string", "default": "null",
+        "nullableVersions": "1+", "taggedVersions": "1+", "tag": 1 },
+    { "name": "myInt16", "type": "int16", "default": "123",
+        "taggedVersions": "1+", "tag": 2 },
+    { "name": "myString", "type": "string", "taggedVersions": "1+", "tag": 3 },
+    { "name": "myBytes", "type": "bytes",
+        "nullableVersions": "1+", "taggedVersions": "1+", "tag": 4 },
+    { "name": "taggedUuid", "type": "uuid", "default": "212d5494-4a8b-4fdf-94b3-88b470beb367",
+        "taggedVersions": "1+", "tag":  5},
+    { "name": "taggedLong", "type": "int64", "default": "0xcafcacafcacafca",
+        "taggedVersions": "1+", "tag":  6},
+    { "name": "zeroCopyByteBuffer", "versions": "1", "type": "bytes", "zeroCopy": true },
+    { "name": "nullableZeroCopyByteBuffer", "versions": "1", "nullableVersions": "0+",
+      "type": "bytes", "zeroCopy": true }
   ]
 }

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -77,7 +77,10 @@ public final class FieldSpec {
         if (!VALID_FIELD_NAMES.matcher(this.name).matches()) {
             throw new RuntimeException("Invalid field name " + this.name);
         }
-        this.versions = Versions.parse(versions, null);
+        this.taggedVersions = Versions.parse(taggedVersions, Versions.NONE);
+        // If versions is not set, but taggedVersions is, default to taggedVersions.
+        this.versions = Versions.parse(versions, this.taggedVersions.empty() ?
+            null : this.taggedVersions);
         if (this.versions == null) {
             throw new RuntimeException("You must specify the version of the " +
                 name + " structure.");
@@ -103,7 +106,6 @@ public final class FieldSpec {
                 throw new RuntimeException("Non-array field " + name + " cannot have fields");
             }
         }
-        this.taggedVersions = Versions.parse(taggedVersions, Versions.NONE);
         if (flexibleVersions == null || flexibleVersions.isEmpty()) {
             this.flexibleVersions = Optional.empty();
         } else {

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1160,7 +1160,7 @@ public final class MessageDataGenerator {
                 buffer.printf("if (%s != null) {%n", field.camelCaseName());
             } else if (nullableVersions.empty()) {
                 if (field.zeroCopy()) {
-                    buffer.printf("if (%s.remaining() > 0) {%n", field.camelCaseName());
+                    buffer.printf("if (%s.hasRemaining()) {%n", field.camelCaseName());
                 } else {
                     buffer.printf("if (%s.length != 0) {%n", field.camelCaseName());
                 }

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -221,7 +221,7 @@ public final class MessageDataGenerator {
         buffer.incrementIndent();
         generateKeyElement(className, struct);
         headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
-        buffer.printf("return find(key);%n");
+        buffer.printf("return find(_key);%n");
         buffer.decrementIndent();
         buffer.printf("}%n");
         buffer.printf("%n");
@@ -234,17 +234,17 @@ public final class MessageDataGenerator {
         buffer.incrementIndent();
         generateKeyElement(className, struct);
         headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
-        buffer.printf("return findAll(key);%n");
+        buffer.printf("return findAll(_key);%n");
         buffer.decrementIndent();
         buffer.printf("}%n");
         buffer.printf("%n");
     }
 
     private void generateKeyElement(String className, StructSpec struct) {
-        buffer.printf("%s key = new %s();%n", className, className);
+        buffer.printf("%s _key = new %s();%n", className, className);
         for (FieldSpec field : struct.fields()) {
             if (field.mapKey()) {
-                buffer.printf("key.set%s(%s);%n",
+                buffer.printf("_key.set%s(%s);%n",
                     field.capitalizedCamelCaseName(),
                     field.camelCaseName());
             }
@@ -896,7 +896,7 @@ public final class MessageDataGenerator {
                             }
                         }).
                         ifMember(__ -> {
-                            generateNonDefaultValueCheck(field);
+                            generateNonDefaultValueCheck(field, field.nullableVersions());
                             buffer.incrementIndent();
                             buffer.printf("_numTaggedFields++;%n");
                             buffer.decrementIndent();
@@ -910,7 +910,7 @@ public final class MessageDataGenerator {
                 });
             if (!field.ignorable()) {
                 cond.ifNotMember(__ -> {
-                    generateNonDefaultValueCheck(field);
+                    generateNonDefaultValueCheck(field, field.nullableVersions());
                     buffer.incrementIndent();
                     headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
                     buffer.printf("throw new UnsupportedVersionException(" +
@@ -940,47 +940,62 @@ public final class MessageDataGenerator {
                         forVersions(field.versions(), field.taggedVersions().intersect(field.versions())).
                         allowMembershipCheckAlwaysFalse(false).
                         ifMember(presentAndTaggedVersions -> {
-                            generateNonDefaultValueCheck(field);
-                            buffer.incrementIndent();
-                            buffer.printf("_writable.writeUnsignedVarint(%d);%n", field.tag().get());
-                            if (field.type().isString()) {
-                                IsNullConditional.forName(field.camelCaseName()).
-                                    nullableVersions(field.nullableVersions()).
-                                    possibleVersions(presentAndTaggedVersions).
-                                    ifNull(() -> {
-                                        buffer.printf("_writable.writeUnsignedVarint(0);%n");
-                                    }).
-                                    ifNotNull(() -> {
+                            IsNullConditional cond = IsNullConditional.forName(field.camelCaseName()).
+                                nullableVersions(field.nullableVersions()).
+                                possibleVersions(presentAndTaggedVersions).
+                                alwaysEmitBlockScope(true).
+                                ifNotNull(() -> {
+                                    if (!field.defaultString().equals("null")) {
+                                        generateNonDefaultValueCheck(field, Versions.NONE);
+                                        buffer.incrementIndent();
+                                    }
+                                    buffer.printf("_writable.writeUnsignedVarint(%d);%n", field.tag().get());
+                                    if (field.type().isString()) {
                                         buffer.printf("byte[] _stringBytes = _cache.getSerializedValue(this.%s);%n",
                                             field.camelCaseName());
-                                        buffer.printf("_writable.writeUnsignedVarint(_stringBytes.length);%n");
+                                        headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                        buffer.printf("_writable.writeUnsignedVarint(_stringBytes.length + " +
+                                            "ByteUtils.sizeOfUnsignedVarint(_stringBytes.length + 1));%n");
+                                        buffer.printf("_writable.writeUnsignedVarint(_stringBytes.length + 1);%n");
                                         buffer.printf("_writable.writeByteArray(_stringBytes);%n");
-                                    }).
-                                    generate(buffer);
-                            } else if (field.type().isVariableLength()) {
-                                if (field.type().isArray()) {
-                                    buffer.printf("_writable.writeUnsignedVarint(_cache.getArraySizeInBytes(this.%s) + 1);%n",
-                                        field.camelCaseName());
-                                } else if (field.type().isBytes()) {
-                                    buffer.printf("_writable.writeUnsignedVarint(this.%s.length + 1);%n",
-                                        field.camelCaseName());
-                                } else {
-                                    throw new RuntimeException("Unable to handle type " + field.type());
-                                }
-                                generateVariableLengthWriter(fieldFlexibleVersions(field),
-                                    field.camelCaseName(),
-                                    field.type(),
-                                    presentAndTaggedVersions,
-                                    field.nullableVersions(),
-                                    field.zeroCopy());
-                            } else {
-                                buffer.printf("_writable.writeUnsignedVarint(%d);%n",
-                                    field.type().fixedLength().get());
-                                buffer.printf("%s;%n",
-                                    primitiveWriteExpression(field.type(), field.camelCaseName()));
+                                    } else if (field.type().isBytes()) {
+                                        headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                        buffer.printf("_writable.writeUnsignedVarint(this.%s.length + " +
+                                                "ByteUtils.sizeOfUnsignedVarint(this.%s.length + 1));%n",
+                                            field.camelCaseName(), field.camelCaseName());
+                                        buffer.printf("_writable.writeUnsignedVarint(this.%s.length + 1);%n",
+                                            field.camelCaseName());
+                                        buffer.printf("_writable.writeByteArray(this.%s);%n",
+                                            field.camelCaseName());
+                                    } else if (field.type().isArray()) {
+                                        headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                        buffer.printf("_writable.writeUnsignedVarint(_cache.getArraySizeInBytes(this.%s));%n",
+                                            field.camelCaseName());
+                                        generateVariableLengthWriter(fieldFlexibleVersions(field),
+                                            field.camelCaseName(),
+                                            field.type(),
+                                            presentAndTaggedVersions,
+                                            Versions.NONE,
+                                            field.zeroCopy());
+                                    } else {
+                                        buffer.printf("_writable.writeUnsignedVarint(%d);%n",
+                                            field.type().fixedLength().get());
+                                        buffer.printf("%s;%n",
+                                            primitiveWriteExpression(field.type(), field.camelCaseName()));
+                                    }
+                                    if (!field.defaultString().equals("null")) {
+                                        buffer.decrementIndent();
+                                        buffer.printf("}%n");
+                                    }
+                                });
+                            if (!field.defaultString().equals("null")) {
+                                cond.ifNull(() -> {
+                                    buffer.printf("_writable.writeUnsignedVarint(%d);%n", field.tag().get());
+                                    buffer.printf("_writable.writeUnsignedVarint(1);%n");
+                                    buffer.printf("_writable.writeUnsignedVarint(0);%n");
+                                });
                             }
-                            buffer.decrementIndent();
-                            buffer.printf("}%n");
+                            cond.generate(buffer);
                         }).
                         generate(buffer);
                     prevTag = field.tag().get();
@@ -1128,28 +1143,45 @@ public final class MessageDataGenerator {
             generate(buffer);
     }
 
-    private void generateNonDefaultValueCheck(FieldSpec field) {
+    private void generateNonDefaultValueCheck(FieldSpec field, Versions nullableVersions) {
         if (field.type().isArray()) {
             if (fieldDefault(field).equals("null")) {
-                buffer.printf("if (%s != null) {%n", field.camelCaseName());
+                buffer.printf("if (%s != null) {%n",
+                    field.camelCaseName());
+            } else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s.isEmpty()) {%n",
+                    field.camelCaseName());
             } else {
-                buffer.printf("if (!%s.isEmpty()) {%n", field.camelCaseName());
+                buffer.printf("if (%s == null || !%s.isEmpty()) {%n",
+                    field.camelCaseName(), field.camelCaseName());
             }
         } else if (field.type().isBytes()) {
             if (fieldDefault(field).equals("null")) {
                 buffer.printf("if (%s != null) {%n", field.camelCaseName());
-            } else {
+            } else if (nullableVersions.empty()) {
                 if (field.zeroCopy()) {
-                    buffer.printf("if (%s.remaining() != 0) {%n", field.camelCaseName());
+                    buffer.printf("if (%s.remaining() > 0) {%n", field.camelCaseName());
                 } else {
                     buffer.printf("if (%s.length != 0) {%n", field.camelCaseName());
+                }
+            } else {
+                if (field.zeroCopy()) {
+                    buffer.printf("if (%s == null || %s.remaining() > 0) {%n",
+                        field.camelCaseName(), field.camelCaseName());
+                } else {
+                    buffer.printf("if (%s == null || %s.length != 0) {%n",
+                        field.camelCaseName(), field.camelCaseName());
                 }
             }
         } else if (field.type().isString()) {
             if (fieldDefault(field).equals("null")) {
                 buffer.printf("if (%s != null) {%n", field.camelCaseName());
+            } else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s.equals(%s)) {%n",
+                    field.camelCaseName(), fieldDefault(field));
             } else {
-                buffer.printf("if (!%s.equals(%s)) {%n", field.camelCaseName(), fieldDefault(field));
+                buffer.printf("if (%s == null || !%s.equals(%s)) {%n",
+                    field.camelCaseName(), field.camelCaseName(), fieldDefault(field));
             }
         } else if (field.type() instanceof FieldType.BoolFieldType) {
             buffer.printf("if (%s%s) {%n",
@@ -1192,7 +1224,7 @@ public final class MessageDataGenerator {
                             generateFieldToStruct(field, presentAndUntaggedVersions);
                         }).
                         ifMember(presentAndTaggedVersions -> {
-                            generateNonDefaultValueCheck(field);
+                            generateNonDefaultValueCheck(field, field.nullableVersions());
                             buffer.incrementIndent();
                             generateTaggedFieldToMap(field, presentAndTaggedVersions);
                             buffer.decrementIndent();
@@ -1273,7 +1305,7 @@ public final class MessageDataGenerator {
                     field.tag().get(), field.camelCaseName());
             } else {
                 buffer.printf("_taggedFields.put(%d, (%s == null) ? null : ByteBuffer.wrap(%s));%n",
-                    field.tag().get(), field.camelCaseName());
+                    field.tag().get(), field.camelCaseName(), field.camelCaseName());
             }
         } else if (field.type().isArray()) {
             IsNullConditional.forField(field).
@@ -1330,14 +1362,7 @@ public final class MessageDataGenerator {
                 ifMember(presentVersions -> {
                     VersionConditional.forVersions(field.taggedVersions(), presentVersions).
                         ifMember(presentAndTaggedVersions -> {
-                            generateNonDefaultValueCheck(field);
-                            buffer.incrementIndent();
-                            buffer.printf("_numTaggedFields++;%n");
-                            buffer.printf("_size += %d;%n",
-                                MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
                             generateFieldSize(field, presentAndTaggedVersions, true);
-                            buffer.decrementIndent();
-                            buffer.printf("}%n");
                         }).
                         ifNotMember(presentAndUntaggedVersions -> {
                             generateFieldSize(field, presentAndUntaggedVersions, false);
@@ -1415,41 +1440,77 @@ public final class MessageDataGenerator {
                                    Versions possibleVersions,
                                    boolean tagged) {
         if (field.type().fixedLength().isPresent()) {
-            if (tagged) {
-                // Account for the tagged field prefix.
-                buffer.printf("_size += %d;%n",
-                    MessageGenerator.sizeOfUnsignedVarint(field.type().fixedLength().get()));
-            }
-            buffer.printf("_size += %d;%n", field.type().fixedLength().get());
-            return;
+            generateFixedLengthFieldSize(field, tagged);
+        } else {
+            generateVariableLengthFieldSize(field, possibleVersions, tagged);
         }
+    }
+
+    private void generateFixedLengthFieldSize(FieldSpec field,
+                                              boolean tagged) {
+        if (tagged) {
+            // Check to see that the field is not set to the default value.
+            // If it is, then we don't need to serialize it.
+            generateNonDefaultValueCheck(field, field.nullableVersions());
+            buffer.incrementIndent();
+            buffer.printf("_numTaggedFields++;%n");
+            buffer.printf("_size += %d;%n",
+                MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+            // Account for the tagged field prefix length.
+            buffer.printf("_size += %d;%n",
+                MessageGenerator.sizeOfUnsignedVarint(field.type().fixedLength().get()));
+            buffer.printf("_size += %d;%n", field.type().fixedLength().get());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        } else {
+            buffer.printf("_size += %d;%n", field.type().fixedLength().get());
+        }
+    }
+
+    private void generateVariableLengthFieldSize(FieldSpec field,
+                                                 Versions possibleVersions,
+                                                 boolean tagged) {
         IsNullConditional.forField(field).
             alwaysEmitBlockScope(true).
             possibleVersions(possibleVersions).
+            nullableVersions(field.nullableVersions()).
             ifNull(() -> {
-                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).
-                    ifMember(__ -> {
-                        if (tagged) {
-                            // Account for the tagged field prefix.
-                            buffer.printf("_size += %d;%n", MessageGenerator.sizeOfUnsignedVarint(
-                                MessageGenerator.sizeOfUnsignedVarint(0)));
-                        }
-                        buffer.printf("_size += %d;%n", MessageGenerator.sizeOfUnsignedVarint(0));
-                    }).
-                    ifNotMember(__ -> {
-                        if (tagged) {
-                            throw new RuntimeException("Tagged field " + field.name() +
-                                " should not be present in non-flexible versions.");
-                        }
-                        if (field.type().isString()) {
-                            buffer.printf("_size += 2;%n");
-                        } else {
-                            buffer.printf("_size += 4;%n");
-                        }
-                    }).
-                    generate(buffer);
+                if (!tagged || !field.defaultString().equals("null")) {
+                    VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).
+                        ifMember(__ -> {
+                            if (tagged) {
+                                buffer.printf("_numTaggedFields++;%n");
+                                buffer.printf("_size += %d;%n",
+                                    MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+                                buffer.printf("_size += %d;%n", MessageGenerator.sizeOfUnsignedVarint(
+                                    MessageGenerator.sizeOfUnsignedVarint(0)));
+                            }
+                            buffer.printf("_size += %d;%n", MessageGenerator.sizeOfUnsignedVarint(0));
+                        }).
+                        ifNotMember(__ -> {
+                            if (tagged) {
+                                throw new RuntimeException("Tagged field " + field.name() +
+                                    " should not be present in non-flexible versions.");
+                            }
+                            if (field.type().isString()) {
+                                buffer.printf("_size += 2;%n");
+                            } else {
+                                buffer.printf("_size += 4;%n");
+                            }
+                        }).
+                        generate(buffer);
+                }
             }).
             ifNotNull(() -> {
+                if (tagged) {
+                    if (!field.defaultString().equals("null")) {
+                        generateNonDefaultValueCheck(field, Versions.NONE);
+                        buffer.incrementIndent();
+                    }
+                    buffer.printf("_numTaggedFields++;%n");
+                    buffer.printf("_size += %d;%n",
+                        MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+                }
                 if (field.type().isString()) {
                     generateStringToBytes(field.camelCaseName());
                     VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).
@@ -1542,6 +1603,10 @@ public final class MessageDataGenerator {
                     }
                 } else {
                     throw new RuntimeException("unhandled type " + field.type());
+                }
+                if (tagged && !field.defaultString().equals("null")) {
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
                 }
             }).
             generate(buffer);
@@ -1730,53 +1795,66 @@ public final class MessageDataGenerator {
                 throw new RuntimeException("Invalid default for boolean field " +
                     field.name() + ": " + field.defaultString());
             }
-        } else if (field.type() instanceof FieldType.Int8FieldType) {
-            if (field.defaultString().isEmpty()) {
-                return "(byte) 0";
-            } else {
-                try {
-                    Byte.decode(field.defaultString());
-                } catch (NumberFormatException e) {
-                    throw new RuntimeException("Invalid default for int8 field " +
-                        field.name() + ": " + field.defaultString(), e);
-                }
-                return "(byte) " + field.defaultString();
+        } else if ((field.type() instanceof FieldType.Int8FieldType) ||
+                   (field.type() instanceof FieldType.Int16FieldType) ||
+                   (field.type() instanceof FieldType.Int32FieldType) ||
+                   (field.type() instanceof FieldType.Int64FieldType)) {
+            int base = 10;
+            String defaultString = field.defaultString();
+            if (defaultString.startsWith("0x")) {
+                base = 16;
+                defaultString = defaultString.substring(2);
             }
-        } else if (field.type() instanceof FieldType.Int16FieldType) {
-            if (field.defaultString().isEmpty()) {
-                return "(short) 0";
-            } else {
-                try {
-                    Short.decode(field.defaultString());
-                } catch (NumberFormatException e) {
-                    throw new RuntimeException("Invalid default for int16 field " +
-                        field.name() + ": " + field.defaultString(), e);
+            if (field.type() instanceof FieldType.Int8FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(byte) 0";
+                } else {
+                    try {
+                        Byte.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int8 field " +
+                            field.name() + ": " + defaultString, e);
+                    }
+                    return "(byte) " + field.defaultString();
                 }
-                return "(short) " + field.defaultString();
-            }
-        } else if (field.type() instanceof FieldType.Int32FieldType) {
-            if (field.defaultString().isEmpty()) {
-                return "0";
-            } else {
-                try {
-                    Integer.decode(field.defaultString());
-                } catch (NumberFormatException e) {
-                    throw new RuntimeException("Invalid default for int32 field " +
-                        field.name() + ": " + field.defaultString(), e);
+            } else if (field.type() instanceof FieldType.Int16FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(short) 0";
+                } else {
+                    try {
+                        Short.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int16 field " +
+                            field.name() + ": " + field.defaultString(), e);
+                    }
+                    return "(short) " + field.defaultString();
                 }
-                return field.defaultString();
-            }
-        } else if (field.type() instanceof FieldType.Int64FieldType) {
-            if (field.defaultString().isEmpty()) {
-                return "0L";
-            } else {
-                try {
-                    Integer.decode(field.defaultString());
-                } catch (NumberFormatException e) {
-                    throw new RuntimeException("Invalid default for int64 field " +
-                        field.name() + ": " + field.defaultString(), e);
+            } else if (field.type() instanceof FieldType.Int32FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0";
+                } else {
+                    try {
+                        Integer.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int32 field " +
+                            field.name() + ": " + field.defaultString(), e);
+                    }
+                    return field.defaultString();
                 }
-                return field.defaultString() + "L";
+            } else if (field.type() instanceof FieldType.Int64FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0L";
+                } else {
+                    try {
+                        Long.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int64 field " +
+                            field.name() + ": " + field.defaultString(), e);
+                    }
+                    return field.defaultString() + "L";
+                }
+            } else {
+                throw new RuntimeException("Unsupported field type " + field.type());
             }
         } else if (field.type() instanceof FieldType.UUIDFieldType) {
             headerGenerator.addImport(MessageGenerator.UUID_CLASS);


### PR DESCRIPTION
Allow tagged fields to have null defaults.  Fix a bunch of cases where this would previously result in null pointer dereferences.

Allow inferring FieldSpec#versions based on FieldSpec#taggedVersions.

Prefix 'key' with an underscore when it is used in the generated code, to avoid potential name collisions.

Allow setting hexadecimal constants and 64-bit contstants in spec files.  Test setting UUID constants.

Add a lot more test cases to SimpleExampleMessage.json.

Add MessageTestUtil#byteBufferToString for debugging.