### PR TITLE
KAFKA-9233: Fix IllegalStateException in Fetcher retrieval of beginni…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -570,6 +570,7 @@ public class Fetcher<K, V> implements Closeable {
         metadata.addTransientTopics(topicsForPartitions(partitions));
         try {
             Map<TopicPartition, Long> timestampsToSearch = partitions.stream()
+                    .distinct()
                     .collect(Collectors.toMap(Function.identity(), tp -> timestamp));
 
             ListOffsetResult result = fetchOffsetsByTimes(timestampsToSearch, timer, false);


### PR DESCRIPTION
…ng or end offsets for duplicate TopicPartition values

Minor bug fix. The issue was introduced in Kafka 2.3.0, likely by [KAFKA-7831](https://issues.apache.org/jira/browse/KAFKA-7831).

Tested by,
`./gradlew clients:test --tests FetcherTest`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
