### PR TITLE
KAFKA-9184: Redundant task creation and periodic rebalances after zombie Connect worker rejoins the group

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1538,10 +1538,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             short priorProtocolVersion = currentProtocolVersion;
             DistributedHerder.this.currentProtocolVersion = member.currentProtocolVersion();
             log.info(
-                "Joined group at generation {} with protocol version {} and got assignment: {}",
+                "Joined group at generation {} with protocol version {} and got assignment: {} with rebalance delay: {}",
                 generation,
                 DistributedHerder.this.currentProtocolVersion,
-                assignment
+                assignment,
+                assignment.delay()
             );
             synchronized (DistributedHerder.this) {
                 DistributedHerder.this.assignment = assignment;
@@ -1611,12 +1612,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
                 // The actual timeout for graceful task stop is applied in worker's stopAndAwaitTask method.
                 startAndStop(callables);
+                log.info("Finished stopping tasks in preparation for rebalance");
 
                 // Ensure that all status updates have been pushed to the storage system before rebalancing.
                 // Otherwise, we may inadvertently overwrite the state with a stale value after the rebalance
                 // completes.
                 statusBackingStore.flush();
-                log.info("Finished stopping tasks in preparation for rebalance");
+                log.info("Finished flushing status backing store in preparation for rebalance");
             } else {
                 log.info("Wasn't unable to resume work after last rebalance, can skip stopping connectors and tasks");
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -401,7 +401,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         }
     }
 
