### PR TITLE
HOTFIX: don't discard ownedPartitions in VP upgrade system test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -240,7 +240,9 @@ public class StreamsUpgradeTest {
                                 info.prevTasks(),
                                 info.standbyTasks(),
                                 info.userEndPoint())
-                                .encode()));
+                                .encode(),
+                            subscription.ownedPartitions()
+                        ));
                 }
                 assignment = super.assign(metadata, new GroupSubscription(downgradedSubscriptions)).groupAssignment();
                 bumpUsedVersion = true;


### PR DESCRIPTION
Previously was flaky roughly 1/8 times, kicked off 15 runs here: https://jenkins.confluent.io/job/system-test-kafka-branch-builder/3252/