### PR TITLE
Group and Txn metadata topics should be queried directly from the controller

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -24,7 +24,6 @@ import kafka.log.LogConfig
 import kafka.message.ProducerCompressionCodec
 import kafka.server._
 import kafka.utils.Logging
-import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1241,13 +1241,13 @@ object GroupCoordinator {
   val NewMemberJoinTimeoutMs: Int = 5 * 60 * 1000
 
   def apply(config: KafkaConfig,
-            zkClient: KafkaZkClient,
+            controllerChannel: BrokerToControllerChannelManager,
             replicaManager: ReplicaManager,
             time: Time,
             metrics: Metrics): GroupCoordinator = {
     val heartbeatPurgatory = DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", config.brokerId)
     val joinPurgatory = DelayedOperationPurgatory[DelayedJoin]("Rebalance", config.brokerId)
-    apply(config, zkClient, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
+    apply(config, controllerChannel, replicaManager, heartbeatPurgatory, joinPurgatory, time, metrics)
   }
 
   private[group] def offsetConfig(config: KafkaConfig) = OffsetConfig(
@@ -1264,7 +1264,7 @@ object GroupCoordinator {
   )
 
   def apply(config: KafkaConfig,
-            zkClient: KafkaZkClient,
+            controllerChannel: BrokerToControllerChannelManager,
             replicaManager: ReplicaManager,
             heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat],
             joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
@@ -1277,7 +1277,7 @@ object GroupCoordinator {
       groupInitialRebalanceDelayMs = config.groupInitialRebalanceDelay)
 
     val groupMetadataManager = new GroupMetadataManager(config.brokerId, config.interBrokerProtocolVersion,
-      offsetConfig, replicaManager, zkClient, time, metrics)
+      offsetConfig, replicaManager, controllerChannel, time, metrics)
     new GroupCoordinator(config.brokerId, groupConfig, offsetConfig, groupMetadataManager, heartbeatPurgatory, joinPurgatory, time, metrics)
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -19,7 +19,7 @@ package kafka.coordinator.transaction
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 
-import kafka.server.{KafkaConfig, MetadataCache, ReplicaManager}
+import kafka.server._
 import kafka.utils.{Logging, Scheduler}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
@@ -36,6 +36,7 @@ object TransactionCoordinator {
             replicaManager: ReplicaManager,
             scheduler: Scheduler,
             zkClient: KafkaZkClient,
+            controllerChannel: BrokerToControllerChannelManager,
             metrics: Metrics,
             metadataCache: MetadataCache,
             time: Time): TransactionCoordinator = {
@@ -52,7 +53,7 @@ object TransactionCoordinator {
       config.requestTimeoutMs)
 
     val producerIdManager = new ProducerIdManager(config.brokerId, zkClient)
-    val txnStateManager = new TransactionStateManager(config.brokerId, zkClient, scheduler, replicaManager, txnConfig,
+    val txnStateManager = new TransactionStateManager(config.brokerId, controllerChannel, scheduler, replicaManager, txnConfig,
       time, metrics)
 
     val logContext = new LogContext(s"[TransactionCoordinator id=${config.brokerId}] ")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -27,7 +27,6 @@ import kafka.message.UncompressedCodec
 import kafka.server.{BrokerToControllerChannelManager, Defaults, FetchLogEnd, ReplicaManager}
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils.{Logging, Pool, Scheduler}
-import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.{Avg, Max}

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -87,7 +87,8 @@ class BrokerToControllerChannelManager(metadataCache: MetadataCache,
         brokerToControllerListenerName,
         config.saslMechanismInterBrokerProtocol,
         time,
-        config.saslInterBrokerHandshakeRequestEnable
+        config.saslInterBrokerHandshakeRequestEnable,
+        logContext
       )
       val selector = new Selector(
         NetworkReceive.UNLIMITED,

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -1,0 +1,177 @@
+package kafka.server
+
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+import java.util.Collections
+
+import kafka.cluster.Broker
+import kafka.utils.{Logging, ShutdownableThread}
+import org.apache.kafka.clients._
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, MetadataRequest, MetadataResponse}
+import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.common.{KafkaFuture, Node}
+import org.apache.kafka.common.internals.{KafkaFutureImpl, Topic}
+import org.apache.kafka.common.message.MetadataRequestData
+import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network._
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.security.JaasContext
+
+import scala.collection.JavaConverters._
+
+class BrokerToControllerChannelManager(metadataCache: MetadataCache,
+                                       time: Time,
+                                       metrics: Metrics,
+                                       config: KafkaConfig,
+                                       threadNamePrefix: Option[String] = None) extends Logging {
+
+  private val requestQueue = new LinkedBlockingQueue[BrokerToControllerQueueItem]
+  private val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
+  private val manualMetadataUpdater = new ManualMetadataUpdater()
+  private lazy val requestThread = newRequestThread
+
+  def shutdown(): Unit = {
+    requestThread.shutdown()
+    requestThread.awaitShutdown()
+  }
+
+  private[server] def newRequestThread = {
+    val brokerToControllerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
+    val brokerToControllerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
+
+    val networkClient = {
+      val channelBuilder = ChannelBuilders.clientChannelBuilder(
+        brokerToControllerSecurityProtocol,
+        JaasContext.Type.SERVER,
+        config,
+        brokerToControllerListenerName,
+        config.saslMechanismInterBrokerProtocol,
+        time,
+        config.saslInterBrokerHandshakeRequestEnable
+      )
+      val selector = new Selector(
+        NetworkReceive.UNLIMITED,
+        Selector.NO_IDLE_TIMEOUT_MS,
+        metrics,
+        time,
+        "BrokerToControllerChannel",
+        Map("BrokerId" -> config.brokerId.toString).asJava,
+        false,
+        channelBuilder,
+        logContext
+      )
+      new NetworkClient(
+        selector,
+        manualMetadataUpdater,
+        config.brokerId.toString,
+        1,
+        0,
+        0,
+        Selectable.USE_DEFAULT_BUFFER_SIZE,
+        Selectable.USE_DEFAULT_BUFFER_SIZE,
+        config.requestTimeoutMs,
+        ClientDnsLookup.DEFAULT,
+        time,
+        false,
+        new ApiVersions,
+        logContext
+      )
+    }
+    val threadName = threadNamePrefix match {
+      case None => s"broker-${config.brokerId}-to-controller-send-thread"
+      case Some(name) => s"$name:broker-${config.brokerId}-to-controller-send-thread"
+    }
+
+    new BrokerToControllerRequestThread(networkClient, manualMetadataUpdater, requestQueue, metadataCache, config,
+      brokerToControllerListenerName, time, threadName)
+  }
+
+  private[server] def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
+                  callback: AbstractResponse => Unit = null): Unit = {
+    // create and start the thread lazily
+    if (!requestThread.isAlive) {
+      info(s"Starting ${requestThread.name}")
+      requestThread.start()
+    }
+    requestQueue.put(BrokerToControllerQueueItem(request, callback))
+  }
+}
+
+case class BrokerToControllerQueueItem(request: AbstractRequest.Builder[_ <: AbstractRequest],
+                     callback: AbstractResponse => Unit)
+
+class BrokerToControllerRequestThread(networkClient: KafkaClient,
+                                      metadataUpdater: ManualMetadataUpdater,
+                                      requestQueue: BlockingQueue[BrokerToControllerQueueItem],
+                                      metadataCache: MetadataCache,
+                                      config: KafkaConfig,
+                                      listenerName: ListenerName,
+                                      time: Time,
+                                      threadName: String) extends ShutdownableThread(threadName) {
+
+  private val socketTimeoutMs = config.controllerSocketTimeoutMs
+  private var activeController: Option[Node] = None
+
+  private[server] def maybeGetActiveController(): Option[Broker] = {
+    metadataCache.getControllerId.flatMap(b => metadataCache.getAliveBroker(b))
+  }
+
+  private[server] def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)
+
+  override def doWork(): Unit = {
+    // just peek the top, will take if the request was successful
+    if (requestQueue.peek() == null) {
+      backoff()
+    } else {
+      val BrokerToControllerQueueItem(request, callback) = requestQueue.peek()
+      try {
+        var clientResponse: ClientResponse = null
+        if (controllerReady()) {
+          trace(s"Sending request: $request")
+          val clientRequest = networkClient.newClientRequest(activeController.get.idString, request,
+            time.milliseconds(), true)
+          clientResponse = NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
+          if (!clientResponse.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
+            requestQueue.take()
+          } else { // TODO: test this case
+            networkClient.close(activeController.get.idString)
+            activeController = None
+          }
+        } else {
+          info("Controller isn't cached, looking for local metadata changes")
+          val controllerOpt = metadataCache.getControllerId.flatMap(metadataCache.getAliveBroker)
+          if (controllerOpt.isDefined) {
+            if (activeController.isEmpty || activeController.exists(_.id != controllerOpt.get.id))
+              info(s"Recorded new controller, from now on will use broker ${controllerOpt.get.id}")
+            else if (activeController.isDefined) // close the old controller connection
+              networkClient.close(activeController.get.idString)
+            activeController = Option(controllerOpt.get.node(listenerName))
+            metadataUpdater.setNodes(metadataCache.getAliveBrokers.map(_.node(listenerName)).asJava)
+          } else {
+            warn("No controller defined in metadata cache, retrying after backoff")
+            backoff()
+          }
+        }
+        if (clientResponse != null) {
+          if (callback != null) {
+            callback(clientResponse.responseBody())
+          }
+        }
+      } catch {
+        case e: Throwable =>
+          activeController match {
+            case Some(controller) => {}
+              warn(s"Broker ${config.brokerId}'s connection to active controller $controller was unsuccessful", e)
+              networkClient.close(controller.idString)
+            case None =>
+              warn(s"No connection with controller", e)
+          }
+      }
+    }
+
+  }
+
+  private[server] def controllerReady(): Boolean = {
+    activeController.isDefined && NetworkClientUtils.awaitReady(networkClient, activeController.get, time, socketTimeoutMs)
+  }
+}

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -295,6 +295,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)
 
         controllerChannel = new BrokerToControllerChannelManager(metadataCache, time, metrics, config, threadNamePrefix)
+        controllerChannel.start()
 
         /* start group coordinator */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -298,12 +298,13 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         /* start group coordinator */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
-        groupCoordinator = GroupCoordinator(config, zkClient, replicaManager, Time.SYSTEM, metrics)
+        groupCoordinator = GroupCoordinator(config, controllerChannel, replicaManager, Time.SYSTEM, metrics)
         groupCoordinator.startup()
 
         /* start transaction coordinator, with a separate background thread scheduler for transaction expiration and log loading */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
-        transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"), zkClient, metrics, metadataCache, Time.SYSTEM)
+        transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1,
+          threadNamePrefix = "transaction-log-manager-"), zkClient, controllerChannel, metrics, metadataCache, Time.SYSTEM)
         transactionCoordinator.startup()
 
         /* Get the authorizer and initialize it if one is specified.*/

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import java.util.concurrent.{CountDownLatch, LinkedBlockingDeque, TimeUnit}

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
@@ -4,20 +4,18 @@ import java.util.concurrent.{CountDownLatch, LinkedBlockingDeque, TimeUnit}
 import java.util.Collections
 
 import kafka.cluster.{Broker, EndPoint}
