### PR TITLE
KAFKA-9224 (EOS improvement): Flush state store after transaction commit

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/CacheFullException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/CacheFullException.java
@@ -17,11 +17,11 @@
 package org.apache.kafka.streams.errors;
 
 /**
- * The exception triggered when the current transaction size is reached.
+ * The exception triggered when the bounded cache is full.
  *
  */
-public class CacheSizeExceedException extends StreamsException {
-    public CacheSizeExceedException(String message) {
+public class CacheFullException extends StreamsException {
+    public CacheFullException(final String message) {
         super(message);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/CacheSizeExceedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/CacheSizeExceedException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+/**
+ * The exception triggered when the current transaction size is reached.
+ *
+ */
+public class CacheSizeExceedException extends StreamsException {
+    public CacheSizeExceedException(String message) {
+        super(message);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -55,15 +55,15 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
         final StateStore store = stateManager.getGlobalStore(name);
 
         if (store instanceof TimestampedKeyValueStore) {
-            return new TimestampedKeyValueStoreReadWriteDecorator((TimestampedKeyValueStore) store);
+            return new TimestampedKeyValueStoreReadWriteDecorator((TimestampedKeyValueStore) store, this::commit);
         } else if (store instanceof KeyValueStore) {
-            return new KeyValueStoreReadWriteDecorator((KeyValueStore) store);
+            return new KeyValueStoreReadWriteDecorator((KeyValueStore) store, this::commit);
         } else if (store instanceof TimestampedWindowStore) {
-            return new TimestampedWindowStoreReadWriteDecorator((TimestampedWindowStore) store);
+            return new TimestampedWindowStoreReadWriteDecorator((TimestampedWindowStore) store, this::commit);
         } else if (store instanceof WindowStore) {
-            return new WindowStoreReadWriteDecorator((WindowStore) store);
+            return new WindowStoreReadWriteDecorator((WindowStore) store, this::commit);
         } else if (store instanceof SessionStore) {
-            return new SessionStoreReadWriteDecorator((SessionStore) store);
+            return new SessionStoreReadWriteDecorator((SessionStore) store, this::commit);
         }
 
         return store;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -113,7 +113,7 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
 
     @Override
     public void commit() {
-        //no-op
+        // no-op
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -192,7 +192,7 @@ public class GlobalStreamThread extends Thread {
         this.logPrefix = String.format("global-stream-thread [%s] ", threadClientId);
         this.logContext = new LogContext(logPrefix);
         this.log = logContext.logger(getClass());
-        this.cache = new ThreadCache(logContext, cacheSizeBytes, this.streamsMetrics);
+        this.cache = new ThreadCache(logContext, cacheSizeBytes, this.streamsMetrics, false);
         this.stateRestoreListener = stateRestoreListener;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -88,10 +88,8 @@ class StandbyContextImpl extends AbstractProcessorContext implements RecordColle
                 new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName())),
                 0,
                 metrics,
-                false)
-        );
+                false));
     }
-
 
     StateManager getStateMgr() {
         return stateManager;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -87,8 +87,8 @@ class StandbyContextImpl extends AbstractProcessorContext implements RecordColle
             new ThreadCache(
                 new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName())),
                 0,
-                metrics
-            )
+                metrics,
+                false)
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -507,7 +507,7 @@ public class StreamThread extends Thread {
             threadProducer = clientSupplier.getProducer(producerConfigs);
         }
 
