### PR TITLE
HOTFIX: remove from restoringByPartition once restored

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -363,6 +363,8 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
         }
         if (allTasksRunning()) {
             restoredPartitions.clear();
+            restoringByPartition.clear();
+            restoring.clear();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -506,11 +506,11 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
     }
 
     @Override
-    public boolean isEmpty() {
+    public boolean isEmpty() throws IllegalStateException {
         if (restoring.isEmpty() && !restoringByPartition.isEmpty()) {
             log.error("Assigned stream tasks in an inconsistent state: the set of restoring tasks is empty but the " +
                       "restoring by partitions map contained {}", restoringByPartition);
-            return false;
+            throw new IllegalStateException("Found inconsistent state: no tasks restoring but nonempty restoringByPartition");
         } else {
             return super.isEmpty()
                        && restoring.isEmpty()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -513,10 +513,6 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
             log.error("Assigned stream tasks in an inconsistent state: the set of restoring tasks is empty but the " +
                       "restoring by partitions map contained {}", restoringByPartition);
             return false;
-        } else if (running.isEmpty() && !runningByPartition.isEmpty()) {
-            log.error("Assigned stream tasks in an inconsistent state: the set of running tasks is empty but the " +
-                          "running by partitions map contained {}", runningByPartition);
-            return false;
         } else {
             return super.isEmpty()
                        && restoring.isEmpty()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -363,8 +363,6 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
         }
         if (allTasksRunning()) {
             restoredPartitions.clear();
-            restoringByPartition.clear();
-            restoring.clear();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -509,11 +509,21 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
 
     @Override
     public boolean isEmpty() {
-        return super.isEmpty()
-            && restoring.isEmpty()
-            && restoringByPartition.isEmpty()
-            && restoredPartitions.isEmpty()
-            && suspended.isEmpty();
+        if (restoring.isEmpty() && !restoringByPartition.isEmpty()) {
+            log.error("Assigned stream tasks in an inconsistent state: the set of restoring tasks is empty but the " +
+                      "restoring by partitions map contained {}", restoringByPartition);
+            return false;
+        } else if (running.isEmpty() && !runningByPartition.isEmpty()) {
+            log.error("Assigned stream tasks in an inconsistent state: the set of running tasks is empty but the " +
+                          "running by partitions map contained {}", runningByPartition);
+            return false;
+        } else {
+            return super.isEmpty()
+                       && restoring.isEmpty()
+                       && restoringByPartition.isEmpty()
+                       && restoredPartitions.isEmpty()
+                       && suspended.isEmpty();
+        }
     }
 
     public String toString(final String indent) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -363,6 +363,12 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
         }
         if (allTasksRunning()) {
             restoredPartitions.clear();
+
+            if (!restoringByPartition.isEmpty()) {
+                log.error("Finished restoring all tasks but found leftover partitions in restoringByPartition: {}",
+                    restoringByPartition);
+                throw new IllegalStateException("Restoration is complete but not all partitions were cleared.");
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -346,6 +346,8 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
             if (restoredPartitions.containsAll(task.changelogPartitions())) {
                 transitionToRunning(task);
                 it.remove();
+                restoringByPartition.keySet().removeAll(task.partitions());
+                restoringByPartition.keySet().removeAll(task.changelogPartitions());
                 log.debug("Stream task {} completed restoration as all its changelog partitions {} have been applied to restore state",
                     task.id(),
                     task.changelogPartitions());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -183,9 +183,15 @@ abstract class AssignedTasks<T extends Task> {
     }
 
     boolean isEmpty() {
-        return runningByPartition.isEmpty()
-                   && running.isEmpty()
-                   && created.isEmpty();
+        if (running.isEmpty() && !runningByPartition.isEmpty()) {
+            log.error("Assigned stream tasks in an inconsistent state: the set of running tasks is empty but the " +
+                          "running by partitions map contained {}", runningByPartition);
+            return false;
+        } else {
+            return runningByPartition.isEmpty()
+                       && running.isEmpty()
+                       && created.isEmpty();
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -182,11 +182,11 @@ abstract class AssignedTasks<T extends Task> {
         created.clear();
     }
 
-    boolean isEmpty() {
+    boolean isEmpty() throws IllegalStateException {
         if (running.isEmpty() && !runningByPartition.isEmpty()) {
             log.error("Assigned stream tasks in an inconsistent state: the set of running tasks is empty but the " +
                           "running by partitions map contained {}", runningByPartition);
-            return false;
+            throw new IllegalStateException("Found inconsistent state: no tasks running but nonempty runningByPartition");
         } else {
             return runningByPartition.isEmpty()
                        && running.isEmpty()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -308,6 +308,16 @@ public class StoreChangelogReader implements ChangelogReader {
             && completedRestorers.isEmpty();
     }
 
+    @Override
+    public String toString() {
+        return "RestoreToOffset: " + restoreToOffsets + "\n" +
+               "PartitionInfo: " + partitionInfo + "\n" +
+               "StateRestorers: " + stateRestorers + "\n" +
+               "NeedsRestoring: " + needsRestoring + "\n" +
+               "NeedsInitializing: " + needsInitializing + "\n" +
+               "CompletedRestorers: " + completedRestorers + "\n";
+    }
+
     private long processNext(final List<ConsumerRecord<byte[], byte[]>> records,
                              final StateRestorer restorer,
                              final Long endOffset) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -300,8 +300,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
     @Override
     public boolean isEmpty() {
-        return partitionInfo.isEmpty()
-            && stateRestorers.isEmpty()
+        return stateRestorers.isEmpty()
             && needsRestoring.isEmpty()
             && restoreToOffsets.isEmpty()
             && needsInitializing.isEmpty()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -310,7 +310,6 @@ public class StoreChangelogReader implements ChangelogReader {
     @Override
     public String toString() {
         return "RestoreToOffset: " + restoreToOffsets + "\n" +
-               "PartitionInfo: " + partitionInfo + "\n" +
                "StateRestorers: " + stateRestorers + "\n" +
                "NeedsRestoring: " + needsRestoring + "\n" +
                "NeedsInitializing: " + needsInitializing + "\n" +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -269,10 +269,16 @@ public class TaskManager {
 
         if (exception != null) {
             throw exception;
-        } else if (!(active.isEmpty() && assignedActiveTasks.isEmpty() && changelogReader.isEmpty())) {
+        } else if (!(active.isEmpty())) {
+            log.error("The set of active tasks was non-empty: {}", active);
+            throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
+        } else if (!(assignedActiveTasks.isEmpty())) {
+            log.error("The set assignedActive tasks was non-empty: {}", assignedActiveTasks);
+            throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
+        } else if (!(changelogReader.isEmpty())) {
+            log.error("The changelog-reader's internal state was non-empty: {}", changelogReader);
             throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
         }
-
         return zombieTasks;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -130,12 +130,15 @@ public class TaskManager {
         }
 
         // Pause all the new partitions until the underlying state store is ready for all the active tasks.
+        log.debug("Pausing all active task partitions until the underlying state stores are ready");
         pausePartitions();
     }
 
     private void resumeSuspended(final Collection<TopicPartition> assignment) {
         final Set<TaskId> suspendedTasks = partitionsToTaskSet(assignment);
         suspendedTasks.removeAll(addedActiveTasks.keySet());
+
+        log.debug("Suspended tasks to be resumed: {}", suspendedTasks);
 
         for (final TaskId taskId : suspendedTasks) {
             final Set<TopicPartition> partitions = assignedActiveTasks.get(taskId);
@@ -160,7 +163,7 @@ public class TaskManager {
     }
 
     private void addNewStandbyTasks(final Map<TaskId, Set<TopicPartition>> newStandbyTasks) {
-        log.trace("New standby tasks to be created: {}", newStandbyTasks);
+        log.debug("New standby tasks to be created: {}", newStandbyTasks);
 
         for (final StandbyTask task : standbyTaskCreator.createTasks(consumer, newStandbyTasks)) {
             standby.addNewTask(task);
@@ -168,7 +171,8 @@ public class TaskManager {
     }
 
     /**
-     * Returns ids of tasks whose states are kept on the local storage.
+     * Returns ids of tasks whose states are kept on the local storage. This includes active, standby, and previously
+     * assigned but not yet cleaned up tasks
      */
     public Set<TaskId> cachedTasksIds() {
         // A client could contain some inactive tasks whose states are still kept on the local storage in the following scenarios:
@@ -269,16 +273,19 @@ public class TaskManager {
 
         if (exception != null) {
             throw exception;
-        } else if (!(active.isEmpty())) {
-            log.error("The set of active tasks was non-empty: {}", active);
-            throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
-        } else if (!(assignedActiveTasks.isEmpty())) {
-            log.error("The set assignedActive tasks was non-empty: {}", assignedActiveTasks);
-            throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
-        } else if (!(changelogReader.isEmpty())) {
-            log.error("The changelog-reader's internal state was non-empty: {}", changelogReader);
+        } else if (!(active.isEmpty() && assignedActiveTasks.isEmpty() && changelogReader.isEmpty())) {
+            if (!(active.isEmpty())) {
+                log.error("The set of active tasks was non-empty: {}", active);
+            }
+            if (!(assignedActiveTasks.isEmpty())) {
+                log.error("The set assignedActiveTasks was non-empty: {}", assignedActiveTasks);
+            }
+            if (!(changelogReader.isEmpty())) {
+                log.error("The changelog-reader's internal state was non-empty: {}", changelogReader);
+            }
             throw new IllegalStateException("TaskManager found leftover active task state after closing all zombies");
         }
+
         return zombieTasks;
     }
 


### PR DESCRIPTION
Minor follow up to https://github.com/apache/kafka/pull/7608:
For some reason the `AssignedStreamTasks#updateRestored` method only updates the `restoring` and `restoredPartitions` data structures, but there is a third map holding restored tasks & partitions: `restoringByPartitions` -- this was causing failures during `onPartitionsLost` due to the new strict emptiness checks introduced in https://github.com/apache/kafka/pull/7608)

Also fixes a strict emptiness check based on a faulty assumption (introduced in https://github.com/apache/kafka/pull/7608) , as the `partitionInfo` in `StoreChangelogReader` is just the latest metadata for all topics and does not need to be, and shouldn't be, empty.

Also improves the `TaskManager#closeLostTasks` logging, by separating by case and logging the specific failure before throwing.

Needs to be cherry-picked to 2.4 as well