### PR TITLE
HOTFIX: Fix unit tests that failed when executed from IDE

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -28,7 +28,7 @@ import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
 public class ClientMetricsTest {
-    private static final String COMMIT_ID = "t35tc0441t";
+    private static final String COMMIT_ID = "test-commit-ID";
     private static final String VERSION = "test-version";
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -16,71 +16,60 @@
  */
 package org.apache.kafka.streams.internals.metrics;
 
-
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.and;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.not;
-import static org.easymock.EasyMock.notNull;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
 public class ClientMetricsTest {
+    private static final String COMMIT_ID = "t35tc0441t";
+    private static final String VERSION = "test-version";
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
 
-    private interface OneParamMetricAdder {
-        void addMetric(final StreamsMetricsImpl streamsMetrics);
-    }
-
-    private interface TwoParamMetricAdder {
-        void addMetric(final StreamsMetricsImpl streamsMetrics, final String value);
-    }
-
-    /*
-     * This test may fail when executed from a IDE since it expects the /kafka/kafka-streams-version.properties on the
-     * class path.
-     */
     @Test
     public void shouldAddVersionMetric() {
         final String name = "version";
         final String description = "The version of the Kafka Streams client";
-        setUpAndVerifyMetricOneParam(name, description, ClientMetrics::addVersionMetric);
+        setUpAndVerifyMetric(name, description, VERSION, () -> ClientMetrics.addVersionMetric(streamsMetrics));
     }
 
-    /*
-     * This test may fail when executed from a IDE since it expects the /kafka/kafka-streams-version.properties on the
-     * class path.
-     */
     @Test
     public void shouldAddCommitIdMetric() {
         final String name = "commit-id";
         final String description = "The version control commit ID of the Kafka Streams client";
-        setUpAndVerifyMetricOneParam(name, description, ClientMetrics::addCommitIdMetric);
+        setUpAndVerifyMetric(name, description, COMMIT_ID, () -> ClientMetrics.addCommitIdMetric(streamsMetrics));
     }
 
     @Test
     public void shouldAddApplicationIdMetric() {
         final String name = "application-id";
         final String description = "The application ID of the Kafka Streams client";
-        setUpAndVerifyMetricTwoParam(name, description, "thisIsAnID", ClientMetrics::addApplicationIdMetric);
+        final String applicationId = "thisIsAnID";
+        setUpAndVerifyMetric(
+            name,
+            description,
+            applicationId,
+            () -> ClientMetrics.addApplicationIdMetric(streamsMetrics, applicationId)
+        );
     }
 
     @Test
     public void shouldAddTopologyDescriptionMetric() {
         final String name = "topology-description";
         final String description = "The description of the topology executed in the Kafka Streams client";
-        setUpAndVerifyMetricTwoParam(
+        final String topologyDescription = "thisIsATopologyDescription";
+        setUpAndVerifyMetric(
             name,
             description,
-            "thisIsATopologyDescription",
-            ClientMetrics::addTopologyDescriptionMetric
+            topologyDescription,
+            () -> ClientMetrics.addTopologyDescriptionMetric(streamsMetrics, topologyDescription)
         );
     }
 
@@ -102,26 +91,10 @@ public class ClientMetricsTest {
         verify(streamsMetrics);
     }
 
-    private void setUpAndVerifyMetricOneParam(final String name,
-                                              final String description,
-                                              final OneParamMetricAdder metricAdder) {
-        streamsMetrics.addClientLevelImmutableMetric(
-            eq(name),
-            eq(description),
-            eq(RecordingLevel.INFO),
-            and(not(eq("unknown")), notNull())
-        );
-        replay(streamsMetrics);
-
-        metricAdder.addMetric(streamsMetrics);
-
-        verify(streamsMetrics);
-    }
-
-    private void setUpAndVerifyMetricTwoParam(final String name,
-                                              final String description,
-                                              final String value,
-                                              final TwoParamMetricAdder metricAdder) {
+    private void setUpAndVerifyMetric(final String name,
+                                      final String description,
+                                      final String value,
+                                      final Runnable metricAdder) {
         streamsMetrics.addClientLevelImmutableMetric(
             eq(name),
             eq(description),
@@ -130,7 +103,7 @@ public class ClientMetricsTest {
         );
         replay(streamsMetrics);
 
-        metricAdder.addMetric(streamsMetrics, value);
+        metricAdder.run();
 
         verify(streamsMetrics);
     }

--- a/streams/src/test/resources/kafka/kafka-streams-version.properties
+++ b/streams/src/test/resources/kafka/kafka-streams-version.properties
@@ -1,0 +1,2 @@
+commitId=t35tc0441t
+version=test-version

--- a/streams/src/test/resources/kafka/kafka-streams-version.properties
+++ b/streams/src/test/resources/kafka/kafka-streams-version.properties
@@ -1,2 +1,16 @@
-commitId=t35tc0441t
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+commitId=test-commit-ID
 version=test-version


### PR DESCRIPTION
`ClientMetricsTest#shouldAddVersionMetric` and `ClientMetricsTest#shouldAddCommitIdMetric` failed
because they assumed the existence of a properties file on the class path that was not there when executedfrom the IDE.
`ClientMetricsTest#shouldAddCommitIdMetric` also failed when the test was executed from an archive of a release candidate. The cause is the missing `.git` directory from which the commit ID is extracted and written to the properties file by gradle.

Both issues are fixed by adding the file to `streams/src/test/resources`.

Additionally, I did some refactorings on the test class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
