### PR TITLE
KAFKA-9110: Improve efficiency of disk reads when TLS is enabled

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -38,6 +38,7 @@ import javax.net.ssl.SSLSession;
 
 import org.apache.kafka.common.errors.SslAuthenticationException;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.ByteBufferUnmapper;
 import org.apache.kafka.common.utils.Utils;
@@ -60,7 +61,6 @@ public class SslTransportLayer implements TransportLayer {
     private final SelectionKey key;
     private final SocketChannel socketChannel;
     private final Logger log;
-    private final ByteBuffer emptyBuf = ByteBuffer.allocate(0);
 
     private HandshakeStatus handshakeStatus;
     private SSLEngineResult handshakeResult;
@@ -98,7 +98,7 @@ public class SslTransportLayer implements TransportLayer {
         this.appReadBuffer = ByteBuffer.allocate(applicationBufferSize());
         netWriteBuffer.limit(0);
         netReadBuffer.limit(0);
-        
+
         state = State.HANDSHAKE;
         //initiate handshake
         sslEngine.beginHandshake();
@@ -167,7 +167,7 @@ public class SslTransportLayer implements TransportLayer {
                 //prep the buffer for the close message
                 netWriteBuffer.clear();
                 //perform the close, since we called sslEngine.closeOutbound
-                SSLEngineResult wrapResult = sslEngine.wrap(emptyBuf, netWriteBuffer);
+                SSLEngineResult wrapResult = sslEngine.wrap(ByteUtils.EMPTY_BUF, netWriteBuffer);
                 //we should be in a close state
                 if (wrapResult.getStatus() != SSLEngineResult.Status.CLOSED) {
                     throw new IOException("Unexpected status returned by SSLEngine.wrap, expected CLOSED, received " +
@@ -446,7 +446,7 @@ public class SslTransportLayer implements TransportLayer {
         //this should never be called with a network buffer that contains data
         //so we can clear it here.
         netWriteBuffer.clear();
-        SSLEngineResult result = sslEngine.wrap(emptyBuf, netWriteBuffer);
+        SSLEngineResult result = sslEngine.wrap(ByteUtils.EMPTY_BUF, netWriteBuffer);
         //prepare the results to be written
         netWriteBuffer.flip();
         handshakeStatus = result.getHandshakeStatus();

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -918,8 +918,10 @@ public class SslTransportLayer implements TransportLayer {
         int bytesToWrite = (int) Math.min(Math.min(count, channelSize - position), Integer.MAX_VALUE);
 
         if (fileChannelBuffer == null) {
-            // same size as `netWriteBuffer`
-            int transferSize = 16384;
+            // Pick a size that allows for reasonably efficient disk reads, keeps the memory overhead per connection
+            // manageable and can typically be drained in a single `write` call. The `netWriteBuffer` is typically 16k
+            // and the socket buffer is typically 64k, so 32k seems like a good number given the mentioned trade-offs.
+            int transferSize = 32768;
             // Allocate a direct buffer to avoid one heap to heap buffer copy. SSLEngine copies the source
             // buffer (fileChannelBuffer) to the destination buffer (netWriteBuffer) and then encrypts in-place.
             // FileChannel.read() to a heap buffer requires a copy from a direct buffer to a heap buffer, which is not
@@ -942,8 +944,13 @@ public class SslTransportLayer implements TransportLayer {
                 fileChannelBuffer.flip();
                 int networkBytesWritten = write(fileChannelBuffer);
                 bytesWritten += networkBytesWritten;
-                if (networkBytesWritten != bytesRead)
+                if (networkBytesWritten < bytesRead) {
+                    log.debug("Unable to write all bytes read from file channel to network write buffer. Read {} bytes " +
+                        "from disk, wrote {} bytes to network buffer, fileChannelBuffer capacity is {}, netWriteBuffer " +
+                        "capacity is {}.", bytesRead, networkBytesWritten, fileChannelBuffer.capacity(),
+                        netWriteBuffer.capacity());
                     break;
+                }
                 pos += networkBytesWritten;
                 fileChannelBuffer.clear();
             }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -930,6 +930,8 @@ public class SslTransportLayer implements TransportLayer {
         }
 
         int totalBytesWritten = 0;
+        // We return the written bytes to the caller so we must adjust the file position to take into account
+        // previously read bytes that are still in the buffer
         long pos = position + fileChannelBuffer.remaining();
         try {
             while (totalBytesWritten < totalBytesToWrite) {

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -930,7 +930,7 @@ public class SslTransportLayer implements TransportLayer {
         }
 
         int totalBytesWritten = 0;
-        long pos = position;
+        long pos = position + fileChannelBuffer.remaining();
         try {
             while (totalBytesWritten < totalBytesToWrite) {
                 int bytesToWrite = fileChannelBuffer.remaining();

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLSession;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ByteBufferUnmapper;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
@@ -183,6 +184,8 @@ public class SslTransportLayer implements TransportLayer {
             netReadBuffer = null;
             netWriteBuffer = null;
             appReadBuffer = null;
+            ByteBufferUnmapper.unmap("fileChannelBuffer", fileChannelBuffer);
+            fileChannelBuffer = null;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -917,8 +917,8 @@ public class SslTransportLayer implements TransportLayer {
         if (fileChannelBuffer == null) {
             // Pick a size that allows for reasonably efficient disk reads, keeps the memory overhead per connection
             // manageable and can typically be drained in a single `write` call. The `netWriteBuffer` is typically 16k
-            // and the socket send buffer is 100k by default, so 64k is a good number given the mentioned trade-offs.
-            int transferSize = 65536;
+            // and the socket send buffer is 100k by default, so 32k is a good number given the mentioned trade-offs.
+            int transferSize = 32768;
             // Allocate a direct buffer to avoid one heap to heap buffer copy. SSLEngine copies the source
             // buffer (fileChannelBuffer) to the destination buffer (netWriteBuffer) and then encrypts in-place.
             // FileChannel.read() to a heap buffer requires a copy from a direct buffer to a heap buffer, which is not

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -640,7 +640,7 @@ public class SslTransportLayer implements TransportLayer {
     * Writes a sequence of bytes to this channel from the given buffer.
     *
     * @param src The buffer from which bytes are to be retrieved
-    * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream
+    * @return The number of bytes read from src, possibly zero, or -1 if the channel has reached end-of-stream
     * @throws IOException If some other I/O error occurs
     */
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -95,12 +95,9 @@ public class SslTransportLayer implements TransportLayer {
         this.netReadBuffer = ByteBuffer.allocate(netReadBufferSize());
         this.netWriteBuffer = ByteBuffer.allocate(netWriteBufferSize());
         this.appReadBuffer = ByteBuffer.allocate(applicationBufferSize());
-
-        //clear & set netRead & netWrite buffers
-        netWriteBuffer.position(0);
         netWriteBuffer.limit(0);
-        netReadBuffer.position(0);
         netReadBuffer.limit(0);
+        
         state = State.HANDSHAKE;
         //initiate handshake
         sslEngine.beginHandshake();

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -184,8 +184,10 @@ public class SslTransportLayer implements TransportLayer {
             netReadBuffer = null;
             netWriteBuffer = null;
             appReadBuffer = null;
-            ByteBufferUnmapper.unmap("fileChannelBuffer", fileChannelBuffer);
-            fileChannelBuffer = null;
+            if (fileChannelBuffer != null) {
+                ByteBufferUnmapper.unmap("fileChannelBuffer", fileChannelBuffer);
+                fileChannelBuffer = null;
+            }
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -665,8 +665,7 @@ public class SslTransportLayer implements TransportLayer {
             } else if (wrapResult.getStatus() == Status.BUFFER_OVERFLOW) {
                 // BUFFER_OVERFLOW means that the last `wrap` call had no effect, so we expand the buffer and try again
                 netWriteBuffer = Utils.ensureCapacity(netWriteBuffer, netWriteBufferSize());
-                netWriteBuffer.position(0);
-                netWriteBuffer.limit(0);
+                netWriteBuffer.position(netWriteBuffer.limit());
             } else if (wrapResult.getStatus() == Status.BUFFER_UNDERFLOW) {
                 throw new IllegalStateException("SSL BUFFER_UNDERFLOW during write");
             } else if (wrapResult.getStatus() == Status.CLOSED) {
@@ -957,10 +956,10 @@ public class SslTransportLayer implements TransportLayer {
                 pos += networkBytesWritten;
             }
             return bytesWritten;
-        } catch (IOException x) {
+        } catch (IOException e) {
             if (bytesWritten > 0)
                 return bytesWritten;
-            throw x;
+            throw e;
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MultiRecordsSend;
+import org.apache.kafka.common.record.RecordsSend;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
@@ -520,7 +521,9 @@ public class FetchResponse<T extends BaseRecords> extends AbstractResponse {
         sends.add(new ByteBufferSend(dest, buffer));
 
         // finally the send for the record set itself
-        sends.add(records.toSend(dest));
+        RecordsSend recordsSend = records.toSend(dest);
+        if (recordsSend.size() > 0)
+            sends.add(recordsSend);
     }
 
     private static <T extends BaseRecords> Struct toStruct(short version, int throttleTimeMs, Errors error,

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -601,7 +601,7 @@ public final class Utils {
         } else {
             buffer.mark();
             buffer.position(offset);
-            buffer.get(dest, 0, length);
+            buffer.get(dest);
             buffer.reset();
         }
         return dest;

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferUnmapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferUnmapperTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
-public class MappedByteBuffersTest {
+public class ByteBufferUnmapperTest {
 
     /**
      * Checks that unmap doesn't throw exceptions.
@@ -34,7 +34,7 @@ public class MappedByteBuffersTest {
         File file = TestUtils.tempFile();
         try (FileChannel channel = FileChannel.open(file.toPath())) {
             MappedByteBuffer map = channel.map(FileChannel.MapMode.READ_ONLY, 0, 0);
-            MappedByteBuffers.unmap(file.getAbsolutePath(), map);
+            ByteBufferUnmapper.unmap(file.getAbsolutePath(), map);
         }
     }
 

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -20,7 +20,6 @@ package kafka.admin
 import java.text.{ParseException, SimpleDateFormat}
 import java.time.{Duration, Instant}
 import java.util.Properties
-import java.util.concurrent.ExecutionException
 
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -27,7 +27,7 @@ import kafka.common.IndexOffsetOverflowException
 import kafka.log.IndexSearchType.IndexSearchEntity
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.{CoreUtils, Logging}
-import org.apache.kafka.common.utils.{MappedByteBuffers, OperatingSystem, Utils}
+import org.apache.kafka.common.utils.{ByteBufferUnmapper, OperatingSystem, Utils}
 
 import scala.math.ceil
 
@@ -319,7 +319,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * Forcefully free the buffer's mmap.
    */
   protected[log] def forceUnmap(): Unit = {
-    try MappedByteBuffers.unmap(file.getAbsolutePath, mmap)
+    try ByteBufferUnmapper.unmap(file.getAbsolutePath, mmap)
     finally mmap = null // Accessing unmapped mmap crashes JVM by SEGV so we null it out to be safe
   }
 


### PR DESCRIPTION
1. Avoid a buffer allocation and a buffer copy per file read.
2. Ensure we flush `netWriteBuffer` successfully before reading from
disk to avoid wasted disk reads.
3. 32k reads instead of 8k reads to reduce the number of disk reads
(improves efficiency for magnetic drives and reduces the number of
system calls).
4. Update SslTransportLayer.write(ByteBuffer) to loop until the socket
buffer is full or the src buffer has no remaining bytes.
5. Renamed MappedByteBuffers to ByteBufferUnmapper since it's also
applicable for direct byte buffers.
6. Skip empty `RecordsSend`
7. Some minor clean-ups for readability.

I ran a simple consumer perf benchmark on a 6 partition topic (large
enough not to fit into page cache) starting from the beginning of the
log with TLS enabled on my 6 core MacBook Pro as a sanity check.
This laptop has fast SSDs so it benefits less from the larger reads
than the case where magnetic disks are used. Consumer throughput
was ~260 MB/s before the changes and ~300 MB/s after
(~15% improvement).

Credit to @junrao  for pointing out that this code could be more efficient.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
