### PR TITLE
KAKFA-9178: remove changelog partitions from restoredPartitions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -226,6 +226,7 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
                                             final List<TopicPartition> closedTaskChangelogs) {
         removeTaskFromRestoring(task);
         closedTaskChangelogs.addAll(task.changelogPartitions());
+        restoredPartitions.removeAll(task.changelogPartitions());
 
         try {
             final boolean clean = !isZombie;


### PR DESCRIPTION
As the ticket suggested, we haven't got a chance to cleanup the `restoredPartitions` with the changelog topics associated with the specific task.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
