### PR TITLE
KAFKA-9093: NullPointerException in KafkaConsumer with group.instance.id

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -568,7 +568,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     final Metrics metrics;
     final KafkaConsumerMetrics kafkaConsumerMetrics;
 
-    private final Logger log;
+    private Logger log;
     private final String clientId;
     private String groupId;
     private final ConsumerCoordinator coordinator;
@@ -670,24 +670,23 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     @SuppressWarnings("unchecked")
     private KafkaConsumer(ConsumerConfig config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
         try {
-            GroupRebalanceConfig groupRebalanceConfig = null;
-            LogContext logContext;
-            Optional<InvalidConfigurationException> exceptionOption = Optional.empty();
+            GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                    GroupRebalanceConfig.ProtocolType.CONSUMER);
 
-            try {
-                groupRebalanceConfig = new GroupRebalanceConfig(config, GroupRebalanceConfig.ProtocolType.CONSUMER);
-                this.groupId = groupRebalanceConfig.groupId;
-            } catch (InvalidConfigurationException e) {
-                this.groupId = config.getString(CommonClientConfigs.GROUP_ID_CONFIG);
-                exceptionOption = Optional.of(e);
-            }
+            this.groupId = groupRebalanceConfig.groupId;
             this.clientId = buildClientId(config.getString(CommonClientConfigs.CLIENT_ID_CONFIG), groupRebalanceConfig);
-            logContext = newLogContext(groupRebalanceConfig);
-            this.log = logContext.logger(getClass());
-            if (exceptionOption.isPresent()) {
-                throw exceptionOption.get();
+
+            LogContext logContext;
+
+            // If group.instance.id is set, we will append it to the log context.
+            if (groupRebalanceConfig.groupInstanceId.isPresent()) {
+                logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
+                        ", clientId=" + clientId + ", groupId=" + groupId + "] ");
+            } else {
+                logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");
             }
 
+            this.log = logContext.logger(getClass());
             boolean enableAutoCommit = config.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
             if (groupId == null) { // overwrite in case of default group id where the config is not explicitly provided
                 if (!config.originals().containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
@@ -816,7 +815,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             log.debug("Kafka consumer initialized");
         } catch (Throwable t) {
             // call close methods if internal objects are already constructed; this is to prevent resource leak. see KAFKA-2121
-            close(0, true);
+            // we do not need to call `close` at all when `log` is null, which means no internal objects were initialized.
+            if (this.log != null) {
+                close(0, true);
+            }
             // now propagate the exception
             throw new KafkaException("Failed to construct kafka consumer", t);
         }
@@ -864,21 +866,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         if (!configuredClientId.isEmpty())
             return configuredClientId;
 
-        if (rebalanceConfig != null && rebalanceConfig.groupId != null && !rebalanceConfig.groupId.isEmpty())
+        if (rebalanceConfig.groupId != null && !rebalanceConfig.groupId.isEmpty())
             return "consumer-" + rebalanceConfig.groupId + "-" + rebalanceConfig.groupInstanceId.orElseGet(() ->
                     CONSUMER_CLIENT_ID_SEQUENCE.getAndIncrement() + "");
 
         return "consumer-" + CONSUMER_CLIENT_ID_SEQUENCE.getAndIncrement();
-    }
-
-    private LogContext newLogContext(GroupRebalanceConfig groupRebalanceConfig) {
-        // If group.instance.id is set, we will append it to the log context.
-        if (groupRebalanceConfig != null && groupRebalanceConfig.groupInstanceId.isPresent()) {
-            return new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
-                    ", clientId=" + clientId + ", groupId=" + groupId + "] ");
-        } else {
-            return new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId + "] ");
-        }
     }
 
     private static Metrics buildMetrics(ConsumerConfig config, Time time, String clientId) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -568,7 +568,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     final Metrics metrics;
     final KafkaConsumerMetrics kafkaConsumerMetrics;
 
-    private final Logger log;
+    private Logger log;
     private final String clientId;
     private String groupId;
     private final ConsumerCoordinator coordinator;
@@ -814,6 +814,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Kafka consumer initialized");
         } catch (Throwable t) {
+            log = log == null ? new LogContext().logger(getClass()) : log;
             // call close methods if internal objects are already constructed; this is to prevent resource leak. see KAFKA-2121
             close(0, true);
             // now propagate the exception

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -72,6 +72,7 @@ public class AppInfoParser {
     public static synchronized void unregisterAppInfo(String prefix, String id, Metrics metrics) {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {
+            id = id == null ? "" : id;
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             if (server.isRegistered(name))
                 server.unregisterMBean(name);

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -72,7 +72,6 @@ public class AppInfoParser {
     public static synchronized void unregisterAppInfo(String prefix, String id, Metrics metrics) {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {
-            id = id == null ? "" : id;
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             if (server.isRegistered(name))
                 server.unregisterMBean(name);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9093

`log` in KafkaConsumer does not get initialized if an invalid value for `group.intance.id` is given during consumer construction.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
