### PR TITLE
KAFKA-9178: restoredPartitions is not cleared until the last restoring task completes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -80,14 +80,17 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
         }
     }
 
-    // Note that restoredPartitions may be nonempty even though restoring is, and will not be cleared in
-    // #updateRestored if this returns false, so we should clear any remaining partitions if restoring is empty
     boolean hasRestoringTasks() {
-        if (restoring.isEmpty()) {
-            restoredPartitions.clear();
-            restoringByPartition.clear();
-        }
         return !restoring.isEmpty();
+    }
+
+    void clearRestoringPartitions() {
+        if (!restoring.isEmpty()) {
+            log.error("Tried to clear restoring partitions but was still restoring the stream tasks {}", restoring);
+            throw new IllegalStateException("Should not clear restoring partitions while set of restoring tasks is non-empty");
+        }
+        restoredPartitions.clear();
+        restoringByPartition.clear();
     }
     
     Set<TaskId> suspendedTaskIds() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -207,7 +207,7 @@ public class StoreChangelogReader implements ChangelogReader {
                         restoreToOffsets.get(partition));
                 restorer.setStartingOffset(restoreConsumer.position(partition));
 
-                log.debug("Calling restorer for partition {} of task {}", partition, active.restoringTaskFor(partition));
+                log.debug("Calling restorer for partition {}", partition);
                 restorer.restoreStarted();
             } else {
                 log.trace("Did not find checkpoint from changelog {} for store {}, rewinding to beginning.", partition, restorer.storeName());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -413,6 +413,8 @@ public class TaskManager {
             final Collection<TopicPartition> restored = changelogReader.restore(active);
             active.updateRestored(restored);
             removeChangelogsFromRestoreConsumer(restored, false);
+        } else {
+            active.clearRestoringPartitions();
         }
 
         if (active.allTasksRunning()) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasksTest.java
@@ -173,8 +173,8 @@ public class AssignedStreamsTasksTest {
     public void shouldCloseRestoringTasks() {
         t1.initializeMetadata();
         EasyMock.expect(t1.initializeStateStores()).andReturn(false);
-        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1)).times(2);
-        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet()).times(3);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1)).times(3);
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.emptySet()).times(4);
         t1.closeStateManager(true);
         EasyMock.expectLastCall();
         EasyMock.replay(t1);


### PR DESCRIPTION
The ideal fix for this PR is blocked by https://issues.apache.org/jira/browse/KAFKA-9177, since any partitions we remove from `restoredPartitions` will just be added back to the set on the next loop unless we remove/pause completed partitions in the restore consumer

For now, we can just remove from `restoredPartitions` whenever we suspend or close a running task.

This PR is for trunk only -- the fix for 2.4 is being included in https://github.com/apache/kafka/pull/7691