### PR TITLE
KAFKA-8972: need to flush state even on unclean close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -678,7 +678,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 throw taskMigratedException;
             }
         } else {
-            flushState();
+            // In the case of unclean close we still need to make sure all the stores are flushed before closing any
+            super.flushState();
 
             if (eosEnabled) {
                 maybeAbortTransactionAndCloseRecordCollector(isZombie);


### PR DESCRIPTION
We need to make sure all stores in a task have been flushed before trying to close any of them, as stores are flushed again on close. Otherwise in the case of a stream-stream join with two attached stores, when the second store is closed it will be flushed and cause a lookup on the first (already-closed) store, which will then throw in `validateStoreOpen`.

During a normal (clean) close, we will always flush first in `StreamTask#suspend` but when closing tasks as zombies (as in the new `onPartitionsLost`) we were not flushing all stores first before closing them one-by-one.