### PR TITLE
MINOR: Preserve backwards-compatibility by renaming the AlterPartitionReassignment metric to PartitionReassignment

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -61,7 +61,7 @@ object ControllerState {
   case object AlterPartitionReassignment extends ControllerState {
     def value = 5
 
-    override def rateAndTimeMetricName: Option[String] = Some("PartitionReassignment")
+    override def rateAndTimeMetricName: Option[String] = Some("PartitionReassignmentRateAndTimeMs")
   }
 
   case object AutoLeaderBalance extends ControllerState {

--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -60,6 +60,8 @@ object ControllerState {
 
   case object AlterPartitionReassignment extends ControllerState {
     def value = 5
+
+    override def rateAndTimeMetricName: Option[String] = Some("PartitionReassignment")
   }
 
   case object AutoLeaderBalance extends ControllerState {


### PR DESCRIPTION
In https://github.com/apache/kafka/commit/18d4e57f6e8c67ffa7937fc855707d3a03cc165a#diff-394389922df5210adf43a8b7064cc4ffL61 we unintentionally renamed the metric with the previous changes to reassignments