### PR TITLE
MINOR: Do not log local address on failed Selector polls

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -364,7 +364,7 @@ public class KafkaChannel implements AutoCloseable {
     public String socketDescription() {
         Socket socket = transportLayer.socketChannel().socket();
         if (socket.getInetAddress() == null)
-            return socket.getLocalAddress().toString();
+            return "[non-connected socket]";
         return socket.getInetAddress().toString();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -363,9 +363,9 @@ public class KafkaChannel implements AutoCloseable {
 
     public String socketDescription() {
         Socket socket = transportLayer.socketChannel().socket();
-        if (socket.getInetAddress() == null)
-            return "[non-connected socket]";
-        return socket.getInetAddress().toString();
+        return "(Remote Address: " + (
+            socket.getInetAddress() == null ? "[non-connected socket]" : socket.getInetAddress().toString()
+        ) + ", Local Address: " + socket.getLocalAddress().toString() + ")";
     }
 
     public void setSend(Send send) {

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -363,9 +363,12 @@ public class KafkaChannel implements AutoCloseable {
 
     public String socketDescription() {
         Socket socket = transportLayer.socketChannel().socket();
+        if (socket == null)
+            return "[non-existing socket]";
+
         return "(Remote Address: " + (
             socket.getInetAddress() == null ? "[non-connected socket]" : socket.getInetAddress().toString()
-        ) + ", Local Address: " + socket.getLocalAddress().toString() + ")";
+            ) + ", Local Address: " + socket.getLocalAddress().toString() + ")";
     }
 
     public void setSend(Send send) {

--- a/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
@@ -147,4 +147,18 @@ public class KafkaChannelTest {
         KafkaChannel channel = new KafkaChannel("0", transport, () -> authenticator, 1024, pool);
         assertEquals("(Remote Address: 192.192.192.192, Local Address: localhost)", channel.socketDescription());
     }
+
+    @Test
+    public void testSocketDescriptionWithNoSocket() {
+        Authenticator authenticator = Mockito.mock(Authenticator.class);
+        TransportLayer transport = Mockito.mock(TransportLayer.class);
+        SocketChannel socketChannel = Mockito.mock(SocketChannel.class);
+
+        when(socketChannel.socket()).thenReturn(null);
+        when(transport.socketChannel()).thenReturn(socketChannel);
+        MemoryPool pool = Mockito.mock(MemoryPool.class);
+
+        KafkaChannel channel = new KafkaChannel("0", transport, () -> authenticator, 1024, pool);
+        assertEquals("[non-existing socket]", channel.socketDescription());
+    }
 }


### PR DESCRIPTION
Previously whenever we would print out a socket description on a socket which was not yet connected, Kafka would log the local IP address in a log similar to:
```
[SocketServer brokerId=6] Failed authentication with <local_ip> (<cause>)
```
Needless to say, this can be confusing.
This patch changes the log message to something more explicit:
```
[SocketServer brokerId=6] Failed authentication with (Remote Address: [non-connected socket], Local Address: localhost) (<cause>)
```