### PR TITLE
MINOR: Fix small typo in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can run checkstyle using:
     ./gradlew checkstyleMain checkstyleTest
 
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
-subproject build directories. They are also are printed to the console. The build will fail if Checkstyle fails.
+subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.


### PR DESCRIPTION
Fixed a small typo in the main README file ("They are also are printed" --> "They are also printed").

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
