### PR TITLE
MINOR: Fix JAAS configuration numbering

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -265,7 +265,7 @@
             <p>ZooKeeper uses "zookeeper" as the service name by default. If you
             want to change this, set the system property
             <tt>zookeeper.sasl.client.username</tt> to the appropriate name
-            (<i>e.g.</i>, <tt>-Dzookeeper.sasl.client.username=zk</tt>).</p></li>
+            (<i>e.g.</i>, <tt>-Dzookeeper.sasl.client.username=zk</tt>).</p>
 
             <p>Brokers may also configure JAAS using the broker configuration property <code>sasl.jaas.config</code>.
             The property name must be prefixed with the listener prefix including the SASL mechanism,
@@ -296,7 +296,7 @@
             <a href="#security_sasl_scram_brokerconfig">SCRAM</a> or
             <a href="#security_sasl_oauthbearer_brokerconfig">OAUTHBEARER</a> for example broker configurations.</p></li>
 
-
+        </li>
         <li><h5><a id="security_jaas_client"
             href="#security_jaas_client">JAAS configuration for Kafka clients</a></h5>
 


### PR DESCRIPTION
7.3.1.1 JAAS configuration for Kafka brokers was followed by
7.3.1.4 JAAS configuration for Kafka clients instead of 7.3.1.2.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