-    private void resetDelay(){
+    private void resetDelay() {
         candidateWorkersForReassignment.clear();
         scheduledRebalance = 0;
         if (delay != 0) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -153,6 +153,9 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
     protected Map<String, ByteBuffer> performTaskAssignment(String leaderId, long maxOffset,
                                                             Map<String, ExtendedWorkerState> memberConfigs,
                                                             WorkerCoordinator coordinator, short protocolVersion) {
+        log.debug("Performing task assignment during generation: {} with memberId: {}",
+                coordinator.generationId(), coordinator.memberId());
+
         // Base set: The previous assignment of connectors-and-tasks is a standalone snapshot that
         // can be used to calculate derived sets
         log.debug("Previous assignments: {}", previousAssignment);
@@ -350,6 +353,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                                          ConnectorsAndTasks newSubmissions,
                                          List<WorkerLoad> completeWorkerAssignment) {
         if (lostAssignments.isEmpty()) {
+            resetDelay();
             return;
         }
 
@@ -359,6 +363,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
         if (scheduledRebalance > 0 && now >= scheduledRebalance) {
             // delayed rebalance expired and it's time to assign resources
+            log.debug("Delayed rebalance expired. Reassigning lost tasks");
             Optional<WorkerLoad> candidateWorkerLoad = Optional.empty();
             if (!candidateWorkersForReassignment.isEmpty()) {
                 candidateWorkerLoad = pickCandidateWorkerForReassignment(completeWorkerAssignment);
@@ -366,15 +371,15 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
             if (candidateWorkerLoad.isPresent()) {
                 WorkerLoad workerLoad = candidateWorkerLoad.get();
+                log.debug("A candidate worker has been found to assign lost tasks: {}", workerLoad.worker());
                 lostAssignments.connectors().forEach(workerLoad::assign);
                 lostAssignments.tasks().forEach(workerLoad::assign);
             } else {
+                log.debug("No single candidate worker was found to assign lost tasks. Treating lost tasks as new tasks");
                 newSubmissions.connectors().addAll(lostAssignments.connectors());
                 newSubmissions.tasks().addAll(lostAssignments.tasks());
             }
-            candidateWorkersForReassignment.clear();
-            scheduledRebalance = 0;
-            delay = 0;
+            resetDelay();
         } else {
             candidateWorkersForReassignment
                     .addAll(candidateWorkersForReassignment(completeWorkerAssignment));
@@ -382,15 +387,27 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 // a delayed rebalance is in progress, but it's not yet time to reassign
                 // unaccounted resources
                 delay = calculateDelay(now);
+                log.debug("Delayed rebalance in progress. Task reassignment is postponed. New computed rebalance delay: {}", delay);
             } else {
                 // This means scheduledRebalance == 0
                 // We could also also extract the current minimum delay from the group, to make
                 // independent of consecutive leader failures, but this optimization is skipped
                 // at the moment
                 delay = maxDelay;
+                log.debug("Resetting rebalance delay to the max: {}. scheduledRebalance: {} now: {} diff scheduledRebalance - now: {}",
+                        delay, scheduledRebalance, now, scheduledRebalance - now);
             }
             scheduledRebalance = now + delay;
         }
+    }
+
+    private void resetDelay(){
+        candidateWorkersForReassignment.clear();
+        scheduledRebalance = 0;
+        if (delay != 0) {
+            log.debug("Resetting delay from previous value: {} to 0", delay);
+        }
+        delay = 0;
     }
 
     private Set<String> candidateWorkersForReassignment(List<WorkerLoad> completeWorkerAssignment) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -245,6 +245,16 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         return JoinGroupRequest.UNKNOWN_MEMBER_ID;
     }
 
+    /**
+     * Return the current generation. The generation refers to this worker's knowledge with
+     * respect to which  generation is the latest one and, therefore, this information is local.
+     *
+     * @return the generation ID or -1 if no generation is defined
+     */
+    public int generationId() {
+        return super.generation().generationId;
+    }
+
     private boolean isLeader() {
         return assignmentSnapshot != null && memberId().equals(assignmentSnapshot.leader());
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -136,10 +136,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
                         log.info("Broker coordinator was unreachable for {}ms. Revoking previous assignment {} to " +
                                 "avoid running tasks while not being a member the group", coordinatorDiscoveryTimeoutMs, assignmentSnapshot);
                         listener.onRevoked(assignmentSnapshot.leader(), assignmentSnapshot.connectors(), assignmentSnapshot.tasks());
-                        assignmentSnapshot.connectors().clear();
-                        assignmentSnapshot.tasks().clear();
-                        assignmentSnapshot.revokedConnectors().clear();
-                        assignmentSnapshot.revokedTasks().clear();
+                        assignmentSnapshot = null;
                     }
                 }
                 now = time.milliseconds();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -56,7 +56,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     private final Logger log;
     private final String restUrl;
     private final ConfigBackingStore configStorage;
-    private ExtendedAssignment assignmentSnapshot;
+    private volatile ExtendedAssignment assignmentSnapshot;
     private ClusterConfigState configSnapshot;
     private final WorkerRebalanceListener listener;
     private final ConnectProtocolCompatibility protocolCompatibility;
@@ -132,10 +132,11 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
                     log.debug("Broker coordinator is ready");
                 } else {
                     log.debug("Can not connect to broker coordinator");
-                    if (assignmentSnapshot != null && !assignmentSnapshot.failed()) {
+                    final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+                    if (localAssignmentSnapshot != null && !localAssignmentSnapshot.failed()) {
                         log.info("Broker coordinator was unreachable for {}ms. Revoking previous assignment {} to " +
-                                "avoid running tasks while not being a member the group", coordinatorDiscoveryTimeoutMs, assignmentSnapshot);
-                        listener.onRevoked(assignmentSnapshot.leader(), assignmentSnapshot.connectors(), assignmentSnapshot.tasks());
+                                "avoid running tasks while not being a member the group", coordinatorDiscoveryTimeoutMs, localAssignmentSnapshot);
+                        listener.onRevoked(localAssignmentSnapshot.leader(), localAssignmentSnapshot.connectors(), localAssignmentSnapshot.tasks());
                         assignmentSnapshot = null;
                     }
                 }