-        final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
+        final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics, false);
 
         final AbstractTaskCreator<StreamTask> activeTaskCreator = new TaskCreator(
             builder,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -57,9 +57,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     private volatile boolean open = false;
 
-    InMemorySessionStore(final String name,
-                         final long retentionPeriod,
-                         final String metricScope) {
+    protected InMemorySessionStore(final String name,
+                                   final long retentionPeriod,
+                                   final String metricScope) {
         this.name = name;
         this.retentionPeriod = retentionPeriod;
         this.metricScope = metricScope;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -68,11 +68,11 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     private volatile boolean open = false;
 
-    InMemoryWindowStore(final String name,
-                        final long retentionPeriod,
-                        final long windowSize,
-                        final boolean retainDuplicates,
-                        final String metricScope) {
+    protected InMemoryWindowStore(final String name,
+                                  final long retentionPeriod,
+                                  final long windowSize,
+                                  final boolean retainDuplicates,
+                                  final String metricScope) {
         this.name = name;
         this.retentionPeriod = retentionPeriod;
         this.windowSize = windowSize;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -346,10 +346,6 @@ class NamedCache {
         }
 
         long size() {
-            return size(key, entry);
-        }
-
-        static long size(final Bytes key, final LRUCacheEntry entry) {
             return key.get().length +
                    8 + // entry
                    8 + // previous

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -346,11 +346,15 @@ class NamedCache {
         }
 
         long size() {
+            return size(key, entry);
+        }
+
+        static long size(Bytes key, LRUCacheEntry entry) {
             return key.get().length +
-                8 + // entry
-                8 + // previous
-                8 + // next
-                entry.size();
+                   8 + // entry
+                   8 + // previous
+                   8 + // next
+                   entry.size();
         }
 
         LRUNode next() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -349,7 +349,7 @@ class NamedCache {
             return size(key, entry);
         }
 
-        static long size(Bytes key, LRUCacheEntry entry) {
+        static long size(final Bytes key, final LRUCacheEntry entry) {
             return key.get().length +
                    8 + // entry
                    8 + // previous

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.CacheSizeExceedException;
+import org.apache.kafka.streams.errors.CacheFullException;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.slf4j.Logger;
 
@@ -174,7 +174,8 @@ public class ThreadCache {
 
     private void maybeRejectPut(final Bytes key, final LRUCacheEntry value) {
         if (bounded && sizeBytes() + NamedCache.LRUNode.size(key, value) > maxCacheSizeBytes) {
-            throw new CacheSizeExceedException("Could not add more records as within a transaction session we could not saturate the cache");
+            throw new CacheFullException("Cache get saturated within current transaction session: the ongoing task will enforce a txn commit to unblock."
+                + "Consider either reducing the commit interval or increasing the cache size for optimal throughput");
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -103,7 +103,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             metrics,
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             NoOpRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, metrics)
+            new ThreadCache(new LogContext("testCache "), 100000, metrics, false)
         ) {
             @Override
             public <K, V> void forward(final K key, final V value, final To to) {
@@ -608,7 +608,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             streamsMetrics,
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             NoOpRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics)
+            new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics, false)
         ) {
             @Override
             public <K, V> void forward(final K key, final V value, final To to) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -194,7 +194,7 @@ public class AbstractProcessorContextTest {
         }
 
         TestProcessorContext(final MockStreamsMetrics metrics) {
-            super(new TaskId(0, 0), new StreamsConfig(config), metrics, new StateManagerStub(), new ThreadCache(new LogContext("name "), 0, metrics));
+            super(new TaskId(0, 0), new StreamsConfig(config), metrics, new StateManagerStub(), new ThreadCache(new LogContext("name "), 0, metrics, false));
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -241,7 +241,7 @@ public class KeyValueStoreTestDriver<K, V> {
         props.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "DEBUG");
 
         context = new InternalMockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, null) {
-            ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics());
+            ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics(), false);
 
             @Override
             public ThreadCache getCache() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             Serdes.String(),
             Serdes.Long(),
             new NoOpRecordCollector(),
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false)
         );
         bytesStore.init(context, bytesStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -71,7 +71,7 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         cacheFlushListener = new CacheFlushListenerStub<>(new StringDeserializer(), new StringDeserializer());
         store = new CachingKeyValueStore(underlyingStore);
         store.setFlushListener(cacheFlushListener, false);
-        cache = new ThreadCache(new LogContext("testCache "), maxCacheSizeBytes, new MockStreamsMetrics(new Metrics()));
+        cache = new ThreadCache(new LogContext("testCache "), maxCacheSizeBytes, new MockStreamsMetrics(new Metrics()), false);
         context = new InternalMockProcessorContext(null, null, null, null, cache);
         topic = "topic";
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, topic, null));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -80,7 +80,7 @@ public class CachingSessionStoreTest {
             new RocksDBSegmentedBytesStore("test", "metrics-scope", 0L, SEGMENT_INTERVAL, schema);
         final RocksDBSessionStore sessionStore = new RocksDBSessionStore(root);
         cachingStore = new CachingSessionStore(sessionStore, SEGMENT_INTERVAL);
-        cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
+        cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()), false);
         final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, "topic", null));
         cachingStore.init(context, cachingStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -99,7 +99,7 @@ public class CachingWindowStoreTest {
         cacheListener = new CachingKeyValueStoreTest.CacheFlushListenerStub<>(keyDeserializer, new StringDeserializer());
         cachingStore = new CachingWindowStore(windowStore, WINDOW_SIZE, SEGMENT_INTERVAL);
         cachingStore.setFlushListener(cacheListener, false);
-        cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
+        cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()), false);
         topic = "topic";
         context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, topic, null));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -70,7 +70,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
             Serdes.String(),
             Serdes.Long(),
             collector,
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())));
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false));
         context.setTime(0);
         store.init(context, store);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
