### PR TITLE
MINOR: return unmodifiableMap for PartitionStates.partitionStateMap

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -89,8 +89,8 @@ public class PartitionStates<S> {
         return map.entrySet().stream().map(entry -> new PartitionState<>(entry.getKey(), entry.getValue()));
     }
 
-    public LinkedHashMap<TopicPartition, S> partitionStateMap() {
-        return map;
+    public Map<TopicPartition, S> partitionStateMap() {
+        return Collections.unmodifiableMap(map);
     }
 
     /**


### PR DESCRIPTION
Discussion https://github.com/apache/kafka/pull/7576#issuecomment-549189987. Makes the map returned by partitionStateMap unmodifiable to prevent mutation.