### PR TITLE
KAFKA-9231: Streams Threads may die from recoverable errors with EOS enabled

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
@@ -177,8 +177,8 @@ public abstract class AbstractTask implements Task {
         try {
             stateMgr.flush();
         } catch (final ProcessorStateException e) {
-            if (e.getCause() instanceof RetriableException) {
-                log.warn("Caught a retriable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
+            if (e.getCause() instanceof ProducerFencedException) {
+                log.warn("Caught a recoverable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
                 throw new TaskMigratedException(this, e);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
@@ -177,7 +176,7 @@ public abstract class AbstractTask implements Task {
         try {
             stateMgr.flush();
         } catch (final ProcessorStateException e) {
-            if (e.getCause() instanceof ProducerFencedException) {
+            if (e.getCause() instanceof RecoverableClientException) {
                 log.warn("Caught a recoverable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
                 throw new TaskMigratedException(this, e);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -177,7 +177,6 @@ public abstract class AbstractTask implements Task {
             stateMgr.flush();
         } catch (final ProcessorStateException e) {
             if (e.getCause() instanceof RecoverableClientException) {
-                log.warn("Caught a recoverable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
                 throw new TaskMigratedException(this, e);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -148,7 +148,7 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
                 // swallow and move on since we are rebalancing
                 log.info("Failed to suspend stream task {} since it got migrated to another thread already. " +
                     "Closing it as zombie and moving on.", id);
-                firstException.compareAndSet(null, closeZombieTask(task));
+                tryCloseZombieTask(task);
                 prevActiveTasks.remove(id);
             } catch (final RuntimeException e) {
                 log.error("Suspending stream task {} failed due to the following error:", id, e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -97,14 +97,12 @@ abstract class AssignedTasks<T extends Task> {
         return running.values();
     }
 
-    RuntimeException closeZombieTask(final T task) {
+    void tryCloseZombieTask(final T task) {
         try {
             task.close(false, true);
         } catch (final RuntimeException e) {
             log.warn("Failed to close zombie {} {} due to {}; ignore and proceed.", taskTypeName, task.id(), e.toString());
-            return e;
         }
-        return null;
     }
 
     boolean hasRunningTasks() {
@@ -259,7 +257,7 @@ abstract class AssignedTasks<T extends Task> {
             } catch (final TaskMigratedException e) {
                 log.info("Failed to close {} {} since it got migrated to another thread already. " +
                     "Closing it as zombie and move on.", taskTypeName, task.id());
-                firstException.compareAndSet(null, closeZombieTask(task));
+                tryCloseZombieTask(task);
             } catch (final RuntimeException t) {
                 log.error("Failed while closing {} {} due to the following error:",
                     task.getClass().getSimpleName(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -101,7 +101,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void flushState() {
-        // this could theoretically throw a ProcessorStateException caused by a kafka.RetriableException,
+        // this could theoretically throw a ProcessorStateException caused by a ProducerFencedException,
         // but in practice this shouldn't happen for global state update tasks, since the stores are not
         // logged and there are no downstream operators after global stores.
         stateMgr.flush();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -101,6 +101,9 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     }
 
     public void flushState() {
+        // this could theoretically throw a ProcessorStateException caused by a kafka.RetriableException,
+        // but in practice this shouldn't happen for global state update tasks, since the stores are not
+        // logged and there are no downstream operators after global stores.
         stateMgr.flush();
         stateMgr.checkpoint(offsets);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecoverableClientException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecoverableClientException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.KafkaException;
+
+/**
+ * Denotes an exception that is recoverable by re-creating the client (ie, the client is no longer in a valid state),
+ * as opposed to retriable (the failure was transient, so the same client can be used again later),
+ * or fatal (the request was actually invalid, so retrying or recovering would not help)
+ */
+public class RecoverableClientException extends KafkaException {
+    public RecoverableClientException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -21,11 +21,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
@@ -122,7 +124,14 @@ public class StandbyTask extends AbstractTask {
     }
 
     private void flushAndCheckpointState() {
-        stateMgr.flush();
+        try {
+            stateMgr.flush();
+        } catch (final ProcessorStateException e) {
+            if (e.getCause() instanceof RetriableException) {
+                log.warn("Caught a retriable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
+                throw new TaskMigratedException(this, e);
+            }
+        }
         stateMgr.checkpoint(Collections.emptyMap());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
-import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.StreamsConfig;
@@ -127,7 +127,7 @@ public class StandbyTask extends AbstractTask {
         try {
             stateMgr.flush();
         } catch (final ProcessorStateException e) {
-            if (e.getCause() instanceof RetriableException) {
+            if (e.getCause() instanceof ProducerFencedException) {
                 log.warn("Caught a retriable Kafka exception while flushing state. Initiating a rebalance to attempt recovery.", e);
                 throw new TaskMigratedException(this, e);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -658,6 +658,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             TaskMigratedException taskMigratedException = null;
             try {
                 commit(false, partitionTimes);
+            } catch (final ProducerFencedException e) {
+                taskMigratedException = new TaskMigratedException(this, e);
             } finally {
                 if (eosEnabled) {
                     stateMgr.checkpoint(activeTaskCheckpointableOffsets());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -188,10 +188,11 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
             throw new ProcessorStateException(fatal);
         }
 
-        maybeSetUpMetricsRecorder(context, configs);
-
         openRocksDB(dbOptions, columnFamilyOptions);
         open = true;
+
+        // Do this last because the prior operations could throw exceptions.
+        maybeSetUpMetricsRecorder(context, configs);
     }
 
     private void maybeSetUpMetricsRecorder(final ProcessorContext context, final Map<String, Object> configs) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -188,6 +189,26 @@ public class RecordCollectorTest {
             }
         });
 
+        collector.send("topic1", "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = RecoverableClientException.class)
+    public void shouldThrowRecoverableExceptionWhenProducerFencedInCallback() {
+        final RecordCollector collector = new RecordCollectorImpl(
+            "test",
+            logContext,
+            new DefaultProductionExceptionHandler(),
+            new Metrics().sensor("skipped-records"));
+        collector.init(new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+            @Override
+            public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
+                callback.onCompletion(null, new ProducerFencedException("asdf"));
+                return null;
+            }
+        });
+
+        collector.send("topic1", "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
         collector.send("topic1", "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1090,7 +1090,7 @@ public class StreamTaskTest {
             fail("should have thrown TaskMigratedException");
         } catch (final TaskMigratedException expected) {
             task = null;
-            assertTrue(expected.getCause() instanceof ProducerFencedException);
+            assertTrue(expected.getCause() instanceof RecoverableClientException);
         }
 
         assertFalse(producer.transactionCommitted());
@@ -1111,7 +1111,7 @@ public class StreamTaskTest {
             fail("should have thrown TaskMigratedException");
         } catch (final TaskMigratedException expected) {
             task = null;
-            assertTrue(expected.getCause() instanceof ProducerFencedException);
+            assertTrue(expected.getCause() instanceof RecoverableClientException);
         }
 
         assertTrue(producer.transactionCommitted());
@@ -1283,7 +1283,7 @@ public class StreamTaskTest {
             task.suspend();
             fail("Should have throws TaskMigratedException");
         } catch (final TaskMigratedException expected) {
-            assertTrue(expected.getCause() instanceof ProducerFencedException);
+            assertTrue(expected.getCause() instanceof RecoverableClientException);
         }
         task = null;
 
@@ -1300,7 +1300,7 @@ public class StreamTaskTest {
             task.suspend();
             fail("Should have throws TaskMigratedException");
         } catch (final TaskMigratedException expected) {
-            assertTrue(expected.getCause() instanceof ProducerFencedException);
+            assertTrue(expected.getCause() instanceof RecoverableClientException);
         }
 
         assertTrue(producer.transactionCommitted());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -22,8 +22,11 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -51,7 +54,9 @@ import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
@@ -1156,6 +1161,190 @@ public class StreamTaskTest {
         assertFalse(producer.transactionAborted());
         assertFalse(producer.transactionCommitted());
         assertTrue(producer.closed());
+    }
+
+    @Test
+    public void shouldMigrateTaskIfFencedDuringFlush() {
+        final StateStore stateStore = new MockKeyValueStore(storeName, true, true);
+
+        final Map<String, String> storeToChangelogTopic = true ? Collections.singletonMap(storeName, storeName + "-changelog") : Collections.emptyMap();
+        final ProcessorTopology topology1 = new ProcessorTopology(
+            asList(source1, source2),
+            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2)),
+            Collections.emptyMap(),
+            singletonList(stateStore),
+            Collections.emptyList(),
+            storeToChangelogTopic,
+            Collections.emptySet()
+        );
+
+        task = new StreamTask(
+            taskId00,
+            partitions,
+            topology1,
+            consumer,
+            changelogReader,
+            createConfig(true),
+            streamsMetrics,
+            stateDirectory,
+            null,
+            time,
+            () -> producer = new MockProducer<>(false, bytesSerializer, bytesSerializer)
+        );
+        task.initializeStateStores();
+        task.initializeTopology();
+        producer.fenceProducer();
+
+        try {
+            task.flushState();
+            fail("Expected a TaskMigratedException");
+        } catch (final TaskMigratedException expected) {
+            assertThat(expected.migratedTask(), is(task));
+        }
+    }
+
+    @Test
+    public void shouldMigrateTaskIfFencedDuringProcess() {
+        final StateStore stateStore = new MockKeyValueStore(storeName, true, true);
+
+        final Map<String, String> storeToChangelogTopic = true ? Collections.singletonMap(storeName, storeName + "-changelog") : Collections.emptyMap();
+        final SourceNode<Integer, Integer> sourceNode = new SourceNode<>("test", singletonList(topic1), new WallclockTimestampExtractor(), intDeserializer, intDeserializer);
+        final SinkNode<Integer, Integer> sinkNode = new SinkNode<>("test-sink", new StaticTopicNameExtractor<>("out-topic"), intSerializer, intSerializer, new StreamPartitioner<Integer, Integer>() {
+            @Override
+            public Integer partition(final String topic,
+                                     final Integer key,
+                                     final Integer value,
+                                     final int numPartitions) {
+                return 1;
+            }
+        });
+
+        sourceNode.addChild(sinkNode);
+
+        final ProcessorTopology topology1 = new ProcessorTopology(
+            asList(sourceNode, sinkNode),
+            mkMap(mkEntry(topic1, sourceNode), mkEntry(topic2, sourceNode)),
+            mkMap(mkEntry("out-topic", sinkNode)),
+            singletonList(stateStore),
+            Collections.emptyList(),
+            storeToChangelogTopic,
+            Collections.emptySet()
+        );
+
+        task = new StreamTask(
+            taskId00,
+            partitions,
+            topology1,
+            consumer,
+            changelogReader,
+            createConfig(true),
+            streamsMetrics,
+            stateDirectory,
+            null,
+            time,
+            () -> producer = new MockProducer<byte[], byte[]>(
+                Cluster.empty(),
+                false,
+                new DefaultPartitioner(),
+                bytesSerializer,
+                bytesSerializer
+            ) {
+                @Override
+                public List<PartitionInfo> partitionsFor(final String topic) {
+                    return singletonList(null);
+                }
+            }
+        );
+        task.initializeStateStores();
+        task.initializeTopology();
+        producer.fenceProducer();
+
+        try {
+
+            task.addRecords(partition1, singletonList(getConsumerRecord(partition1, 0)));
+            task.process();
+            fail("Expected a TaskMigratedException");
+        } catch (final TaskMigratedException expected) {
+            assertThat(expected.migratedTask(), is(task));
+        }
+    }
+
+    @Test
+    public void shouldMigrateTaskIfFencedDuringPunctuate() {
+        task = createStatelessTask(createConfig(true));
+
+        final RecordCollectorImpl recordCollector = new RecordCollectorImpl("StreamTask",
+                                                                            new LogContext("StreamTaskTest "), new DefaultProductionExceptionHandler(), new Metrics().sensor("skipped-records"));
+        recordCollector.init(producer);
+
+        task.initializeStateStores();
+        task.initializeTopology();
+        producer.fenceProducer();
+        try {
+            task.punctuate(
+                processorSystemTime,
+                5,
+                PunctuationType.WALL_CLOCK_TIME,
+                timestamp -> recordCollector.send(
+                    "result-topic1",
+                    3,
+                    5,
+                    null,
+                    0,
+                    time.milliseconds(),
+                    new IntegerSerializer(),
+                    new IntegerSerializer()
+                )
+            );
+            fail("Expected a TaskMigratedException");
+        } catch (final TaskMigratedException expected) {
+            assertThat(expected.migratedTask(), is(task));
+        }
+    }
+
+    @Test
+    public void shouldMigrateTaskIfFencedDuringCommit() {
+        final ProcessorTopology topology1 = withSources(
+            asList(source1, source2, processorStreamTime, processorSystemTime),
+            mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2))
+        );
+
+        source1.addChild(processorStreamTime);
+        source2.addChild(processorStreamTime);
+        source1.addChild(processorSystemTime);
+        source2.addChild(processorSystemTime);
+
+        task = new StreamTask(
+            taskId00,
+            partitions,
+            topology1,
+            consumer,
+            changelogReader,
+            createConfig(true),
+            streamsMetrics,
+            stateDirectory,
+            null,
+            time,
+            () -> producer = new MockProducer<>(false, bytesSerializer, bytesSerializer)) {
+            @Override
+            protected void flushState() {
+                // do nothing so that we actually make it to the commit interaction.
+            }
+        };
+
+        final RecordCollectorImpl recordCollector = new RecordCollectorImpl("StreamTask",
+                                                                            new LogContext("StreamTaskTest "), new DefaultProductionExceptionHandler(), new Metrics().sensor("skipped-records"));
+        recordCollector.init(producer);
+
+        task.initializeStateStores();
+        task.initializeTopology();
+        producer.fenceProducer();
+        try {
+            task.commit();
+            fail("Expected a TaskMigratedException");
+        } catch (final TaskMigratedException expected) {
+            assertThat(expected.migratedTask(), is(task));
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskSuite.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskSuite.java
@@ -16,18 +16,23 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.common.KafkaException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
- * Denotes an exception that is recoverable by re-creating the client (ie, the client is no longer in a valid state),
- * as opposed to retriable (the failure was transient, so the same client can be used again later),
- * or fatal (the request was actually invalid, so retrying or recovering would not help)
+ * This suite runs all the tests related to task management. It's intended to simplify feature testing from IDEs.
  *
- * This class also serves the dual purpose of capturing the stack trace as early as possible,
- * at the site of the Producer call, since the exeptions that cause this don't record stack traces.
+ * If desired, it can also be added to a Gradle build task, although this isn't strictly necessary, since all
+ * these tests are already included in the `:streams:test` task.
  */
-public class RecoverableClientException extends KafkaException {
-    public RecoverableClientException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    AbstractTaskTest.class,
+    StreamTaskTest.class,
+    StandbyTaskTest.class,
+    AssignedStreamsTasksTest.class,
+})
+public class TaskSuite {
 }
+
+


### PR DESCRIPTION
We missed a branch in which we might catch a ProducerFencedException. It should always be converted to a TaskMigratedException.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
