### PR TITLE
KAFKA-7016: Don't fill in stack traces

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/ApiException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ApiException.java
@@ -42,10 +42,4 @@ public class ApiException extends KafkaException {
         super();
     }
 
-    /* avoid the expensive and useless stack trace for api exceptions */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
@@ -41,10 +41,4 @@ public class SerializationException extends KafkaException {
         super();
     }
 
-    /* avoid the expensive and useless stack trace for serialization exceptions */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
-
 }


### PR DESCRIPTION
Stack traces are useful.

I'm pretty sure this exists in all versions of Kafka, but we should consider cherry-picking it back to at least a few older versions we may still do a bugfix for.