### PR TITLE
KAFKA-9267: ZkSecurityMigrator should not create /controller node

### DIFF
--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -31,7 +31,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.Queue
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.util.control.Breaks.{break, breakable}
 
 /**
  * This tool is to be used when making access to ZooKeeper authenticated or 
@@ -223,12 +222,10 @@ class ZkSecurityMigrator(zkClient: KafkaZkClient) extends Logging {
     try {
       setAclIndividually("/")
       for (path <- ZkData.SecureRootPaths) {
-        breakable{
-          debug("Going to set ACL for %s".format(path))
-          if (path == ControllerZNode.path && !zkClient.pathExists(path)) {
-            debug("Ignoring to set ACL for %s, because it doesn't exist".format(path))
-            break()
-          }
+        debug("Going to set ACL for %s".format(path))
+        if (path == ControllerZNode.path && !zkClient.pathExists(path)) {
+          debug("Ignoring to set ACL for %s, because it doesn't exist".format(path))
+        } else {
           zkClient.makeSurePersistentPathExists(path)
           setAclsRecursively(path)
         }


### PR DESCRIPTION
[KAFKA-9267](https://issues.apache.org/jira/browse/KAFKA-9267)

ZkSecurityMigrator might create a PERSISTENT /controller node with null data, it will lead to controller can't elect.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
