### PR TITLE
MINOR: Use IntegrationTestHarness properly in BaseAdminIntegrationTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -14,16 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package integration.kafka.api
+package kafka.api
 
 import java.util
 import java.util.Properties
 import java.util.concurrent.ExecutionException
 
-import kafka.api.IntegrationTestHarness
 import kafka.security.auth.{Cluster, Topic}
 import kafka.server.KafkaConfig
-import kafka.utils.Implicits._
 import kafka.utils.Logging
 import kafka.utils.TestUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig, CreateTopicsOptions, CreateTopicsResult, DescribeClusterOptions, DescribeTopicsOptions, NewTopic, TopicDescription}

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -17,6 +17,7 @@
 package integration.kafka.api
 
 import java.util
+import java.util.Properties
 import java.util.concurrent.ExecutionException
 
 import kafka.api.IntegrationTestHarness
@@ -45,9 +46,8 @@ import scala.compat.java8.OptionConverters._
  * authentication/authorization layers, we may add the test case here.
  */
 abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logging {
-  val brokerCount = 3
-  val consumerCount = 1
-  val producerCount = 1
+  def brokerCount = 3
+  override def logDirCount = 2
 
   var client: Admin = _
 
@@ -187,14 +187,9 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
     Cluster.supportedOperations.map(operation => operation.toJava)
   }
 
-  override def generateConfigs: Seq[KafkaConfig] = {
-    val cfgs = createBrokerConfigs(brokerCount, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, logDirCount = 2)
-    cfgs.foreach { config =>
-      config.setProperty(KafkaConfig.ListenersProp, s"${listenerName.value}://localhost:$RandomPort")
-      config.remove(KafkaConfig.InterBrokerSecurityProtocolProp)
-      config.setProperty(KafkaConfig.InterBrokerListenerNameProp, listenerName.value)
-      config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"${listenerName.value}:${securityProtocol.name}")
+  override def modifyConfigs(configs: Seq[Properties]): Unit = {
+    super.modifyConfigs(configs)
+    configs.foreach { config =>
       config.setProperty(KafkaConfig.DeleteTopicEnableProp, "true")
       config.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
       config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, "false")
@@ -204,8 +199,6 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
       if (!config.containsKey(KafkaConfig.SslTruststorePasswordProp))
         config.setProperty(KafkaConfig.SslTruststorePasswordProp, "some.invalid.pass")
     }
-    cfgs.foreach(_ ++= serverConfig)
-    cfgs.map(KafkaConfig.fromProps)
   }
 
   def createConfig(): util.Map[String, Object] = {

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -54,13 +54,13 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   protected def interBrokerListenerName: ListenerName = listenerName
 
   protected def modifyConfigs(props: Seq[Properties]): Unit = {
-    configureListeners(props)
     props.foreach(_ ++= serverConfig)
   }
 
   override def generateConfigs: Seq[KafkaConfig] = {
     val cfgs = TestUtils.createBrokerConfigs(brokerCount, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
       trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, logDirCount = logDirCount)
+    configureListeners(cfgs)
     modifyConfigs(cfgs)
     cfgs.map(KafkaConfig.fromProps)
   }

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit}
 import java.util.{Collections, Optional, Properties}
 import java.{time, util}
 
-import integration.kafka.api.BaseAdminIntegrationTest
 import kafka.log.LogConfig
 import kafka.security.auth.Group
 import kafka.server.{Defaults, KafkaConfig, KafkaServer}

--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -49,11 +49,6 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
     closeSasl()
   }
 
-  override def modifyConfigs(props: Seq[Properties]): Unit = {
-    super.modifyConfigs(props)
-    configureListeners(props)
-  }
-
   /**
    * Checks that everyone can access ZkData.SecureZkRootPaths and ZkData.SensitiveZkRootPaths
    * when zookeeper.set.acl=false, even if ZooKeeper is SASL-enabled.

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -15,7 +15,6 @@ package kafka.api
 import java.io.File
 import java.util
 
-import integration.kafka.api.BaseAdminIntegrationTest
 import kafka.log.LogConfig
 import kafka.security.auth.{All, Allow, Alter, AlterConfigs, Authorizer, ClusterAction, Create, Delete, Deny, Describe, Group, Operation, PermissionType, SimpleAclAuthorizer, Topic, Acl => AuthAcl, Resource => AuthResource}
 import kafka.security.authorizer.AuthorizerWrapper


### PR DESCRIPTION
The latter was previously hardcoding logDirCount instead of using the
method defined in the superclass since it was unnecessarily duplicating
logic.

Also tweak IntegrationTestHarness and remove unnecessary method
override from SaslPlainPlaintextConsumerTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
