### PR TITLE
KAFKA-8972 (2.4 blocker): TaskManager state should always be updated after rebalance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -692,7 +692,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
     @Override
     public void onLeavePrepare() {
-        log.debug("Executing onLeavePrepare with generation {} and memberId {}", generation(), memberId());
+        // Save the current Generation and use that to get the memberId, as the hb thread can change it at any time
+        final Generation currentGeneration = generation();
+        final String memberId = currentGeneration.memberId;
+
+        log.debug("Executing onLeavePrepare with generation {} and memberId {}", currentGeneration, memberId);
 
         // we should reset assignment and trigger the callback before leaving group
         Set<TopicPartition> droppedPartitions = new HashSet<>(subscriptions.assignedPartitions());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -692,6 +692,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
     @Override
     public void onLeavePrepare() {
+        log.debug("Executing onLeavePrepare with generation {} and memberId {}", generation(), memberId());
+
         // we should reset assignment and trigger the callback before leaving group
         Set<TopicPartition> droppedPartitions = new HashSet<>(subscriptions.assignedPartitions());
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
@@ -33,7 +33,7 @@ class AssignedStandbyTasks extends AssignedTasks<StandbyTask> {
     @Override
     public void shutdown(final boolean clean) {
         final String shutdownType = clean ? "Clean" : "Unclean";
-        log.debug(shutdownType + " shutdown of all standby tasks" + "\n" +
+        log.debug("{} shutdown of all standby tasks" + "\n" +
                       "non-initialized standby tasks to close: {}" + "\n" +
                       "running standby tasks to close: {}",
             clean, created.keySet(), running.keySet());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
@@ -36,7 +36,7 @@ class AssignedStandbyTasks extends AssignedTasks<StandbyTask> {
         log.debug("{} shutdown of all standby tasks" + "\n" +
                       "non-initialized standby tasks to close: {}" + "\n" +
                       "running standby tasks to close: {}",
-            clean, created.keySet(), running.keySet());
+            shutdownType, created.keySet(), running.keySet());
         super.shutdown(clean);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -494,7 +494,7 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
     @Override
     public void shutdown(final boolean clean) {
         final String shutdownType = clean ? "Clean" : "Unclean";
-        log.debug(shutdownType + " shutdown of all active tasks" + "\n" +
+        log.debug("{} shutdown of all active tasks" + "\n" +
                       "non-initialized stream tasks to close: {}" + "\n" +
                       "restoring tasks to close: {}" + "\n" +
                       "running stream tasks to close: {}" + "\n" +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -499,7 +499,7 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
                       "restoring tasks to close: {}" + "\n" +
                       "running stream tasks to close: {}" + "\n" +
                       "suspended stream tasks to close: {}",
-            clean, created.keySet(), restoring.keySet(), running.keySet(), suspended.keySet());
+            shutdownType, created.keySet(), restoring.keySet(), running.keySet(), suspended.keySet());
         super.shutdown(clean);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1110,7 +1110,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // Check if this was a version probing rebalance and check the error code to trigger another rebalance if so
         if (maybeUpdateSubscriptionVersion(receivedAssignmentMetadataVersion, latestCommonlySupportedVersion)) {
             setAssignmentErrorCode(AssignorError.VERSION_PROBING.code());
-            return;
         }
 
         // version 1 field

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -68,15 +68,7 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             if (streamThread.setState(State.PARTITIONS_ASSIGNED) == null) {
                 log.debug(
                     "Skipping task creation in rebalance because we are already in {} state.",
-                    streamThread.state()
-                );
-            } else if (streamThread.getAssignmentErrorCode() != AssignorError.NONE.code()) {
-                log.debug(
-                    "Encountered assignment error during partition assignment: {}. Skipping task initialization and "
-                        + "pausing any partitions we may have been assigned.",
-                    streamThread.getAssignmentErrorCode()
-                );
-                taskManager.pausePartitions();
+                    streamThread.state());
             } else {
                 // Close non-reassigned tasks before initializing new ones as we may have suspended active
                 // tasks that become standbys or vice versa

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -64,15 +64,13 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         final long start = time.milliseconds();
         List<TopicPartition> revokedStandbyPartitions = null;
 
-        final int assignmentErrorCode = streamThread.getAssignmentErrorCode();
         try {
             if (streamThread.setState(State.PARTITIONS_ASSIGNED) == null) {
                 log.debug(
                     "Skipping task creation in rebalance because we are already in {} state.",
                     streamThread.state()
                 );
-            } else if (assignmentErrorCode != AssignorError.NONE.code()
-                    && assignmentErrorCode != AssignorError.VERSION_PROBING.code()) {
+            } else if (streamThread.getAssignmentErrorCode() != AssignorError.NONE.code()) {
                 log.debug(
                     "Encountered assignment error during partition assignment: {}. Skipping task initialization and "
                         + "pausing any partitions we may have been assigned.",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -64,13 +64,15 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         final long start = time.milliseconds();
         List<TopicPartition> revokedStandbyPartitions = null;
 
+        final int assignmentErrorCode = streamThread.getAssignmentErrorCode();
         try {
             if (streamThread.setState(State.PARTITIONS_ASSIGNED) == null) {
                 log.debug(
                     "Skipping task creation in rebalance because we are already in {} state.",
                     streamThread.state()
                 );
-            } else if (streamThread.getAssignmentErrorCode() != AssignorError.NONE.code()) {
+            } else if (assignmentErrorCode != AssignorError.NONE.code()
+                    && assignmentErrorCode != AssignorError.VERSION_PROBING.code()) {
                 log.debug(
                     "Encountered assignment error during partition assignment: {}. Skipping task initialization and "
                         + "pausing any partitions we may have been assigned.",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -467,21 +467,22 @@ public class TaskManager {
         }
 
         log.debug("Assigning metadata with: " +
-                      "\tactiveTasks: {},\n" +
-                      "\tstandbyTasks: {}\n" +
-                      "The updated active task states are: \n" +
+                      "\tpreviousAssignedActiveTasks: {},\n" +
+                      "\tpreviousAssignedStandbyTasks: {}\n" +
+                      "The updated task states are: \n" +
                       "\tassignedActiveTasks {},\n" +
                       "\tassignedStandbyTasks {},\n" +
                       "\taddedActiveTasks {},\n" +
                       "\taddedStandbyTasks {},\n" +
                       "\trevokedActiveTasks {},\n" +
                       "\trevokedStandbyTasks {}",
-                  activeTasks, standbyTasks,
                   assignedActiveTasks, assignedStandbyTasks,
+                  activeTasks, standbyTasks,
                   addedActiveTasks, addedStandbyTasks,
                   revokedActiveTasks, revokedStandbyTasks);
-        this.assignedActiveTasks = activeTasks;
-        this.assignedStandbyTasks = standbyTasks;
+
+        assignedActiveTasks = activeTasks;
+        assignedStandbyTasks = standbyTasks;
     }
 
     public void updateSubscriptionsFromAssignment(final List<TopicPartition> partitions) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -270,7 +270,6 @@ public class TaskManager {
         if (exception != null) {
             throw exception;
         } else if (!(active.isEmpty() && assignedActiveTasks.isEmpty() && changelogReader.isEmpty())) {
-            log.error("Some state was non-empty after closing all owned tasks as zombies.");
             throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -270,6 +270,7 @@ public class TaskManager {
         if (exception != null) {
             throw exception;
         } else if (!(active.isEmpty() && assignedActiveTasks.isEmpty() && changelogReader.isEmpty())) {
+            log.error("Some state was non-empty after closing all owned tasks as zombies.");
             throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -195,7 +195,6 @@ public class StreamsUpgradeTest {
             if (maybeUpdateSubscriptionVersion(usedVersion, info.commonlySupportedVersion())) {
                 setAssignmentErrorCode(AssignorError.VERSION_PROBING.code());
                 usedSubscriptionMetadataVersionPeek.set(usedSubscriptionMetadataVersion);
-                return;
             }
 
             final List<TopicPartition> partitions = new ArrayList<>(assignment.partitions());


### PR DESCRIPTION
Currently when we identify version probing we return early from `onAssignment` and never get to updating the TaskManager and general state with the new assignment. Since we do actually give out "real" assignments even during version probing, a StreamThread should take real ownership of its tasks/partitions including cleaning them up in `onPartitionsRevoked` which gets invoked when we call `onLeavePrepare` as part of triggering the follow-up rebalance.

Every member will always get an assignment encoded with the lowest common version, so there should be no problem decoding a VP assignment. We should just allow `onAssignment` to proceed as usual so that the `TaskManager` is in a consistent state, and knows what all its tasks/partitions are when the first rebalance completes and the next one is triggered.

Should be cherry-picked to 2.4