### PR TITLE
KAFKA-9223: Mask exit procedure in rebalance integration test to prevent call to System::exit

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -89,6 +89,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 .numBrokers(1)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)
+                .maskExitProcedures(true)
                 .build();
 
         // start the clusters


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9223)

We've been encountering some build instability that appears to be due to the `RebalanceSourceConnectorsIntegrationTest` class. Somehow, that test is causing an ungraceful shutdown of one or more of its embedded Connect workers, which then in turn invoke `Exit::exit`. The Connect integration test framework has support for overriding the behavior of `Exit::exit` to prevent it from calling `System::exit`; the changes here use that feature to help bring back build stability.
Now, if the embedded Connect worker fails to shut down gracefully, a warning is logged but the test still passes and (more importantly), `System::exit` is never invoked.

If approved, this fix should be backported through to 2.3, when the test was introduced.

Tested locally 10x over with all integration tests. No other test appears to be invoking `Exit::exit`, so I've restricted the scope of the changes here to just the RebalanceSourceConnectorsIntegrationTest.