### PR TITLE
KAFKA-9157: Avoid generating empty segments if all records are deleted after cleaning

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2319,6 +2319,11 @@ class Log(@volatile private var _dir: File,
     }
   }
 
+  private[log] def removeEmptySegmentsAndMaybeUpdateLogStartOffset(segments: Seq[LogSegment]): Unit = lock synchronized {
+    removeAndDeleteSegments(segments.filter(_.size == 0), true)
+    maybeIncrementLogStartOffset(this.segments.firstKey, SegmentDeletion)
+  }
+
   /**
     * This function does not acquire Log.lock. The caller has to make sure log segments don't get deleted during
     * this call, and also protects against calling this function on the same segment in parallel.

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -612,6 +612,7 @@ private[log] class Cleaner(val id: Int,
       // swap in new segment
       info(s"Swapping in cleaned segment $cleaned for segment(s) $segments in log $log")
       log.replaceSegments(List(cleaned), segments)
+      log.removeEmptySegmentsAndMaybeUpdateLogStartOffset(List(cleaned))
     } catch {
       case e: LogCleaningAbortedException =>
         try cleaned.deleteIfExists()

--- a/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/AbstractLogCleanerIntegrationTest.scala
@@ -141,6 +141,7 @@ abstract class AbstractLogCleanerIntegrationTest {
       val value = counter.toString
       val appendInfo = log.appendAsLeader(TestUtils.singletonRecords(value = value.toString.getBytes, codec = codec,
         key = key.toString.getBytes, magicValue = magicValue), leaderEpoch = 0)
+      log.updateHighWatermark(log.logEndOffset)
       incCounter()
       (key, value, appendInfo.firstOffset.get)
     }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -128,6 +128,7 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest with K
 
     val T0 = time.milliseconds
     writeKeyDups(numKeys = 100, numDups = 3, log, CompressionType.NONE, timestamp = T0, startValue = 0, step = 1)
+    log.updateHighWatermark(log.logEndOffset)
 
     val startSizeBlock0 = log.size
 
@@ -146,7 +147,7 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest with K
 
     // write the second block of data: all zero keys
     val appends1 = writeKeyDups(numKeys = 100, numDups = 1, log, CompressionType.NONE, timestamp = T1, startValue = 0, step = 0)
-
+    log.updateHighWatermark(log.logEndOffset)
     // roll the active segment
     log.roll()
     val activeSegAtT1 = log.activeSegment

--- a/core/src/test/scala/unit/kafka/log/LogCleanerLagIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerLagIntegrationTest.scala
@@ -58,6 +58,7 @@ class LogCleanerLagIntegrationTest(compressionCodecName: String) extends Abstrac
     // t = T0
     val T0 = time.milliseconds
     val appends0 = writeDups(numKeys = 100, numDups = 3, log, codec, timestamp = T0)
+    log.updateHighWatermark(log.logEndOffset)
     val startSizeBlock0 = log.size
     debug(s"total log size at T0: $startSizeBlock0")
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9157

If all records are deleted after cleaning, we should avoid generating empty log segments.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