-import kafka.utils.{MockTime, TestUtils}
+import kafka.utils.TestUtils
 import org.apache.kafka.test.{TestUtils => ClientsTestUtils}
 import org.apache.kafka.clients.{ManualMetadataUpdater, Metadata, MockClient}
-import org.apache.kafka.clients.MockClient.MockMetadataUpdater
 import org.apache.kafka.common.utils.SystemTime
 import org.apache.kafka.common.message.MetadataRequestData
 import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.junit.Assert.{assertEquals, assertFalse}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 import org.mockito.Mockito._
-
-import scala.collection.JavaConverters._
 
 class BrokerToControllerRequestChannelTest {
 
@@ -49,12 +47,16 @@ class BrokerToControllerRequestChannelTest {
     val responseLatch = new CountDownLatch(1)
     val queueItem = BrokerToControllerQueueItem(
       new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response)
+        assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
       })
     requestQueue.put(queueItem)
+    // initialize to the controller
     testRequestThread.doWork()
-    responseLatch.await(10, TimeUnit.SECONDS)
+    // send and process the request
+    testRequestThread.doWork()
+
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
   }
 
   @Test
@@ -62,150 +64,108 @@ class BrokerToControllerRequestChannelTest {
     // in this test the current broker is 1, and the controller changes from 2 -> 3 then back: 3 -> 2
     val time = new SystemTime
     val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
-    val oldControllerId = 2
+    val oldControllerId = 1
     val newControllerId = 2
 
     val metadata = mock(classOf[Metadata])
-    val mockClient = spy(new MockClient(time, metadata))
+    val mockClient = new MockClient(time, metadata)
 
     val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
     val metadataCache = mock(classOf[MetadataCache])
     val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
     val oldController = new Broker(oldControllerId,
       Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+    val oldControllerNode = oldController.node(listenerName)
     val newController = new Broker(newControllerId,
       Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
 
-    when(metadataCache.getControllerId)
-      .thenReturn(Some(oldControllerId))
-      .thenReturn(Some(newControllerId))
-      .thenReturn(Some(oldControllerId))
+    when(metadataCache.getControllerId).thenReturn(Some(oldControllerId), Some(newControllerId))
     when(metadataCache.getAliveBroker(oldControllerId)).thenReturn(Some(oldController))
     when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
 
     val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = spy(new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
-      requestQueue, metadataCache, config, listenerName, time, ""))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
+      requestQueue, metadataCache, config, listenerName, time, "")
 
     val responseLatch = new CountDownLatch(1)
 
     val queueItem = BrokerToControllerQueueItem(
       new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response)
+        assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
       })
     requestQueue.put(queueItem)