@@ -166,7 +167,8 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     @Override
     public JoinGroupRequestProtocolCollection metadata() {
         configSnapshot = configStorage.snapshot();
-        ExtendedWorkerState workerState = new ExtendedWorkerState(restUrl, configSnapshot.offset(), assignmentSnapshot);
+        final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+        ExtendedWorkerState workerState = new ExtendedWorkerState(restUrl, configSnapshot.offset(), localAssignmentSnapshot);
         switch (protocolCompatibility) {
             case EAGER:
                 return ConnectProtocol.metadataRequest(workerState);
@@ -194,17 +196,18 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
                 listener.onRevoked(newAssignment.leader(), newAssignment.revokedConnectors(), newAssignment.revokedTasks());
             }
 
-            if (assignmentSnapshot != null) {
-                assignmentSnapshot.connectors().removeAll(newAssignment.revokedConnectors());
-                assignmentSnapshot.tasks().removeAll(newAssignment.revokedTasks());
-                log.debug("After revocations snapshot of assignment: {}", assignmentSnapshot);
-                newAssignment.connectors().addAll(assignmentSnapshot.connectors());
-                newAssignment.tasks().addAll(assignmentSnapshot.tasks());
+            final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+            if (localAssignmentSnapshot != null) {
+                localAssignmentSnapshot.connectors().removeAll(newAssignment.revokedConnectors());
+                localAssignmentSnapshot.tasks().removeAll(newAssignment.revokedTasks());
+                log.debug("After revocations snapshot of assignment: {}", localAssignmentSnapshot);
+                newAssignment.connectors().addAll(localAssignmentSnapshot.connectors());
+                newAssignment.tasks().addAll(localAssignmentSnapshot.tasks());
             }
             log.debug("Augmented new assignment: {}", newAssignment);
         }
         assignmentSnapshot = newAssignment;
-        listener.onAssigned(assignmentSnapshot, generation);
+        listener.onAssigned(newAssignment, generation);
     }
 
     @Override
@@ -218,19 +221,21 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     protected void onJoinPrepare(int generation, String memberId) {
         log.info("Rebalance started");
         leaderState(null);
+        final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
         if (currentConnectProtocol == EAGER) {
-            log.debug("Revoking previous assignment {}", assignmentSnapshot);
-            if (assignmentSnapshot != null && !assignmentSnapshot.failed())
-                listener.onRevoked(assignmentSnapshot.leader(), assignmentSnapshot.connectors(), assignmentSnapshot.tasks());
+            log.debug("Revoking previous assignment {}", localAssignmentSnapshot);
+            if (localAssignmentSnapshot != null && !localAssignmentSnapshot.failed())
+                listener.onRevoked(localAssignmentSnapshot.leader(), localAssignmentSnapshot.connectors(), localAssignmentSnapshot.tasks());
         } else {
             log.debug("Cooperative rebalance triggered. Keeping assignment {} until it's "
-                      + "explicitly revoked.", assignmentSnapshot);
+                      + "explicitly revoked.", localAssignmentSnapshot);
         }
     }
 
     @Override
     protected boolean rejoinNeededOrPending() {
-        return super.rejoinNeededOrPending() || (assignmentSnapshot == null || assignmentSnapshot.failed()) || rejoinRequested;
+        final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+        return super.rejoinNeededOrPending() || (localAssignmentSnapshot == null || localAssignmentSnapshot.failed()) || rejoinRequested;
     }
 
     @Override
