### PR TITLE
MINOR: fix typo in processor-api developer guide docs

### DIFF
--- a/docs/streams/developer-guide/processor-api.html
+++ b/docs/streams/developer-guide/processor-api.html
@@ -195,7 +195,7 @@
                     <a class="reference internal" href="#streams-developer-guide-state-store-custom"><span class="std std-ref">implement your own custom store type</span></a>.
                     It&#8217;s common practice to leverage an existing store type via the <code class="docutils literal"><span class="pre">Stores</span></code> factory.</p>
                 <p>Note that, when using Kafka Streams, you normally don&#8217;t create or instantiate state stores directly in your code.
-                    Rather, you define state stores indirectly by creating a so-called <code class="docutils literal"><span class="pre">StoreBuilder</span></code>.  This buildeer is used by
+                    Rather, you define state stores indirectly by creating a so-called <code class="docutils literal"><span class="pre">StoreBuilder</span></code>.  This builder is used by
                     Kafka Streams as a factory to instantiate the actual state stores locally in application instances when and where
                     needed.</p>
                 <p>The following store types are available out of the box.</p>


### PR DESCRIPTION
Fixed a small typo on the Processor API page of the Kafka Streams developer guide docs. ("buildeer" changed to "builder")

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
