### PR TITLE
MINOR: Fix Streams EOS system tests by adding clean-up of state dir

### DIFF
--- a/tests/kafkatest/tests/streams/streams_eos_test.py
+++ b/tests/kafkatest/tests/streams/streams_eos_test.py
@@ -67,6 +67,9 @@ class StreamsEosTest(KafkaTest):
         self.add_streams3(processor2, processor3, processor1)
         self.stop_streams3(processor1, processor3, processor2)
         self.stop_streams2(processor1, processor3)
+
+        processor1.clean_node_enabled = True
+
         self.stop_streams(processor1)
 
         self.driver.stop()
@@ -109,6 +112,9 @@ class StreamsEosTest(KafkaTest):
         self.add_streams3(processor2, processor3, processor1)
         self.abort_streams(processor1, processor3, processor2)
         self.stop_streams2(processor1, processor3)
+
+        processor1.clean_node_enabled = True
+
         self.stop_streams(processor1)
 
         self.driver.stop()

--- a/tests/kafkatest/tests/streams/streams_eos_test.py
+++ b/tests/kafkatest/tests/streams/streams_eos_test.py
@@ -58,19 +58,16 @@ class StreamsEosTest(KafkaTest):
 
         self.driver.start()
 
-        processor1.clean_node_enabled = False
-
         self.add_streams(processor1)
+        processor1.clean_node_enabled = False
         self.add_streams2(processor1, processor2)
         self.add_streams3(processor1, processor2, processor3)
         self.stop_streams3(processor2, processor3, processor1)
         self.add_streams3(processor2, processor3, processor1)
         self.stop_streams3(processor1, processor3, processor2)
         self.stop_streams2(processor1, processor3)
-
-        processor1.clean_node_enabled = True
-
         self.stop_streams(processor1)
+        processor1.clean_node_enabled = True
 
         self.driver.stop()
 
@@ -101,9 +98,8 @@ class StreamsEosTest(KafkaTest):
 
         self.driver.start()
 
-        processor1.clean_node_enabled = False
-
         self.add_streams(processor1)
+        processor1.clean_node_enabled = False
         self.add_streams2(processor1, processor2)
         self.add_streams3(processor1, processor2, processor3)
         self.abort_streams(processor2, processor3, processor1)
@@ -112,10 +108,8 @@ class StreamsEosTest(KafkaTest):
         self.add_streams3(processor2, processor3, processor1)
         self.abort_streams(processor1, processor3, processor2)
         self.stop_streams2(processor1, processor3)
-
-        processor1.clean_node_enabled = True
-
         self.stop_streams(processor1)
+        processor1.clean_node_enabled = True
 
         self.driver.stop()
 


### PR DESCRIPTION
Recently, system tests `test_rebalance_[simple|complex]` failed
repeatedly with a verfication error. The cause was most probably
the missing clean-up of a state directory of one of the processors.

A node is cleaned up when a service on that node is started and when 
a test is torn down.

If the clean-up flag `clean_node_enabled` of a EOS Streams service is 
unset, the clean-up of the node is skipped.

The clean-up flag of `processor1` in the EOS tests should stay set before
its first start, so that the node is cleaned before the service is started.
Afterwards for the multiple restarts of `processor1` the cleans-up flag should
be unset to re-use the local state.

After the multiple restarts are done, the clean-up flag of processor1 should
again be set to trigger node clean-up during the test teardown.

A dirty node can lead to test failures when tests from Streams EOS tests are
scheduled on the same node, because the state store would not start empty
since it reads the local state that was not cleaned up.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
