### PR TITLE
MINOR: Add validation in MockAdminClient for replication factor

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -175,6 +175,11 @@ public class MockAdminClient extends AdminClient {
                 continue;
             }
             int replicationFactor = newTopic.replicationFactor();
+            if (replicationFactor > brokers.size())
+                throw new IllegalArgumentException(
+                    String.format("NewTopic %s cannot have a replication factor of %d that is larger than the number of brokers %s",
+                        newTopic, replicationFactor, brokers));
+
             List<Node> replicas = new ArrayList<>(replicationFactor);
             for (int i = 0; i < replicationFactor; ++i) {
                 replicas.add(brokers.get(i));


### PR DESCRIPTION
Previously, creating a MockAdminClient with a number of brokers and trying to create a topic with a larger replication factor through it would result in an IndexOutOfBoundsException