### PR TITLE
KAFKA-9139: Fix dynamic broker config definitions not resolving their type.

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -631,7 +631,7 @@ class AdminManager(val config: KafkaConfig,
     if (configType != null)
       configType
     else
-      synonyms.map(config.typeOf).find(_ != null).getOrElse(DynamicConfig.Broker.typeOf(name))
+      synonyms.iterator.map(config.typeOf).find(_ != null).getOrElse(DynamicConfig.Broker.typeOf(name))
   }
 
   private def configSynonyms(name: String, synonyms: List[String], isSensitive: Boolean): List[DescribeConfigsResponse.ConfigSynonym] = {

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -631,7 +631,7 @@ class AdminManager(val config: KafkaConfig,
     if (configType != null)
       configType
     else
-      synonyms.iterator.map(config.typeOf).find(_ != null).orNull
+      synonyms.iterator.map(config.typeOf).find(_ != null).getOrElse(DynamicConfig.Broker.typeOf(name))
   }
 
   private def configSynonyms(name: String, synonyms: List[String], isSensitive: Boolean): List[DescribeConfigsResponse.ConfigSynonym] = {

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -631,7 +631,7 @@ class AdminManager(val config: KafkaConfig,
     if (configType != null)
       configType
     else
-      synonyms.iterator.map(config.typeOf).find(_ != null).getOrElse(DynamicConfig.Broker.typeOf(name))
+      synonyms.map(config.typeOf).find(_ != null).getOrElse(DynamicConfig.Broker.typeOf(name))
   }
 
   private def configSynonyms(name: String, synonyms: List[String], isSensitive: Boolean): List[DescribeConfigsResponse.ConfigSynonym] = {

--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -66,11 +66,7 @@ object DynamicConfig {
 
     def validate(props: Properties) = DynamicConfig.validate(brokerConfigDef, props, customPropsAllowed = true)
 
-    def typeOf(key: String): ConfigDef.Type =
-      brokerConfigDef.configKeys.get(key) match {
-        case null => null
-        case configKey => configKey.`type`
-      }
+    def typeOf(key: String): ConfigDef.Type = brokerConfigDef.configKeys.asScala.get(key).map(_.`type`).orNull
   }
 
   object Client {

--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -65,6 +65,12 @@ object DynamicConfig {
     def names = brokerConfigDef.names
 
     def validate(props: Properties) = DynamicConfig.validate(brokerConfigDef, props, customPropsAllowed = true)
+
+    def typeOf(key: String): ConfigDef.Type =
+      brokerConfigDef.configKeys.get(key) match {
+        case null => null
+        case configKey => configKey.`type`
+      }
   }
 
   object Client {


### PR DESCRIPTION
As a consequence, the values for the dynamic config's keys were being
treated as sensitive, and therefore no value (null) was being passed
back to the client.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
