### PR TITLE
MINOR: Bring back the NewPartitionReassignment#of() public API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -18,15 +18,21 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A new partition reassignment, which can be applied via {@link AdminClient#alterPartitionReassignments(Map, AlterPartitionReassignmentsOptions)}.
  */
 public class NewPartitionReassignment {
     private final List<Integer> targetReplicas;
+
+    public static Optional<NewPartitionReassignment> of(Integer... brokers) {
+      return Optional.of(new NewPartitionReassignment(Arrays.asList(brokers)));
+    }
 
     public NewPartitionReassignment(List<Integer> targetReplicas) {
         this.targetReplicas = Collections.unmodifiableList(new ArrayList<>(targetReplicas));

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -31,7 +31,7 @@ public class NewPartitionReassignment {
     private final List<Integer> targetReplicas;
 
     public static Optional<NewPartitionReassignment> of(Integer... brokers) {
-      return Optional.of(new NewPartitionReassignment(Arrays.asList(brokers)));
+        return Optional.of(new NewPartitionReassignment(Arrays.asList(brokers)));
     }
 
     public NewPartitionReassignment(List<Integer> targetReplicas) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitionReassignment.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,11 +29,16 @@ import java.util.Optional;
 public class NewPartitionReassignment {
     private final List<Integer> targetReplicas;
 
-    public static Optional<NewPartitionReassignment> of(Integer... brokers) {
-        return Optional.of(new NewPartitionReassignment(Arrays.asList(brokers)));
+    /**
+     * @throws IllegalArgumentException if no replicas are supplied
+     */
+    public static Optional<NewPartitionReassignment> of(List<Integer> replicas) {
+        if (replicas == null || replicas.size() == 0)
+            throw new IllegalArgumentException("Cannot create a new partition reassignment without any replicas");
+        return Optional.of(new NewPartitionReassignment(replicas));
     }
 
-    public NewPartitionReassignment(List<Integer> targetReplicas) {
+    private NewPartitionReassignment(List<Integer> targetReplicas) {
         this.targetReplicas = Collections.unmodifiableList(new ArrayList<>(targetReplicas));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2051,7 +2051,7 @@ public class KafkaAdminClientTest {
             TopicPartition tp2 = new TopicPartition("B", 0);
             Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments = new HashMap<>();
             reassignments.put(tp1, Optional.empty());
-            reassignments.put(tp2, newPartitionReassignment(Arrays.asList(1, 2, 3)));
+            reassignments.put(tp2, NewPartitionReassignment.of(Arrays.asList(1, 2, 3)));
 
             // 1. server returns less responses than number of partitions we sent
             AlterPartitionReassignmentsResponseData responseData1 = new AlterPartitionReassignmentsResponseData();
@@ -2142,9 +2142,9 @@ public class KafkaAdminClientTest {
             TopicPartition invalidTopicTP = new TopicPartition("", 0);
             TopicPartition invalidPartitionTP = new TopicPartition("ABC", -1);
             Map<TopicPartition, Optional<NewPartitionReassignment>> invalidTopicReassignments = new HashMap<>();
-            invalidTopicReassignments.put(invalidPartitionTP, newPartitionReassignment(Arrays.asList(1, 2, 3)));
-            invalidTopicReassignments.put(invalidTopicTP, newPartitionReassignment(Arrays.asList(1, 2, 3)));
-            invalidTopicReassignments.put(tp1, newPartitionReassignment(Arrays.asList(1, 2, 3)));
+            invalidTopicReassignments.put(invalidPartitionTP, NewPartitionReassignment.of(Arrays.asList(1, 2, 3)));
+            invalidTopicReassignments.put(invalidTopicTP, NewPartitionReassignment.of(Arrays.asList(1, 2, 3)));
+            invalidTopicReassignments.put(tp1, NewPartitionReassignment.of(Arrays.asList(1, 2, 3)));
 
             AlterPartitionReassignmentsResponseData singlePartResponseData =
                     new AlterPartitionReassignmentsResponseData()
@@ -2770,9 +2770,5 @@ public class KafkaAdminClientTest {
                 }
             }
         }
-    }
-
-    private static Optional<NewPartitionReassignment> newPartitionReassignment(List<Integer> targetReplicas) {
-        return Optional.of(new NewPartitionReassignment(targetReplicas));
     }
 }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -1140,7 +1140,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   def reassignmentEntry(tp: TopicPartition, replicas: Seq[Int]): (TopicPartition, java.util.Optional[NewPartitionReassignment]) =
-    tp -> java.util.Optional.of(new NewPartitionReassignment(replicas.map(_.asInstanceOf[Integer]).asJava))
+    tp -> NewPartitionReassignment.of(replicas.map(_.asInstanceOf[Integer]).asJava)
 
   def cancelReassignmentEntry(tp: TopicPartition): (TopicPartition, java.util.Optional[NewPartitionReassignment]) =
     tp -> java.util.Optional.empty()

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -16,7 +16,7 @@
   */
 package kafka.admin
 
-import java.util.{Collections, Optional, Properties}
+import java.util.{Collections, Properties}
 
 import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
 import kafka.common.AdminCommandFailedException
@@ -674,7 +674,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     val targetReplica = brokerIds.diff(replicasOfFirstPartition).head
 
     adminClient.alterPartitionReassignments(Collections.singletonMap(firstTopicPartition,
-      Optional.of(new NewPartitionReassignment(Collections.singletonList(targetReplica)))))
+      NewPartitionReassignment.of(Collections.singletonList(targetReplica))))
 
     // let's wait until the LAIR is propagated
     TestUtils.waitUntilTrue(() => {


### PR DESCRIPTION
This API was removed previously in an unrelated change, but seems worth keeping