@@ -75,7 +75,7 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
             Serdes.String(),
             Serdes.Long(),
             collector,
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())));
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false));
         context.setTime(0);
         store.init(context, store);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
@@ -60,7 +60,7 @@ public class KeyValueSegmentsTest {
             Serdes.String(),
             Serdes.Long(),
             new NoOpRecordCollector(),
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false)
         );
         segments = new KeyValueSegments(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueBytesStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueBytesStoreIteratorTest.java
@@ -40,7 +40,7 @@ public class MergedSortedCacheKeyValueBytesStoreIteratorTest {
     @Before
     public void setUp() throws Exception {
         store = new InMemoryKeyValueStore(namespace);
-        cache = new ThreadCache(new LogContext("testCache "), 10000L, new MockStreamsMetrics(new Metrics()));
+        cache = new ThreadCache(new LogContext("testCache "), 10000L, new MockStreamsMetrics(new Metrics()), false);
     }
 
     @Test
@@ -147,7 +147,7 @@ public class MergedSortedCacheKeyValueBytesStoreIteratorTest {
     @Test
     public void shouldPeekNextKey() throws Exception {
         final KeyValueStore<Bytes, byte[]> kv = new InMemoryKeyValueStore("one");
-        final ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1000000L, new MockStreamsMetrics(new Metrics()));
+        final ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1000000L, new MockStreamsMetrics(new Metrics()), false);
         final byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}};
         for (int i = 0; i < bytes.length - 1; i += 2) {
             kv.put(Bytes.wrap(bytes[i]), bytes[i]);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
@@ -45,7 +45,7 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
     };
 
     private final List<KeyValue<Long, byte[]>> windowStoreKvPairs = new ArrayList<>();
-    private final ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1000000L,  new MockStreamsMetrics(new Metrics()));
+    private final ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1000000L, new MockStreamsMetrics(new Metrics()), false);
     private final String namespace = "0.0-one";
     private final StateSerdes<String, String> stateSerdes = new StateSerdes<>("foo", Serdes.String(), Serdes.String());
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -69,7 +69,7 @@ public class MeteredTimestampedWindowStoreTest {
             streamsMetrics,
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             NoOpRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics)
+            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics, false)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -115,7 +115,7 @@ public class MeteredWindowStoreTest {
             streamsMetrics,
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             NoOpRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics)
+            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics, false)
         );
         storeLevelGroup =
             StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? STORE_LEVEL_GROUP_FROM_0100_TO_24 : STORE_LEVEL_GROUP;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -252,14 +252,15 @@ public class NamedCacheTest {
         final LRUCacheEntry dirty = new LRUCacheEntry(new byte[]{3}, null, true, 0, 0, 0, "");
         final LRUCacheEntry clean = new LRUCacheEntry(new byte[]{3});
         final Bytes key = Bytes.wrap(new byte[] {3});
-        cache.setListener(new ThreadCache.DirtyEntryFlushListener() {
-            @Override
-            public void apply(final List<ThreadCache.DirtyEntry> dirty) {
-                cache.put(key, clean);
-            }
-        });
+        cache.setListener(dirty1 -> cache.put(key, clean));
         cache.put(key, dirty);
         cache.evict();
+    }
+
+    @Test
+    public void testEntrySize() {
+        assertEquals(47, NamedCache.LRUNode.size(Bytes.wrap(new byte[]{1}),
+            new LRUCacheEntry(new byte[]{1}, null, true, -1, -1, -1, "")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -61,7 +61,8 @@ public class SegmentIteratorTest {
                 new ThreadCache(
                     new LogContext("testCache "),
                     0,
-                    new MockStreamsMetrics(new Metrics()), false));
+                    new MockStreamsMetrics(new Metrics()),
+                    false));
         segmentOne.openDB(context);
         segmentTwo.openDB(context);
         segmentOne.put(Bytes.wrap("a".getBytes()), "1".getBytes());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -61,7 +61,7 @@ public class SegmentIteratorTest {
                 new ThreadCache(
                     new LogContext("testCache "),
                     0,
-                    new MockStreamsMetrics(new Metrics())));
+                    new MockStreamsMetrics(new Metrics()), false));
         segmentOne.openDB(context);
         segmentTwo.openDB(context);
         segmentOne.put(Bytes.wrap("a".getBytes()), "1".getBytes());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -126,7 +126,7 @@ public abstract class SessionBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics())));
