### PR TITLE
HOTFIX: remove reference to unused Assignment error code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -622,7 +622,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (!totalAddedPartitions.isEmpty()) {
             log.error("With the COOPERATIVE protocol, owned partitions cannot be " +
                 "reassigned to other members; however the assignor has reassigned partitions {} which are still owned " +
-                "by some members; return the error code to all members to let them stop", totalAddedPartitions);
+                "by some members", totalAddedPartitions);
 
             throw new IllegalStateException("Assignor supporting the COOPERATIVE protocol violates its requirements");
         }


### PR DESCRIPTION
The original draft of KIP-429 made extensive use of an error code to communicate rebalance updates to all members, however this was removed after some discussion. We should take it out of the log messages as well to avoid confusion

Should be cherry-picked to 2.4