### PR TITLE
KAFKA-9230: Refactor user-customizable Streams metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsMetrics.java
@@ -35,6 +35,60 @@ public interface StreamsMetrics {
     Map<MetricName, ? extends Metric> metrics();
 
     /**
+     * Add a latency, rate and total sensor for a specific operation, which will include the following metrics:
+     * <ol>
+     * <li>average latency</li>
+     * <li>max latency</li>
+     * <li>invocation rate (num.operations / time unit)</li>
+     * <li>total invocation count</li>
+     * </ol>
+     * Whenever a user record this sensor via {@link Sensor#record(double)} etc, it will be counted as one invocation
+     * of the operation, and hence the rate / count metrics will be updated accordingly; and the recorded latency value
+     * will be used to update the average / max latency as well.
+     * The time unit of the latency can be defined by the user.
+     *
+     * Note that you can add more metrics to this sensor after you created it, which can then be updated upon
+     * {@link Sensor#record(double)} calls; but additional user-customized metrics will not be managed by {@link StreamsMetrics}.
+     *
+     * @param scopeName          name of the scope, which will be used as part of the metrics type, e.g.: "stream-[scope]-metrics".
+     * @param entityName         name of the entity, which will be used as part of the metric tags, e.g.: "[scope]-id" = "[entity]".
+     * @param operationName      name of the operation, which will be used as the name of the metric, e.g.: "[operation]-latency-avg".
+     * @param recordingLevel     the recording level (e.g., INFO or DEBUG) for this sensor.
+     * @param tags               additional tags of the sensor
+     * @return The added sensor.
+     */
+    Sensor addLatencyRateTotalSensor(final String scopeName,
+                                     final String entityName,
+                                     final String operationName,
+                                     final Sensor.RecordingLevel recordingLevel,
+                                     final String... tags);
+
+    /**
+     * Add a rate and a total sensor for a specific operation, which will include the following metrics:
+     * <ol>
+     * <li>invocation rate (num.operations / time unit)</li>
+     * <li>total invocation count</li>
+     * </ol>
+     * Whenever a user record this sensor via {@link Sensor#record(double)} etc,
+     * it will be counted as one invocation of the operation, and hence the rate / count metrics will be updated accordingly.
+     *
+     * Note that you can add more metrics to this sensor after created it, which can then be updated upon {@link Sensor#record(double)} calls;
+     * but additional user-customized metrics will not be managed by {@link StreamsMetrics}.
+     *
+     * @param scopeName          name of the scope, which will be used as part of the metrics type, e.g.: "stream-[scope]-metrics".
+     * @param entityName         name of the entity, which will be used as part of the metric tags, e.g.: "[scope]-id" = "[entity]".
+     * @param operationName      name of the operation, which will be used as the name of the metric, e.g.: "[operation]-total".
+     * @param recordingLevel     the recording level (e.g., INFO or DEBUG) for this sensor.
+     * @param tags               additional tags of the sensor
+     * @return The added sensor.
+     */
+    Sensor addRateTotalSensor(final String scopeName,
+                              final String entityName,
+                              final String operationName,
+                              final Sensor.RecordingLevel recordingLevel,
+                              final String... tags);
+
+    /**
      * Add a latency and throughput sensor for a specific operation, which will include the following sensors:
      * <ol>
      *   <li>average latency</li>
@@ -67,6 +121,7 @@ public interface StreamsMetrics {
      * @param startNs start of measurement time in nanoseconds.
      * @param endNs   end of measurement time in nanoseconds.
      */
+    @Deprecated
     void recordLatency(final Sensor sensor,
                        final long startNs,
                        final long endNs);
@@ -100,6 +155,7 @@ public interface StreamsMetrics {
      * @param sensor add Sensor whose throughput we are recording
      * @param value  throughput value
      */
+    @Deprecated
     void recordThroughput(final Sensor sensor,
                           final long value);
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsMetrics.java
@@ -39,18 +39,17 @@ public interface StreamsMetrics {
      * <ol>
      * <li>average latency</li>
      * <li>max latency</li>
-     * <li>invocation rate (num.operations / time unit)</li>
+     * <li>invocation rate (num.operations / seconds)</li>
      * <li>total invocation count</li>
      * </ol>
-     * Whenever a user record this sensor via {@link Sensor#record(double)} etc, it will be counted as one invocation
+     * Whenever a user records this sensor via {@link Sensor#record(double)} etc, it will be counted as one invocation
      * of the operation, and hence the rate / count metrics will be updated accordingly; and the recorded latency value
      * will be used to update the average / max latency as well.
-     * The time unit of the latency can be defined by the user.
      *
      * Note that you can add more metrics to this sensor after you created it, which can then be updated upon
-     * {@link Sensor#record(double)} calls; but additional user-customized metrics will not be managed by {@link StreamsMetrics}.
+     * {@link Sensor#record(double)} calls.
      *
-     * @param scopeName          name of the scope, which will be used as part of the metrics type, e.g.: "stream-[scope]-metrics".
+     * @param scopeName          name of the scope, which will be used as part of the metric type, e.g.: "stream-[scope]-metrics".
      * @param entityName         name of the entity, which will be used as part of the metric tags, e.g.: "[scope]-id" = "[entity]".
      * @param operationName      name of the operation, which will be used as the name of the metric, e.g.: "[operation]-latency-avg".
      * @param recordingLevel     the recording level (e.g., INFO or DEBUG) for this sensor.
@@ -69,11 +68,11 @@ public interface StreamsMetrics {
      * <li>invocation rate (num.operations / time unit)</li>
      * <li>total invocation count</li>
      * </ol>
-     * Whenever a user record this sensor via {@link Sensor#record(double)} etc,
+     * Whenever a user records this sensor via {@link Sensor#record(double)} etc,
      * it will be counted as one invocation of the operation, and hence the rate / count metrics will be updated accordingly.
      *
-     * Note that you can add more metrics to this sensor after created it, which can then be updated upon {@link Sensor#record(double)} calls;
-     * but additional user-customized metrics will not be managed by {@link StreamsMetrics}.
+     * Note that you can add more metrics to this sensor after you created it, which can then be updated upon
+     * {@link Sensor#record(double)} calls.
      *
      * @param scopeName          name of the scope, which will be used as part of the metrics type, e.g.: "stream-[scope]-metrics".
      * @param entityName         name of the entity, which will be used as part of the metric tags, e.g.: "[scope]-id" = "[entity]".
@@ -104,7 +103,10 @@ public interface StreamsMetrics {
      * @param recordingLevel the recording level (e.g., INFO or DEBUG) for this sensor.
      * @param tags           additional tags of the sensor
      * @return The added sensor.
+     * @deprecated since 2.5. Use {@link #addLatencyRateTotalSensor(String, String, String, Sensor.RecordingLevel, String...) addLatencyRateTotalSensor()}
+     * instead.
      */
+    @Deprecated
     Sensor addLatencyAndThroughputSensor(final String scopeName,
                                          final String entityName,
                                          final String operationName,
@@ -120,6 +122,7 @@ public interface StreamsMetrics {
      * @param sensor  sensor whose latency we are recording.
      * @param startNs start of measurement time in nanoseconds.
      * @param endNs   end of measurement time in nanoseconds.
+     * @deprecated since 2.5. Use {@link Sensor#record(double) Sensor#record()} instead.
      */
     @Deprecated
     void recordLatency(final Sensor sensor,
@@ -142,7 +145,10 @@ public interface StreamsMetrics {
      * @param recordingLevel the recording level (e.g., INFO or DEBUG) for this sensor.
      * @param tags           additional tags of the sensor
      * @return The added sensor.
+     * @deprecated since 2.5. Use {@link #addRateTotalSensor(String, String, String, Sensor.RecordingLevel, String...)
+     * addRateTotalSensor()} instead.
      */
+    @Deprecated
     Sensor addThroughputSensor(final String scopeName,
                                final String entityName,
                                final String operationName,
@@ -154,6 +160,7 @@ public interface StreamsMetrics {
      *
      * @param sensor add Sensor whose throughput we are recording
      * @param value  throughput value
+     * @deprecated since 2.5. Use {@link Sensor#record() Sensor#record()} instead.
      */
     @Deprecated
     void recordThroughput(final Sensor sensor,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -37,7 +37,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
@@ -130,8 +129,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static final String AVG_VALUE_DOC = "The average value of ";
     public static final String MAX_VALUE_DOC = "The maximum value of ";
-    public static final String AVG_LATENCY_DOC = "The average latency of ";
-    public static final String MAX_LATENCY_DOC = "The maximum latency of ";
 
     public static final String GROUP_PREFIX_WO_DELIMITER = "stream";
     public static final String GROUP_PREFIX = GROUP_PREFIX_WO_DELIMITER + "-";
@@ -145,8 +142,13 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String BUFFER_LEVEL_GROUP_0100_TO_24 = GROUP_PREFIX + "buffer" + GROUP_SUFFIX;
     public static final String CACHE_LEVEL_GROUP = GROUP_PREFIX + "record-cache" + GROUP_SUFFIX;
 
+    public static final String OPERATIONS = " operations";
     public static final String TOTAL_DESCRIPTION = "The total number of ";
     public static final String RATE_DESCRIPTION = "The average per-second number of ";
+    public static final String AVG_LATENCY_DESCRIPTION = "The average latency of ";
+    public static final String MAX_LATENCY_DESCRIPTION = "The maximum latency of ";
+    public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
+    public static final String RATE_DESCRIPTION_SUFFIX = " per second";
 
     public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {
         Objects.requireNonNull(metrics, "Metrics cannot be null");
@@ -232,11 +234,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return tagMap;
     }
 
-    private Map<String, String> threadLevelTagMap(final String threadId, final String... tags) {
-        final Map<String, String> tagMap = threadLevelTagMap(threadId);
-        return addTags(tagMap, tags);
-    }
-
     public final void removeAllClientLevelMetrics() {
         synchronized (clientLevelMetrics) {
             while (!clientLevelMetrics.isEmpty()) {
@@ -283,20 +280,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                  final String bufferName) {
         final Map<String, String> tagMap = taskLevelTagMap(threadId, taskName);
         tagMap.put(BUFFER_ID_TAG, bufferName);
-        return tagMap;
-    }
-
-    private Map<String, String> addTags(final Map<String, String> tagMap,
-                                        final String... tags) {
-        if (tags != null) {
-            if ((tags.length % 2) != 0) {
-                throw new IllegalArgumentException("Tags needs to be specified in key-value pairs");
-            }
-
-            for (int i = 0; i < tags.length; i += 2) {
-                tagMap.put(tags[i], tags[i + 1]);
-            }
-        }
         return tagMap;
     }
 
@@ -477,23 +460,85 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     @Override
+    @Deprecated
     public void recordLatency(final Sensor sensor, final long startNs, final long endNs) {
         sensor.record(endNs - startNs);
     }
 
     @Override
+    @Deprecated
     public void recordThroughput(final Sensor sensor, final long value) {
         sensor.record(value);
     }
 
-    private Map<String, String> constructTags(final String threadId,
-                                              final String scopeName,
-                                              final String entityName,
-                                              final String... tags) {
-        final String[] updatedTags = Arrays.copyOf(tags, tags.length + 2);
-        updatedTags[tags.length] = scopeName + "-id";
-        updatedTags[tags.length + 1] = entityName;
-        return threadLevelTagMap(threadId, updatedTags);
+    private Map<String, String> customizedTags(final String threadId,
+                                               final String scopeName,
+                                               final String entityName,
+                                               final String... tags) {
+        final Map<String, String> tagMap = threadLevelTagMap(threadId);
+        tagMap.put(scopeName + "-id", entityName);
+        if (tags != null) {
+            if ((tags.length % 2) != 0) {
+                throw new IllegalArgumentException("Tags needs to be specified in key-value pairs");
+            }
+            for (int i = 0; i < tags.length; i += 2) {
+                tagMap.put(tags[i], tags[i + 1]);
+            }
+        }
+        return tagMap;
+    }
+
+    private Sensor customInvocationRateAndCountSensor(final String threadId,
+                                                      final String groupName,
+                                                      final String entityName,
+                                                      final String operationName,
+                                                      final Map<String, String> tags,
+                                                      final Sensor.RecordingLevel recordingLevel) {
+        final Sensor sensor = metrics.sensor(externalChildSensorName(threadId, operationName, entityName), recordingLevel);
+        addInvocationRateAndCountToSensor(
+            sensor,
+            groupName,
+            tags,
+            operationName,
+            RATE_DESCRIPTION_PREFIX + operationName + OPERATIONS + RATE_DESCRIPTION_SUFFIX,
+            TOTAL_DESCRIPTION + operationName + OPERATIONS
+        );
+        return sensor;
+    }
+
+    @Override
+    public Sensor addLatencyRateTotalSensor(final String scopeName,
+                                            final String entityName,
+                                            final String operationName,
+                                            final Sensor.RecordingLevel recordingLevel,
+                                            final String... tags) {
+        final String threadId = Thread.currentThread().getName();
+        final String group = groupNameFromScope(scopeName);
+        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        final Sensor sensor =
+            customInvocationRateAndCountSensor(threadId, group, entityName, operationName, tagMap, recordingLevel);
+        addAvgAndMaxToSensor(
+            sensor,
+            group,
+            tagMap,
+            operationName + LATENCY_SUFFIX,
+            AVG_LATENCY_DESCRIPTION + operationName,
+            MAX_LATENCY_DESCRIPTION + operationName
+        );
+
+        return sensor;
+    }
+
+    @Override
+    public Sensor addRateTotalSensor(final String scopeName,
+                                     final String entityName,
+                                     final String operationName,
+                                     final Sensor.RecordingLevel recordingLevel,
+                                     final String... tags) {
+        final String threadId = Thread.currentThread().getName();
+        final String group = groupNameFromScope(scopeName);
+        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        return customInvocationRateAndCountSensor(threadId, group, entityName, operationName, tagMap, recordingLevel);
     }
 
     /**
@@ -508,8 +553,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         final String group = groupNameFromScope(scopeName);
 
         final String threadId = Thread.currentThread().getName();
-        final Map<String, String> tagMap = constructTags(threadId, scopeName, entityName, tags);
-        final Map<String, String> allTagMap = constructTags(threadId, scopeName, "all", tags);
+        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        final Map<String, String> allTagMap = customizedTags(threadId, scopeName, "all", tags);
 
         // first add the global operation metrics if not yet, with the global tags only
         final Sensor parent = metrics.sensor(externalParentSensorName(threadId, operationName), recordingLevel);
@@ -543,8 +588,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         final String group = groupNameFromScope(scopeName);
 
         final String threadId = Thread.currentThread().getName();
-        final Map<String, String> tagMap = constructTags(threadId, scopeName, entityName, tags);
-        final Map<String, String> allTagMap = constructTags(threadId, scopeName, "all", tags);
+        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        final Map<String, String> allTagMap = customizedTags(threadId, scopeName, "all", tags);
 
         // first add the global operation metrics if not yet, with the global tags only
         final Sensor parent = metrics.sensor(
@@ -601,20 +646,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         );
     }
 
-    public static void addAvgAndMaxToSensor(final Sensor sensor,
-                                            final String group,
-                                            final Map<String, String> tags,
-                                            final String operation) {
-        addAvgAndMaxToSensor(
-            sensor,
-            group,
-            tags,
-            operation,
-            AVG_VALUE_DOC + operation + ".",
-            MAX_VALUE_DOC + operation + "."
-        );
-    }
-
     public static void addAvgAndMaxLatencyToSensor(final Sensor sensor,
                                                    final String group,
                                                    final Map<String, String> tags,
@@ -623,7 +654,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             new MetricName(
                 operation + "-latency-avg",
                 group,
-                AVG_LATENCY_DOC + operation + " operation.",
+                AVG_LATENCY_DESCRIPTION + operation + " operation.",
                 tags),
             new Avg()
         );
@@ -631,7 +662,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             new MetricName(
                 operation + "-latency-max",
                 group,
-                MAX_LATENCY_DOC + operation + " operation.",
+                MAX_LATENCY_DESCRIPTION + operation + " operation.",
                 tags),
             new Max()
         );

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -536,14 +536,21 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                      final Sensor.RecordingLevel recordingLevel,
                                      final String... tags) {
         final String threadId = Thread.currentThread().getName();
-        final String group = groupNameFromScope(scopeName);
         final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
-        return customInvocationRateAndCountSensor(threadId, group, entityName, operationName, tagMap, recordingLevel);
+        return customInvocationRateAndCountSensor(
+            threadId,
+            groupNameFromScope(scopeName),
+            entityName,
+            operationName,
+            tagMap,
+            recordingLevel
+        );
     }
 
     /**
      * @throws IllegalArgumentException if tags is not constructed in key-value pairs
      */
+    @Deprecated
     @Override
     public Sensor addLatencyAndThroughputSensor(final String scopeName,
                                                 final String entityName,
@@ -579,6 +586,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     /**
      * @throws IllegalArgumentException if tags is not constructed in key-value pairs
      */
+    @Deprecated
     @Override
     public Sensor addThroughputSensor(final String scopeName,
                                       final String entityName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -250,7 +250,7 @@ public class MeteredKeyValueStore<K, V>
             try {
                 iter.close();
             } finally {
-                streamsMetrics.recordLatency(sensor, startNs, time.nanoseconds());
+                sensor.record(time.nanoseconds() - startNs);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
@@ -61,7 +61,7 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V> {
         try {
             iter.close();
         } finally {
-            metrics.recordLatency(this.sensor, this.startNs, time.nanoseconds());
+            sensor.record(time.nanoseconds() - startNs);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
@@ -68,7 +68,7 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
         try {
             iter.close();
         } finally {
-            metrics.recordLatency(sensor, startNs, time.nanoseconds());
+            sensor.record(time.nanoseconds() - startNs);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -311,16 +311,16 @@ public class StreamsMetricsImplTest {
         final String entity = "entity";
         final String operation = "put";
 
-        final Sensor sensor1 = streamsMetrics.addSensor(sensorName, Sensor.RecordingLevel.DEBUG);
+        final Sensor sensor1 = streamsMetrics.addSensor(sensorName, RecordingLevel.DEBUG);
         streamsMetrics.removeSensor(sensor1);
 
-        final Sensor sensor1a = streamsMetrics.addSensor(sensorName, Sensor.RecordingLevel.DEBUG, sensor1);
+        final Sensor sensor1a = streamsMetrics.addSensor(sensorName, RecordingLevel.DEBUG, sensor1);
         streamsMetrics.removeSensor(sensor1a);
 
-        final Sensor sensor2 = streamsMetrics.addLatencyAndThroughputSensor(scope, entity, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor sensor2 = streamsMetrics.addLatencyRateTotalSensor(scope, entity, operation, RecordingLevel.DEBUG);
         streamsMetrics.removeSensor(sensor2);
 
-        final Sensor sensor3 = streamsMetrics.addThroughputSensor(scope, entity, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor sensor3 = streamsMetrics.addRateTotalSensor(scope, entity, operation, RecordingLevel.DEBUG);
         streamsMetrics.removeSensor(sensor3);
 
         assertEquals(Collections.emptyMap(), streamsMetrics.parentSensors());
@@ -341,13 +341,13 @@ public class StreamsMetricsImplTest {
         final String processorNodeName = "processorNodeName";
         final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
 
-        final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         final int numberOfTaskMetrics = registry.metrics().size();
 
-        final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent1);
+        final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent1);
         addAvgAndMaxLatencyToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
@@ -357,13 +357,13 @@ public class StreamsMetricsImplTest {
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, Sensor.RecordingLevel.DEBUG, parent2);
+        final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent2);
         addAvgAndMaxLatencyToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
@@ -379,6 +379,7 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testLatencyMetrics() {
         final int defaultMetrics = streamsMetrics.metrics().size();
 
@@ -386,7 +387,7 @@ public class StreamsMetricsImplTest {
         final String entity = "entity";
         final String operation = "put";
 
-        final Sensor sensor1 = streamsMetrics.addLatencyAndThroughputSensor(scope, entity, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor sensor1 = streamsMetrics.addLatencyAndThroughputSensor(scope, entity, operation, RecordingLevel.DEBUG);
 
         // 2 meters and 4 non-meter metrics plus a common metric that keeps track of total registered metrics in Metrics() constructor
         final int meterMetricsCount = 2; // Each Meter is a combination of a Rate and a Total
@@ -398,6 +399,7 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testThroughputMetrics() {
         final int defaultMetrics = streamsMetrics.metrics().size();
 
@@ -405,7 +407,7 @@ public class StreamsMetricsImplTest {
         final String entity = "entity";
         final String operation = "put";
 
-        final Sensor sensor1 = streamsMetrics.addThroughputSensor(scope, entity, operation, Sensor.RecordingLevel.DEBUG);
+        final Sensor sensor1 = streamsMetrics.addThroughputSensor(scope, entity, operation, RecordingLevel.DEBUG);
 
         final int meterMetricsCount = 2; // Each Meter is a combination of a Rate and a Total
         // 2 meter metrics plus a common metric that keeps track of total registered metrics in Metrics() constructor
@@ -426,11 +428,11 @@ public class StreamsMetricsImplTest {
         final String entity = "entity";
         final String operation = "op";
 
-        final Sensor sensor = streamsMetrics.addLatencyAndThroughputSensor(
+        final Sensor sensor = streamsMetrics.addLatencyRateTotalSensor(
             scope,
             entity,
             operation,
-            Sensor.RecordingLevel.INFO
+            RecordingLevel.INFO
         );
 
         final double latency = 100.0;


### PR DESCRIPTION
As proposed in KIP-444, the user customizable metrics shall be refactored. The refactoring consists of:
- adding methods `addLatencyRateTotalSensor` and `addRateTotalSensor` to interface `StreamMetrics`
- implement the newly added methods in `StreamsMetricsImpl`
- deprecate methods `recordThroughput()` and `recordLatency()` in `StreamsMetrics`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
