### PR TITLE
MINOR: Do not hold on to request buffers unless the request is using zero-copy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -120,13 +120,6 @@ import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.apache.kafka.common.protocol.types.Type.BYTES;
-import static org.apache.kafka.common.protocol.types.Type.COMPACT_BYTES;
-import static org.apache.kafka.common.protocol.types.Type.COMPACT_NULLABLE_BYTES;
-import static org.apache.kafka.common.protocol.types.Type.NULLABLE_BYTES;
-import static org.apache.kafka.common.protocol.types.Type.RECORDS;
 
 /**
  * Identifiers for all the Kafka APIs
@@ -237,7 +230,6 @@ public enum ApiKeys {
 
     public final Schema[] requestSchemas;
     public final Schema[] responseSchemas;
-    public final boolean requiresDelayedAllocation;
 
     ApiKeys(int id, String name, Schema[] requestSchemas, Schema[] responseSchemas) {
         this(id, name, false, requestSchemas, responseSchemas);
@@ -267,14 +259,6 @@ public enum ApiKeys {
                 throw new IllegalStateException("Response schema for api " + name + " for version " + i + " is null");
         }
 
-        boolean requestRetainsBufferReference = false;
-        for (Schema requestVersionSchema : requestSchemas) {
-            if (retainsBufferReference(requestVersionSchema)) {
-                requestRetainsBufferReference = true;
-                break;
-            }
-        }
-        this.requiresDelayedAllocation = requestRetainsBufferReference;
         this.requestSchemas = requestSchemas;
         this.responseSchemas = responseSchemas;
     }
@@ -369,19 +353,4 @@ public enum ApiKeys {
     public static void main(String[] args) {
         System.out.println(toHtml());
     }
-
-    private static boolean retainsBufferReference(Schema schema) {
-        final AtomicBoolean hasBuffer = new AtomicBoolean(false);
-        Schema.Visitor detector = new Schema.Visitor() {
-            @Override
-            public void visit(Type field) {
-                if (field == BYTES || field == NULLABLE_BYTES || field == RECORDS ||
-                    field == COMPACT_BYTES || field == COMPACT_NULLABLE_BYTES)
-                    hasBuffer.set(true);
-            }
-        };
-        schema.walk(detector);
-        return hasBuffer.get();
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -82,7 +82,6 @@ import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.protocol.types.Type;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -383,7 +383,7 @@ public class SaslClientAuthenticator implements Authenticator {
                 ByteBuffer tokenBuf = ByteBuffer.wrap(saslToken);
                 if (saslAuthenticateVersion != DISABLE_KAFKA_SASL_AUTHENTICATE_HEADER) {
                     SaslAuthenticateRequestData data = new SaslAuthenticateRequestData()
-                            .setAuthBytes(tokenBuf.array());
+                            .setAuthBytes(tokenBuf);
                     SaslAuthenticateRequest request = new SaslAuthenticateRequest.Builder(data).build(saslAuthenticateVersion);
                     tokenBuf = request.serialize(nextRequestHeader(ApiKeys.SASL_AUTHENTICATE, saslAuthenticateVersion));
                 }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -449,7 +449,7 @@ public class SaslServerAuthenticator implements Authenticator {
 
             try {
                 byte[] responseToken = saslServer.evaluateResponse(
-                        Utils.copyArray(saslAuthenticateRequest.data().authBytes()));
+                        Utils.toArray(saslAuthenticateRequest.data().authBytes()));
                 if (reauthInfo.reauthenticating() && saslServer.isComplete())
                     reauthInfo.ensurePrincipalUnchanged(principal());
                 // For versions with SASL_AUTHENTICATE header, send a response to SASL_AUTHENTICATE request even if token is empty.

--- a/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
@@ -18,8 +18,10 @@
   "type": "request",
   "name": "DescribeDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Owners", "type": "[]DescribeDelegationTokenOwner", "versions": "0+", "nullableVersions": "0+",
       "about": "Each owner that we want to describe delegation tokens for, or null to describe all tokens.", "fields": [

--- a/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
@@ -18,7 +18,9 @@
   "type": "response",
   "name": "DescribeDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
   "flexibleVersions": "none",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
@@ -18,8 +18,10 @@
   "type": "request",
   "name": "ExpireDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Hmac", "type": "bytes", "versions": "0+",
       "about": "The HMAC of the delegation token to be expired." },

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
@@ -18,8 +18,10 @@
   "type": "response",
   "name": "ExpireDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -72,7 +72,7 @@
         ]},
         { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "ignorable": true,
           "about": "The preferred read replica for the consumer to use on its next fetch request"},
-        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "zeroCopy": true,
           "about": "The record data." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/ProduceRequest.json
+++ b/clients/src/main/resources/common/message/ProduceRequest.json
@@ -47,7 +47,7 @@
         "about": "Each partition to produce to.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
-        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+", "zeroCopy": true,
           "about": "The record data to be produced." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
@@ -18,8 +18,10 @@
   "type": "request",
   "name": "RenewDelegationTokenRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "Hmac", "type": "bytes", "versions": "0+",
       "about": "The HMAC of the delegation token to be renewed." },

--- a/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
@@ -18,8 +18,10 @@
   "type": "response",
   "name": "RenewDelegationTokenResponse",
   // Starting in version 1, on quota violation, brokers send out responses before throttling.
-  "validVersions": "0-1",
-  "flexibleVersions": "none",
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0-1",
   "flexibleVersions": "none",
   "fields": [
-    { "name": "AuthBytes", "type": "bytes", "versions": "0+",
+    { "name": "AuthBytes", "type": "bytes", "versions": "0+", "zeroCopy": true,
       "about": "The SASL authentication bytes from the client, as defined by the SASL mechanism." }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -16,21 +16,105 @@
  */
 package org.apache.kafka.common.protocol;
 
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Type;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
+import java.util.Arrays;
+
+import static org.apache.kafka.common.protocol.ApiKeys.ADD_OFFSETS_TO_TXN;
+import static org.apache.kafka.common.protocol.ApiKeys.ADD_PARTITIONS_TO_TXN;
+import static org.apache.kafka.common.protocol.ApiKeys.ALTER_CONFIGS;
+import static org.apache.kafka.common.protocol.ApiKeys.ALTER_REPLICA_LOG_DIRS;
+import static org.apache.kafka.common.protocol.ApiKeys.CREATE_ACLS;
+import static org.apache.kafka.common.protocol.ApiKeys.CREATE_PARTITIONS;
+import static org.apache.kafka.common.protocol.ApiKeys.DELETE_ACLS;
+import static org.apache.kafka.common.protocol.ApiKeys.DELETE_RECORDS;
+import static org.apache.kafka.common.protocol.ApiKeys.DESCRIBE_ACLS;
+import static org.apache.kafka.common.protocol.ApiKeys.DESCRIBE_CONFIGS;
+import static org.apache.kafka.common.protocol.ApiKeys.DESCRIBE_LOG_DIRS;
+import static org.apache.kafka.common.protocol.ApiKeys.END_TXN;
+import static org.apache.kafka.common.protocol.ApiKeys.FETCH;
+import static org.apache.kafka.common.protocol.ApiKeys.LIST_OFFSETS;
+import static org.apache.kafka.common.protocol.ApiKeys.OFFSET_FOR_LEADER_EPOCH;
+import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
+import static org.apache.kafka.common.protocol.ApiKeys.TXN_OFFSET_COMMIT;
+import static org.apache.kafka.common.protocol.ApiKeys.WRITE_TXN_MARKERS;
+import static org.apache.kafka.common.protocol.types.Type.BYTES;
+import static org.apache.kafka.common.protocol.types.Type.COMPACT_BYTES;
+import static org.apache.kafka.common.protocol.types.Type.COMPACT_NULLABLE_BYTES;
+import static org.apache.kafka.common.protocol.types.Type.NULLABLE_BYTES;
+import static org.apache.kafka.common.protocol.types.Type.RECORDS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ProtoUtilsTest {
+    @Rule
+    final public Timeout globalTimeout = Timeout.millis(30000);
+
     @Test
     public void testDelayedAllocationSchemaDetection() throws Exception {
-        //verifies that schemas known to retain a reference to the underlying byte buffer are correctly detected.
+        // Verifies that schemas known to retain a reference to the underlying byte buffer
+        // are correctly detected.  This is important because we cannot reuse buffers containing
+        // requests of these types until the request has been completely processed.
         for (ApiKeys key : ApiKeys.values()) {
-            if (key == ApiKeys.PRODUCE || key == ApiKeys.JOIN_GROUP || key == ApiKeys.SYNC_GROUP || key == ApiKeys.SASL_AUTHENTICATE
-                || key == ApiKeys.EXPIRE_DELEGATION_TOKEN || key == ApiKeys.RENEW_DELEGATION_TOKEN) {
-                assertTrue(key + " should require delayed allocation", key.requiresDelayedAllocation);
-            } else {
-                assertFalse(key + " should not require delayed allocation", key.requiresDelayedAllocation);
+            switch (key) {
+                case PRODUCE:
+                case SASL_AUTHENTICATE:
+                    assertTrue(key + " should require delayed allocation",
+                        ApiMessageType.fromApiKey(key.id).requestContainsZeroCopyFields());
+                    break;
+                default:
+                    assertFalse(key + " should not require delayed allocation",
+                        ApiMessageType.fromApiKey(key.id).requestContainsZeroCopyFields());
+                    break;
+            }
+        }
+    }
+
+    /**
+     * There are still some requests that use manual serialization via Struct objects rather than
+     * automatically generated code.  Bytes fields in these requests will always be treated as
+     * zero-copy, because the Struct.java code always uses ByteBuffers here.  This test checks
+     * that bytes fields in these requests are marked as zero-copy to reflect this fact.
+     */
+    @Test
+    public void testRequestsUsingManualSerializationDoNotContainBytesFields() {
+        for (ApiKeys key : Arrays.asList(
+                ADD_OFFSETS_TO_TXN,
+                ADD_PARTITIONS_TO_TXN,
+                ALTER_CONFIGS,
+                ALTER_REPLICA_LOG_DIRS,
+                CREATE_ACLS,
+                CREATE_PARTITIONS,
+                DELETE_ACLS,
+                DELETE_RECORDS,
+                DESCRIBE_ACLS,
+                DESCRIBE_CONFIGS,
+                DESCRIBE_LOG_DIRS,
+                END_TXN,
+                FETCH,
+                LIST_OFFSETS,
+                OFFSET_FOR_LEADER_EPOCH,
+                PRODUCE,
+                TXN_OFFSET_COMMIT,
+                WRITE_TXN_MARKERS)) {
+            if (!ApiMessageType.fromApiKey(key.id).requestContainsZeroCopyFields()) {
+                for (short v = key.oldestVersion(); v <= key.latestVersion(); v++) {
+                    key.requestSchemas[v].walk(new Schema.Visitor() {
+                        @Override
+                        public void visit(Type field) {
+                            if (field == BYTES || field == NULLABLE_BYTES || field == RECORDS ||
+                                    field == COMPACT_BYTES || field == COMPACT_NULLABLE_BYTES) {
+                                throw new RuntimeException("Request using manual serialization " + key +
+                                    " must not include byte buffers unless they are marked as zeroCopy.");
+                            }
+                        }
+                    });
+                }
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -135,6 +135,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
@@ -1427,7 +1428,7 @@ public class RequestResponseTest {
     }
 
     private SaslAuthenticateRequest createSaslAuthenticateRequest() {
-        SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(new byte[0]);
+        SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(ByteUtils.EMPTY_BUF);
         return new SaslAuthenticateRequest(data);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1890,7 +1890,7 @@ public class SaslAuthenticatorTest {
         String authString = "\u0000" + TestJaasConfig.USERNAME + "\u0000" + TestJaasConfig.PASSWORD;
         ByteBuffer authBuf = ByteBuffer.wrap(authString.getBytes("UTF-8"));
         if (enableSaslAuthenticateHeader) {
-            SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(authBuf.array());
+            SaslAuthenticateRequestData data = new SaslAuthenticateRequestData().setAuthBytes(authBuf);
             SaslAuthenticateRequest request = new SaslAuthenticateRequest.Builder(data).build();
             sendKafkaRequestReceiveResponse(node, ApiKeys.SASL_AUTHENTICATE, request);
         } else {

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -20,22 +20,10 @@
   "fields": [
     { "name": "processId", "versions": "1+", "type": "uuid" },
     { "name": "myTaggedIntArray", "type": "[]int32",
-        "versions": "1+", "taggedVersions": "1+", "tag": 0 },
-
-    {
-      "name": "zeroCopyByteBuffer",
-      "type": "bytes",
-      "zeroCopy": true,
-      "versions": "1",
-      "about": "Byte buffer field."
-    },
-    {
-      "name": "nullableZeroCopyByteBuffer",
-      "type": "bytes",
-      "zeroCopy": true,
-      "nullableVersions": "0+",
-      "versions": "1",
-      "about": "Nullable byte buffer field."
-    }
+      "versions": "1+", "taggedVersions": "1+", "tag": 0 },
+    { "name": "zeroCopyByteBuffer", "versions": "1+", "type": "bytes",
+      "zeroCopy": true },
+    { "name": "nullableZeroCopyByteBuffer", "versions": "1+", "type": "bytes",
+      "zeroCopy": true, "nullableVersions": "1+" }
   ]
 }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -40,7 +40,7 @@ import org.apache.kafka.common.requests.CreateAclsRequest.AclCreation
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType => AdminResourceType}
 import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrincipal, KafkaPrincipalBuilder, SecurityProtocol}
-import org.apache.kafka.common.utils.{Sanitizer, SecurityUtils}
+import org.apache.kafka.common.utils.{ByteUtils, Sanitizer, SecurityUtils}
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
@@ -355,7 +355,7 @@ class RequestQuotaTest extends BaseRequestTest {
           new SaslHandshakeRequest.Builder(new SaslHandshakeRequestData().setMechanism("PLAIN"))
 
         case ApiKeys.SASL_AUTHENTICATE =>
-          new SaslAuthenticateRequest.Builder(new SaslAuthenticateRequestData().setAuthBytes(new Array[Byte](0)))
+          new SaslAuthenticateRequest.Builder(new SaslAuthenticateRequestData().setAuthBytes(ByteUtils.EMPTY_BUF))
 
         case ApiKeys.API_VERSIONS =>
           new ApiVersionsRequest.Builder()

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1900,4 +1900,8 @@ public final class MessageDataGenerator {
             return messageFlexibleVersions;
         }
     }
+
+    boolean containsZeroCopyFields() {
+        return structRegistry.containsZeroCopyFields();
+    }
 }

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -136,13 +136,14 @@ public final class MessageGenerator {
                     String javaName = spec.generatedClassName() + JAVA_SUFFIX;
                     outputFileNames.add(javaName);
                     Path outputPath = Paths.get(outputDir, javaName);
+                    MessageDataGenerator generator;
                     try (BufferedWriter writer = Files.newBufferedWriter(outputPath)) {
-                        MessageDataGenerator generator = new MessageDataGenerator(packageName);
+                        generator = new MessageDataGenerator(packageName);
                         generator.generate(spec);
                         generator.write(writer);
                     }
                     numProcessed++;
-                    messageTypeGenerator.registerMessageType(spec);
+                    messageTypeGenerator.registerMessageType(spec, generator.containsZeroCopyFields());
                 } catch (Exception e) {
                     throw new RuntimeException("Exception while processing " + inputPath.toString(), e);
                 }


### PR DESCRIPTION
Rather than just assuming that any request containing a field of type "bytes" uses zero copy,  do not hold on to request buffers unless the byte buffer in question is zero-copy. ProduceRequest and SaslAuthenticateRequest are the only ones which do.

Make RenewDelegationTokenRequest and RenewDelegationTokenResponse flexible.

Make ExpireDelegationTokenRequest and ExpireDelegationTokenResponse flexible.

SimpleExampleMessage.json: fix formatting, etc.