### PR TITLE
Remove --zookeeper usages from kafka.py

### DIFF
--- a/tests/kafkatest/utils/__init__.py
+++ b/tests/kafkatest/utils/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import kafkatest_version, is_version, is_int, is_int_with_prefix, node_is_reachable, validate_delivery
+from util import kafkatest_version, is_version, is_int, is_int_with_prefix, node_is_reachable, validate_delivery, join_shell

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -17,6 +17,7 @@ from kafkatest import __version__ as __kafkatest_version__
 import math
 import re
 import time
+from pipes import quote
 
 
 def kafkatest_version():
@@ -182,3 +183,9 @@ def validate_delivery(acked, consumed, idempotence_enabled=False, check_lost_dat
             msg += "(There are also %d duplicate messages in the log - but that is an acceptable outcome)\n" % num_duplicates
 
     return success, msg
+
+
+def join_shell(split_command):
+    """Return an escaped command from the given parts"""
+    # TODO replace this with shlex.join in Python 3
+    return ' '.join(quote(str(arg)) for arg in split_command)


### PR DESCRIPTION
Also use `pipes.quote` for building up commands (rather than string concatenation) 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
