### PR TITLE
KAFKA-9219: prevent NullPointerException when polling metrics from Kafka Connect

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -306,6 +306,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             Measurable numConnectors = new Measurable() {
                 @Override
                 public double measure(MetricConfig config, long now) {
+                    if (assignmentSnapshot == null) {
+                        return 0.0;
+                    }
                     return assignmentSnapshot.connectors().size();
                 }
             };
@@ -313,6 +316,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             Measurable numTasks = new Measurable() {
                 @Override
                 public double measure(MetricConfig config, long now) {
+                    if (assignmentSnapshot == null) {
+                        return 0.0;
+                    }
                     return assignmentSnapshot.tasks().size();
                 }
             };


### PR DESCRIPTION
`assignmentSnapshot` may not always get initialized in some cases. If `assignmentSnapshot` is not initialized, registering `assigned-connectors` and `assigned-tasks` metrics upfront will cause
NullPointerException when the two metrics are polled via JmxReporter later

```
[2019-11-05 23:56:57,909] WARN Error getting JMX attribute 'assigned-tasks' (org.apache.kafka.common.metrics.JmxReporter:202)
java.lang.NullPointerException
	at org.apache.kafka.connect.runtime.distributed.WorkerCoordinator$WorkerCoordinatorMetrics$2.measure(WorkerCoordinator.java:316)
	at org.apache.kafka.common.metrics.KafkaMetric.metricValue(KafkaMetric.java:66)
	at org.apache.kafka.common.metrics.JmxReporter$KafkaMbean.getAttribute(JmxReporter.java:190)
	at org.apache.kafka.common.metrics.JmxReporter$KafkaMbean.getAttributes(JmxReporter.java:200)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttributes(DefaultMBeanServerInterceptor.java:709)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.getAttributes(JmxMBeanServer.java:705)
	at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1449)
	at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76)
	at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309)
	at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401)
	at javax.management.remote.rmi.RMIConnectionImpl.getAttributes(RMIConnectionImpl.java:675)
	at sun.reflect.GeneratedMethodAccessor11.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
	at sun.rmi.transport.Transport$1.run(Transport.java:200)
	at sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:573)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:835)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:688)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:687)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
[2019-11-05 23:57:02,821] INFO [Worker clientId=connect-1, groupId=backup-mm2] Herder stopped (org.apache.kafka.connect.runtime.distributed.DistributedHerder:629)
[2019-11-05 23:57:02,821] INFO [Worker clientId=connect-2, groupId=cv-mm2] Herder stopping (org.apache.kafka.connect.runtime.distributed.DistributedHerder:609)
[2019-11-05 23:57:07,822] INFO [Worker clientId=connect-2, groupId=cv-mm2] Herder stopped (org.apache.kafka.connect.runtime.distributed.DistributedHerder:629)
[2019-11-05 23:57:07,822] INFO Kafka MirrorMaker stopped. (org.apache.kafka.connect.mirror.MirrorMaker:191)
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
