### PR TITLE
KAFKA-6049: Add time window support for cogroup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
@@ -265,4 +265,14 @@ public interface CogroupedKStream<K, VOut> {
                               final Named named,
                               final Materialized<K, VOut, KeyValueStore<Bytes, byte[]>> materialized);
 
+
+    /**
+     * Create a new {@link TimeWindowedCogroupedKStream} instance that can be used to perform windowed
+     * aggregations.
+     *
+     * @param windows the specification of the aggregation {@link Windows}
+     * @param <W>     the window type
+     * @return an instance of {@link TimeWindowedCogroupedKStream}
+     */
+    <W extends Window> TimeWindowedCogroupedKStream<K, VOut> windowedBy(final Windows<W> windows);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -22,23 +22,19 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.WindowStore;
 
 /**
  * {@code TimeWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link org.apache.kafka.streams.KeyValue} pairs.
- * It is an intermediate representation of a {@link KGroupedStream} in order to apply a windowed aggregation operation on the original
+ * It is an intermediate representation of a {@link CogroupedKStream} in order to apply a windowed aggregation operation on the original
  * {@link KGroupedStream} records resulting in a windowed {@link KTable}.
  * <p>
  * The specified {@code windows} define either hopping time windows that can be overlapping or tumbling (c.f.
  * {@link TimeWindows}) or they define landmark windows (c.f. {@link UnlimitedWindows}).
- * The result is written into a local windowed {@link org.apache.kafka.streams.state.KeyValueStore} (which is basically an ever-updating
+ * The result is written into a local windowed {@link WindowStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
  *
- * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
- * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
-
  * A {@code WindowedCogroupKStream} must be obtained from a {@link CogroupedKStream} via {@link CogroupedKStream#windowedBy(Windows)} .
  *
  * @param <K> Type of keys
@@ -50,17 +46,19 @@ import org.apache.kafka.streams.state.WindowStore;
 public interface TimeWindowedCogroupedKStream<K, V> {
 
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and defined window.
      * Records with {@code null} key or value are ignored.
-     *
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
-     * {@link Initializer}) and the record's value.
+     * The specified {@link Initializer} is applied once directly before the first input record
+     * for each key in each window is processed to provide an initial intermediate aggregation result
+     * that is used to process the first record for each key in each window.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
+     * a new aggregate using the current aggregate (or for the very first record using the intermediate
+     * aggregation result provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate(Initializer)} can be used to compute aggregate functions like
      * count or sum etc...
      * <p>
@@ -70,30 +68,21 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
      * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
      * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     *
      * String key = "some-word";
      * long fromTime = ...;
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
-     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
-     * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
@@ -105,15 +94,17 @@ public interface TimeWindowedCogroupedKStream<K, V> {
     /**
      * Aggregate the values of records in this stream by the grouped key.
      * Records with {@code null} key or value are ignored.
-     *
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
-     * {@link Initializer}) and the record's value.
+     * The specified {@link Initializer} is applied once directly before the first input record
+     * for each key in each window is processed to provide an initial intermediate aggregation result
+     * that is used to process the first record for each key in each window.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
+     * a new aggregate using the current aggregate (or for the very first record using the intermediate
+     * aggregation result provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate(Initializer, Materialized)} can be used to compute aggregate functions like
      * count or sum etc...
      * <p>
@@ -123,21 +114,18 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
      * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
      * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     *
      * String key = "some-word";
      * long fromTime = ...;
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -146,7 +134,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
@@ -156,18 +144,21 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+
     /**
      * Aggregate the values of records in this stream by the grouped key.
      * Records with {@code null} key or value are ignored.
-     *
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
-     * {@link Initializer}) and the record's value.
+     * The specified {@link Initializer} is applied once directly before the first input record
+     * for each key in each window is processed to provide an initial intermediate aggregation
+     * result that is used to process the first record for each key in each window.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
+     * a new aggregate using the current aggregate (or for the very first record using the intermediate
+     * aggregation result provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate(Initializer, Named)} can be used to compute aggregate functions like
      * count or sum etc...
      * <p>
@@ -177,30 +168,21 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
      * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
      * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     *
      * String key = "some-word";
      * long fromTime = ...;
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
-     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
-     * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
@@ -214,15 +196,16 @@ public interface TimeWindowedCogroupedKStream<K, V> {
     /**
      * Aggregate the values of records in this stream by the grouped key.
      * Records with {@code null} key or value are ignored.
-     *
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
-     * {@link Initializer}) and the record's value.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each window is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record for each key in each window.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
+     * a new aggregate using the current aggregate (or for the very first record using the intermediate
+     * aggregation result provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate(Initializer, Named, Materialized)} can be used to compute aggregate functions like
      * count or sum etc...
      * <p>
@@ -232,21 +215,18 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
      * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
      * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     *
      * String key = "some-word";
      * long fromTime = ...;
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -255,7 +235,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
@@ -267,6 +247,5 @@ public interface TimeWindowedCogroupedKStream<K, V> {
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Named named,
                                      final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
-
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream;
+
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreType;
+import org.apache.kafka.streams.state.WindowStore;
+
+/**
+ * {@code TimeWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link org.apache.kafka.streams.KeyValue} pairs.
+ * It is an intermediate representation of a {@link KGroupedStream} in order to apply a windowed aggregation operation on the original
+ * {@link KGroupedStream} records resulting in a windowed {@link KTable}.
+ * <p>
+ * The specified {@code windows} define either hopping time windows that can be overlapping or tumbling (c.f.
+ * {@link TimeWindows}) or they define landmark windows (c.f. {@link UnlimitedWindows}).
+ * The result is written into a local windowed {@link org.apache.kafka.streams.state.KeyValueStore} (which is basically an ever-updating
+ * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
+ *
+ * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
+ * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
+
+ * A {@code WindowedCogroupKStream} must be obtained from a {@link CogroupedKStream} via {@link CogroupedKStream#windowedBy(Windows)} .
+ *
+ * @param <K> Type of keys
+ * @param <V> Type of values
+ * @see KStream
+ * @see KGroupedStream
+ * @see CogroupedKStream
+ */
+public interface TimeWindowedCogroupedKStream<K, V> {
+
+    /**
+     * Aggregate the values of records in this stream by the grouped key.
+     * Records with {@code null} key or value are ignored.
+     *
+     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * <p>
+     * The specified {@link Initializer} is applied once directly before the first input record is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
+     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate(Initializer)} can be used to compute aggregate functions like
+     * count or sum etc...
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
+     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     *
+     * <p>
+     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     *
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
+     * alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     *
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
+     * latest (rolling) aggregate for each key
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer);
+
+    /**
+     * Aggregate the values of records in this stream by the grouped key.
+     * Records with {@code null} key or value are ignored.
+     *
+     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * <p>
+     * The specified {@link Initializer} is applied once directly before the first input record is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
+     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate(Initializer, Materialized)} can be used to compute aggregate functions like
+     * count or sum etc...
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
+     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     *
+     * <p>
+     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     *
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
+     * alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     *
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
+     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
+     * latest (rolling) aggregate for each key
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                     final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+    /**
+     * Aggregate the values of records in this stream by the grouped key.
+     * Records with {@code null} key or value are ignored.
+     *
+     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * <p>
+     * The specified {@link Initializer} is applied once directly before the first input record is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
+     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate(Initializer, Named)} can be used to compute aggregate functions like
+     * count or sum etc...
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
+     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     *
+     * <p>
+     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     *
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
+     * alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     *
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
+     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
+     * latest (rolling) aggregate for each key
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                     final Named named);
+
+    /**
+     * Aggregate the values of records in this stream by the grouped key.
+     * Records with {@code null} key or value are ignored.
+     *
+     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * <p>
+     * The specified {@link Initializer} is applied once directly before the first input record is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Aggregator} (defined in the creation of {@link CogroupedKStream}) is applied for each input record and computes a new aggregate using the current
+     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate(Initializer, Named, Materialized)} can be used to compute aggregate functions like
+     * count or sum etc...
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
+     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     *
+     * <p>
+     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     *
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
+     * alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     *
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
+     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
+     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
+     * latest (rolling) aggregate for each key
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                     final Named named,
+                                     final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.state.WindowStore;
  * <p>
  * The specified {@code windows} define either hopping time windows that can be overlapping or tumbling (c.f.
  * {@link TimeWindows}) or they define landmark windows (c.f. {@link UnlimitedWindows}).
- * The result is written into a local windowed {@link WindowStore} (which is basically an ever-updating
+ * The result is written into a local {@link WindowStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
  *
  * A {@code WindowedCogroupKStream} must be obtained from a {@link CogroupedKStream} via {@link CogroupedKStream#windowedBy(Windows)} .
@@ -128,12 +128,12 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * }</pre>
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and cannot contain characters other than ASCII
      * alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -234,7 +234,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.CogroupedKStream;
@@ -29,11 +33,6 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.state.KeyValueStore;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 
 public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> implements CogroupedKStream<K, VOut> {
 
@@ -100,7 +99,6 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
                 builder,
                 sourceNodes,
                 name,
-                keySerde,
                 aggregateBuilder,
                 streamsGraphNode,
                 groupPatterns);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -24,6 +24,9 @@ import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -87,6 +90,20 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     @Override
     public KTable<K, VOut> aggregate(final Initializer<VOut> initializer) {
         return aggregate(initializer, Materialized.with(keySerde, null));
+    }
+
+    @Override
+    public <W extends Window> TimeWindowedCogroupedKStream<K, VOut> windowedBy(final Windows<W> windows) {
+        Objects.requireNonNull(windows, "windows can't be null");
+        return new TimeWindowedCogroupedKStreamImpl<>(windows,
+                builder,
+                sourceNodes,
+                name,
+                keySerde,
+                null,
+                aggregateBuilder,
+                streamsGraphNode,
+                groupPatterns);
     }
 
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -95,12 +95,12 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     @Override
     public <W extends Window> TimeWindowedCogroupedKStream<K, VOut> windowedBy(final Windows<W> windows) {
         Objects.requireNonNull(windows, "windows can't be null");
-        return new TimeWindowedCogroupedKStreamImpl<>(windows,
+        return new TimeWindowedCogroupedKStreamImpl<>(
+                windows,
                 builder,
                 sourceNodes,
                 name,
                 keySerde,
-                null,
                 aggregateBuilder,
                 streamsGraphNode,
                 groupPatterns);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Aggregator;
+import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends
+    AbstractStream<K, V> implements
+        TimeWindowedCogroupedKStream<K, V> {
+
+    private static final String AGGREGATE_NAME = "KCOGROUPSTREAM-AGGREGATE-";
+    private final Windows<W> windows;
+    private final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder;
+    private final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns;
+
+    TimeWindowedCogroupedKStreamImpl(final Windows<W> windows,
+                                     final InternalStreamsBuilder builder,
+                                     final Set<String> sourceNodes,
+                                     final String name,
+                                     final Serde<K> keySerde,
+                                     final Serde<V> valSerde,
+                                     final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
+                                     final StreamsGraphNode streamsGraphNode,
+                                     final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
+        super(name, keySerde, valSerde, sourceNodes, streamsGraphNode, builder);
+        this.windows = windows;
+        this.aggregateBuilder = aggregateBuilder;
+        this.groupPatterns = groupPatterns;
+    }
+
+
+    @Override
+    public KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer) {
+        return aggregate(initializer, Materialized.with(keySerde, null));
+    }
+
+    @Override
+    public KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                            final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized) {
+        return aggregate(initializer, NamedInternal.empty(), materialized);
+    }
+
+    @Override
+    public KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                            final Named named) {
+        return aggregate(initializer, named, Materialized.with(keySerde, null));
+    }
+
+    @Override
+    public KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                            final Named named,
+                                            final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized) {
+        Objects.requireNonNull(initializer, "initializer can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+        Objects.requireNonNull(materialized, "materialized can't be null");
+        final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materializedInternal = new MaterializedInternal<>(
+            materialized,
+            builder,
+            AGGREGATE_NAME);
+        return aggregateBuilder.build(
+            groupPatterns,
+            initializer,
+            NamedInternal.empty(),
+            materialize(materializedInternal),
+            materializedInternal.keySerde()
+                    != null
+                    ? new FullTimeWindowedSerde<>(
+                    materializedInternal
+                            .keySerde(),
+                    windows.size()) : null,
+            materializedInternal.valueSerde(),
+            materializedInternal.queryableStoreName(),
+            windows,
+            null,
+            null);
+    }
+
+    @SuppressWarnings("deprecation")
+    // continuing to support Windows#maintainMs/segmentInterval in fallback mode
+    private StoreBuilder<TimestampedWindowStore<K, V>> materialize(final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
+        WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
+        if (supplier == null) {
+            if (materialized.retention() != null) {
+                // new style retention: use Materialized retention and default segmentInterval
+                final long retentionPeriod = materialized.retention().toMillis();
+
+                if ((windows.size() + windows.gracePeriodMs()) > retentionPeriod) {
+                    throw new IllegalArgumentException("The retention period of the window store "
+                                                       + name
+                                                       + " must be no smaller than its window size plus the grace period."
+                                                       + " Got size=[" + windows.size() + "],"
+                                                       + " grace=[" + windows.gracePeriodMs()
+                                                       + "],"
+                                                       + " retention=[" + retentionPeriod
+                                                       + "]");
+                }
+
+                supplier = Stores.persistentTimestampedWindowStore(
+                    materialized.storeName(),
+                    Duration.ofMillis(retentionPeriod),
+                    Duration.ofMillis(windows.size()),
+                    false
+                );
+
+            } else {
+                // old style retention: use deprecated Windows retention/segmentInterval.
+
+                // NOTE: in the future, when we remove Windows#maintainMs(), we should set the default retention
+                // to be (windows.size() + windows.grace()). This will yield the same default behavior.
+
+                if ((windows.size() + windows.gracePeriodMs()) > windows.maintainMs()) {
+                    throw new IllegalArgumentException("The retention period of the window store "
+                                                       + name
+                                                       + " must be no smaller than its window size plus the grace period."
+                                                       + " Got size=[" + windows.size() + "],"
+                                                       + " grace=[" + windows.gracePeriodMs()
+                                                       + "],"
+                                                       + " retention=[" + windows.maintainMs()
+                                                       + "]");
+                }
+
+                supplier = new RocksDbWindowBytesStoreSupplier(
+                    materialized.storeName(),
+                    windows.maintainMs(),
+                    Math.max(windows.maintainMs() / (windows.segments - 1), 60_000L),
+                    windows.size(),
+                    false,
+                    true);
+            }
+        }
+        final StoreBuilder<TimestampedWindowStore<K, V>> builder = Stores
+            .timestampedWindowStoreBuilder(
+                supplier,
+                materialized.keySerde(),
+                materialized.valueSerde()
+            );
+
+        if (materialized.loggingEnabled()) {
+            builder.withLoggingEnabled(materialized.logConfig());
+        } else {
+            builder.withLoggingDisabled();
+        }
+
+        if (materialized.cachingEnabled()) {
+            builder.withCachingEnabled();
+        }
+        return builder;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KTable;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
@@ -52,11 +51,11 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
                                      final InternalStreamsBuilder builder,
                                      final Set<String> sourceNodes,
                                      final String name,
-                                     final Serde<K> keySerde,
                                      final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
                                      final StreamsGraphNode streamsGraphNode,
                                      final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
-        super(name, keySerde, null, sourceNodes, streamsGraphNode, builder);
+        super(name, null, null, sourceNodes, streamsGraphNode, builder);
+        //keySerde and valueSerde are null because there are many different groupStreams that they could be from
         this.windows = windows;
         this.aggregateBuilder = aggregateBuilder;
         this.groupPatterns = groupPatterns;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -17,6 +17,10 @@
 
 package org.apache.kafka.streams.kstream.internals;
 
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Aggregator;
@@ -36,15 +40,10 @@ import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends AbstractStream<K, V>
         implements TimeWindowedCogroupedKStream<K, V> {
 
-    private static final String AGGREGATE_NAME = "KCOGROUPSTREAM-AGGREGATE-";
+    private static final String AGGREGATE_NAME = "COGROUPKSTREAM-AGGREGATE-";
     private final Windows<W> windows;
     private final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder;
     private final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns;
@@ -57,7 +56,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
                                      final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
                                      final StreamsGraphNode streamsGraphNode,
                                      final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
-        super(name, null, null, sourceNodes, streamsGraphNode, builder);
+        super(name, keySerde, null, sourceNodes, streamsGraphNode, builder);
         this.windows = windows;
         this.aggregateBuilder = aggregateBuilder;
         this.groupPatterns = groupPatterns;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Properties;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
@@ -43,11 +47,6 @@ import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CogroupedKStreamImplTest {
     private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
@@ -130,6 +129,11 @@ public class CogroupedKStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullMaterializedOnAggregateWithNames() {
         cogroupedStream.aggregate(STRING_INITIALIZER, Named.as("name"), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullWindowOnWindowedBy() {
+        cogroupedStream.windowedBy(null);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -20,7 +20,6 @@ package org.apache.kafka.streams.kstream.internals;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
@@ -43,7 +42,6 @@ import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockAggregator;
@@ -98,7 +96,7 @@ public class TimeWindowedCogroupedKStreamImplTest {
     }
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate() {
-        windowedCogroupedStream.aggregate(null, Named.as("test") );
+        windowedCogroupedStream.aggregate(null, Named.as("test"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -265,9 +263,9 @@ public class TimeWindowedCogroupedKStreamImplTest {
                                                final String expectedKey,
                                                final String expectedValue,
                                                final long expectedTimestamp) {
-        TestRecord<Windowed<String>, String> realRecord = outputTopic.readRecord();
-        TestRecord<String, String> nonWindowedRecord = new TestRecord<>(realRecord.getKey().key(), realRecord.getValue(), null, realRecord.timestamp());
-        TestRecord<String, String> testRecord = new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp);
+        final TestRecord<Windowed<String>, String> realRecord = outputTopic.readRecord();
+        final TestRecord<String, String> nonWindowedRecord = new TestRecord<>(realRecord.getKey().key(), realRecord.getValue(), null, realRecord.timestamp());
+        final TestRecord<String, String> testRecord = new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp);
         assertThat(nonWindowedRecord, equalTo(testRecord));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -90,7 +90,7 @@ public class TimeWindowedCogroupedKStreamImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullMaterializedOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Materialized<String, String, WindowStore<Bytes,byte[]>>) null);
+        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Materialized<String, String, WindowStore<Bytes, byte[]>>) null);
     }
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullNamedOnAggregate() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals;
+
+import static java.time.Duration.ofMillis;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Properties;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.CogroupedKStream;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.test.MockAggregator;
+import org.apache.kafka.test.MockInitializer;
+import org.apache.kafka.test.MockProcessorSupplier;
+import org.apache.kafka.test.StreamsTestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimeWindowedCogroupedKStreamImplTest {
+
+    private final MockProcessorSupplier<Windowed<String>, String> processorSupplier = new MockProcessorSupplier<>();
+    private static final String TOPIC = "topic";
+    private static final String TOPIC2 = "topic2";
+    private final StreamsBuilder builder = new StreamsBuilder();
+    private KGroupedStream<String, String> groupedStream;
+
+    private KGroupedStream<String, String> groupedStream2;
+    private CogroupedKStream<String, String> cogroupedStream;
+    private TimeWindowedCogroupedKStream<String, String> windowedCogroupedStream;
+
+    private final Properties props = StreamsTestUtils
+        .getStreamsConfig(Serdes.String(), Serdes.String());
+
+    @Before
+    public void setup() {
+        final KStream<String, String> stream = builder.stream(TOPIC, Consumed
+            .with(Serdes.String(), Serdes.String()));
+        final KStream<String, String> stream2 = builder.stream(TOPIC2, Consumed
+            .with(Serdes.String(), Serdes.String()));
+
+        groupedStream = stream.groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        groupedStream2 = stream2.groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        cogroupedStream = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER).cogroup(groupedStream2, MockAggregator.TOSTRING_REMOVER);
+        windowedCogroupedStream = cogroupedStream.windowedBy(TimeWindows.of(ofMillis(500L)));
+    }
+
+    @Test
+    public void timeWindowTest() {
+        assertNotNull(windowedCogroupedStream);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullInitializerOnAggregate() {
+        windowedCogroupedStream.aggregate(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullMaterializedOnAggregate() {
+        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Materialized<String, String, WindowStore<Bytes,byte[]>>) null);
+    }
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullNamedOnAggregate() {
+        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Named) null);
+    }
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullNamedAndMaterializedOnAggregate() {
+        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullInitializerNamedAndMaterializedOnAggregate() {
+        windowedCogroupedStream.aggregate(null, null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullInitializerAndNamedOnAggregate() {
+        windowedCogroupedStream.aggregate(null, null, Materialized.as("test"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotHaveNullInitializerAndMaterializedOnAggregate() {
+        windowedCogroupedStream.aggregate(null, NamedInternal.empty(), null);
+    }
+
+    @Test
+    public void timeWindowAggregateTest() {
+        final KTable<Windowed<String>, String> customers = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER).windowedBy(TimeWindows.of(ofMillis(500L))).aggregate(MockInitializer.STRING_INIT);
+        customers.toStream().process(processorSupplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic = driver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+            testInputTopic.pipeInput("1", "A", 0);
+            testInputTopic.pipeInput("11", "A", 0);
+            testInputTopic.pipeInput("11", "A", 1);
+            testInputTopic.pipeInput("1", "A", 2);
+        }
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A", 2)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A", 1)));
+    }
+
+    @Test
+    public void timeWindowAggregateTest2StreamsTest() {
+
+        final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT);
+        customers.toStream().process(processorSupplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic = driver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+            testInputTopic.pipeInput("1", "A", 0);
+            testInputTopic.pipeInput("11", "A", 0);
+            testInputTopic.pipeInput("11", "A", 1);
+            testInputTopic.pipeInput("1", "A", 2);
+            testInputTopic.pipeInput("1", "B", 3);
+            testInputTopic.pipeInput("11", "B", 3);
+            testInputTopic.pipeInput("11", "B", 4);
+            testInputTopic.pipeInput("1", "B", 4);
+        }
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A+B+B", 4)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A+B+B", 4)));
+    }
+
+    @Test
+    public void timeWindowMixAggregatorsTest() {
+
+        final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT);
+        customers.toStream().process(processorSupplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic = driver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+            final TestInputTopic<String, String> testInputTopic2 = driver.createInputTopic(TOPIC2, new StringSerializer(), new StringSerializer());
+            testInputTopic.pipeInput("1", "A", 0);
+            testInputTopic.pipeInput("11", "A", 0);
+            testInputTopic.pipeInput("11", "A", 1);
+            testInputTopic.pipeInput("1", "A", 2);
+            testInputTopic2.pipeInput("1", "B", 3);
+            testInputTopic2.pipeInput("11", "B", 3);
+            testInputTopic2.pipeInput("11", "B", 4);
+            testInputTopic2.pipeInput("1", "B", 4);
+        }
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A-B-B", 4)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A-B-B", 4)));
+    }
+
+    @Test
+    public void timeWindowAggregateManyWindowsTest() {
+
+        final KTable<Windowed<String>, String> customers = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER).windowedBy(TimeWindows.of(ofMillis(500L))).aggregate(MockInitializer.STRING_INIT);
+        customers.toStream().process(processorSupplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic = driver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+            testInputTopic.pipeInput("1", "A", 0);
+            testInputTopic.pipeInput("11", "A", 0);
+            testInputTopic.pipeInput("11", "A", 501L);
+            testInputTopic.pipeInput("1", "A", 501L);
+        }
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A", 0)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A", 0)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(500, 1000))),
+            equalTo(ValueAndTimestamp.make("0+A", 501)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(500, 1000))),
+            equalTo(ValueAndTimestamp.make("0+A", 501)));
+    }
+
+
+    @Test
+    public void timeWindowMixAggregatorsManyWindowsTest() {
+
+        final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT);
+        customers.toStream().process(processorSupplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic = driver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+            final TestInputTopic<String, String> testInputTopic2 = driver.createInputTopic(TOPIC2, new StringSerializer(), new StringSerializer());
+            testInputTopic.pipeInput("1", "A", 0);
+            testInputTopic.pipeInput("11", "A", 0);
+            testInputTopic.pipeInput("11", "A", 1);
+            testInputTopic.pipeInput("1", "A", 2);
+            testInputTopic2.pipeInput("1", "B", 3);
+            testInputTopic2.pipeInput("11", "B", 3);
+            testInputTopic2.pipeInput("11", "B", 501);
+            testInputTopic2.pipeInput("1", "B", 501);
+        }
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A-B", 3)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(0, 500))),
+            equalTo(ValueAndTimestamp.make("0+A+A-B", 3)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("1", new TimeWindow(500, 1000))),
+            equalTo(ValueAndTimestamp.make("0-B", 501)));
+        assertThat(
+            processorSupplier.theCapturedProcessor().lastValueAndTimestampPerKey
+                .get(new Windowed<>("11", new TimeWindow(500, 1000))),
+            equalTo(ValueAndTimestamp.make("0-B", 501)));
+    }
+
+}


### PR DESCRIPTION
adding TimeWindowedCogroupedKStream options to the cogroup operator

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
