### PR TITLE
KAFKA-9218: MirrorMaker 2 can fail to create topics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1872,6 +1872,7 @@ project(':connect:mirror') {
     compile libs.slf4jApi
 
     testCompile libs.junit
+    testCompile libs.mockitoCore
     testCompile project(':clients').sourceSets.test.output
     testCompile project(':connect:runtime').sourceSets.test.output
     testCompile project(':core')

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Map.Entry;
 
 /**
@@ -156,5 +157,22 @@ public class NewTopic {
                 append(", configs=").append(configs).
                 append(")");
         return bld.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final NewTopic that = (NewTopic) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(numPartitions, that.numPartitions) &&
+            Objects.equals(replicationFactor, that.replicationFactor) &&
+            Objects.equals(replicasAssignments, that.replicasAssignments) &&
+            Objects.equals(configs, that.configs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, numPartitions, replicationFactor, replicasAssignments, configs);
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -72,8 +72,8 @@ public class MirrorSourceConnector extends SourceConnector {
     private String connectorName;
     private TopicFilter topicFilter;
     private ConfigPropertyFilter configPropertyFilter;
-    private List<TopicPartition> knownTopicPartitions = Collections.emptyList();
-    private Set<String> knownTargetTopics = Collections.emptySet();
+    private List<TopicPartition> knownSourceTopicPartitions = Collections.emptyList();
+    private List<TopicPartition> knownTargetTopicPartitions = Collections.emptyList();
     private ReplicationPolicy replicationPolicy;
     private int replicationFactor;
     private AdminClient sourceAdminClient;
@@ -84,8 +84,8 @@ public class MirrorSourceConnector extends SourceConnector {
     }
 
     // visible for testing
-    MirrorSourceConnector(List<TopicPartition> knownTopicPartitions, MirrorConnectorConfig config) {
-        this.knownTopicPartitions = knownTopicPartitions;
+    MirrorSourceConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorConnectorConfig config) {
+        this.knownSourceTopicPartitions = knownSourceTopicPartitions;
         this.config = config;
     }
 
@@ -116,14 +116,14 @@ public class MirrorSourceConnector extends SourceConnector {
         scheduler = new Scheduler(MirrorSourceConnector.class, config.adminTimeout());
         scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
         scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
-        scheduler.execute(this::createTopicPartitions, "creating downstream topic-partitions");
+        scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
         scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
         scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
         scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
             "syncing topic configs");
         scheduler.scheduleRepeatingDelayed(this::refreshTopicPartitions, config.refreshTopicsInterval(),
             "refreshing topics");
-        log.info("Started {} with {} topic-partitions.", connectorName, knownTopicPartitions.size());
+        log.info("Started {} with {} topic-partitions.", connectorName, knownSourceTopicPartitions.size());
         log.info("Starting {} took {} ms.", connectorName, System.currentTimeMillis() - start);
     }
 
@@ -157,16 +157,16 @@ public class MirrorSourceConnector extends SourceConnector {
     // t3 -> [t0p2, t0p5, t1p0, t2p1]
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
-        if (!config.enabled() || knownTopicPartitions.isEmpty()) {
+        if (!config.enabled() || knownSourceTopicPartitions.isEmpty()) {
             return Collections.emptyList();
         }
-        int numTasks = Math.min(maxTasks, knownTopicPartitions.size());
+        int numTasks = Math.min(maxTasks, knownSourceTopicPartitions.size());
         List<List<TopicPartition>> roundRobinByTask = new ArrayList<>(numTasks);
         for (int i = 0; i < numTasks; i++) {
             roundRobinByTask.add(new ArrayList<>());
         }
         int count = 0;
-        for (TopicPartition partition : knownTopicPartitions) {
+        for (TopicPartition partition : knownSourceTopicPartitions) {
             int index = count % numTasks;
             roundRobinByTask.get(index).add(partition);
             count++;
@@ -186,57 +186,70 @@ public class MirrorSourceConnector extends SourceConnector {
         return "1";
     }
 
-    private List<TopicPartition> findTopicPartitions()
+    // visible for testing
+    List<TopicPartition> findSourceTopicPartitions()
             throws InterruptedException, ExecutionException {
         Set<String> topics = listTopics(sourceAdminClient).stream()
             .filter(this::shouldReplicateTopic)
             .collect(Collectors.toSet());
-        return describeTopics(topics).stream()
+        return describeTopics(sourceAdminClient, topics).stream()
             .flatMap(MirrorSourceConnector::expandTopicDescription)
             .collect(Collectors.toList());
     }
 
-    private void refreshTopicPartitions()
+    // visible for testing
+    void refreshTopicPartitions()
             throws InterruptedException, ExecutionException {
-        List<TopicPartition> topicPartitions = findTopicPartitions();
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findExistingTargetTopicPartitions();
+        List<TopicPartition> targetTopicPartitionsUpstream = knownTargetTopicPartitions.stream()
+                .map(x -> new TopicPartition(replicationPolicy.upstreamTopic(x.topic()), x.partition()))
+                .collect(Collectors.toList());
+
         Set<TopicPartition> newTopicPartitions = new HashSet<>();
-        newTopicPartitions.addAll(topicPartitions);
-        newTopicPartitions.removeAll(knownTopicPartitions);
+        newTopicPartitions.addAll(knownSourceTopicPartitions);
+        newTopicPartitions.removeAll(targetTopicPartitionsUpstream);
         Set<TopicPartition> deadTopicPartitions = new HashSet<>();
-        deadTopicPartitions.addAll(knownTopicPartitions);
-        deadTopicPartitions.removeAll(topicPartitions);
+        deadTopicPartitions.addAll(targetTopicPartitionsUpstream);
+        deadTopicPartitions.removeAll(knownSourceTopicPartitions);
         if (!newTopicPartitions.isEmpty() || !deadTopicPartitions.isEmpty()) {
             log.info("Found {} topic-partitions on {}. {} are new. {} were removed. Previously had {}.",
-                    topicPartitions.size(), sourceAndTarget.source(), newTopicPartitions.size(), 
-                    deadTopicPartitions.size(), knownTopicPartitions.size());
+                    knownSourceTopicPartitions.size(), sourceAndTarget.source(), newTopicPartitions.size(),
+                    deadTopicPartitions.size(), knownSourceTopicPartitions.size());
             log.trace("Found new topic-partitions: {}", newTopicPartitions);
-            knownTopicPartitions = topicPartitions;
-            knownTargetTopics = findExistingTargetTopics(); 
-            createTopicPartitions();
+            computeAndCreateTopicPartitions();
             context.requestTaskReconfiguration();
         }
     }
 
     private void loadTopicPartitions()
             throws InterruptedException, ExecutionException {
-        knownTopicPartitions = findTopicPartitions();
-        knownTargetTopics = findExistingTargetTopics(); 
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findExistingTargetTopicPartitions();
     }
 
     private void refreshKnownTargetTopics()
             throws InterruptedException, ExecutionException {
-        knownTargetTopics = findExistingTargetTopics();
+        knownTargetTopicPartitions = findExistingTargetTopicPartitions();
     }
 
-    private Set<String> findExistingTargetTopics()
+    // visible for testing
+    List<TopicPartition> findExistingTargetTopicPartitions()
             throws InterruptedException, ExecutionException {
-        return listTopics(targetAdminClient).stream()
+        Set<String> topics = listTopics(targetAdminClient).stream()
             .filter(x -> sourceAndTarget.source().equals(replicationPolicy.topicSource(x)))
             .collect(Collectors.toSet());
+        return describeTopics(targetAdminClient, topics).stream()
+                .flatMap(MirrorSourceConnector::expandTopicDescription)
+                .collect(Collectors.toList());
     }
 
     private Set<String> topicsBeingReplicated() {
-        return knownTopicPartitions.stream()
+        Set<String> knownTargetTopics = knownTargetTopicPartitions.stream()
+                .map(x -> x.topic())
+                .distinct()
+                .collect(Collectors.toSet());
+        return knownSourceTopicPartitions.stream()
             .map(x -> x.topic())
             .distinct()
             .filter(x -> knownTargetTopics.contains(formatRemoteTopic(x)))
@@ -267,11 +280,16 @@ public class MirrorSourceConnector extends SourceConnector {
         MirrorUtils.createSinglePartitionCompactedTopic(config.offsetSyncsTopic(), config.offsetSyncsTopicReplicationFactor(), config.sourceAdminConfig());
     }
 
-    private void createTopicPartitions()
+    // visible for testing
+    void computeAndCreateTopicPartitions()
             throws InterruptedException, ExecutionException {
-        Map<String, Long> partitionCounts = knownTopicPartitions.stream()
+        Map<String, Long> partitionCounts = knownSourceTopicPartitions.stream()
             .collect(Collectors.groupingBy(x -> x.topic(), Collectors.counting())).entrySet().stream()
             .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> x.getValue()));
+        Set<String> knownTargetTopics = knownTargetTopicPartitions.stream()
+            .map(x -> x.topic())
+            .distinct()
+            .collect(Collectors.toSet());
         List<NewTopic> newTopics = partitionCounts.entrySet().stream()
             .filter(x -> !knownTargetTopics.contains(x.getKey()))
             .map(x -> new NewTopic(x.getKey(), x.getValue().intValue(), (short) replicationFactor))
@@ -279,6 +297,12 @@ public class MirrorSourceConnector extends SourceConnector {
         Map<String, NewPartitions> newPartitions = partitionCounts.entrySet().stream()
             .filter(x -> knownTargetTopics.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> NewPartitions.increaseTo(x.getValue().intValue())));
+        createTopicPartitions(partitionCounts, newTopics, newPartitions);
+    }
+
+    // visible for testing
+    void createTopicPartitions(Map<String, Long> partitionCounts, List<NewTopic> newTopics,
+            Map<String, NewPartitions> newPartitions) {
         targetAdminClient.createTopics(newTopics, new CreateTopicsOptions()).values().forEach((k, v) -> v.whenComplete((x, e) -> {
             if (e != null) {
                 log.warn("Could not create topic {}.", k, e);
@@ -307,9 +331,9 @@ public class MirrorSourceConnector extends SourceConnector {
         return sourceAdminClient.describeAcls(ANY_TOPIC_ACL).values().get();
     }
 
-    private Collection<TopicDescription> describeTopics(Collection<String> topics)
+    private static Collection<TopicDescription> describeTopics(AdminClient adminClient, Collection<String> topics)
             throws InterruptedException, ExecutionException {
-        return sourceAdminClient.describeTopics(topics).all().get().values();
+        return adminClient.describeTopics(topics).all().get().values();
     }
 
     @SuppressWarnings("deprecation")

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -192,7 +192,7 @@ public class MirrorSourceConnectorTest {
 
         List<TopicPartition> sourceTopicPartitions = Arrays.asList(new TopicPartition("topic", 0));
         doReturn(sourceTopicPartitions).when(connector).findSourceTopicPartitions();
-        doReturn(Collections.emptyList()).when(connector).findExistingTargetTopicPartitions();
+        doReturn(Collections.emptyList()).when(connector).findTargetTopicPartitions();
         doNothing().when(connector).createTopicPartitions(any(), any(), any());
 
         connector.refreshTopicPartitions();
@@ -210,7 +210,7 @@ public class MirrorSourceConnectorTest {
                 eq(Collections.emptyMap()));
 
         List<TopicPartition> targetTopicPartitions = Arrays.asList(new TopicPartition("source.topic", 0));
-        doReturn(targetTopicPartitions).when(connector).findExistingTargetTopicPartitions();
+        doReturn(targetTopicPartitions).when(connector).findTargetTopicPartitions();
         connector.refreshTopicPartitions();
 
         // once target topic is created, refreshTopicPartitions() will NOT call computeAndCreateTopicPartitions() again

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.kafka.connect.mirror;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -28,7 +25,9 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewTopic;
 
 import org.junit.Test;
 
@@ -36,8 +35,21 @@ import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.TASK_TOPIC_P
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MirrorSourceConnectorTest {
 
@@ -122,25 +134,25 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testMirrorSourceConnectorTaskConfig() {
-        List<TopicPartition> knownTopicPartitions = new ArrayList<>();
+        List<TopicPartition> knownSourceTopicPartitions = new ArrayList<>();
 
         // topic `t0` has 8 partitions
-        knownTopicPartitions.add(new TopicPartition("t0", 0));
-        knownTopicPartitions.add(new TopicPartition("t0", 1));
-        knownTopicPartitions.add(new TopicPartition("t0", 2));
-        knownTopicPartitions.add(new TopicPartition("t0", 3));
-        knownTopicPartitions.add(new TopicPartition("t0", 4));
-        knownTopicPartitions.add(new TopicPartition("t0", 5));
-        knownTopicPartitions.add(new TopicPartition("t0", 6));
-        knownTopicPartitions.add(new TopicPartition("t0", 7));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 0));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 1));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 2));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 3));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 4));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 5));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 6));
+        knownSourceTopicPartitions.add(new TopicPartition("t0", 7));
 
         // topic `t1` has 2 partitions
-        knownTopicPartitions.add(new TopicPartition("t1", 0));
-        knownTopicPartitions.add(new TopicPartition("t1", 1));
+        knownSourceTopicPartitions.add(new TopicPartition("t1", 0));
+        knownSourceTopicPartitions.add(new TopicPartition("t1", 1));
 
         // topic `t2` has 2 partitions
-        knownTopicPartitions.add(new TopicPartition("t2", 0));
-        knownTopicPartitions.add(new TopicPartition("t2", 1));
+        knownSourceTopicPartitions.add(new TopicPartition("t2", 0));
+        knownSourceTopicPartitions.add(new TopicPartition("t2", 1));
 
         // MirrorConnectorConfig example for test
         Map<String, String> props = new HashMap<>();
@@ -151,7 +163,7 @@ public class MirrorSourceConnectorTest {
         MirrorConnectorConfig config = new MirrorConnectorConfig(props);
 
         // MirrorSourceConnector as minimum to run taskConfig()
-        MirrorSourceConnector connector = new MirrorSourceConnector(knownTopicPartitions, config);
+        MirrorSourceConnector connector = new MirrorSourceConnector(knownSourceTopicPartitions, config);
 
         // distribute the topic-partition to 3 tasks by round-robin
         List<Map<String, String>> output = connector.taskConfigs(3);
@@ -169,5 +181,39 @@ public class MirrorSourceConnectorTest {
 
         Map<String, String> t3 = output.get(2);
         assertEquals("t0-2,t0-5,t1-0,t2-1", t3.get(TASK_TOPIC_PARTITIONS));
+    }
+
+    @Test
+    public void testRefreshTopicPartitions() throws Exception {
+        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
+        connector.initialize(mock(ConnectorContext.class));
+        connector = spy(connector);
+
+        List<TopicPartition> sourceTopicPartitions = Arrays.asList(new TopicPartition("topic", 0));
+        doReturn(sourceTopicPartitions).when(connector).findSourceTopicPartitions();
+        doReturn(Collections.emptyList()).when(connector).findExistingTargetTopicPartitions();
+        doNothing().when(connector).createTopicPartitions(any(), any(), any());
+
+        connector.refreshTopicPartitions();
+        // if target topic is not created, refreshTopicPartitions() will call createTopicPartitions() again
+        connector.refreshTopicPartitions();
+
+        Map<String, Long> expectedPartitionCounts = new HashMap<>();
+        expectedPartitionCounts.put("source.topic", 1L);
+        List<NewTopic> expectedNewTopics = Arrays.asList(new NewTopic("source.topic", 1, (short) 0));
+
+        verify(connector, times(2)).computeAndCreateTopicPartitions();
+        verify(connector, times(2)).createTopicPartitions(
+                eq(expectedPartitionCounts),
+                eq(expectedNewTopics),
+                eq(Collections.emptyMap()));
+
+        List<TopicPartition> targetTopicPartitions = Arrays.asList(new TopicPartition("source.topic", 0));
+        doReturn(targetTopicPartitions).when(connector).findExistingTargetTopicPartitions();
+        connector.refreshTopicPartitions();
+
+        // once target topic is created, refreshTopicPartitions() will NOT call computeAndCreateTopicPartitions() again
+        verify(connector, times(2)).computeAndCreateTopicPartitions();
     }
 }


### PR DESCRIPTION
When the scheduled refreshTopicPartitions runs, check existing topics in both source and target clusters in order to compute topic partitions to be created on target.

If a temporary failure to create the target topic is encountered (e.g. insufficient number of brokers), on the next refresh the target topic creation will be re-attempted.

Co-authored-by: Edoardo Comar <ecomar@uk.ibm.com>
Co-authored-by: Mickael Maison <mickael.maison@uk.ibm.com>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
