### PR TITLE
[MINOR] fix requested array size exceeds VM limit

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -271,7 +271,7 @@ class LogCleaner(initialConfig: CleanerConfig,
 
     protected override def loggerName = classOf[LogCleaner].getName
 
-    if (config.dedupeBufferSize / config.numThreads > Int.MaxValue -2 )
+    if (config.dedupeBufferSize / config.numThreads > Int.MaxValue - 2)
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
 
     val cleaner = new Cleaner(id = threadId,

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -271,11 +271,16 @@ class LogCleaner(initialConfig: CleanerConfig,
 
     protected override def loggerName = classOf[LogCleaner].getName
 
-    if (config.dedupeBufferSize / config.numThreads > Int.MaxValue - 2)
+    /**
+      * @see SEE [[http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/ec45423a4700#l3.12]] for more information
+      */
+    val MAX_ARRAY_SIZE : Int = Int.MaxValue -8
+
+    if (config.dedupeBufferSize / config.numThreads > MAX_ARRAY_SIZE)
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
 
     val cleaner = new Cleaner(id = threadId,
-                              offsetMap = new SkimpyOffsetMap(memory = math.min(config.dedupeBufferSize / config.numThreads, Int.MaxValue - 2).toInt,
+                              offsetMap = new SkimpyOffsetMap(memory = math.min(config.dedupeBufferSize / config.numThreads, MAX_ARRAY_SIZE).toInt,
                                                               hashAlgorithm = config.hashAlgorithm),
                               ioBufferSize = config.ioBufferSize / config.numThreads / 2,
                               maxIoBufferSize = config.maxMessageSize,

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -271,11 +271,11 @@ class LogCleaner(initialConfig: CleanerConfig,
 
     protected override def loggerName = classOf[LogCleaner].getName
 
-    if (config.dedupeBufferSize / config.numThreads > Int.MaxValue)
+    if (config.dedupeBufferSize / config.numThreads > Int.MaxValue -2 )
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
 
     val cleaner = new Cleaner(id = threadId,
-                              offsetMap = new SkimpyOffsetMap(memory = math.min(config.dedupeBufferSize / config.numThreads, Int.MaxValue).toInt,
+                              offsetMap = new SkimpyOffsetMap(memory = math.min(config.dedupeBufferSize / config.numThreads, Int.MaxValue - 2).toInt,
                                                               hashAlgorithm = config.hashAlgorithm),
                               ioBufferSize = config.ioBufferSize / config.numThreads / 2,
                               maxIoBufferSize = config.maxMessageSize,


### PR DESCRIPTION
if the dedup buffer size per thread is bigger or equal than 2G (aka Int.MaxValue), kafka won't be able to start with exception of:
```
2019-11-20 16:06:07,530] FATAL [Kafka Server ], Fatal error during KafkaServer startup. Prepare to shutdown (kafka.server.KafkaServer)
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
        at java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:57)
        at java.nio.ByteBuffer.allocate(ByteBuffer.java:335)
        at kafka.log.SkimpyOffsetMap.<init>(OffsetMap.scala:45)
        at kafka.log.LogCleaner$CleanerThread.<init>(LogCleaner.scala:214)
        at kafka.log.LogCleaner$$anonfun$3.apply(LogCleaner.scala:105)
        at kafka.log.LogCleaner$$anonfun$3.apply(LogCleaner.scala:105)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.immutable.Range.foreach(Range.scala:160)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.AbstractTraversable.map(Traversable.scala:104)
        at kafka.log.LogCleaner.<init>(LogCleaner.scala:105)
        at kafka.log.LogManager.<init>(LogManager.scala:78)
        at kafka.log.LogManager$.apply(LogManager.scala:598)
        at kafka.server.KafkaServer.startup(KafkaServer.scala:215)
        at kafka.server.KafkaServerStartable.startup(KafkaServerStartable.scala:38)
        at kafka.Kafka$.main(Kafka.scala:65)
        at kafka.Kafka.main(Kafka.scala)
```

**For more detailed reference**: https://plumbr.io/outofmemoryerror/requested-array-size-exceeds-vm-limit