### PR TITLE
[WIP] MINOR: add configurable timeout/backoff to JmxTool

### DIFF
--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -74,6 +74,8 @@ class JmxMixin(object):
         cmd = "%s %s " % (self.path.script("kafka-run-class.sh", use_jmxtool_version), self.jmx_class_name())
         cmd += "--reporting-interval %d --jmx-url service:jmx:rmi:///jndi/rmi://127.0.0.1:%d/jmxrmi" % (self.jmx_poll_ms, self.jmx_port)
         cmd += " --wait"
+        cmd += " --wait-timeout %d" % 60000
+        cmd += " --wait-backoff %d" % 5000
         for jmx_object_name in self.jmx_object_names:
             cmd += " --object-name %s" % jmx_object_name
         cmd += " --attributes "


### PR DESCRIPTION
### what
add two new configurable args to `JmxTool`:
1. `wait-timeout`  - In milliseconds, how long to wait for requested JMX objects.
2. `wait-backoff` - In milliseconds, the wait interval in between queries for requested JMX objects.

### why
Sometimes it may take some time for the JMX metrics of an application to appear. It would be nice to be able to configure this timeout. On top of that, control over the backoff would be nice too.

### TODOs
- [ ] test the case where we don't specify these options
- [ ] confirm that the backoff works as expected

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
