### PR TITLE
KAFKA-9180: Introduce BrokerMetadataCheckpointTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ systest/
 *.swp
 clients/src/generated
 clients/src/generated-test
+jmh-benchmarks/generated
 streams/src/generated

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -1,0 +1,25 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
+package kafka.server
+
+import java.io.File
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BrokerMetadataCheckpointTest {
+  @Test
+  def testReadWithNonExistentFile(): Unit = {
+    assertEquals(None, new BrokerMetadataCheckpoint(new File("path/that/does/not/exist")).read())
+  }
+}


### PR DESCRIPTION
While investigating KAFKA-9180, I noticed that we had no
unit test coverage. It turns out that the behavior was
correct, so we just fix the test coverage issue.

Also updated .gitignore with jmh-benchmarks/generated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
