### PR TITLE
MINOR: Update docs about ZooKeeper upgrade issue from 3.4.X to 3.5.6

### DIFF
--- a/config/zookeeper.properties
+++ b/config/zookeeper.properties
@@ -22,3 +22,7 @@ maxClientCnxns=0
 # Set the port to something non-conflicting if choosing to enable this
 admin.enableServer=false
 # admin.serverPort=8080
+# Enable snapshot.trust.empty config if the ZK upgrade from 3.4.X to 3.5.6 is failing
+# with "java.io.IOException: No snapshot found, but there are log entries" error.
+# Check upgrade docs for more details.
+# snapshot.trust.empty=true

--- a/config/zookeeper.properties
+++ b/config/zookeeper.properties
@@ -22,6 +22,7 @@ maxClientCnxns=0
 # Set the port to something non-conflicting if choosing to enable this
 admin.enableServer=false
 # admin.serverPort=8080
+
 # Enable snapshot.trust.empty config if the ZK upgrade from 3.4.X to 3.5.6 is failing
 # with "java.io.IOException: No snapshot found, but there are log entries" error.
 # Check upgrade docs for more details.

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -68,6 +68,17 @@
     </li>
 </ol>
 
+<p><b>Additional Upgrade Notes:</b></p>
+
+<ol>
+    <li>ZooKeeper has been upgraded to 3.5.6. If the ZooKeeper upgrade from 3.4.X to 3.5.6 is failing
+        with "java.io.IOException: No snapshot found, but there are log entries" error, then we may need to add
+        <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_advancedConfiguration">snapshot.trust.empty=true</a>
+        config to the <code>config/zookeeper.properties</code>. For more details about the issue please refer to
+        <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3056">ZOOKEEPER-3056</a>.
+    </li>
+</ol>
+
 <h5><a id="upgrade_240_notable" href="#upgrade_240_notable">Notable changes in 2.4.0</a></h5>
 <ul>
     <li>A new Admin API has been added for partition reassignments. Due to changing the way Kafka propagates reassignment information,

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -71,11 +71,12 @@
 <p><b>Additional Upgrade Notes:</b></p>
 
 <ol>
-    <li>ZooKeeper has been upgraded to 3.5.6. If the ZooKeeper upgrade from 3.4.X to 3.5.6 is failing
-        with "java.io.IOException: No snapshot found, but there are log entries" error, then we may need to add
-        <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_advancedConfiguration">snapshot.trust.empty=true</a>
-        config to the <code>config/zookeeper.properties</code>. For more details about the issue please refer to
-        <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3056">ZOOKEEPER-3056</a>.
+    <li>ZooKeeper has been upgraded to 3.5.6. ZooKeeper upgrade from 3.4.X to 3.5.6 can fail
+        with <code>java.io.IOException: No snapshot found, but there are log entries</code> error, if there are no snapshot files.
+        It is suggested to set <code>snapshot.trust.empty=true</code> config to the <code>config/zookeeper.properties</code> to allow ZooKeeper servers recover without snapshot files.
+        If the config is set during upgrade, It is recommended to set the value back to false after upgrading and restart ZooKeeper process.
+        For more details about the issue and config, please refer to <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3056">ZOOKEEPER-3056</a>
+        and <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_advancedConfiguration">ZooKeeper advanced configuration</a>.
     </li>
 </ol>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -71,12 +71,9 @@
 <p><b>Additional Upgrade Notes:</b></p>
 
 <ol>
-    <li>ZooKeeper has been upgraded to 3.5.6. ZooKeeper upgrade from 3.4.X to 3.5.6 can fail
-        with <code>java.io.IOException: No snapshot found, but there are log entries</code> error, if there are no snapshot files.
-        It is suggested to set <code>snapshot.trust.empty=true</code> config to the <code>config/zookeeper.properties</code> to allow ZooKeeper servers recover without snapshot files.
-        If the config is set during upgrade, It is recommended to set the value back to false after upgrading and restart ZooKeeper process.
-        For more details about the issue and config, please refer to <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3056">ZOOKEEPER-3056</a>
-        and <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_advancedConfiguration">ZooKeeper advanced configuration</a>.
+    <li>ZooKeeper has been upgraded to 3.5.6. Set <code>snapshot.trust.empty=true</code> in <code>zookeeper.properties</code> before the upgrade
+        to avoid <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3056">ZOOKEEPER-3056</a>. After the new version starts successfully, it is safe to remove this config.
+        See <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_advancedConfiguration">ZooKeeper advanced configuration</a> for more details.
     </li>
 </ol>
 


### PR DESCRIPTION
ZK upgrade from 3.4.X to 3.5.6 fails with "java.io.IOException: No snapshot found" if there are no snapshot files. This was discussed in https://issues.apache.org/jira/browse/ZOOKEEPER-3056

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