@@ -252,7 +257,8 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
     }
 
     private boolean isLeader() {
-        return assignmentSnapshot != null && memberId().equals(assignmentSnapshot.leader());
+        final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+        return localAssignmentSnapshot != null && memberId().equals(localAssignmentSnapshot.leader());
     }
 
     public String ownerUrl(String connector) {
@@ -330,20 +336,22 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             Measurable numConnectors = new Measurable() {
                 @Override
                 public double measure(MetricConfig config, long now) {
-                    if (assignmentSnapshot == null) {
+                    final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+                    if (localAssignmentSnapshot == null) {
                         return 0.0;
                     }
-                    return assignmentSnapshot.connectors().size();
+                    return localAssignmentSnapshot.connectors().size();
                 }
             };
 
             Measurable numTasks = new Measurable() {
                 @Override
                 public double measure(MetricConfig config, long now) {
-                    if (assignmentSnapshot == null) {
+                    final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
+                    if (localAssignmentSnapshot == null) {
                         return 0.0;
                     }
-                    return assignmentSnapshot.tasks().size();
+                    return localAssignmentSnapshot.tasks().size();
                 }
             };
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import static org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -159,15 +159,6 @@ public class WorkerGroupMember {
         coordinator.poll(0);
     }
 
-    /**
-     * A lightweight wrapper call that answers whether there's an active connection to the broker
-     * coordinator.
-     * @return true if there is no active connection to a broker coordinator
-     */
-    public boolean coordinatorUnknown() {
-        return coordinator.coordinatorUnknown();
-    }
-
     public void poll(long timeout) {
         if (timeout < 0)
             throw new IllegalArgumentException("Timeout must not be negative");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -151,8 +151,21 @@ public class WorkerGroupMember {
         stop(false);
     }
 
+    /**
+     * Ensure that the connection to the broker coordinator is up and that the worker is an
+     * active member of the group.
+     */
     public void ensureActive() {
         coordinator.poll(0);
+    }
+
+    /**
+     * A lightweight wrapper call that answers whether there's an active connection to the broker
+     * coordinator.
+     * @return true if there is no active connection to a broker coordinator
+     */
+    public boolean coordinatorUnknown() {
+        return coordinator.coordinatorUnknown();
     }
 
     public void poll(long timeout) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.integration;
 
 import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -65,29 +66,27 @@ public class ConnectWorkerIntegrationTest {
     private static final int NUM_WORKERS = 3;
     private static final String CONNECTOR_NAME = "simple-source";
 
+    private EmbeddedConnectCluster.Builder connectBuilder;
     private EmbeddedConnectCluster connect;
+    Map<String, String> workerProps = new HashMap<>();
+    Properties brokerProps = new Properties();
 
     @Before
     public void setup() throws IOException {
         // setup Connect worker properties
-        Map<String, String> workerProps = new HashMap<>();
         workerProps.put(OFFSET_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(OFFSET_COMMIT_INTERVAL_MS));
         workerProps.put(CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, "All");
 
         // setup Kafka broker properties
-        Properties brokerProps = new Properties();
         brokerProps.put("auto.create.topics.enable", String.valueOf(false));
 
         // build a Connect cluster backed by Kafka and Zk
-        connect = new EmbeddedConnectCluster.Builder()
+        connectBuilder = new EmbeddedConnectCluster.Builder()
                 .name("connect-cluster")
                 .numWorkers(NUM_WORKERS)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)
-                .build();
-
-        // start the clusters
-        connect.start();
+                .maskExitProcedures(true); // true is the default, setting here as example
     }
 
     @After
@@ -102,6 +101,10 @@ public class ConnectWorkerIntegrationTest {
      */
     @Test
     public void testAddAndRemoveWorker() throws Exception {
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
         int numTasks = 4;
         // create test topic
         connect.kafka().createTopic("test-topic", NUM_TOPIC_PARTITIONS);
@@ -149,6 +152,10 @@ public class ConnectWorkerIntegrationTest {
      */
     @Test
     public void testRestartFailedTask() throws Exception {
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
         int numTasks = 1;
 
         // Properties for the source connector. The task should fail at startup due to the bad broker address.
@@ -178,6 +185,56 @@ public class ConnectWorkerIntegrationTest {
         // Ensure the task started successfully this time
         waitForCondition(() -> assertConnectorAndTasksRunning(CONNECTOR_NAME, numTasks).orElse(false),
             CONNECTOR_SETUP_DURATION_MS, "Connector tasks are not all in running state.");
+    }
+
+    /**
+     * Verify that a set of tasks restarts correctly after a broker goes offline and back online
+     */
+    @Test
+    public void testBrokerCoordinator() throws Exception {
+        workerProps.put(DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, String.valueOf(5000));
+        connect = connectBuilder.workerProps(workerProps).build();
+        // start the clusters
+        connect.start();
+        int numTasks = 4;
+        // create test topic
+        connect.kafka().createTopic("test-topic", NUM_TOPIC_PARTITIONS);
+
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, String.valueOf(numTasks));
+        props.put("topic", "test-topic");
+        props.put("throughput", String.valueOf(1));
+        props.put("messages.per.poll", String.valueOf(10));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+
+        waitForCondition(() -> assertWorkersUp(NUM_WORKERS).orElse(false),
+                WORKER_SETUP_DURATION_MS, "Initial group of workers did not start in time.");
+
+        // start a source connector
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForCondition(() -> assertConnectorAndTasksRunning(CONNECTOR_NAME, numTasks).orElse(false),
+                CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
+
+        connect.kafka().stopOnlyKafka();
+
+        waitForCondition(() -> assertWorkersUp(NUM_WORKERS).orElse(false),
+                WORKER_SETUP_DURATION_MS, "Group of workers did not remain the same after broker shutdown");
+
+        connect.kafka().startOnlyKafkaOnSamePorts();
+
+        // Allow for the workers to discover that the coordinator is unavailable
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+
+        waitForCondition(() -> assertWorkersUp(NUM_WORKERS).orElse(false),
+                WORKER_SETUP_DURATION_MS, "Group of workers did not remain the same within the "
+                        + "designated time.");
+
+        waitForCondition(() -> assertConnectorAndTasksRunning(CONNECTOR_NAME, numTasks).orElse(false),
+                CONNECTOR_SETUP_DURATION_MS, "Connector tasks did not start in time.");
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -170,6 +170,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -234,6 +236,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -314,6 +318,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -369,6 +375,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -438,6 +446,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -507,6 +517,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -563,6 +575,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test
@@ -596,6 +610,8 @@ public class IncrementalCooperativeAssignorTest {
 
         verify(coordinator, times(rebalanceNum)).configSnapshot();
         verify(coordinator, times(rebalanceNum)).leaderState(any());
+        verify(coordinator, times(rebalanceNum)).generationId();
+        verify(coordinator, times(rebalanceNum)).memberId();
     }
 
     @Test


### PR DESCRIPTION
Zombie workers, defined as workers that lose connectivity with the Kafka broker coordinator and get kicked out of the group but don't experience a jvm restart, have been keeping their tasks running. This side-effect is more disrupting with the new Incremental Cooperative rebalance protocol. When such workers return: 
a) they join the group with existing assignment and this leads to redundant tasks running in the Connect cluster, and
b) they interfere with the computation of lost tasks, which before this fix would lead to the scheduled rebalance delay not being reset correctly back to 0. This results in periodic rebalances. 

This fix focuses on resolving the above side-effects as follows: 
* Each worker now tracks its connectivity with the broker coordinator in an unblocking manner. This allows the worker to detect that the broker coordinator is unreachable. The timeout is set to be equal to the heartbeat interval. If during this time the connection remains inactive, the worker will proactively stop all its connectors and tasks and will keep attempting to connect to the coordinator. 
* The incremental cooperative assignor will keep the delay to a positive value as long as it can detect lost tasks. If the set of tasks that are computed as lost becomes empty, the delay will be set to zero and no additional rebalancing will be scheduled. 

Besides the test included in this PR, the improvements are being tested with a framework that deploys a Connect cluster on docker images and introduces network partitions between all or selected workers and the Kafka brokers. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
