### PR TITLE
Using AclCommand,avoid call the global method loadcache in SimpleAclAuthorizer

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -29,11 +29,12 @@ object AclCommand {
 
   class SimpleAclAuthorizer extends kafka.security.auth.SimpleAclAuthorizer{
     /**
-     * in AclCommand,configure SimpleAclAuthorizer,but no need call loadCache.
-     * If there are a lot of topics, loadCache will be very slow.
+     * When using AclCommand,avoid call the global method loadcache in SimpleAclAuthorizer.
+     * now we have 20,000 topics in a new cluster,all these topics need to be authed for each project group.No matter how to run AclCommand, it will be very slow.
+     * this updating can improve the running time from minutes to less than one second
      */
     override protected def loadCache()  {
-      println("no need loadCache");
+      println("there's no need to call loadCache");
     }
   }
 

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -34,7 +34,7 @@ object AclCommand {
      * this updating can improve the running time from minutes to less than one second
      */
     override protected def loadCache()  {
-      println("there's no need to call loadCache");
+      println("AclCommand:there's no need to call loadCache");
     }
   }
 

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -27,6 +27,16 @@ import scala.collection.JavaConverters._
 
 object AclCommand {
 
+  class SimpleAclAuthorizer extends kafka.security.auth.SimpleAclAuthorizer{
+    /**
+     * in AclCommand,configure SimpleAclAuthorizer,but no need call loadCache.
+     * If there are a lot of topics, loadCache will be very slow.
+     */
+    override protected def loadCache()  {
+      println("no need loadCache");
+    }
+  }
+
   val Newline = scala.util.Properties.lineSeparator
   val ResourceTypeToValidOperations = Map[ResourceType, Set[Operation]] (
     Topic -> Set(Read, Write, Describe, All, Delete),

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -226,7 +226,7 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     if (zkUtils != null) zkUtils.close()
   }
 
-  private def loadCache()  {
+  protected def loadCache()  {
     inWriteLock(lock) {
       val resourceTypes = zkUtils.getChildren(SimpleAclAuthorizer.AclZkPath)
       for (rType <- resourceTypes) {

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -35,7 +35,7 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
      * this updating can improve the running time from minutes to less than one second
      */
     override protected def loadCache()  {
-      println("there's no need to call loadCache");
+      println("AclCommandTest:there's no need to call loadCache");
     }
   }
 
@@ -122,6 +122,25 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
   def testInvalidAuthorizerProperty() {
     val args = Array("--authorizer-properties", "zookeeper.connect " + zkConnect)
     AclCommand.withAuthorizer(new AclCommandOptions(args))(null)
+  }
+
+  @Test
+  def testInitSimpleAclAuthorizerLocal() {
+    val brokerProps = TestUtils.createBrokerConfig(0, zkConnect)
+    brokerProps.put(KafkaConfig.AuthorizerClassNameProp, "kafka.security.auth.SimpleAclAuthorizer")
+    withAuthorizer(brokerProps) { authorizer =>
+      println("authorizer.class="+authorizer.getClass)
+    }
+    println("local:success init SimpleAclAuthorizer ")
+  }
+
+  @Test
+  def testInitSimpleAclAuthorizer() {
+    val args = Array("--authorizer-properties", "zookeeper.connect=" + zkConnect,"--add","--allow-principal",  "User:user1","--operation","add","--topic","topic1")
+    AclCommand.withAuthorizer(new AclCommandOptions(args)) { authorizer =>
+      println("authorizer.class="+authorizer.getClass)
+    }
+    println("success init SimpleAclAuthorizer")
   }
 
   private def testRemove(resources: Set[Resource], resourceCmd: Array[String], args: Array[String], brokerProps: Properties) {

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -28,6 +28,17 @@ import org.junit.Test
 
 class AclCommandTest extends ZooKeeperTestHarness with Logging {
 
+  class SimpleAclAuthorizer extends kafka.security.auth.SimpleAclAuthorizer{
+    /**
+     * When using AclCommand,avoid call the global method loadcache in SimpleAclAuthorizer.
+     * now we have 20,000 topics in a new cluster,all these topics need to be authed for each project group.No matter how to run AclCommand, it will be very slow.
+     * this updating can improve the running time from minutes to less than one second
+     */
+    override protected def loadCache()  {
+      println("there's no need to call loadCache");
+    }
+  }
+
   private val Users = Set(KafkaPrincipal.fromString("User:CN=writeuser,OU=Unknown,O=Unknown,L=Unknown,ST=Unknown,C=Unknown"), KafkaPrincipal.fromString("User:test2"))
   private val Hosts = Set("host1", "host2")
   private val AllowHostCommand = Array("--allow-host", "host1", "--allow-host", "host2")

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
@@ -298,7 +298,7 @@ public class KStreamAggregationDedupIntegrationTest {
             valueDeserializer.getClass().getName());
         return IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerProperties,
             outputTopic,
-            numMessages, 2 * 60 * 1000);
+            numMessages, 3 * 60 * 1000);
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
@@ -298,7 +298,7 @@ public class KStreamAggregationDedupIntegrationTest {
             valueDeserializer.getClass().getName());
         return IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerProperties,
             outputTopic,
-            numMessages, 60 * 1000);
+            numMessages, 2 * 60 * 1000);
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -290,7 +290,7 @@ public class QueryableStateIntegrationTest {
                     }
 
                 }
-            }, 30000, "waiting for metadata, store and value to be non null");
+            }, 60000, "waiting for metadata, store and value to be non null");
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -290,7 +290,7 @@ public class QueryableStateIntegrationTest {
                     }
 
                 }
-            }, 60000, "waiting for metadata, store and value to be non null");
+            }, 120000, "waiting for metadata, store and value to be non null");
         }
     }
 
@@ -322,7 +322,7 @@ public class QueryableStateIntegrationTest {
                     }
 
                 }
-            }, 30000, "waiting for metadata, store and value to be non null");
+            }, 120000, "waiting for metadata, store and value to be non null");
         }
     }
 
@@ -668,7 +668,7 @@ public class QueryableStateIntegrationTest {
             config,
             topic,
             numRecs,
-            60 * 1000);
+            120 * 1000);
     }
 
     private Set<KeyValue<String, Long>> fetch(final ReadOnlyWindowStore<String, Long> store,


### PR DESCRIPTION
in AclCommand,configure SimpleAclAuthorizer,but no need call loadCache.
If there are a lot of topics, loadCache will be very slow.
now we have 20,000 topics in a new cluster,all these topics need to be authed for each project group.No matter how to run AclCommand, it will be very slow.
this updating can improve the running time from minutes to less than one second