### PR TITLE
MINOR: clarify KafkaStreams.close javadoc

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -969,7 +969,8 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * Shutdown this {@code KafkaStreams} by signaling all the threads to stop, and then wait up to the timeout for the
      * threads to join.
-     * A {@code timeout} of 0 means to wait forever.
+     * A {@code timeout} of Duration.ZERO (or any other zero duration) results makes the close operation asynchronous.
+     * Negative-duration timeouts are rejected.
      *
      * @param timeout  how long to wait for the threads to shutdown
      * @return {@code true} if all threads were successfully stopped&mdash;{@code false} if the timeout was reached

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -969,7 +969,7 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * Shutdown this {@code KafkaStreams} by signaling all the threads to stop, and then wait up to the timeout for the
      * threads to join.
-     * A {@code timeout} of Duration.ZERO (or any other zero duration) results makes the close operation asynchronous.
+     * A {@code timeout} of Duration.ZERO (or any other zero duration) makes the close operation asynchronous.
      * Negative-duration timeouts are rejected.
      *
      * @param timeout  how long to wait for the threads to shutdown


### PR DESCRIPTION
The javadoc on the `KafkaStreams#close(Duration)` overload incorrectly stated
that a zero-duration timeout would wait forever. In fact, it will not wait at all and
makes the execution asynchronous.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
