### PR TITLE
KAFKA-9149 Avoid temp byte array creation when use ByteBufferSerializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -99,7 +99,7 @@ public final class ProducerBatch {
      *
      * @return The RecordSend corresponding to this record or null if there isn't sufficient room.
      */
-    public FutureRecordMetadata tryAppend(long timestamp, byte[] key, byte[] value, Header[] headers, Callback callback, long now) {
+    public FutureRecordMetadata tryAppend(long timestamp, ByteBuffer key, ByteBuffer value, Header[] headers, Callback callback, long now) {
         if (!recordsBuilder.hasRoomFor(timestamp, key, value, headers)) {
             return null;
         } else {
@@ -109,8 +109,8 @@ public final class ProducerBatch {
             this.lastAppendTime = now;
             FutureRecordMetadata future = new FutureRecordMetadata(this.produceFuture, this.recordCount,
                                                                    timestamp, checksum,
-                                                                   key == null ? -1 : key.length,
-                                                                   value == null ? -1 : value.length,
+                                                                   key == null ? -1 : key.remaining(),
+                                                                   value == null ? -1 : value.remaining(),
                                                                    Time.SYSTEM);
             // we have to keep every future returned to the users in case the batch needs to be
             // split to several new batches and resent.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -184,8 +184,8 @@ public final class RecordAccumulator {
      */
     public RecordAppendResult append(TopicPartition tp,
                                      long timestamp,
-                                     byte[] key,
-                                     byte[] value,
+                                     ByteBuffer key,
+                                     ByteBuffer value,
                                      Header[] headers,
                                      Callback callback,
                                      long maxTimeToBlock,
@@ -262,7 +262,7 @@ public final class RecordAccumulator {
      *  and memory records built) in one of the following cases (whichever comes first): right before send,
      *  if it is expired, or when the producer is closed.
      */
-    private RecordAppendResult tryAppend(long timestamp, byte[] key, byte[] value, Header[] headers,
+    private RecordAppendResult tryAppend(long timestamp, ByteBuffer key, ByteBuffer value, Header[] headers,
                                          Callback callback, Deque<ProducerBatch> deque) {
         ProducerBatch last = deque.peekLast();
         if (last != null) {

--- a/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
@@ -429,22 +429,9 @@ public final class LegacyRecord {
         return crc;
     }
 
-    /**
-     * Write a record using raw fields (without validation). This should only be used in testing.
-     */
-    public static void write(DataOutputStream out,
-                             byte magic,
-                             long crc,
-                             byte attributes,
-                             long timestamp,
-                             byte[] key,
-                             byte[] value) throws IOException {
-        write(out, magic, crc, attributes, timestamp, wrapNullable(key), wrapNullable(value));
-    }
-
     // Write a record to the buffer, if the record's compression type is none, then
     // its value payload should be already compressed with the specified type
-    private static void write(DataOutputStream out,
+    public static void write(DataOutputStream out,
                               byte magic,
                               long crc,
                               byte attributes,
@@ -508,15 +495,10 @@ public final class LegacyRecord {
         return attributes;
     }
 
-    // visible only for testing
-    public static long computeChecksum(byte magic, byte attributes, long timestamp, byte[] key, byte[] value) {
-        return computeChecksum(magic, attributes, timestamp, wrapNullable(key), wrapNullable(value));
-    }
-
     /**
      * Compute the checksum of the record from the attributes, key and value payloads
      */
-    private static long computeChecksum(byte magic, byte attributes, long timestamp, ByteBuffer key, ByteBuffer value) {
+    public static long computeChecksum(byte magic, byte attributes, long timestamp, ByteBuffer key, ByteBuffer value) {
         Crc32 crc = new Crc32();
         crc.update(magic);
         crc.update(attributes);

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.serialization;
 import java.nio.ByteBuffer;
 
 public class ByteBufferSerializer implements Serializer<ByteBuffer> {
+    @Override
     public byte[] serialize(String topic, ByteBuffer data) {
         if (data == null)
             return null;
@@ -36,5 +37,14 @@ public class ByteBufferSerializer implements Serializer<ByteBuffer> {
         data.get(ret, 0, ret.length);
         data.rewind();
         return ret;
+    }
+
+    @Override
+    public ByteBuffer serializeToBuffer(String topic, ByteBuffer data) {
+        if (data == null) {
+            return null;
+        }
+        data.rewind();
+        return data;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedSerializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.apache.kafka.common.header.Headers;
@@ -58,6 +59,11 @@ public interface ExtendedSerializer<T> extends Serializer<T> {
         }
 
         @Override
+        public ByteBuffer serializeToBuffer(String topic, Headers headers, T data) {
+            return serializeToBuffer(topic, data);
+        }
+
+        @Override
         public void configure(Map<String, ?> configs, boolean isKey) {
             serializer.configure(configs, isKey);
         }
@@ -65,6 +71,11 @@ public interface ExtendedSerializer<T> extends Serializer<T> {
         @Override
         public byte[] serialize(String topic, T data) {
             return serializer.serialize(topic, data);
+        }
+
+        @Override
+        public ByteBuffer serializeToBuffer(String topic, T data) {
+            return serializer.serializeToBuffer(topic, data);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/serialization/Serializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Serializer.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Utils;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -51,6 +53,17 @@ public interface Serializer<T> extends Closeable {
     byte[] serialize(String topic, T data);
 
     /**
+     * Convert {@code data} into a ByteBuffer.
+     *
+     * @param topic topic associated with data
+     * @param data typed data
+     * @return serialized ByteBuffer
+     */
+    default ByteBuffer serializeToBuffer(String topic, T data) {
+        return Utils.wrapNullable(serialize(topic, data));
+    }
+
+    /**
      * Convert {@code data} into a byte array.
      *
      * @param topic topic associated with data
@@ -60,6 +73,18 @@ public interface Serializer<T> extends Closeable {
      */
     default byte[] serialize(String topic, Headers headers, T data) {
         return serialize(topic, data);
+    }
+
+    /**
+     * Convert {@code data} into a ByteBuffer.
+     *
+     * @param topic topic associated with data
+     * @param headers headers associated with the record
+     * @param data typed data
+     * @return serialized ByteBuffer
+     */
+    default ByteBuffer serializeToBuffer(String topic, Headers headers, T data) {
+        return serializeToBuffer(topic, data);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -134,7 +134,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 
-@SuppressWarnings("deprecation")
 public class FetcherTest {
     private static final double EPSILON = 0.0001;
 
@@ -462,12 +461,12 @@ public class FetcherTest {
         DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
 
         byte magic = RecordBatch.MAGIC_VALUE_V1;
-        byte[] key = "foo".getBytes();
-        byte[] value = "baz".getBytes();
+        ByteBuffer key = ByteBuffer.wrap("foo".getBytes());
+        ByteBuffer value = ByteBuffer.wrap("baz".getBytes());
         long offset = 0;
         long timestamp = 500L;
 
-        int size = LegacyRecord.recordSize(magic, key.length, value.length);
+        int size = LegacyRecord.recordSize(magic, key.remaining(), value.remaining());
         byte attributes = LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME);
         long crc = LegacyRecord.computeChecksum(magic, attributes, timestamp, key, value);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -53,6 +53,7 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -540,10 +541,10 @@ public class KafkaProducerTest {
         KafkaProducer<String, String> producer = new KafkaProducer<>(configs, keySerializer, valueSerializer, metadata,
                 null, null, Time.SYSTEM);
 
-        when(keySerializer.serialize(any(), any(), any())).then(invocation ->
-                invocation.<String>getArgument(2).getBytes());
-        when(valueSerializer.serialize(any(), any(), any())).then(invocation ->
-                invocation.<String>getArgument(2).getBytes());
+        when(keySerializer.serializeToBuffer(any(), any(), any())).then(invocation ->
+                ByteBuffer.wrap(invocation.<String>getArgument(2).getBytes()));
+        when(valueSerializer.serializeToBuffer(any(), any(), any())).then(invocation ->
+                ByteBuffer.wrap(invocation.<String>getArgument(2).getBytes()));
 
         String value = "value";
         String key = "key";
@@ -559,8 +560,8 @@ public class KafkaProducerTest {
         //ensure existing headers are not changed, and last header for key is still original value
         assertArrayEquals(record.headers().lastHeader("test").value(), "header2".getBytes());
 
-        verify(valueSerializer).serialize(topic, record.headers(), value);
-        verify(keySerializer).serialize(topic, record.headers(), key);
+        verify(valueSerializer).serializeToBuffer(topic, record.headers(), value);
+        verify(keySerializer).serializeToBuffer(topic, record.headers(), key);
 
         producer.close(Duration.ofMillis(0));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
@@ -28,7 +28,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 public class DefaultPartitionerTest {
-    private final static byte[] KEY_BYTES = "key".getBytes();
+    private byte[] keyBytes = "key".getBytes();
     private final static Node[] NODES = new Node[] {
         new Node(0, "localhost", 99),
         new Node(1, "localhost", 100),
@@ -45,7 +45,7 @@ public class DefaultPartitionerTest {
         final Partitioner partitioner = new DefaultPartitioner();
         final Cluster cluster = new Cluster("clusterId", asList(NODES), PARTITIONS,
             Collections.<String>emptySet(), Collections.<String>emptySet());
-        int partition = partitioner.partition("test",  null, KEY_BYTES, null, null, cluster);
-        assertEquals("Same key should yield same partition", partition, partitioner.partition("test", null, KEY_BYTES, null, null, cluster));
+        int partition = partitioner.partition("test",  null, keyBytes, null, null, cluster);
+        assertEquals("Same key should yield same partition", partition, partitioner.partition("test", null, keyBytes, null, null, cluster));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -151,8 +151,8 @@ public class SenderTest {
     @Test
     public void testSimple() throws Exception {
         long offset = 0;
-        Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
         assertEquals("We should have a single produce request in flight.", 1, client.inFlightRequestCount());
@@ -178,8 +178,8 @@ public class SenderTest {
         // start off support produce request v3
         apiVersions.update("0", NodeApiVersions.create());
 
-        Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // now the partition leader supports only v2
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 0, (short) 2));
@@ -217,14 +217,14 @@ public class SenderTest {
         // start off support produce request v3
         apiVersions.update("0", NodeApiVersions.create());
 
-        Future<RecordMetadata> future1 = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future1 = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // now the partition leader supports only v2
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 0, (short) 2));
 
-        Future<RecordMetadata> future2 = accumulator.append(tp1, 0L, "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future2 = accumulator.append(tp1, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // start off support produce request v3
         apiVersions.update("0", NodeApiVersions.create());
@@ -318,7 +318,8 @@ public class SenderTest {
                 1, metricsRegistry, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
 
         // Append a message so that topic metrics are created
-        accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()),
+                null, null, MAX_BLOCK_TIMEOUT, false);
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
         client.respond(produceResponse(tp0, 0, Errors.NONE, 0));
@@ -345,7 +346,8 @@ public class SenderTest {
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
                     maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
             // do a successful retry
-            Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+            Future<RecordMetadata> future = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                    ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
             sender.runOnce(); // connect
             sender.runOnce(); // send produce request
             String id = client.requests().peek().destination();
@@ -374,7 +376,8 @@ public class SenderTest {
             assertEquals(0, sender.inFlightBatches(tp0).size());
 
             // do an unsuccessful retry
-            future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+            future = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                    ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
             sender.runOnce(); // send produce request
             assertEquals(1, sender.inFlightBatches(tp0).size());
             for (int i = 0; i < maxRetries + 1; i++) {
@@ -408,7 +411,8 @@ public class SenderTest {
 
             // Send the first message.
             TopicPartition tp2 = new TopicPartition("test", 1);
-            accumulator.append(tp2, 0L, "key1".getBytes(), "value1".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+            accumulator.append(tp2, 0L, ByteBuffer.wrap("key1".getBytes()), ByteBuffer.wrap("value1".getBytes()),
+                    null, null, MAX_BLOCK_TIMEOUT, false);
             sender.runOnce(); // connect
             sender.runOnce(); // send produce request
             String id = client.requests().peek().destination();
@@ -421,7 +425,8 @@ public class SenderTest {
 
             time.sleep(900);
             // Now send another message to tp2
-            accumulator.append(tp2, 0L, "key2".getBytes(), "value2".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+            accumulator.append(tp2, 0L, ByteBuffer.wrap("key2".getBytes()), ByteBuffer.wrap("value2".getBytes()),
+                    null, null, MAX_BLOCK_TIMEOUT, false);
 
             // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
             MetadataResponse metadataUpdate2 = TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2));
@@ -442,8 +447,8 @@ public class SenderTest {
         int messagesPerBatch = 10;
         final AtomicInteger expiryCallbackCount = new AtomicInteger(0);
         final AtomicReference<Exception> unexpectedException = new AtomicReference<>();
-        final byte[] key = "key".getBytes();
-        final byte[] value = "value".getBytes();
+        final ByteBuffer key = ByteBuffer.wrap("key".getBytes());
+        final ByteBuffer value = ByteBuffer.wrap("value".getBytes());
         final long maxBlockTimeMs = 1000;
         Callback callback = new Callback() {
             @Override
@@ -494,7 +499,8 @@ public class SenderTest {
         long offset = 0;
         client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
 
-        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertTrue("Topic not added to metadata", metadata.containsTopic(tp0.topic()));
         client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
@@ -511,7 +517,8 @@ public class SenderTest {
         time.sleep(ProducerMetadata.TOPIC_EXPIRY_MS);
         client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
         assertFalse("Unused topic has not been expired", metadata.containsTopic(tp0.topic()));
-        future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertTrue("Topic not added to metadata", metadata.containsTopic(tp0.topic()));
         client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
@@ -553,7 +560,8 @@ public class SenderTest {
     @Test
     public void testCanRetryWithoutIdempotence() throws Exception {
         // do a successful retry
-        Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
         String id = client.requests().peek().destination();
@@ -592,7 +600,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -601,7 +610,8 @@ public class SenderTest {
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
@@ -642,7 +652,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -651,11 +662,13 @@ public class SenderTest {
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
          // Send third ProduceRequest
-        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         assertEquals(3, client.inFlightRequestCount());
@@ -670,7 +683,8 @@ public class SenderTest {
         sender.runOnce(); // receive response 0
 
         // Queue the fourth request, it shouldn't be sent until the first 3 complete.
-        Future<RecordMetadata> request4 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request4 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
@@ -742,7 +756,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -751,7 +766,8 @@ public class SenderTest {
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
@@ -801,8 +817,10 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest with multiple messages.
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false);
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -816,7 +834,8 @@ public class SenderTest {
         sender.runOnce();
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(3, transactionManager.sequenceNumber(tp0).longValue());
@@ -843,7 +862,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -852,7 +872,8 @@ public class SenderTest {
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
@@ -925,14 +946,16 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
         assertEquals(1, client.inFlightRequestCount());
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, client.inFlightRequestCount());
         assertFalse(request1.isDone());
@@ -993,7 +1016,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         Node node = metadata.fetch().nodes().get(0);
         time.sleep(10000L);
         client.disconnect(node.idString());
@@ -1015,13 +1039,15 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         // We separate the two appends by 1 second so that the two batches
         // don't expire at the same time.
         time.sleep(1000L);
 
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(2, sender.inFlightBatches(tp0).size());
@@ -1043,7 +1069,8 @@ public class SenderTest {
         assertEquals(0, sender.inFlightBatches(tp0).size());
 
         // let's enqueue another batch, which should not be dequeued until the unresolved state is clear.
-        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         time.sleep(20);
         assertFalse(request2.isDone());
 
@@ -1082,11 +1109,13 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
 
         time.sleep(1000L);
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
 
         assertEquals(2, client.inFlightRequestCount());
@@ -1103,7 +1132,8 @@ public class SenderTest {
         assertFutureFailure(request1, TimeoutException.class);
         assertTrue(transactionManager.hasUnresolvedSequence(tp0));
         // let's enqueue another batch, which should not be dequeued until the unresolved state is clear.
-        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         time.sleep(20);
         assertFalse(request2.isDone());
@@ -1135,7 +1165,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         sendIdempotentProducerResponse(0, tp0, Errors.NOT_LEADER_FOR_PARTITION, -1);
 
@@ -1174,10 +1205,10 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                 senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect and send.
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1216,10 +1247,10 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, 10,
             senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-            "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-            "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+            ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+            ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect and send.
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1255,10 +1286,10 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, 10,
             senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-            "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-            "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+            ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+            ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect and send.
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1291,10 +1322,10 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                 senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> successfulResponse = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect.
         sender.runOnce();  // send.
 
@@ -1338,7 +1369,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         String nodeId = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(nodeId), "localhost", 0);
@@ -1347,7 +1379,8 @@ public class SenderTest {
         assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, client.inFlightRequestCount());
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
@@ -1391,7 +1424,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1408,8 +1442,10 @@ public class SenderTest {
         assertEquals(OptionalLong.of(1000L), transactionManager.lastAckedOffset(tp0));
 
         // Send second ProduceRequest, a single batch with 2 records.
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false);
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(3, transactionManager.sequenceNumber(tp0).longValue());
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
@@ -1449,7 +1485,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1466,7 +1503,8 @@ public class SenderTest {
         assertEquals(OptionalLong.of(1000L), transactionManager.lastAckedOffset(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
@@ -1507,7 +1545,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1524,14 +1563,16 @@ public class SenderTest {
         assertEquals(OptionalLong.of(1000L), transactionManager.lastAckedOffset(tp0));
 
         // Send second ProduceRequest
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
 
         // Send the third ProduceRequest, in parallel with the second. It should be retried even though the
         // lastAckedOffset > logStartOffset when its UnknownProducerResponse comes back.
-        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request3 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(3, transactionManager.sequenceNumber(tp0).longValue());
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
@@ -1596,7 +1637,8 @@ public class SenderTest {
         assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         assertEquals(1, client.inFlightRequestCount());
@@ -1613,7 +1655,8 @@ public class SenderTest {
         assertEquals(OptionalLong.of(1000L), transactionManager.lastAckedOffset(tp0));
 
         // Send second ProduceRequest,
-        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertEquals(2, transactionManager.sequenceNumber(tp0).longValue());
         assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
@@ -1656,8 +1699,8 @@ public class SenderTest {
         assertTrue(transactionManager.hasProducerId());
 
         // cluster authorization is a fatal error for the producer
-        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         client.prepareResponse(new MockClient.RequestMatcher() {
             @Override
             public boolean matches(AbstractRequest body) {
@@ -1683,12 +1726,12 @@ public class SenderTest {
         assertTrue(transactionManager.hasProducerId());
 
         // cluster authorization is a fatal error for the producer
-        Future<RecordMetadata> future1 = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
-        Future<RecordMetadata> future2 = accumulator.append(tp1, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future2 = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
 
         client.respond(new MockClient.RequestMatcher() {
@@ -1724,8 +1767,8 @@ public class SenderTest {
         prepareAndReceiveInitProducerId(producerId, Errors.NONE);
         assertTrue(transactionManager.hasProducerId());
 
-        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         client.prepareResponse(new MockClient.RequestMatcher() {
             @Override
             public boolean matches(AbstractRequest body) {
@@ -1749,8 +1792,8 @@ public class SenderTest {
         prepareAndReceiveInitProducerId(producerId, Errors.NONE);
         assertTrue(transactionManager.hasProducerId());
 
-        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         client.prepareUnsupportedVersionResponse(new MockClient.RequestMatcher() {
             @Override
             public boolean matches(AbstractRequest body) {
@@ -1780,7 +1823,8 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                 senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         client.prepareResponse(new MockClient.RequestMatcher() {
             @Override
             public boolean matches(AbstractRequest body) {
@@ -1822,7 +1866,8 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                 senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect.
         sender.runOnce();  // send.
         String id = client.requests().peek().destination();
@@ -1861,7 +1906,8 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                 senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect.
         sender.runOnce();  // send.
 
@@ -1925,9 +1971,11 @@ public class SenderTest {
             client.prepareMetadataUpdate(metadataUpdate1);
             // Send the first message.
             Future<RecordMetadata> f1 =
-                    accumulator.append(tp, 0L, "key1".getBytes(), new byte[batchSize / 2], null, null, MAX_BLOCK_TIMEOUT, false).future;
+                    accumulator.append(tp, 0L, ByteBuffer.wrap("key1".getBytes()), ByteBuffer.allocate(batchSize / 2),
+                            null, null, MAX_BLOCK_TIMEOUT, false).future;
             Future<RecordMetadata> f2 =
-                    accumulator.append(tp, 0L, "key2".getBytes(), new byte[batchSize / 2], null, null, MAX_BLOCK_TIMEOUT, false).future;
+                    accumulator.append(tp, 0L, ByteBuffer.wrap("key2".getBytes()), ByteBuffer.allocate(batchSize / 2),
+                            null, null, MAX_BLOCK_TIMEOUT, false).future;
             sender.runOnce(); // connect
             sender.runOnce(); // send produce request
 
@@ -1997,7 +2045,8 @@ public class SenderTest {
 
         // Send first ProduceRequest
         Future<RecordMetadata> request1 =
-            accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+            accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                    ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(1, sender.inFlightBatches(tp0).size());
@@ -2022,7 +2071,8 @@ public class SenderTest {
         setupWithTransactionState(null, true, null);
 
         // Send first ProduceRequest
-        Future<RecordMetadata> request = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         assertEquals(1, client.inFlightRequestCount());
         assertEquals("Expect one in-flight batch in accumulator", 1, sender.inFlightBatches(tp0).size());
@@ -2048,7 +2098,8 @@ public class SenderTest {
         setupWithTransactionState(null, true, null);
 
         // Send first ProduceRequest
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false);
         sender.runOnce();  // send request
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(1, sender.inFlightBatches(tp0).size());
@@ -2056,7 +2107,8 @@ public class SenderTest {
         time.sleep(deliveryTimeoutMs / 2);
 
         // Send second ProduceRequest
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false);
         sender.runOnce();  // must not send request because the partition is muted
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(1, sender.inFlightBatches(tp0).size());
@@ -2080,8 +2132,8 @@ public class SenderTest {
 
         // Send first ProduceRequest
         Future<RecordMetadata> request1 =
-            accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null,
-                MAX_BLOCK_TIMEOUT, false).future;
+            accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // send request
         assertEquals(1, client.inFlightRequestCount());
         time.sleep(deliverTimeoutMs);
@@ -2109,11 +2161,11 @@ public class SenderTest {
         long deliverTimeoutMs = 1500L;
         // create a producer batch with more than one record so it is eligible for splitting
         Future<RecordMetadata> request1 =
-            accumulator.append(tp0, time.milliseconds(), "key1".getBytes(), "value1".getBytes(), null, null,
-                MAX_BLOCK_TIMEOUT, false).future;
+            accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key1".getBytes()),
+                ByteBuffer.wrap("value1".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         Future<RecordMetadata> request2 =
-            accumulator.append(tp0, time.milliseconds(), "key2".getBytes(), "value2".getBytes(), null, null,
-                MAX_BLOCK_TIMEOUT, false).future;
+            accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key2".getBytes()),
+                ByteBuffer.wrap("value2".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // send request
         sender.runOnce();
@@ -2141,8 +2193,8 @@ public class SenderTest {
 
         setupWithTransactionState(null);
 
-        accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null,
-                MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, 0L, ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false);
 
         sender.runOnce();
         sender.runOnce();
@@ -2166,8 +2218,10 @@ public class SenderTest {
         setupWithTransactionState(null, true, null);
 
         // Send multiple ProduceRequest across multiple partitions.
-        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), "k1".getBytes(), "v1".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> request2 = accumulator.append(tp1, time.milliseconds(), "k2".getBytes(), "v2".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request1 = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("k1".getBytes()),
+                ByteBuffer.wrap("v1".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> request2 = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("k2".getBytes()),
+                ByteBuffer.wrap("v2".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // Send request.
         sender.runOnce();
@@ -2326,11 +2380,11 @@ public class SenderTest {
 
         // create a producer batch with more than one record so it is eligible for splitting
         Future<RecordMetadata> request1 =
-                accumulator.append(tp0, time.milliseconds(), "key1".getBytes(), "value1".getBytes(), null, null,
-                        MAX_BLOCK_TIMEOUT, false).future;
+                accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key1".getBytes()),
+                        ByteBuffer.wrap("value1".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         Future<RecordMetadata> request2 =
-                accumulator.append(tp0, time.milliseconds(), "key2".getBytes(), "value2".getBytes(), null, null,
-                        MAX_BLOCK_TIMEOUT, false).future;
+                accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key2".getBytes()),
+                        ByteBuffer.wrap("value2".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
 
         // send request
         sender.runOnce();
@@ -2482,8 +2536,8 @@ public class SenderTest {
     }
 
     private void assertSendFailure(Class<? extends RuntimeException> expectedError) throws Exception {
-        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(),
-                null, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> future = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertTrue(future.isDone());
         try {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -153,8 +153,8 @@ public class TransactionManagerTest {
 
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
-        FutureRecordMetadata sendFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        FutureRecordMetadata sendFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
         prepareProduceResponse(Errors.NONE, pid, epoch);
@@ -762,7 +762,8 @@ public class TransactionManagerTest {
                 CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
         long currentTimeMs = time.milliseconds();
         ProducerBatch batch = new ProducerBatch(tp, builder, currentTimeMs);
-        batch.tryAppend(currentTimeMs, new byte[0], value.getBytes(), new Header[0], null, currentTimeMs);
+        batch.tryAppend(currentTimeMs, ByteBuffer.wrap(new byte[0]),
+            ByteBuffer.wrap(value.getBytes()), new Header[0], null, currentTimeMs);
         return batch;
     }
 
@@ -799,8 +800,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
@@ -1250,8 +1251,9 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(unauthorizedPartition, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
+                ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS,
+                null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
         sender.runOnce();
@@ -1274,8 +1276,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
         sender.runOnce();
@@ -1309,14 +1311,16 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
         Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
-                "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+                ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null,
+                MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertTrue(transactionManager.isPartitionAdded(tp0));
 
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
         Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
-                "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+                ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null,
+                MAX_BLOCK_TIMEOUT, false).future;
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
         sender.runOnce();
         assertTrue(transactionManager.hasAbortableError());
@@ -1341,8 +1345,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
         sender.runOnce();
@@ -1376,7 +1380,8 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
 
         Future<RecordMetadata> authorizedTopicProduceFuture = accumulator.append(tp0, time.milliseconds(),
-                "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+                ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS,
+                null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();
         assertTrue(transactionManager.isPartitionAdded(tp0));
 
@@ -1389,7 +1394,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(unauthorizedPartition);
         Future<RecordMetadata> unauthorizedTopicProduceFuture = accumulator.append(unauthorizedPartition, time.milliseconds(),
-                "key".getBytes(), "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+                ByteBuffer.wrap("key".getBytes()), ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null,
+                MAX_BLOCK_TIMEOUT, false).future;
         prepareAddPartitionsToTxn(singletonMap(unauthorizedPartition, Errors.TOPIC_AUTHORIZATION_FAILED));
         sender.runOnce();
         assertTrue(transactionManager.hasAbortableError());
@@ -1418,8 +1424,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        FutureRecordMetadata nextTransactionFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(singletonMap(tp0, Errors.NONE));
         sender.runOnce();
@@ -1471,8 +1477,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
 
@@ -1517,8 +1523,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
@@ -1533,8 +1539,8 @@ public class TransactionManagerTest {
         // In the mean time, the user does a second produce to a different partition
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp1);
-        Future<RecordMetadata> secondResponseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> secondResponseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp1, epoch, pid);
         prepareProduceResponse(Errors.NONE, pid, epoch);
@@ -1569,8 +1575,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
@@ -1608,8 +1614,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         TransactionalRequestResult commitResult = transactionManager.beginCommit();
         assertFalse(responseFuture.isDone());
@@ -1658,8 +1664,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
@@ -1687,8 +1693,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
@@ -1725,8 +1731,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
         sender.runOnce();
@@ -1775,8 +1781,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxn(tp0, Errors.NONE);
         sender.runOnce();
@@ -1831,8 +1837,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         sender.runOnce();  // Send AddPartitionsRequest
@@ -1860,8 +1866,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
 
@@ -1893,8 +1899,8 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, producerEpoch, producerId);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         sender.runOnce();  // Send AddPartitions and let it fail
         assertFalse(responseFuture.isDone());
@@ -1933,8 +1939,8 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, producerEpoch, producerId);
         prepareProduceResponse(Errors.REQUEST_TIMED_OUT, producerId, producerEpoch);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         sender.runOnce();  // Send AddPartitions
         sender.runOnce();  // Send ProduceRequest and let it fail
@@ -1969,8 +1975,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, epoch, pid);
@@ -2130,12 +2136,12 @@ public class TransactionManagerTest {
         transactionManager.beginTransaction();
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp1);
-        accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
 
         assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(transactionManager.isSendToPartitionAllowed(tp1));
@@ -2187,8 +2193,8 @@ public class TransactionManagerTest {
         PartitionInfo part1 = new PartitionInfo(topic, 1, node1, null, null);
         Cluster cluster = new Cluster(null, Collections.singletonList(node1), Collections.singletonList(part1),
                 Collections.emptySet(), Collections.emptySet());
-        accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
         Map<Integer, List<ProducerBatch>> drainedBatches = accumulator.drain(cluster, Collections.singleton(node1),
                 Integer.MAX_VALUE,
                 time.milliseconds());
@@ -2207,8 +2213,8 @@ public class TransactionManagerTest {
         doInitTransactions(pid, epoch);
         transactionManager.beginTransaction();
         // Don't execute transactionManager.maybeAddPartitionToTransaction(tp0). This should result in an error on drain.
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
         Node node1 = new Node(0, "localhost", 1111);
         PartitionInfo part1 = new PartitionInfo(topic, 0, node1, null, null);
 
@@ -2234,8 +2240,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
         prepareProduceResponse(Errors.NOT_LEADER_FOR_PARTITION, pid, epoch);
@@ -2263,8 +2269,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
 
@@ -2312,10 +2318,10 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp1);
 
-        Future<RecordMetadata> firstBatchResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
-        Future<RecordMetadata> secondBatchResponse = accumulator.append(tp1, time.milliseconds(), "key".getBytes(),
-               "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> firstBatchResponse = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> secondBatchResponse = accumulator.append(tp1, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+               ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(firstBatchResponse.isDone());
         assertFalse(secondBatchResponse.isDone());
@@ -2377,8 +2383,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
 
@@ -2444,8 +2450,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
 
         assertFalse(responseFuture.isDone());
 
@@ -2643,8 +2649,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
+        accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false);
 
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
@@ -2685,8 +2691,8 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp0);
 
-        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
-                "value".getBytes(), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
+        Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), ByteBuffer.wrap("key".getBytes()),
+                ByteBuffer.wrap("value".getBytes()), Record.EMPTY_HEADERS, null, MAX_BLOCK_TIMEOUT, false).future;
         assertFalse(responseFuture.isDone());
         prepareAddPartitionsToTxn(tp0, error);
         sender.runOnce();  // attempt send addPartitions.

--- a/clients/src/test/java/org/apache/kafka/common/record/LegacyRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LegacyRecordTest.java
@@ -83,8 +83,8 @@ public class LegacyRecordTest {
                 magic,
                 attributes,
                 this.timestamp,
-                this.key == null ? null : this.key.array(),
-                this.value == null ? null : this.value.array()
+                this.key == null ? null : this.key,
+                this.value == null ? null : this.value
         ));
         assertTrue(record.isValid());
         for (int i = LegacyRecord.CRC_OFFSET + LegacyRecord.CRC_LENGTH; i < record.sizeInBytes(); i++) {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -39,6 +39,7 @@ import kafka.server.QuotaType
 import kafka.server.KafkaServer
 
 import scala.collection.mutable
+import java.nio.ByteBuffer
 
 /* We have some tests in this class instead of `BaseConsumerTest` in order to keep the build time under control. */
 class PlaintextConsumerTest extends BaseConsumerTest {
@@ -73,9 +74,9 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   trait SerializerImpl extends Serializer[Array[Byte]]{
     var serializer = new ByteArraySerializer()
 
-    override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = {
+    override def serializeToBuffer(topic: String, headers: Headers, data: Array[Byte]): ByteBuffer = {
       headers.add("content-type", "application/octet-stream".getBytes)
-      serializer.serialize(topic, data)
+      serializer.serializeToBuffer(topic, data)
     }
 
     override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = serializer.configure(configs, isKey)


### PR DESCRIPTION
Avoid temp byte array creation when use ByteBufferSerializer