### PR TITLE
KAFKA-9232: Coordinator new member heartbeat completion does not work for JoinGroup v3

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1091,9 +1091,9 @@ class GroupCoordinator(val brokerId: Int,
               leaderId = group.leaderOrNull,
               error = Errors.NONE)
 
-            group.maybeInvokeJoinCallback(member, joinResult)
-            completeAndScheduleNextHeartbeatExpiration(group, member)
             member.isNew = false
+            completeAndScheduleNextHeartbeatExpiration(group, member)
+            group.maybeInvokeJoinCallback(member, joinResult)
           }
         }
       }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1091,9 +1091,9 @@ class GroupCoordinator(val brokerId: Int,
               leaderId = group.leaderOrNull,
               error = Errors.NONE)
 
-            member.isNew = false
-            completeAndScheduleNextHeartbeatExpiration(group, member)
             group.maybeInvokeJoinCallback(member, joinResult)
+            completeAndScheduleNextHeartbeatExpiration(group, member)
+            member.isNew = false
           }
         }
       }

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -86,15 +86,16 @@ private[group] class MemberMetadata(var memberId: String,
   }
 
   def shouldKeepAlive(deadlineMs: Long): Boolean = {
-    if (isNew)
-    // New members are expired after the static join timeout
+    if (isNew) {
+      // New members are expired after the static join timeout
       latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
-    else if (isAwaitingJoin || isAwaitingSync)
-    // Don't remove members as long as they have a request in purgatory
+    } else if (isAwaitingJoin || isAwaitingSync) {
+      // Don't remove members as long as they have a request in purgatory
       true
-    else
-    // Otherwise check for session expiration
+    } else {
+      // Otherwise check for session expiration
       latestHeartbeat + sessionTimeoutMs > deadlineMs
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -86,14 +86,11 @@ private[group] class MemberMetadata(var memberId: String,
   }
 
   def shouldKeepAlive(deadlineMs: Long): Boolean = {
-    if (isNew)
-    // New members are expired after the static join timeout
-      latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
-    else if (isAwaitingJoin || isAwaitingSync)
-    // Don't remove members as long as they have a request in purgatory
+    if (isAwaitingJoin)
+      !isNew || latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
+    else if (isNew || isAwaitingSync)
       true
     else
-    // Otherwise check for session expiration
       latestHeartbeat + sessionTimeoutMs > deadlineMs
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -88,7 +88,9 @@ private[group] class MemberMetadata(var memberId: String,
   def shouldKeepAlive(deadlineMs: Long): Boolean = {
     if (isAwaitingJoin)
       !isNew || latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
-    else awaitingSyncCallback != null ||
+    else if (isNew || isAwaitingSync)
+      true
+    else
       latestHeartbeat + sessionTimeoutMs > deadlineMs
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -86,11 +86,14 @@ private[group] class MemberMetadata(var memberId: String,
   }
 
   def shouldKeepAlive(deadlineMs: Long): Boolean = {
-    if (isAwaitingJoin)
-      !isNew || latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
-    else if (isNew || isAwaitingSync)
+    if (isNew)
+    // New members are expired after the static join timeout
+      latestHeartbeat + GroupCoordinator.NewMemberJoinTimeoutMs > deadlineMs
+    else if (isAwaitingJoin || isAwaitingSync)
+    // Don't remove members as long as they have a request in purgatory
       true
     else
+    // Otherwise check for session expiration
       latestHeartbeat + sessionTimeoutMs > deadlineMs
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -1882,7 +1882,7 @@ class GroupCoordinatorTest {
 
     val nextGenerationId = joinResult.generationId
 
-    // with no leader SyncGroup, the follower's request should failure with an error indicating
+    // with no leader SyncGroup, the follower's request should fail with an error indicating
     // that it should rejoin
     EasyMock.reset(replicaManager)
     val followerSyncFuture = sendSyncGroupFollower(groupId, nextGenerationId, otherJoinResult.memberId, None)


### PR DESCRIPTION
The v3 JoinGroup logic does not properly complete the initial heartbeat for new members, which then expires after the static 5 minute timeout. The core issue is in the `shouldKeepAlive` method, which returns false when it should return true.