### PR TITLE
KAFKA-9140: Also reset join future when generation was reset in order to re-join

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -420,8 +420,10 @@ public abstract class AbstractCoordinator implements Closeable {
 
                     onJoinComplete(generationSnapshot.generationId, generationSnapshot.memberId, generationSnapshot.protocol, memberAssignment);
 
-                    // We reset the join group future only after the completion callback returns. This ensures
+                    // Generally speaking we should always resetJoinGroupFuture once the future is done, but here
+                    // we can only reset the join group future after the completion callback returns. This ensures
                     // that if the callback is woken up, we will retry it on the next joinGroupIfNeeded.
+                    // And because of that we should explicitly trigger resetJoinGroupFuture in other conditions below.
                     resetJoinGroupFuture();
                     needsJoinPrepare = true;
                 } else {
@@ -449,12 +451,10 @@ public abstract class AbstractCoordinator implements Closeable {
         return true;
     }
 
-    // reset join-group future in order to retry the join-group request
     private synchronized void resetJoinGroupFuture() {
         this.joinFuture = null;
     }
 
-    // reset state to UNJOINED and request re-join
     private void resetStateAndRejoin() {
         rejoinNeeded = true;
         state = MemberState.UNJOINED;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -427,7 +427,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 } else {
                     log.info("Generation data was cleared by heartbeat thread. Initiating rejoin.");
                     resetStateAndRejoin();
-
+                    resetJoinGroupFuture();
                     return false;
                 }
             } else {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -428,9 +428,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     needsJoinPrepare = true;
                 } else {
                     log.info("Generation data was cleared by heartbeat thread. Initiating rejoin.");
-                    synchronized (AbstractCoordinator.this) {
-                        resetStateAndRejoin();
-                    }
+                    resetStateAndRejoin();
                     resetJoinGroupFuture();
                     return false;
                 }
@@ -455,7 +453,7 @@ public abstract class AbstractCoordinator implements Closeable {
         this.joinFuture = null;
     }
 
-    private void resetStateAndRejoin() {
+    private synchronized void resetStateAndRejoin() {
         rejoinNeeded = true;
         state = MemberState.UNJOINED;
     }


### PR DESCRIPTION
Otherwise the join-group would not be resend and we'd just fall into the endless loop.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
