### PR TITLE
MINOR: Fix version range check in MessageTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -331,7 +331,6 @@ public final class MessageTest {
 
             if (version < 6) {
                 requestData.topics().get(0).partitions().get(0).setCommittedLeaderEpoch(-1);
-
             }
 
             if (version < 7) {
@@ -598,7 +597,7 @@ public final class MessageTest {
     }
 
     private void testAllMessageRoundTripsFromVersion(short fromVersion, Message message) throws Exception {
-        for (short version = fromVersion; version < message.highestSupportedVersion(); version++) {
+        for (short version = fromVersion; version <= message.highestSupportedVersion(); version++) {
             testEquivalentMessageRoundTrip(version, message);
         }
     }


### PR DESCRIPTION
This patch fixes the test utility `testAllMessageRoundTripsFromVersion` in `MessageTest` which was unintentionally excluding the highest version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