+                new MockStreamsMetrics(new Metrics()), false));
 
         sessionStore.init(context, sessionStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionBytesStoreTest.java
@@ -126,7 +126,8 @@ public abstract class SessionBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics()), false));
+                new MockStreamsMetrics(new Metrics()),
+                false));
 
         sessionStore.init(context, sessionStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -497,6 +497,8 @@ public class ThreadCacheTest {
         cache.put(namespace1, key2, value);
         assertEquals(94, cache.sizeBytes());
         assertThrows(CacheFullException.class, operation);
+        // The add operation will still succeed after a cache full exception.
+        assertEquals(141, cache.sizeBytes());
     }
 
     private LRUCacheEntry dirtyEntry(final byte[] key) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
@@ -60,7 +60,7 @@ public class TimestampedSegmentsTest {
             Serdes.String(),
             Serdes.Long(),
             new NoOpRecordCollector(),
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false)
         );
         segments = new TimestampedSegments(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
@@ -60,7 +60,10 @@ public class TimestampedSegmentsTest {
             Serdes.String(),
             Serdes.Long(),
             new NoOpRecordCollector(),
-            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()), false)
+            new ThreadCache(new LogContext("testCache "),
+                            0,
+                            new MockStreamsMetrics(new Metrics()),
+                            false)
         );
         segments = new TimestampedSegments(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
@@ -138,7 +138,7 @@ public abstract class WindowBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics())));
+                new MockStreamsMetrics(new Metrics()), false));
 
         windowStore.init(context, windowStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowBytesStoreTest.java
@@ -138,7 +138,8 @@ public abstract class WindowBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics()), false));
+                new MockStreamsMetrics(new Metrics()),
+                false));
 
         windowStore.init(context, windowStore);
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -309,9 +309,9 @@ public class TopologyTestDriver implements Closeable {
         streamsMetrics.setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
         TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, TASK_ID.toString(), streamsMetrics);
         final ThreadCache cache = new ThreadCache(
-            new LogContext("topology-test-driver "),
+            new LogContext("topology-test-driver"),
             Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
-            streamsMetrics);
+            streamsMetrics, false);
         final StateRestoreListener stateRestoreListener = new StateRestoreListener() {
             @Override
             public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {}

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -311,7 +311,8 @@ public class TopologyTestDriver implements Closeable {
         final ThreadCache cache = new ThreadCache(
             new LogContext("topology-test-driver"),
             Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
-            streamsMetrics, false);
+            streamsMetrics,
+            false);
         final StateRestoreListener stateRestoreListener = new StateRestoreListener() {
             @Override
             public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {}


### PR DESCRIPTION
This patch attempts to enforce a strict order to flush the state store only after ongoing transaction gets committed under EOS. Major changes include:

- Rewrite `StreamTask.commit` to separate EOS and non EOS commit scenario
- Under EOS,  we make the atomic operation in the following order: commit ongoing transaction, flush the store, begin another transaction. This means there is no intermediate data left within the cache and the ongoing modification to the state store only gets visible after the transaction gets committed.
- Add a `bounded` config on the stream thread cache to reject further writes. This feature is important as under EOS the thread cache is the only container we are going to leverage. When the cache is almost full, it will begin throwing a `CacheFullException` to the caller.
- In ProcessorContext, handle `CacheFullException` by requesting a task commit in next round. This should only be needed on ReadWrite access to state stores for general put operation, and avoiding further interruption to the application.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