-
+    mockClient.prepareResponse(expectedResponse)
+    // initialize the thread with oldController
     testRequestThread.doWork()
     // assert queue correctness
     assertFalse(requestQueue.isEmpty)
     assertEquals(1, requestQueue.size())
     assertEquals(queueItem, requestQueue.peek())
+    // disconnect the node
+    mockClient.setUnreachable(oldControllerNode, time.milliseconds() + 5000)
     // verify that the client closed the connection to the faulty controller
-    verify(mockClient, times(1)).close(oldController.node(listenerName).idString())
-
-    mockClient.prepareResponse(expectedResponse)
+    testRequestThread.doWork()
+    assertFalse(requestQueue.isEmpty)
+    assertEquals(1, requestQueue.size())
+    // should connect to the new controller
+    testRequestThread.doWork()
+    // should send the request and process the response
     testRequestThread.doWork()
 
-    requestQueue.put(queueItem)
-
-    responseLatch.await(10, TimeUnit.SECONDS)
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
   }
 
   @Test
-  def testControllerNotReady(): Unit = {
-    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
-    val time = new MockTime()
-    val brokerConfig = TestUtils.createBrokerConfig(1, "localhost:2181")
-    brokerConfig.put(KafkaConfig.RequestTimeoutMsProp, 2000.asInstanceOf[Object])
-    val config = new KafkaConfig(brokerConfig)
-    val controllerId = 2
+  def testNotController(): Unit = {
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val oldControllerId = 1
+    val newControllerId = 2
 
-    val metadataUpdater = new ManualMetadataUpdater()
-    val mockClient = new MockClient(time, mock(classOf[MockMetadataUpdater]))
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
 
     val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
     val metadataCache = mock(classOf[MetadataCache])
     val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
-    val activeController = new Broker(controllerId,
-      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+    val oldController = new Broker(oldControllerId,
+      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+    val newController = new Broker(2,
+      Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
 
-    when(metadataCache.getControllerId).thenReturn(Some(controllerId))
-    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
-    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
+    when(metadataCache.getControllerId).thenReturn(Some(oldControllerId), Some(newControllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
+    when(metadataCache.getAliveBroker(oldControllerId)).thenReturn(Some(oldController))
+    when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
 
-    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, metadataUpdater, requestQueue, metadataCache,
+    val responseWithNotControllerError = ClientsTestUtils.metadataUpdateWith("cluster1", 2,
+      Collections.singletonMap("a", Errors.NOT_CONTROLLER),
+      Collections.singletonMap("a", new Integer(2)))
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
-    mockClient.prepareResponse(expectedResponse)
+
 
     val responseLatch = new CountDownLatch(1)
     val queueItem = BrokerToControllerQueueItem(
       new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response)
+        assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
       })
     requestQueue.put(queueItem)
-
-    // controller not ready yet
-    mockClient.delayReady(activeController.node(listenerName), 5000)
+    // initialize to the controller
     testRequestThread.doWork()
-    assertEquals(1, requestQueue.size())
-    // some time passes and the controller becomes ready
-    time.sleep(5100)
+    // send and process the request
+    mockClient.prepareResponse(responseWithNotControllerError)
     testRequestThread.doWork()
-    assertEquals(0, requestQueue.size())
-    responseLatch.await(10, TimeUnit.SECONDS)
-  }
-
-  @Test
-  def testBackoff(): Unit = {
-    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
-    val time = new MockTime()
-    val brokerConfig = TestUtils.createBrokerConfig(1, "localhost:2181")
-    brokerConfig.put(KafkaConfig.RequestTimeoutMsProp, 2000.asInstanceOf[Object])
-    val config = new KafkaConfig(brokerConfig)
-    val controllerId = 2
-
-    val metadataUpdater = spy(new ManualMetadataUpdater())
-    val mockClient = new MockClient(time, mock(classOf[MockMetadataUpdater]))
-
-    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
-    val metadataCache = mock(classOf[MetadataCache])
-    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
-    val activeController = new Broker(controllerId,
-      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
-
-    when(metadataCache.getControllerId)
-      .thenReturn(None)
-      .thenReturn(Some(controllerId))
-    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
-    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
-
-    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
-    val testRequestThread = spy(new BrokerToControllerRequestThread(mockClient, metadataUpdater, requestQueue, metadataCache,
-      config, listenerName, time, ""))
+    // reinitialize the controller to a different node
+    testRequestThread.doWork()
+    // process the request again
     mockClient.prepareResponse(expectedResponse)
+    testRequestThread.doWork()
 
-    val responseLatch = new CountDownLatch(1)
-    val queueItem = BrokerToControllerQueueItem(
-      new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response)
-        responseLatch.countDown()
-      })
-    requestQueue.put(queueItem)
-
-    // controller isn't ready yet
-    testRequestThread.doWork()
-    assertEquals(1, requestQueue.size())
-    // for the second time the metadata cache is updated with the controller but not ready yet
-    testRequestThread.doWork()
-    assertEquals(1, requestQueue.size())
-    // third time's the charm
-    testRequestThread.doWork()
-    assertEquals(0, requestQueue.size())
-    verify(testRequestThread).backoff()
-    verify(metadataUpdater).setNodes(Seq(activeController.getNode(listenerName).get).asJava)
-    responseLatch.await(10, TimeUnit.SECONDS)
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
   }
 }

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestChannelTest.scala
@@ -1,0 +1,211 @@
+package kafka.server
+
+import java.util.concurrent.{CountDownLatch, LinkedBlockingDeque, TimeUnit}
+import java.util.Collections
+
+import kafka.cluster.{Broker, EndPoint}
+import kafka.utils.{MockTime, TestUtils}
+import org.apache.kafka.test.{TestUtils => ClientsTestUtils}
+import org.apache.kafka.clients.{ManualMetadataUpdater, Metadata, MockClient}
+import org.apache.kafka.clients.MockClient.MockMetadataUpdater
+import org.apache.kafka.common.utils.SystemTime
+import org.apache.kafka.common.message.MetadataRequestData
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.requests.MetadataRequest
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.Assert.{assertEquals, assertFalse}
+import org.junit.Test
+import org.mockito.Mockito._
+
+import scala.collection.JavaConverters._
+
+class BrokerToControllerRequestChannelTest {
+
+  @Test
+  def testRequestsSent(): Unit = {
+    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val controllerId = 2
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val activeController = new Broker(controllerId,
+      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+
+    when(metadataCache.getControllerId).thenReturn(Some(controllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
+    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+      config, listenerName, time, "")
+    mockClient.prepareResponse(expectedResponse)
+
+    val responseLatch = new CountDownLatch(1)
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response)
+        responseLatch.countDown()
+      })
+    requestQueue.put(queueItem)
+    testRequestThread.doWork()
+    responseLatch.await(10, TimeUnit.SECONDS)
+  }
+
+  @Test
+  def testControllerChanged(): Unit = {
+    // in this test the current broker is 1, and the controller changes from 2 -> 3 then back: 3 -> 2
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val oldControllerId = 2
+    val newControllerId = 2
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = spy(new MockClient(time, metadata))
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val oldController = new Broker(oldControllerId,
+      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+    val newController = new Broker(newControllerId,
+      Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+
+    when(metadataCache.getControllerId)
+      .thenReturn(Some(oldControllerId))
+      .thenReturn(Some(newControllerId))
+      .thenReturn(Some(oldControllerId))
+    when(metadataCache.getAliveBroker(oldControllerId)).thenReturn(Some(oldController))
+    when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = spy(new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
+      requestQueue, metadataCache, config, listenerName, time, ""))
+
+    val responseLatch = new CountDownLatch(1)
+
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response)
+        responseLatch.countDown()
+      })
+    requestQueue.put(queueItem)
+
+    testRequestThread.doWork()
+    // assert queue correctness
+    assertFalse(requestQueue.isEmpty)
+    assertEquals(1, requestQueue.size())
+    assertEquals(queueItem, requestQueue.peek())
+    // verify that the client closed the connection to the faulty controller
+    verify(mockClient, times(1)).close(oldController.node(listenerName).idString())
+
+    mockClient.prepareResponse(expectedResponse)
+    testRequestThread.doWork()
+
+    requestQueue.put(queueItem)
+
+    responseLatch.await(10, TimeUnit.SECONDS)
+  }
+
+  @Test
+  def testControllerNotReady(): Unit = {
+    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
+    val time = new MockTime()
+    val brokerConfig = TestUtils.createBrokerConfig(1, "localhost:2181")
+    brokerConfig.put(KafkaConfig.RequestTimeoutMsProp, 2000.asInstanceOf[Object])
+    val config = new KafkaConfig(brokerConfig)
+    val controllerId = 2
+
+    val metadataUpdater = new ManualMetadataUpdater()
+    val mockClient = new MockClient(time, mock(classOf[MockMetadataUpdater]))
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val activeController = new Broker(controllerId,
+      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+
+    when(metadataCache.getControllerId).thenReturn(Some(controllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
+    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, metadataUpdater, requestQueue, metadataCache,
+      config, listenerName, time, "")
+    mockClient.prepareResponse(expectedResponse)
+
+    val responseLatch = new CountDownLatch(1)
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response)
+        responseLatch.countDown()
+      })
+    requestQueue.put(queueItem)
+
+    // controller not ready yet
+    mockClient.delayReady(activeController.node(listenerName), 5000)
+    testRequestThread.doWork()
+    assertEquals(1, requestQueue.size())
+    // some time passes and the controller becomes ready
+    time.sleep(5100)
+    testRequestThread.doWork()
+    assertEquals(0, requestQueue.size())
+    responseLatch.await(10, TimeUnit.SECONDS)
+  }
+
+  @Test
+  def testBackoff(): Unit = {
+    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
+    val time = new MockTime()
+    val brokerConfig = TestUtils.createBrokerConfig(1, "localhost:2181")
+    brokerConfig.put(KafkaConfig.RequestTimeoutMsProp, 2000.asInstanceOf[Object])
+    val config = new KafkaConfig(brokerConfig)
+    val controllerId = 2
+
+    val metadataUpdater = spy(new ManualMetadataUpdater())
+    val mockClient = new MockClient(time, mock(classOf[MockMetadataUpdater]))
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val activeController = new Broker(controllerId,
+      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None)
+
+    when(metadataCache.getControllerId)
+      .thenReturn(None)
+      .thenReturn(Some(controllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
+    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = spy(new BrokerToControllerRequestThread(mockClient, metadataUpdater, requestQueue, metadataCache,
+      config, listenerName, time, ""))
+    mockClient.prepareResponse(expectedResponse)
+
+    val responseLatch = new CountDownLatch(1)
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response)
+        responseLatch.countDown()
+      })
+    requestQueue.put(queueItem)
+
+    // controller isn't ready yet
+    testRequestThread.doWork()
+    assertEquals(1, requestQueue.size())
+    // for the second time the metadata cache is updated with the controller but not ready yet
+    testRequestThread.doWork()
+    assertEquals(1, requestQueue.size())
+    // third time's the charm
+    testRequestThread.doWork()
+    assertEquals(0, requestQueue.size())
+    verify(testRequestThread).backoff()
+    verify(metadataUpdater).setNodes(Seq(activeController.getNode(listenerName).get).asJava)
+    responseLatch.await(10, TimeUnit.SECONDS)
+  }
+}

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -48,6 +48,7 @@ abstract class AbstractCoordinatorConcurrencyTest[M <: CoordinatorMember] {
   val scheduler = new MockScheduler(time)
   var replicaManager: TestReplicaManager = _
   var zkClient: KafkaZkClient = _
+  var controllerChannel: BrokerToControllerChannelManager = _
   val serverProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
   val random = new Random
 
@@ -58,6 +59,7 @@ abstract class AbstractCoordinatorConcurrencyTest[M <: CoordinatorMember] {
     replicaManager.createDelayedProducePurgatory(timer)
 
     zkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
+    controllerChannel = EasyMock.createNiceMock(classOf[BrokerToControllerChannelManager])
   }
 
   @After

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -34,7 +34,6 @@ import java.util.concurrent.locks.ReentrantLock
 
 import kafka.cluster.Partition
 import kafka.log.AppendOrigin
-import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.internals.{KafkaFutureImpl, Topic}

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -31,7 +31,6 @@ import kafka.log.{AppendOrigin, Log, LogAppendInfo}
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server._
 import kafka.utils.{KafkaScheduler, MockTime, TestUtils}
-import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol


### PR DESCRIPTION
GroupMetadataManager and TransactionStateManager should use a direct broker-to-controller channel to query the number of partitions instead of relying on Zookeeper.

This change introduces a new class that always sends the request to the active controller. In case the cached controller isn't available or not the controller it closes the connection and tries to refresh itself from the local metadataCache until it finds the active controller.

`BrokerToControllerMetadataManager` manages the request queue that is consumed by the request thread and also controls its lifecycle. Lazy initialization is used as the means of creating the thread so it won't try to create it before there is an actual need for it. The public methods of this class supposed to implement the high level functions that are queried by various classes (in this case `GroupMetadataManager` and `TransactionStateManager`) and return `KafkaFuture` so that the users of this class can work asynchronously over a blocking connection that the `BrokerToControllerRequestThread` implements.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
