### PR TITLE
MINOR: Fix --enable-autocommit flag in verifiable consumer

### DIFF
--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -310,7 +310,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
             cmd += " --assignment-strategy %s" % self.assignment_strategy
 
         if self.enable_autocommit:
-            cmd += " --enable-autocommit %s" % self.enable_autocommit
+            cmd += " --enable-autocommit "
 
         cmd += " --reset-policy %s --group-id %s --topic %s --broker-list %s --session-timeout %s" % \
                (self.reset_policy, self.group_id, self.topic,


### PR DESCRIPTION
The --enable-autocommit argument is a flag. It does not take a parameter. This was broken in #7724.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
