### PR TITLE
KAFKA-9077: Fix reading of metrics of Streams' SimpleBenchmark

### DIFF
--- a/tests/kafkatest/services/performance/streams_performance.py
+++ b/tests/kafkatest/services/performance/streams_performance.py
@@ -39,7 +39,7 @@ class StreamsSimpleBenchmarkService(StreamsTestBaseService):
             self.jmx_option = "stream-jmx"
             JmxMixin.__init__(self,
                               num_nodes=1,
-                              jmx_object_names=['kafka.streams:type=stream-metrics,client-id=simple-benchmark,thread-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
+                              jmx_object_names=['kafka.streams:type=stream-thread-metrics,client-id=simple-benchmark,thread-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
                               jmx_attributes=['process-latency-avg',
                                               'process-rate',
                                               'commit-latency-avg',

--- a/tests/kafkatest/services/performance/streams_performance.py
+++ b/tests/kafkatest/services/performance/streams_performance.py
@@ -39,7 +39,7 @@ class StreamsSimpleBenchmarkService(StreamsTestBaseService):
             self.jmx_option = "stream-jmx"
             JmxMixin.__init__(self,
                               num_nodes=1,
-                              jmx_object_names=['kafka.streams:type=stream-metrics,client-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
+                              jmx_object_names=['kafka.streams:type=stream-metrics,client-id=simple-benchmark,thread-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
                               jmx_attributes=['process-latency-avg',
                                               'process-rate',
                                               'commit-latency-avg',

--- a/tests/kafkatest/services/performance/streams_performance.py
+++ b/tests/kafkatest/services/performance/streams_performance.py
@@ -39,7 +39,7 @@ class StreamsSimpleBenchmarkService(StreamsTestBaseService):
             self.jmx_option = "stream-jmx"
             JmxMixin.__init__(self,
                               num_nodes=1,
-                              jmx_object_names=['kafka.streams:type=stream-thread-metrics,client-id=simple-benchmark,thread-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
+                              jmx_object_names=['kafka.streams:type=stream-thread-metrics,thread-id=simple-benchmark-StreamThread-%d' %(i+1) for i in range(num_threads)],
                               jmx_attributes=['process-latency-avg',
                                               'process-rate',
                                               'commit-latency-avg',


### PR DESCRIPTION
With KIP-444 the metrics definitions are refactored. Thus, Streams' SimpleBenchmark needs to be updated to correctly access the refactored metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
