### PR TITLE
KAFKA-9133: add extra bounds check for dirty offset before cleaning

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -537,11 +537,13 @@ private[log] object LogCleanerManager extends Logging {
         warn(s"The last checkpoint dirty offset for partition $topicPartition is $checkpointDirtyOffset, " +
           s"which is larger than the log end offset ${log.logEndOffset}. Resetting to the log start offset $logStartOffset.")
         logStartOffset
-      } else if (checkpointDirtyOffset > log.activeSegment.baseOffset) {
+      } else if (checkpointDirtyOffset > log.activeSegment.baseOffset && logStartOffset > log.activeSegment.baseOffset) {
         // The dirty offset has gotten ahead of the active segment base offset.
-        warn(s"The last checkpoint dirty offset for partition $topicPartition is $checkpointDirtyOffset, " +
-          s"which is larger than the active log segment base offset ${log.activeSegment.baseOffset}. Resetting to the log start offset $logStartOffset.")
-        logStartOffset
+        warn(s"The log start offset for partition $topicPartition is $logStartOffset and " +
+          s"its last checkpoint dirty offset is $checkpointDirtyOffset. " +
+          s"Both are larger than the active log segment base offset ${log.activeSegment.baseOffset}. " +
+          s"Resetting to the active log segment base offset ${log.activeSegment.baseOffset}.")
+        log.activeSegment.baseOffset
       } else {
         checkpointDirtyOffset
       }

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -537,6 +537,11 @@ private[log] object LogCleanerManager extends Logging {
         warn(s"The last checkpoint dirty offset for partition $topicPartition is $checkpointDirtyOffset, " +
           s"which is larger than the log end offset ${log.logEndOffset}. Resetting to the log start offset $logStartOffset.")
         logStartOffset
+      } else if (checkpointDirtyOffset > log.activeSegment.baseOffset) {
+        // The dirty offset has gotten ahead of the active segment base offset.
+        warn(s"The last checkpoint dirty offset for partition $topicPartition is $checkpointDirtyOffset, " +
+          s"which is larger than the active log segment base offset ${log.activeSegment.baseOffset}. Resetting to the log start offset $logStartOffset.")
+        logStartOffset
       } else {
         checkpointDirtyOffset
       }

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -355,6 +355,7 @@ class LogTest {
     assertEquals(0 until 5, nonActiveBaseOffsetsFrom(0L))
     assertEquals(Seq.empty, nonActiveBaseOffsetsFrom(5L))
     assertEquals(2 until 5, nonActiveBaseOffsetsFrom(2L))
+    assertEquals(0 until 5, nonActiveBaseOffsetsFrom(6L))
   }
 
   @Test


### PR DESCRIPTION
To avoid the issue described in KAFKA-9133, I added an extra check to ensure the dirty offset is not larger than the active segment base offset. If it is, we reset to the log start offset.

