### PR TITLE
KIP-543: Support broker topic actions in ConfigCommand.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
@@ -78,8 +78,8 @@ public class ConfigEntry {
      * @param isReadOnly whether the config is read-only and cannot be updated
      * @param synonyms Synonym configs in order of precedence
      */
-    ConfigEntry(String name, String value, ConfigSource source, boolean isSensitive, boolean isReadOnly,
-                List<ConfigSynonym> synonyms) {
+    public ConfigEntry(String name, String value, ConfigSource source, boolean isSensitive, boolean isReadOnly,
+                       List<ConfigSynonym> synonyms) {
         Objects.requireNonNull(name, "name should not be null");
         this.name = name;
         this.value = value;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
@@ -78,8 +78,8 @@ public class ConfigEntry {
      * @param isReadOnly whether the config is read-only and cannot be updated
      * @param synonyms Synonym configs in order of precedence
      */
-    public ConfigEntry(String name, String value, ConfigSource source, boolean isSensitive, boolean isReadOnly,
-                       List<ConfigSynonym> synonyms) {
+    ConfigEntry(String name, String value, ConfigSource source, boolean isSensitive, boolean isReadOnly,
+                List<ConfigSynonym> synonyms) {
         Objects.requireNonNull(name, "name should not be null");
         this.name = name;
         this.value = value;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -87,5 +88,10 @@ public class ConfigTest {
     public void shouldImplementToStringProperly() {
         assertThat(config.toString(), containsString(E1.toString()));
         assertThat(config.toString(), containsString(E2.toString()));
+    }
+
+    public static ConfigEntry newConfigEntry(String name, String value, ConfigEntry.ConfigSource source, boolean isSensitive,
+                                             boolean isReadOnly, List<ConfigEntry.ConfigSynonym> synonyms) {
+        return new ConfigEntry(name, value, source, isSensitive, isReadOnly, synonyms);
     }
 }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -28,10 +28,11 @@ import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, PasswordEncod
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.CommonClientConfigs
-import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeConfigsOptions, AdminClient => JAdminClient, Config => JConfig}
+import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeClusterOptions, AdminClient => JAdminClient, Config => JConfig, ListTopicsOptions}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.errors.InvalidConfigurationException
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
@@ -44,20 +45,22 @@ import scala.collection._
  * This script can be used to change configs for topics/clients/users/brokers dynamically
  * An entity described or altered by the command may be one of:
  * <ul>
- *     <li> topic: --entity-type topics --entity-name <topic>
- *     <li> client: --entity-type clients --entity-name <client-id>
- *     <li> user: --entity-type users --entity-name <user-principal>
- *     <li> <user, client>: --entity-type users --entity-name <user-principal> --entity-type clients --entity-name <client-id>
- *     <li> broker: --entity-type brokers --entity-name <broker>
- *     <li> broker-logger: --entity-type broker-loggers --entity-name <broker>
+ *     <li> topic: --topic <topic> OR --entity-type topics --entity-name <topic>
+ *     <li> client: --client <client> OR --entity-type clients --entity-name <client-id>
+ *     <li> user: --user <user-principal> OR --entity-type users --entity-name <user-principal>
+ *     <li> <user, client>: --user <user-principal> --client <client-id> OR
+ *                          --entity-type users --entity-name <user-principal> --entity-type clients --entity-name <client-id>
+ *     <li> broker: --broker <broker-id> OR --entity-type brokers --entity-name <broker-id>
+ *     <li> broker-logger: --broker-logger <broker-id> OR --entity-type broker-loggers --entity-name <broker-id>
  * </ul>
- * --entity-default may be used instead of --entity-name when describing or altering default configuration for users and clients.
+ * --user-defaults, --client-defaults, or --broker-defaults may be when describing or altering default configuration for users,
+ * clients, and brokers, respectively. Alternatively, --entity-default may be used instead of --entity-name.
  *
  */
 object ConfigCommand extends Config {
 
   val BrokerLoggerConfigType = "broker-loggers"
-  val BrokerSupportedConfigTypes = Seq(ConfigType.Broker, BrokerLoggerConfigType)
+  val BrokerSupportedConfigTypes = Seq(ConfigType.Topic, ConfigType.Broker, BrokerLoggerConfigType)
   val DefaultScramIterations = 4096
   // Dynamic broker configs can only be updated using the new AdminClient once brokers have started
   // so that configs may be fully validated. Prior to starting brokers, updates may be performed using
@@ -81,7 +84,7 @@ object ConfigCommand extends Config {
       if (opts.options.has(opts.zkConnectOpt)) {
         processCommandWithZk(opts.options.valueOf(opts.zkConnectOpt), opts)
       } else {
-        processBrokerConfig(opts)
+        processCommand(opts)
       }
     } catch {
       case e @ (_: IllegalArgumentException | _: InvalidConfigurationException | _: OptionException) =>
@@ -103,15 +106,15 @@ object ConfigCommand extends Config {
     val adminZkClient = new AdminZkClient(zkClient)
     try {
       if (opts.options.has(opts.alterOpt))
-        alterConfig(zkClient, opts, adminZkClient)
+        alterConfigWithZk(zkClient, opts, adminZkClient)
       else if (opts.options.has(opts.describeOpt))
-        describeConfig(zkClient, opts, adminZkClient)
+        describeConfigWithZk(zkClient, opts, adminZkClient)
     } finally {
       zkClient.close()
     }
   }
 
-  private[admin] def alterConfig(zkClient: KafkaZkClient, opts: ConfigCommandOptions, adminZkClient: AdminZkClient): Unit = {
+  private[admin] def alterConfigWithZk(zkClient: KafkaZkClient, opts: ConfigCommandOptions, adminZkClient: AdminZkClient): Unit = {
     val configsToBeAdded = parseConfigsToBeAdded(opts)
     val configsToBeDeleted = parseConfigsToBeDeleted(opts)
     val entity = parseEntity(opts)
@@ -221,7 +224,7 @@ object ConfigCommand extends Config {
     }
   }
 
-  private def describeConfig(zkClient: KafkaZkClient, opts: ConfigCommandOptions, adminZkClient: AdminZkClient): Unit = {
+  private def describeConfigWithZk(zkClient: KafkaZkClient, opts: ConfigCommandOptions, adminZkClient: AdminZkClient): Unit = {
     val configEntity = parseEntity(opts)
     val describeAllUsers = configEntity.root.entityType == ConfigType.User && !configEntity.root.sanitizedName.isDefined && !configEntity.child.isDefined
     val entities = configEntity.getAllEntities(zkClient)
@@ -267,114 +270,156 @@ object ConfigCommand extends Config {
       Seq.empty
   }
 
-  private def processBrokerConfig(opts: ConfigCommandOptions): Unit = {
+  private def processCommand(opts: ConfigCommandOptions): Unit = {
     val props = if (opts.options.has(opts.commandConfigOpt))
       Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt))
     else
       new Properties()
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
     val adminClient = JAdminClient.create(props)
-    val entityName = if (opts.options.has(opts.entityName))
-      opts.options.valueOf(opts.entityName)
-    else // default entity
-      ""
 
-    val entityTypes = opts.options.valuesOf(opts.entityType).asScala
-    if (entityTypes.size != 1)
-      throw new IllegalArgumentException(s"Exactly one --entity-type (out of ${BrokerSupportedConfigTypes.mkString(",")}) must be specified with --bootstrap-server")
+    if (opts.entityTypes.size != 1)
+      throw new IllegalArgumentException(s"Exactly one entity type (out of ${BrokerSupportedConfigTypes.mkString(",")}) must be specified with --bootstrap-server")
+
+    val entityNames = opts.entityNames
+    if (entityNames.size > 1)
+      throw new IllegalArgumentException(s"At most one entity name must be specified with --bootstrap-server")
+    else if (opts.options.has(opts.alterOpt) && entityNames.size != 0)
+      throw new IllegalArgumentException(s"Exactly one entity name must be specified with --bootstrap-server for --alter")
 
     try {
       if (opts.options.has(opts.alterOpt))
-        alterBrokerConfig(adminClient, opts, entityTypes.head, entityName)
+        alterConfig(adminClient, opts)
       else if (opts.options.has(opts.describeOpt))
-        describeBrokerConfig(adminClient, opts, entityTypes.head, entityName)
+        describeConfig(adminClient, opts)
     } finally {
       adminClient.close()
     }
   }
 
-  private[admin] def alterBrokerConfig(adminClient: Admin, opts: ConfigCommandOptions,
-                                       entityType: String, entityName: String): Unit = {
+  private[admin] def alterConfig(adminClient: Admin, opts: ConfigCommandOptions): Unit = {
+    val entityType = opts.entityTypes.head
+    val entityName = opts.entityNames.head
     val configsToBeAdded = parseConfigsToBeAdded(opts).asScala.map { case (k, v) => (k, new ConfigEntry(k, v)) }
     val configsToBeDeleted = parseConfigsToBeDeleted(opts)
 
-    if (entityType == ConfigType.Broker) {
-      val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityName)
-      val oldConfig = brokerConfig(adminClient, entityName, includeSynonyms = false)
-        .map { entry => (entry.name, entry) }.toMap
+    entityType match {
+      case ConfigType.Topic =>
+        val oldConfig = getConfig(adminClient, entityType, entityName, includeSynonyms = false)
+          .map { entry => (entry.name, entry) }.toMap
 
-      // fail the command if any of the configs to be deleted does not exist
-      val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
-      if (invalidConfigs.nonEmpty)
-        throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
+        // fail the command if any of the configs to be deleted does not exist
+        val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
+        if (invalidConfigs.nonEmpty)
+          throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
 
-      val newEntries = oldConfig ++ configsToBeAdded -- configsToBeDeleted
-      val sensitiveEntries = newEntries.filter(_._2.value == null)
-      if (sensitiveEntries.nonEmpty)
-        throw new InvalidConfigurationException(s"All sensitive broker config entries must be specified for --alter, missing entries: ${sensitiveEntries.keySet}")
-      val newConfig = new JConfig(newEntries.asJava.values)
+        val configResource = new ConfigResource(ConfigResource.Type.TOPIC, entityName)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
+          ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
+        ).asJavaCollection
+        adminClient.incrementalAlterConfigs(Map(configResource -> alterEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
 
-      val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
-      adminClient.alterConfigs(Map(configResource -> newConfig).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
-    } else if (entityType == BrokerLoggerConfigType) {
-      val configResource = new ConfigResource(ConfigResource.Type.BROKER_LOGGER, entityName)
-      val validLoggers = brokerLoggerConfigs(adminClient, entityName).map(_.name)
-      // fail the command if any of the configured broker loggers do not exist
-      val invalidBrokerLoggers = configsToBeDeleted.filterNot(validLoggers.contains) ++ configsToBeAdded.keys.filterNot(validLoggers.contains)
-      if (invalidBrokerLoggers.nonEmpty)
-        throw new InvalidConfigurationException(s"Invalid broker logger(s): ${invalidBrokerLoggers.mkString(",")}")
+      case ConfigType.Broker =>
+        val oldConfig = getConfig(adminClient, entityType, entityName, includeSynonyms = false)
+          .map { entry => (entry.name, entry) }.toMap
 
-      val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
-      val alterLogLevelEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
-        ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
-      ).asJavaCollection
+        // fail the command if any of the configs to be deleted does not exist
+        val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
+        if (invalidConfigs.nonEmpty)
+          throw new InvalidConfigurationException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
 
-      adminClient.incrementalAlterConfigs(Map(configResource -> alterLogLevelEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
+        val newEntries = oldConfig ++ configsToBeAdded -- configsToBeDeleted
+        val sensitiveEntries = newEntries.filter(_._2.value == null)
+        if (sensitiveEntries.nonEmpty)
+          throw new InvalidConfigurationException(s"All sensitive broker config entries must be specified for --alter, missing entries: ${sensitiveEntries.keySet}")
+        val newConfig = new JConfig(newEntries.asJava.values)
+
+        val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityName)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        adminClient.alterConfigs(Map(configResource -> newConfig).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
+
+      case BrokerLoggerConfigType =>
+        val validLoggers = getConfig(adminClient, entityType, entityName, includeSynonyms = true).map(_.name)
+        // fail the command if any of the configured broker loggers do not exist
+        val invalidBrokerLoggers = configsToBeDeleted.filterNot(validLoggers.contains) ++ configsToBeAdded.keys.filterNot(validLoggers.contains)
+        if (invalidBrokerLoggers.nonEmpty)
+          throw new InvalidConfigurationException(s"Invalid broker logger(s): ${invalidBrokerLoggers.mkString(",")}")
+
+        val configResource = new ConfigResource(ConfigResource.Type.BROKER_LOGGER, entityName)
+        val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+        val alterLogLevelEntries = (configsToBeAdded.values.map(new AlterConfigOp(_, AlterConfigOp.OpType.SET))
+          ++ configsToBeDeleted.map { k => new AlterConfigOp(new ConfigEntry(k, ""), AlterConfigOp.OpType.DELETE) }
+        ).asJavaCollection
+        adminClient.incrementalAlterConfigs(Map(configResource -> alterLogLevelEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
+
+      case _ => throw new IllegalArgumentException(s"Unsupported entity type: ${entityType}")
     }
 
     if (entityName.nonEmpty)
-      println(s"Completed updating config for broker: $entityName.")
+      println(s"Completed updating config for ${entityType.dropRight(1)} ${entityName}.")
     else
-      println(s"Completed updating default config for brokers in the cluster,")
+      println(s"Completed updating default config for ${entityType} in the cluster.")
   }
 
-  private def describeBrokerConfig(adminClient: Admin, opts: ConfigCommandOptions,
-                                   entityType: String, entityName: String): Unit = {
-    val configs = if (entityType == ConfigType.Broker)
-      brokerConfig(adminClient, entityName, includeSynonyms = true)
-    else // broker logger
-      brokerLoggerConfigs(adminClient, entityName)
+  private def describeConfig(adminClient: Admin, opts: ConfigCommandOptions): Unit = {
+    val entityType = opts.entityTypes.head
+    val entityName = opts.entityNames.headOption
 
-    if (entityName.nonEmpty)
-      println(s"Configs for broker $entityName are:")
-    else
-      println(s"Default config for brokers in the cluster are:")
-    configs.foreach { config =>
-      val synonyms = config.synonyms.asScala.map(synonym => s"${synonym.source}:${synonym.name}=${synonym.value}").mkString(", ")
-      println(s"  ${config.name}=${config.value} sensitive=${config.isSensitive} synonyms={$synonyms}")
+    val entities = entityName
+      .map(name => List(name))
+      .getOrElse(entityType match {
+        case ConfigType.Topic =>
+          adminClient.listTopics(new ListTopicsOptions().listInternal(true)).names().get().asScala.toSeq
+        case ConfigType.Broker | BrokerLoggerConfigType =>
+          adminClient.describeCluster(new DescribeClusterOptions()).nodes().get().asScala.map(_.idString).toSeq :+ ConfigEntityName.Default
+      })
+
+    entities.foreach { entity =>
+      entity match {
+        case "" =>
+          println(s"Default config for ${entityType} in the cluster are:")
+        case _ =>
+          println(s"Configs for ${entityType.dropRight(1)} ${entity} are:")
+      }
+      getConfig(adminClient, entityType, entity, includeSynonyms = true).foreach { entry =>
+        val synonyms = entry.synonyms.asScala.map(synonym => s"${synonym.source}:${synonym.name}=${synonym.value}").mkString(", ")
+        println(s"  ${entry.name}=${entry.value} sensitive=${entry.isSensitive} synonyms={$synonyms}")
+      }
     }
   }
 
-  private def brokerConfig(adminClient: Admin, entityName: String, includeSynonyms: Boolean): Seq[ConfigEntry] = {
-    val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityName)
-    val configSource = if (!entityName.isEmpty)
-      ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG
-    else
-      ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG
-    val describeOpts = new DescribeConfigsOptions().includeSynonyms(includeSynonyms)
-    val configs = adminClient.describeConfigs(Collections.singleton(configResource), describeOpts).all.get(30, TimeUnit.SECONDS)
-    configs.get(configResource).entries.asScala
-      .filter(entry => entry.source == configSource)
-      .toSeq
-  }
+  private def getConfig(adminClient: Admin, entityType: String, entityName: String, includeSynonyms: Boolean): Seq[ConfigEntry] = {
+    def validateBrokerId(): Unit = try entityName.toInt catch {
+      case _: NumberFormatException =>
+        throw new IllegalArgumentException(s"The entity name for ${entityType} must be a valid integer broker id, found: ${entityName}")
+    }
 
-  /**
-    * Returns all the valid broker logger configurations
-    */
-  private def brokerLoggerConfigs(adminClient: Admin, entityName: String): Seq[ConfigEntry] = {
-    val configResource = new ConfigResource(ConfigResource.Type.BROKER_LOGGER, entityName)
+    val (configResourceType, configSourceFilter) = entityType match {
+      case ConfigType.Topic =>
+        if (!entityName.isEmpty)
+          Topic.validate(entityName)
+        (ConfigResource.Type.TOPIC, Some(ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG))
+      case ConfigType.Broker => entityName match {
+        case "" =>
+          (ConfigResource.Type.BROKER, Some(ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG))
+        case _ =>
+          validateBrokerId()
+          (ConfigResource.Type.BROKER, Some(ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG))
+      }
+      case BrokerLoggerConfigType =>
+        if (!entityName.isEmpty)
+          validateBrokerId()
+        (ConfigResource.Type.BROKER_LOGGER, None)
+    }
+
+    val configResource = new ConfigResource(configResourceType, entityName)
     val configs = adminClient.describeConfigs(Collections.singleton(configResource)).all.get(30, TimeUnit.SECONDS)
-    configs.get(configResource).entries.asScala.toSeq
+    configs.get(configResource).entries.asScala
+      .filter(entry => configSourceFilter match {
+        case Some(configSource) => entry.source == configSource
+        case None => true
+      }).toSeq
   }
 
   case class Entity(entityType: String, sanitizedName: Option[String]) {
@@ -601,15 +646,13 @@ object ConfigCommand extends Config {
         (entityFlags ++ entityDefaultsFlags).exists(entity => options.has(entity._1)))
         throw new IllegalArgumentException("--entity-{type,name,default} should not be used in conjunction with specific entity flags")
 
-      val hasEntityName = options.has(entityName) || entityFlags.exists(entity => options.has(entity._1))
-      val hasEntityDefault = options.has(entityDefault) || entityDefaultsFlags.exists(entity => options.has(entity._1))
+      val hasEntityName = entityNames.exists(!_.isEmpty)
+      val hasEntityDefault = entityNames.exists(_.isEmpty)
 
       if (!options.has(bootstrapServerOpt) && !options.has(zkConnectOpt))
         throw new IllegalArgumentException("One of the required --bootstrap-server or --zookeeper arguments must be specified")
       else if (options.has(bootstrapServerOpt) && options.has(zkConnectOpt))
         throw new IllegalArgumentException("Only one of --bootstrap-server or --zookeeper must be specified")
-      else if (options.has(bootstrapServerOpt) && !hasEntityName && !hasEntityDefault)
-        throw new IllegalArgumentException(s"At least one entity name or default entity must be specified with --bootstrap-server")
 
       if (hasEntityName && (entityTypeVals.contains(ConfigType.Broker) || entityTypeVals.contains(BrokerLoggerConfigType))) {
         Seq(entityName, broker, brokerLogger).filter(options.has(_)).map(options.valueOf(_)).foreach { brokerId =>
@@ -620,7 +663,7 @@ object ConfigCommand extends Config {
         }
       }
 
-      if (entityTypeVals.contains(ConfigType.Client) || entityTypeVals.contains(ConfigType.Topic) || entityTypeVals.contains(ConfigType.User))
+      if (entityTypeVals.contains(ConfigType.Client) || entityTypeVals.contains(ConfigType.User))
         CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt)
 
       if (options.has(describeOpt) && entityTypeVals.contains(BrokerLoggerConfigType) && !hasEntityName)

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -157,7 +157,7 @@ object ConfigCommand extends Config {
 
     adminZkClient.changeConfigs(entityType, entityName, configs)
 
-    println(s"Completed Updating config for entity: $entity.")
+    println(s"Completed updating config for entity: $entity.")
   }
 
   private def preProcessScramCredentials(configsToBeAdded: Properties): Unit = {
@@ -284,7 +284,7 @@ object ConfigCommand extends Config {
     val entityNames = opts.entityNames
     if (entityNames.size > 1)
       throw new IllegalArgumentException(s"At most one entity name must be specified with --bootstrap-server")
-    else if (opts.options.has(opts.alterOpt) && entityNames.size != 0)
+    else if (opts.options.has(opts.alterOpt) && entityNames.size != 1)
       throw new IllegalArgumentException(s"Exactly one entity name must be specified with --bootstrap-server for --alter")
 
     try {

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -342,7 +342,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     var alteredConfigs = false
 
     def newConfigEntry(name: String, value: String): ConfigEntry =
-      new ConfigEntry(name, value, ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG, false, false, List.empty[ConfigEntry.ConfigSynonym].asJava)
+      ConfigTest.newConfigEntry(name, value, ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG, false, false, List.empty[ConfigEntry.ConfigSynonym].asJava)
 
     val resource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
     val configEntries = List(newConfigEntry("min.insync.replicas", "1"), newConfigEntry("unclean.leader.election.enable", "1")).asJava

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -87,27 +87,41 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
   }
 
   @Test
-  def shouldParseArgumentsForClientsEntityType(): Unit = {
-    testArgumentParse("clients")
+  def shouldParseArgumentsForClientsEntityTypeUsingZookeeper(): Unit = {
+    testArgumentParse("clients", zkConfig = true)
+  }
+
+  @Test
+  def shouldParseArgumentsForUsersEntityTypeUsingZookeeper(): Unit = {
+    testArgumentParse("clients", zkConfig = true)
+  }
+
+  @Test
+  def shouldParseArgumentsForTopicsEntityTypeUsingZookeeper(): Unit = {
+    testArgumentParse("topics", zkConfig = true)
   }
 
   @Test
   def shouldParseArgumentsForTopicsEntityType(): Unit = {
-    testArgumentParse("topics")
+    testArgumentParse("topics", zkConfig = false)
+  }
+
+  @Test
+  def shouldParseArgumentsForBrokersEntityTypeUsingZookeeper(): Unit = {
+    testArgumentParse("brokers", zkConfig = true)
   }
 
   @Test
   def shouldParseArgumentsForBrokersEntityType(): Unit = {
-    testArgumentParse("brokers")
+    testArgumentParse("brokers", zkConfig = false)
   }
 
   @Test
   def shouldParseArgumentsForBrokerLoggersEntityType(): Unit = {
-    testArgumentParse("broker-loggers",
-      zkConfig = false)
+    testArgumentParse("broker-loggers", zkConfig = false)
   }
 
-  def testArgumentParse(entityType: String, zkConfig: Boolean=true): Unit = {
+  def testArgumentParse(entityType: String, zkConfig: Boolean): Unit = {
     val shortFlag: String = s"--${entityType.dropRight(1)}"
 
     val connectOpts = if (zkConfig)
@@ -230,35 +244,56 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def shouldFailIfUnrecognisedEntityType(): Unit = {
+  def shouldFailIfUnrecognisedEntityTypeUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "client", "--entity-type", "not-recognised", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldFailIfUnrecognisedEntityType(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", "client", "--entity-type", "not-recognised", "--alter", "--add-config", "a=b,c=d"))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldFailIfBrokerEntityTypeIsNotAnIntegerUsingZookeeper(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+      "--entity-name", "A", "--entity-type", "brokers", "--alter", "--add-config", "a=b,c=d"))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailIfBrokerEntityTypeIsNotAnInteger(): Unit = {
-    val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "A", "--entity-type", "brokers", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def shouldFailIfShortBrokerEntityTypeIsNotAnIntegerUsingZookeeper(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+      "--broker", "A", "--alter", "--add-config", "a=b,c=d"))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailIfShortBrokerEntityTypeIsNotAnInteger(): Unit = {
-    val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--broker", "A", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def shouldFailIfMixedEntityTypeFlags(): Unit = {
+  def shouldFailIfMixedEntityTypeFlagsUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "A", "--entity-type", "users", "--client", "B", "--describe"))
     createOpts.checkArgs()
   }
 
   @Test
-  def shouldAddClientConfig(): Unit = {
+  def shouldAddClientConfigUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "my-client-id",
       "--entity-type", "clients",
@@ -273,11 +308,11 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
 
-    ConfigCommand.alterConfig(null, createOpts, new TestAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new TestAdminZkClient(zkClient))
   }
 
   @Test
-  def shouldAddTopicConfig(): Unit = {
+  def shouldAddTopicConfigUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "my-topic",
       "--entity-type", "topics",
@@ -292,7 +327,67 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
 
-    ConfigCommand.alterConfig(null, createOpts, new TestAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new TestAdminZkClient(zkClient))
+  }
+
+  @Test
+  def shouldAlterTopicConfig(): Unit = {
+    val resourceName = "my-topic"
+    val alterOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", resourceName,
+      "--entity-type", "topics",
+      "--alter",
+      "--add-config", "delete.retention.ms=1000000,min.insync.replicas=2",
+      "--delete-config", "unclean.leader.election.enable"))
+    var alteredConfigs = false
+
+    def newConfigEntry(name: String, value: String): ConfigEntry =
+      new ConfigEntry(name, value, ConfigEntry.ConfigSource.DYNAMIC_TOPIC_CONFIG, false, false, List.empty[ConfigEntry.ConfigSynonym].asJava)
+
+    val resource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
+    val configEntries = List(newConfigEntry("min.insync.replicas", "1"), newConfigEntry("unclean.leader.election.enable", "1")).asJava
+    val future = new KafkaFutureImpl[util.Map[ConfigResource, Config]]
+    future.complete(util.Collections.singletonMap(resource, new Config(configEntries)))
+    val describeResult: DescribeConfigsResult = EasyMock.createNiceMock(classOf[DescribeConfigsResult])
+    EasyMock.expect(describeResult.all()).andReturn(future).once()
+
+    val alterFuture = new KafkaFutureImpl[Void]
+    alterFuture.complete(null)
+    val alterResult: AlterConfigsResult = EasyMock.createNiceMock(classOf[AlterConfigsResult])
+    EasyMock.expect(alterResult.all()).andReturn(alterFuture)
+
+    val node = new Node(1, "localhost", 9092)
+    val mockAdminClient = new MockAdminClient(util.Collections.singletonList(node), node) {
+      override def describeConfigs(resources: util.Collection[ConfigResource], options: DescribeConfigsOptions): DescribeConfigsResult = {
+        assertEquals(1, resources.size)
+        val resource = resources.iterator.next
+        assertEquals(resource.`type`, ConfigResource.Type.TOPIC)
+        assertEquals(resource.name, resourceName)
+        describeResult
+      }
+
+      override def incrementalAlterConfigs(configs: util.Map[ConfigResource, util.Collection[AlterConfigOp]], options: AlterConfigsOptions): AlterConfigsResult = {
+        assertEquals(1, configs.size)
+        val entry = configs.entrySet.iterator.next
+        val resource = entry.getKey
+        val alterConfigOps = entry.getValue
+        assertEquals(ConfigResource.Type.TOPIC, resource.`type`)
+        assertEquals(3, alterConfigOps.size)
+
+        val expectedConfigOps = List(
+          new AlterConfigOp(newConfigEntry("delete.retention.ms", "1000000"), AlterConfigOp.OpType.SET),
+          new AlterConfigOp(newConfigEntry("min.insync.replicas", "2"), AlterConfigOp.OpType.SET),
+          new AlterConfigOp(newConfigEntry("unclean.leader.election.enable", ""), AlterConfigOp.OpType.DELETE)
+        )
+        assertEquals(expectedConfigOps, alterConfigOps.asScala.toList)
+        alteredConfigs = true
+        alterResult
+      }
+    }
+    EasyMock.replay(alterResult, describeResult)
+    ConfigCommand.alterConfig(mockAdminClient, alterOpts)
+    assertTrue(alteredConfigs)
+    EasyMock.reset(alterResult, describeResult)
   }
 
   @Test
@@ -311,7 +406,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
 
-    ConfigCommand.alterConfig(null, alterOpts, new TestAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, alterOpts, new TestAdminZkClient(zkClient))
   }
 
   @Test
@@ -340,8 +435,8 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     new ConfigCommandOptions(optsList.toArray).checkArgs()
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
-  def testNoSpecifiedEntityOptionWithDescribeBrokersInBootstrapServerIsNotAllowed(): Unit = {
+  @Test
+  def testNoSpecifiedEntityOptionWithDescribeBrokersInBootstrapServerIsAllowed(): Unit = {
     val optsList = List("--bootstrap-server", "localhost:9092",
       "--entity-type", ConfigType.Broker,
       "--describe"
@@ -429,7 +524,11 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
     EasyMock.replay(alterResult, describeResult)
-    ConfigCommand.alterBrokerConfig(mockAdminClient, alterOpts, ConfigType.Broker, resourceName)
+    val alterResourceName = if (resourceName.nonEmpty)
+      resourceName
+    else
+      ConfigEntityName.Default
+    ConfigCommand.alterConfig(mockAdminClient, alterOpts)
     assertEquals(Map("message.max.bytes" -> "10", "num.io.threads" -> "5"), brokerConfigs.toMap)
     EasyMock.reset(alterResult, describeResult)
   }
@@ -484,13 +583,13 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
     EasyMock.replay(alterResult, describeResult)
-    ConfigCommand.alterBrokerConfig(mockAdminClient, alterOpts, ConfigCommand.BrokerLoggerConfigType, resourceName)
+    ConfigCommand.alterConfig(mockAdminClient, alterOpts)
     assertTrue(alteredConfigs)
     EasyMock.reset(alterResult, describeResult)
   }
 
   @Test
-  def shouldSupportCommaSeparatedValues(): Unit = {
+  def shouldSupportCommaSeparatedValuesUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "my-topic",
       "--entity-type", "topics",
@@ -498,27 +597,35 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--add-config", "a=b,c=[d,e ,f],g=[h,i]"))
 
     class TestAdminZkClient(zkClient: KafkaZkClient) extends AdminZkClient(zkClient) {
-      override def changeBrokerConfig(brokerIds: Seq[Int], configChange: Properties): Unit = {
-        assertEquals(Seq(1), brokerIds)
+      override def changeTopicConfig(topic: String, configChange: Properties): Unit = {
+        assertEquals("my-topic", topic)
         assertEquals("b", configChange.get("a"))
         assertEquals("d,e ,f", configChange.get("c"))
         assertEquals("h,i", configChange.get("g"))
       }
-
-      override def changeTopicConfig(topic: String, configs: Properties): Unit = {}
     }
 
-    ConfigCommand.alterConfig(null, createOpts, new TestAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new TestAdminZkClient(zkClient))
   }
 
   @Test (expected = classOf[IllegalArgumentException])
-  def shouldNotUpdateBrokerConfigIfMalformedEntityName(): Unit = {
+  def shouldNotUpdateBrokerConfigIfMalformedEntityNameUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "1,2,3", //Don't support multiple brokers currently
       "--entity-type", "brokers",
       "--alter",
       "--add-config", "leader.replication.throttled.rate=10"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+  }
+
+  @Test (expected = classOf[IllegalArgumentException])
+  def shouldNotUpdateBrokerConfigIfMalformedEntityName(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", "1,2,3", //Don't support multiple brokers currently
+      "--entity-type", "brokers",
+      "--alter",
+      "--add-config", "leader.replication.throttled.rate=10"))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
   }
 
   @Test
@@ -531,11 +638,11 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       brokerId.map(id => Array("--entity-name", id)).getOrElse(Array("--entity-default"))
     }
 
-    def alterConfig(configs: Map[String, String], brokerId: Option[String],
-                    encoderConfigs: Map[String, String] = Map.empty): Unit = {
+    def alterConfigWithZk(configs: Map[String, String], brokerId: Option[String],
+                          encoderConfigs: Map[String, String] = Map.empty): Unit = {
       val configStr = (configs ++ encoderConfigs).map { case (k, v) => s"$k=$v" }.mkString(",")
       val addOpts = new ConfigCommandOptions(alterOpts ++ entityOpt(brokerId) ++ Array("--add-config", configStr))
-      ConfigCommand.alterConfig(zkClient, addOpts, adminZkClient)
+      ConfigCommand.alterConfigWithZk(zkClient, addOpts, adminZkClient)
     }
 
     def verifyConfig(configs: Map[String, String], brokerId: Option[String]): Unit = {
@@ -544,14 +651,14 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     }
 
     def alterAndVerifyConfig(configs: Map[String, String], brokerId: Option[String]): Unit = {
-      alterConfig(configs, brokerId)
+      alterConfigWithZk(configs, brokerId)
       verifyConfig(configs, brokerId)
     }
 
     def deleteAndVerifyConfig(configNames: Set[String], brokerId: Option[String]): Unit = {
       val deleteOpts = new ConfigCommandOptions(alterOpts ++ entityOpt(brokerId) ++
         Array("--delete-config", configNames.mkString(",")))
-      ConfigCommand.alterConfig(zkClient, deleteOpts, adminZkClient)
+      ConfigCommand.alterConfigWithZk(zkClient, deleteOpts, adminZkClient)
       verifyConfig(Map.empty, brokerId)
     }
 
@@ -569,19 +676,19 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
 
     // Listener configs: should work only with listener name
     alterAndVerifyConfig(Map("listener.name.external.ssl.keystore.location" -> "/tmp/test.jks"), Some(brokerId))
-    intercept[ConfigException](alterConfig(Map("ssl.keystore.location" -> "/tmp/test.jks"), Some(brokerId)))
+    intercept[ConfigException](alterConfigWithZk(Map("ssl.keystore.location" -> "/tmp/test.jks"), Some(brokerId)))
 
     // Per-broker config configured at default cluster-level should fail
-    intercept[ConfigException](alterConfig(Map("listener.name.external.ssl.keystore.location" -> "/tmp/test.jks"), None))
+    intercept[ConfigException](alterConfigWithZk(Map("listener.name.external.ssl.keystore.location" -> "/tmp/test.jks"), None))
     deleteAndVerifyConfig(Set("listener.name.external.ssl.keystore.location"), Some(brokerId))
 
     // Password config update without encoder secret should fail
-    intercept[IllegalArgumentException](alterConfig(Map("listener.name.external.ssl.keystore.password" -> "secret"), Some(brokerId)))
+    intercept[IllegalArgumentException](alterConfigWithZk(Map("listener.name.external.ssl.keystore.password" -> "secret"), Some(brokerId)))
 
     // Password config update with encoder secret should succeed and encoded password must be stored in ZK
     val configs = Map("listener.name.external.ssl.keystore.password" -> "secret", "log.cleaner.threads" -> "2")
     val encoderConfigs = Map(KafkaConfig.PasswordEncoderSecretProp -> "encoder-secret")
-    alterConfig(configs, Some(brokerId), encoderConfigs)
+    alterConfigWithZk(configs, Some(brokerId), encoderConfigs)
     val brokerConfigs = zkClient.getEntityConfigs("brokers", brokerId)
     assertFalse("Encoder secret stored in ZooKeeper", brokerConfigs.contains(KafkaConfig.PasswordEncoderSecretProp))
     assertEquals("2", brokerConfigs.getProperty("log.cleaner.threads")) // not encoded
@@ -597,7 +704,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       KafkaConfig.PasswordEncoderIterationsProp -> "1024",
       KafkaConfig.PasswordEncoderKeyFactoryAlgorithmProp -> "PBKDF2WithHmacSHA1",
       KafkaConfig.PasswordEncoderKeyLengthProp -> "64")
-    alterConfig(configs2, Some(brokerId), encoderConfigs2)
+    alterConfigWithZk(configs2, Some(brokerId), encoderConfigs2)
     val brokerConfigs2 = zkClient.getEntityConfigs("brokers", brokerId)
     val encodedPassword2 = brokerConfigs2.getProperty("listener.name.internal.ssl.keystore.password")
     assertEquals("secret2", ConfigCommand.createPasswordEncoder(encoderConfigs).decode(encodedPassword2).value)
@@ -605,45 +712,97 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
 
 
     // Password config update at default cluster-level should fail
-    intercept[ConfigException](alterConfig(configs, None, encoderConfigs))
+    intercept[ConfigException](alterConfigWithZk(configs, None, encoderConfigs))
 
     // Dynamic config updates using ZK should fail if broker is running.
     registerBrokerInZk(brokerId.toInt)
-    intercept[IllegalArgumentException](alterConfig(Map("message.max.size" -> "210000"), Some(brokerId)))
-    intercept[IllegalArgumentException](alterConfig(Map("message.max.size" -> "220000"), None))
+    intercept[IllegalArgumentException](alterConfigWithZk(Map("message.max.size" -> "210000"), Some(brokerId)))
+    intercept[IllegalArgumentException](alterConfigWithZk(Map("message.max.size" -> "220000"), None))
 
     // Dynamic config updates using ZK should for a different broker that is not running should succeed
     alterAndVerifyConfig(Map("message.max.size" -> "230000"), Some("2"))
   }
 
   @Test (expected = classOf[IllegalArgumentException])
-  def shouldNotUpdateBrokerConfigIfMalformedConfig(): Unit = {
+  def shouldNotUpdateBrokerConfigIfMalformedConfigUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "1",
       "--entity-type", "brokers",
       "--alter",
       "--add-config", "a=="))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
   }
 
   @Test (expected = classOf[IllegalArgumentException])
-  def shouldNotUpdateBrokerConfigIfMalformedBracketConfig(): Unit = {
+  def shouldNotUpdateBrokerConfigIfMalformedConfig(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", "1",
+      "--entity-type", "brokers",
+      "--alter",
+      "--add-config", "a=="))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+  }
+
+  @Test (expected = classOf[IllegalArgumentException])
+  def shouldNotUpdateBrokerConfigIfMalformedBracketConfigUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "1",
       "--entity-type", "brokers",
       "--alter",
       "--add-config", "a=[b,c,d=e"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+  }
+
+  @Test (expected = classOf[IllegalArgumentException])
+  def shouldNotUpdateBrokerConfigIfMalformedBracketConfig(): Unit = {
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", "1",
+      "--entity-type", "brokers",
+      "--alter",
+      "--add-config", "a=[b,c,d=e"))
+    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
   }
 
   @Test (expected = classOf[InvalidConfigurationException])
-  def shouldNotUpdateBrokerConfigIfNonExistingConfigIsDeleted(): Unit = {
+  def shouldNotUpdateConfigIfNonExistingConfigIsDeletedUsingZookeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "my-topic",
       "--entity-type", "topics",
       "--alter",
       "--delete-config", "missing_config1, missing_config2"))
-    ConfigCommand.alterConfig(null, createOpts, new DummyAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+  }
+
+  @Test (expected = classOf[InvalidConfigurationException])
+  def shouldNotUpdateConfigIfNonExistingConfigIsDeleted(): Unit = {
+    val resourceName = "my-topic"
+    val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
+      "--entity-name", resourceName,
+      "--entity-type", "topics",
+      "--alter",
+      "--delete-config", "missing_config1, missing_config2"))
+
+    val resource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
+    val configEntries = List.empty[ConfigEntry].asJava
+    val future = new KafkaFutureImpl[util.Map[ConfigResource, Config]]
+    future.complete(util.Collections.singletonMap(resource, new Config(configEntries)))
+    val describeResult: DescribeConfigsResult = EasyMock.createNiceMock(classOf[DescribeConfigsResult])
+    EasyMock.expect(describeResult.all()).andReturn(future).once()
+
+    val node = new Node(1, "localhost", 9092)
+    val mockAdminClient = new MockAdminClient(util.Collections.singletonList(node), node) {
+      override def describeConfigs(resources: util.Collection[ConfigResource], options: DescribeConfigsOptions): DescribeConfigsResult = {
+        assertEquals(1, resources.size)
+        val resource = resources.iterator.next
+        assertEquals(resource.`type`, ConfigResource.Type.TOPIC)
+        assertEquals(resource.name, resourceName)
+        describeResult
+      }
+    }
+
+    EasyMock.replay(describeResult)
+    ConfigCommand.alterConfig(mockAdminClient, createOpts)
+    EasyMock.reset(describeResult)
   }
 
   @Test
@@ -669,7 +828,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
 
-    ConfigCommand.alterConfig(null, createOpts, new TestAdminZkClient(zkClient))
+    ConfigCommand.alterConfigWithZk(null, createOpts, new TestAdminZkClient(zkClient))
   }
 
   @Test
@@ -707,14 +866,14 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       }
     }
     val optsA = createOpts("userA", "SCRAM-SHA-256=[iterations=8192,password=abc, def]")
-    ConfigCommand.alterConfig(null, optsA, CredentialChange("userA", Set("SCRAM-SHA-256"), 8192))
+    ConfigCommand.alterConfigWithZk(null, optsA, CredentialChange("userA", Set("SCRAM-SHA-256"), 8192))
     val optsB = createOpts("userB", "SCRAM-SHA-256=[iterations=4096,password=abc, def],SCRAM-SHA-512=[password=1234=abc]")
-    ConfigCommand.alterConfig(null, optsB, CredentialChange("userB", Set("SCRAM-SHA-256", "SCRAM-SHA-512"), 4096))
+    ConfigCommand.alterConfigWithZk(null, optsB, CredentialChange("userB", Set("SCRAM-SHA-256", "SCRAM-SHA-512"), 4096))
 
     val del256 = deleteOpts("userB", "SCRAM-SHA-256")
-    ConfigCommand.alterConfig(null, del256, CredentialChange("userB", Set("SCRAM-SHA-512"), 4096))
+    ConfigCommand.alterConfigWithZk(null, del256, CredentialChange("userB", Set("SCRAM-SHA-512"), 4096))
     val del512 = deleteOpts("userB", "SCRAM-SHA-512")
-    ConfigCommand.alterConfig(null, del512, CredentialChange("userB", Set(), 4096))
+    ConfigCommand.alterConfigWithZk(null, del512, CredentialChange("userB", Set(), 4096))
   }
 
   @Test
@@ -909,4 +1068,12 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     override def changeTopicConfig(topic: String, configs: Properties): Unit = {}
   }
 
+  class DummyAdminClient(node: Node) extends MockAdminClient(util.Collections.singletonList(node), node) {
+    override def describeConfigs(resources: util.Collection[ConfigResource]): DescribeConfigsResult =
+      EasyMock.createNiceMock(classOf[DescribeConfigsResult])
+    override def incrementalAlterConfigs(configs: util.Map[ConfigResource, util.Collection[AlterConfigOp]],
+      options: AlterConfigsOptions): AlterConfigsResult = EasyMock.createNiceMock(classOf[AlterConfigsResult])
+    override def alterConfigs(configs: util.Map[ConfigResource, Config], options: AlterConfigsOptions): AlterConfigsResult =
+      EasyMock.createNiceMock(classOf[AlterConfigsResult])
+  }
 }

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -374,12 +374,12 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
         assertEquals(ConfigResource.Type.TOPIC, resource.`type`)
         assertEquals(3, alterConfigOps.size)
 
-        val expectedConfigOps = List(
+        val expectedConfigOps = Set(
           new AlterConfigOp(newConfigEntry("delete.retention.ms", "1000000"), AlterConfigOp.OpType.SET),
           new AlterConfigOp(newConfigEntry("min.insync.replicas", "2"), AlterConfigOp.OpType.SET),
           new AlterConfigOp(newConfigEntry("unclean.leader.election.enable", ""), AlterConfigOp.OpType.DELETE)
         )
-        assertEquals(expectedConfigOps, alterConfigOps.asScala.toList)
+        assertEquals(expectedConfigOps, alterConfigOps.asScala.toSet)
         alteredConfigs = true
         alterResult
       }


### PR DESCRIPTION
Improves the broker-side functionality of kafka-config.sh to include
topic operations, as well as support for listing of brokers and
topics when provided an empty entity name.

Minor changes to functionality to make it equivalent to the ZK-version.
Because listing of entities was not supported for the broker, the
command was not distinguishing between empty and default entities,
where the former is a request to list the entities, the latter is for
the default configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
