### PR TITLE
MINOR: Rat should ignore generated directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,8 @@ if (file('.git').exists()) {
         '**/id_rsa.pub',
         'checkstyle/suppressions.xml',
         'streams/quickstart/java/src/test/resources/projects/basic/goal.txt',
-        'streams/streams-scala/logs/*'
+        'streams/streams-scala/logs/*',
+        '**/generated/**'
     ])
   }
 }


### PR DESCRIPTION
For some reason, PR builds are failing due to the `rat` license
check even though it should ignore files included in `.gitignore`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
