### PR TITLE
KAFKA-8953: Rename UsePreviousTimeOnInvalidTimestamp to UsePartitionTimeOnInvalidTimestamp

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -511,7 +511,7 @@
                   silently drop the record.
                   This log-and-skip strategy allows Kafka Streams to make progress instead of failing if there are records with an
                   invalid built-in timestamp in your input data.</li>
-                <li><a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestamp.html">UsePreviousTimeOnInvalidTimestamp</a>.
+                <li><a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestamp.html">UsePartitionTimeOnInvalidTimestamp</a>.
                   This extractor returns the record&#8217;s built-in timestamp if it is valid (i.e. not negative).  If the record does not
                   have a valid built-in timestamps, the extractor returns the previously extracted valid timestamp from a record of the
                   same topic partition as the current record as a timestamp estimation.  In case that no timestamp can be estimated, it

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -72,6 +72,11 @@
         More details about the new config <code>StreamsConfig#TOPOLOGY_OPTIMIZATION</code> can be found in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-295%3A+Add+Streams+Configuration+Allowing+for+Optional+Topology+Optimization">KIP-295</a>.
     </p>
 
+    <h3><a id="streams_api_changes_250" href="#streams_api_changes_250">Streams API changes in 2.5.0</a></h3>
+    <p>
+        As of 2.5.0 Kafka we deprecated UsePreviousTimeOnInvalidTimestamp and replaced it with UsePartitionTimeOnInvalidTimeStamp as per <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
+    </p>
+
     <h3><a id="streams_api_changes_240" href="#streams_api_changes_240">Streams API changes in 2.4.0</a></h3>
     <p>     
          As of 2.4.0 Kafka Streams offers a KTable-KTable foreign-key join (as per <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-213+Support+non-key+joining+in+KTable">KIP-213</a>). 
@@ -824,7 +829,7 @@
         <li> method <code>extract()</code> has a second parameter now </li>
         <li> new default timestamp extractor class <code>FailOnInvalidTimestamp</code>
             (it gives the same behavior as old (and removed) default extractor <code>ConsumerRecordTimestampExtractor</code>) </li>
-        <li> new alternative timestamp extractor classes <code>LogAndSkipOnInvalidTimestamp</code> and <code>UsePartitionTimeOnInvalidTimestamps</code> </li>
+        <li> new alternative timestamp extractor classes <code>LogAndSkipOnInvalidTimestamp</code> and <code>UsePreviousTimeOnInvalidTimestamps</code> </li>
     </ul>
 
     <p> Relaxed type constraints of many DSL interfaces, classes, and methods (cf. <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-100+-+Relax+Type+constraints+in+Kafka+Streams+API">KIP-100</a>). </p>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -74,7 +74,8 @@
 
     <h3><a id="streams_api_changes_250" href="#streams_api_changes_250">Streams API changes in 2.5.0</a></h3>
     <p>
-        As of 2.5.0 Kafka we deprecated UsePreviousTimeOnInvalidTimestamp and replaced it with UsePartitionTimeOnInvalidTimeStamp as per <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
+        As of 2.5.0 Kafka we deprecated <code>UsePreviousTimeOnInvalidTimestamp</code> and replaced it with <code>UsePartitionTimeOnInvalidTimeStamp</code> as per
+        <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
     </p>
 
     <h3><a id="streams_api_changes_240" href="#streams_api_changes_240">Streams API changes in 2.4.0</a></h3>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -824,7 +824,7 @@
         <li> method <code>extract()</code> has a second parameter now </li>
         <li> new default timestamp extractor class <code>FailOnInvalidTimestamp</code>
             (it gives the same behavior as old (and removed) default extractor <code>ConsumerRecordTimestampExtractor</code>) </li>
-        <li> new alternative timestamp extractor classes <code>LogAndSkipOnInvalidTimestamp</code> and <code>UsePreviousTimeOnInvalidTimestamps</code> </li>
+        <li> new alternative timestamp extractor classes <code>LogAndSkipOnInvalidTimestamp</code> and <code>UsePartitionTimeOnInvalidTimestamps</code> </li>
     </ul>
 
     <p> Relaxed type constraints of many DSL interfaces, classes, and methods (cf. <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-100+-+Relax+Type+constraints+in+Kafka+Streams+API">KIP-100</a>). </p>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ExtractRecordMetadataTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ExtractRecordMetadataTimestamp.java
@@ -39,7 +39,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  *
  * @see FailOnInvalidTimestamp
  * @see LogAndSkipOnInvalidTimestamp
- * @see UsePreviousTimeOnInvalidTimestamp
+ * @see UsePartitionTimeOnInvalidTimestamp
  * @see WallclockTimestampExtractor
  */
 abstract class ExtractRecordMetadataTimestamp implements TimestampExtractor {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/FailOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/FailOnInvalidTimestamp.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * If you need <i>processing-time</i> semantics, use {@link WallclockTimestampExtractor}.
  *
  * @see LogAndSkipOnInvalidTimestamp
- * @see UsePreviousTimeOnInvalidTimestamp
+ * @see UsePartitionTimeOnInvalidTimestamp
  * @see WallclockTimestampExtractor
  */
 public class FailOnInvalidTimestamp extends ExtractRecordMetadataTimestamp {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/LogAndSkipOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/LogAndSkipOnInvalidTimestamp.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * If you need <i>processing-time</i> semantics, use {@link WallclockTimestampExtractor}.
  *
  * @see FailOnInvalidTimestamp
- * @see UsePreviousTimeOnInvalidTimestamp
+ * @see UsePartitionTimeOnInvalidTimestamp
  * @see WallclockTimestampExtractor
  */
 public class LogAndSkipOnInvalidTimestamp extends ExtractRecordMetadataTimestamp {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestamp.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 /**
  * Retrieves embedded metadata timestamps from Kafka messages.
  * If a record has a negative (invalid) timestamp, a new timestamp will be inferred from the current stream-time.
- * <p></p>
+ * <p>
  * Embedded metadata timestamp was introduced in "KIP-32: Add timestamps to Kafka message" for the new
  * 0.10+ Kafka message format.
  * <p>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestamp.java
@@ -20,8 +20,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.errors.StreamsException;
 
 /**
- * @deprecated UsePreviousTimeOnInvalidTimestamp will be deprecated in the future, please use
- * {@link UsePartitionTimeOnInvalidTimestamp} instead
  * Retrieves embedded metadata timestamps from Kafka messages.
  * If a record has a negative (invalid) timestamp, a new timestamp will be inferred from the current stream-time.
  * <p></p>
@@ -44,9 +42,8 @@ import org.apache.kafka.streams.errors.StreamsException;
  * @see LogAndSkipOnInvalidTimestamp
  * @see WallclockTimestampExtractor
  */
-@Deprecated
-public class UsePreviousTimeOnInvalidTimestamp extends ExtractRecordMetadataTimestamp {
 
+public class UsePartitionTimeOnInvalidTimestamp extends ExtractRecordMetadataTimestamp {
     /**
      * Returns the current stream-time as new timestamp for the record.
      *
@@ -67,6 +64,4 @@ public class UsePreviousTimeOnInvalidTimestamp extends ExtractRecordMetadataTime
         }
         return partitionTime;
     }
-
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestamp.java
@@ -37,13 +37,12 @@ import org.apache.kafka.streams.errors.StreamsException;
  * using this extractor effectively provides <i>ingestion-time</i> semantics.
  * <p>
  * If you need <i>processing-time</i> semantics, use {@link WallclockTimestampExtractor}.
- * @deprecated UsePreviousTimeOnInvalidTimestamp will be deprecated in the future, please use
- * {@link UsePartitionTimeOnInvalidTimestamp} instead
- *
+ * @deprecated since 2.5. Use {@link UsePartitionTimeOnInvalidTimestamp} instead
  * @see FailOnInvalidTimestamp
  * @see LogAndSkipOnInvalidTimestamp
  * @see WallclockTimestampExtractor
  */
+@SuppressWarnings("deprecation")
 @Deprecated
 public class UsePreviousTimeOnInvalidTimestamp extends ExtractRecordMetadataTimestamp {
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestamp.java
@@ -20,11 +20,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.errors.StreamsException;
 
 /**
- * @deprecated UsePreviousTimeOnInvalidTimestamp will be deprecated in the future, please use
- * {@link UsePartitionTimeOnInvalidTimestamp} instead
  * Retrieves embedded metadata timestamps from Kafka messages.
  * If a record has a negative (invalid) timestamp, a new timestamp will be inferred from the current stream-time.
- * <p></p>
+ * <p>
  * Embedded metadata timestamp was introduced in "KIP-32: Add timestamps to Kafka message" for the new
  * 0.10+ Kafka message format.
  * <p>
@@ -39,6 +37,8 @@ import org.apache.kafka.streams.errors.StreamsException;
  * using this extractor effectively provides <i>ingestion-time</i> semantics.
  * <p>
  * If you need <i>processing-time</i> semantics, use {@link WallclockTimestampExtractor}.
+ * @deprecated UsePreviousTimeOnInvalidTimestamp will be deprecated in the future, please use
+ * {@link UsePartitionTimeOnInvalidTimestamp} instead
  *
  * @see FailOnInvalidTimestamp
  * @see LogAndSkipOnInvalidTimestamp

--- a/streams/src/main/java/org/apache/kafka/streams/processor/WallclockTimestampExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/WallclockTimestampExtractor.java
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  *
  * @see FailOnInvalidTimestamp
  * @see LogAndSkipOnInvalidTimestamp
- * @see UsePreviousTimeOnInvalidTimestamp
+ * @see UsePartitionTimeOnInvalidTimestamp
  */
 public class WallclockTimestampExtractor implements TimestampExtractor {
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestampTest.java
@@ -24,18 +24,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-public class UsePreviousTimeOnInvalidTimestampTest extends TimestampExtractorTest {
+public class UsePartitionTimeOnInvalidTimestampTest extends TimestampExtractorTest {
 
     @Test
     public void extractMetadataTimestamp() {
-        testExtractMetadataTimestamp(new UsePreviousTimeOnInvalidTimestamp());
+        testExtractMetadataTimestamp(new UsePartitionTimeOnInvalidTimestamp());
     }
 
     @Test
-    public void usePreviousTimeOnInvalidTimestamp() {
+    public void usePartitionTimeOnInvalidTimestamp() {
         final long previousTime = 42;
 
-        final TimestampExtractor extractor = new UsePreviousTimeOnInvalidTimestamp();
+        final TimestampExtractor extractor = new UsePartitionTimeOnInvalidTimestamp();
         final long timestamp = extractor.extract(
             new ConsumerRecord<>("anyTopic", 0, 0, null, null),
             previousTime
@@ -46,7 +46,7 @@ public class UsePreviousTimeOnInvalidTimestampTest extends TimestampExtractorTes
 
     @Test
     public void shouldThrowStreamsException() {
-        final TimestampExtractor extractor = new UsePreviousTimeOnInvalidTimestamp();
+        final TimestampExtractor extractor = new UsePartitionTimeOnInvalidTimestamp();
         final ConsumerRecord<Object, Object> record = new ConsumerRecord<>("anyTopic", 0, 0, null, null);
         try {
             extractor.extract(record, -1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
@@ -24,29 +24,28 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-public class UsePartitionTimeOnInvalidTimestampTest extends TimestampExtractorTest {
-
+public class UsePreviousTimeOnInvalidTimestampTest extends TimestampExtractorTest {
     @Test
     public void extractMetadataTimestamp() {
-        testExtractMetadataTimestamp(new UsePartitionTimeOnInvalidTimestamp());
+        testExtractMetadataTimestamp(new UsePreviousTimeOnInvalidTimestamp());
     }
 
     @Test
-    public void usePartitionTimeOnInvalidTimestamp() {
-        final long partitionTime = 42;
+    public void usePreviousTimeOnInvalidTimestamp() {
+        final long previousTime = 42;
 
-        final TimestampExtractor extractor = new UsePartitionTimeOnInvalidTimestamp();
+        final TimestampExtractor extractor = new UsePreviousTimeOnInvalidTimestamp();
         final long timestamp = extractor.extract(
-            new ConsumerRecord<>("anyTopic", 0, 0, null, null),
-                partitionTime
+                new ConsumerRecord<>("anyTopic", 0, 0, null, null),
+                previousTime
         );
 
-        assertThat(timestamp, is(partitionTime));
+        assertThat(timestamp, is(previousTime));
     }
 
     @Test
     public void shouldThrowStreamsException() {
-        final TimestampExtractor extractor = new UsePartitionTimeOnInvalidTimestamp();
+        final TimestampExtractor extractor = new UsePreviousTimeOnInvalidTimestamp();
         final ConsumerRecord<Object, Object> record = new ConsumerRecord<>("anyTopic", 0, 0, null, null);
         try {
             extractor.extract(record, -1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
@@ -36,8 +36,8 @@ public class UsePreviousTimeOnInvalidTimestampTest extends TimestampExtractorTes
 
         final TimestampExtractor extractor = new UsePreviousTimeOnInvalidTimestamp();
         final long timestamp = extractor.extract(
-                new ConsumerRecord<>("anyTopic", 0, 0, null, null),
-                previousTime
+            new ConsumerRecord<>("anyTopic", 0, 0, null, null),
+            previousTime
         );
 
         assertThat(timestamp, is(previousTime));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/UsePreviousTimeOnInvalidTimestampTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("deprecation")
 public class UsePreviousTimeOnInvalidTimestampTest extends TimestampExtractorTest {
     @Test
     public void extractMetadataTimestamp() {


### PR DESCRIPTION
*Added deprecate annotation in UsePreviousTimeOnInvalidTimestamp and created a new class UsePartitionTimeOnInvalidTimestamp. Also replaced usage of UsePreviousTimeOnInvalidTimestam with new class name, don't know if this was necessary but can be reverted back if necessary*

*Also renamed the test class of UsePreviousTimeOnInvalidTimestamp with new class name*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
