### PR TITLE
KAFKA-8904: Improve producer's topic metadata fetching.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -164,7 +164,7 @@ public class Metadata implements Closeable {
             throw new IllegalArgumentException("Invalid leader epoch " + leaderEpoch + " (must be non-negative)");
 
         boolean updated = updateLastSeenEpoch(topicPartition, leaderEpoch, oldEpoch -> leaderEpoch > oldEpoch);
-        this.needUpdate = this.needUpdate || updated;
+        this.needFullUpdate = this.needFullUpdate || updated;
         return updated;
     }
 
@@ -352,7 +352,7 @@ public class Metadata implements Closeable {
             }
         }
 
-        Map<Integer, Node> nodes = new ArrayList<>(metadataResponse.brokersById());
+        Map<Integer, Node> nodes = metadataResponse.brokersById();
         if (isPartialUpdate)
             return this.cache.mergeWith(metadataResponse.clusterId(), nodes, partitions,
                 unauthorizedTopics, invalidTopics, internalTopics, metadataResponse.controller(),

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -239,10 +239,7 @@ public class Metadata implements Closeable {
     /**
      * Update metadata assuming the current request version. This is mainly for convenience in testing.
      */
-    public synchronized void update(MetadataResponse response, long nowMs) {
-        this.update(this.requestVersion, response, false, nowMs);
-    }
-    public synchronized void update(MetadataResponse response, boolean isPartialUpdate, long nowMs) {
+    public synchronized void updateWithCurrentRequestVersion(MetadataResponse response, boolean isPartialUpdate, long nowMs) {
         this.update(this.requestVersion, response, isPartialUpdate, nowMs);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -147,11 +147,12 @@ public class Metadata implements Closeable {
         return this.updateVersion;
     }
 
-    public synchronized void requestUpdateForNewTopics() {
+    public synchronized int requestUpdateForNewTopics() {
         // Override the timestamp of last refresh to let immediate update.
         this.lastRefreshMs = 0;
         this.needPartialUpdate = true;
         this.requestVersion++;
+        return this.updateVersion;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -230,7 +230,7 @@ public class Metadata implements Closeable {
     }
 
     public synchronized void bootstrap(List<InetSocketAddress> addresses) {
-        requestUpdate();
+        this.needFullUpdate = true;
         this.updateVersion += 1;
         this.cache = MetadataCache.bootstrap(addresses);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -168,8 +168,7 @@ public class MetadataCache {
         // For all topic metadata that's to be retained, we must update the partition info's nodes since it's possible that
         // a node has been modified or removed. Update the node object for known nodes, otherwise clear all nodes that were
         // removed and let the metadata resolution process request an update, if necessary.
-        ArrayList<PartitionInfoAndEpoch> newPartitions = new ArrayList<>(addPartitions.size());
-        newPartitions.addAll(addPartitions);
+        ArrayList<PartitionInfoAndEpoch> newPartitions = new ArrayList<>(addPartitions);
         for (Map.Entry<TopicPartition, MetadataCache.PartitionInfoAndEpoch> entry : metadataByPartition.entrySet()) {
             if (!shouldRetainTopic.test(entry.getKey().topic())) {
                 continue;

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -24,13 +24,18 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.requests.MetadataResponse;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -103,6 +108,109 @@ public class MetadataCache {
 
     ClusterResource clusterResource() {
         return new ClusterResource(clusterId);
+    }
+
+    /**
+     * Replaces all nodes in {@code oldNodeArray} with the corresponding node object with the same id in {@code nodeMap}.
+     * If a node is not found, then it is removed from the array.
+     *
+     * @param nodeMap mapping of node ids to nodes
+     * @param oldNodeArray the original node array
+     * @return the updated node array
+     */
+    private Node[] resolveNodeArray(Map<Integer, Node> nodeMap, Node[] oldNodeArray) {
+        Node[] newNodeArray = new Node[oldNodeArray.length];
+        int index = 0;
+        for (Node oldNode : oldNodeArray) {
+            Node newNode = nodeMap.get(oldNode.id());
+            if (newNode == null) {
+                continue;
+            }
+            newNodeArray[index] = newNode;
+            ++index;
+        }
+        if (index != newNodeArray.length) {
+            newNodeArray = Arrays.copyOf(newNodeArray, index);
+        }
+        return newNodeArray;
+    }
+
+    /**
+     * Merges the metadata cache's contents with the provided metadata, returning a new metadata cache. The provided
+     * metadata is presumed to be more recent than the cache's metadata, and therefore all overlapping metadata will
+     * be overridden.
+     *
+     * @param newClusterId the new cluster Id
+     * @param newNodes the new set of nodes
+     * @param addPartitions partitions to add
+     * @param addUnauthorizedTopics unauthorized topics to add
+     * @param addInternalTopics internal topics to add
+     * @param newController the new controller node
+     * @param retainTopic returns whether a topic's metadata should be retained
+     * @return the merged metadata cache
+     */
+    MetadataCache mergeWith(String newClusterId,
+                            List<Node> newNodes,
+                            Collection<PartitionInfoAndEpoch> addPartitions,
+                            Set<String> addUnauthorizedTopics,
+                            Set<String> addInvalidTopics,
+                            Set<String> addInternalTopics,
+                            Node newController,
+                            BiPredicate<String, Boolean> retainTopic) {
+
+        Predicate<String> shouldRetainTopic = topic -> retainTopic.test(topic, internalTopics.contains(topic));
+
+        Map<Integer, Node> nodeMap = new HashMap<>(newNodes.size());
+        for (Node node : newNodes) {
+            nodeMap.put(node.id(), node);
+        }
+
+        // For all topic metadata that's to be retained, we must update the partition info's nodes since it's possible that
+        // a node has been modified or removed. Update the node object for known nodes, otherwise clear all nodes that were
+        // removed and let the metadata resolution process request an update, if necessary.
+        ArrayList<PartitionInfoAndEpoch> newPartitions = new ArrayList<>(addPartitions.size());
+        newPartitions.addAll(addPartitions);
+        for (Map.Entry<TopicPartition, MetadataCache.PartitionInfoAndEpoch> entry : metadataByPartition.entrySet()) {
+            if (!shouldRetainTopic.test(entry.getKey().topic())) {
+                continue;
+            }
+
+            PartitionInfo oldPartitionInfo = entry.getValue().partitionInfo();
+            PartitionInfo newPartitionInfo = new PartitionInfo(entry.getKey().topic(),
+                                                               entry.getKey().partition(),
+                                                               nodeMap.get(oldPartitionInfo.leader().id()),
+                                                               resolveNodeArray(nodeMap, oldPartitionInfo.replicas()),
+                                                               resolveNodeArray(nodeMap, oldPartitionInfo.inSyncReplicas()),
+                                                               resolveNodeArray(nodeMap, oldPartitionInfo.offlineReplicas()));
+            newPartitions.add(new PartitionInfoAndEpoch(newPartitionInfo, entry.getValue().epoch()));
+        }
+
+        Set<String> newUnauthorizedTopics = fillSet(addUnauthorizedTopics, unauthorizedTopics, shouldRetainTopic);
+        Set<String> newInvalidTopics = fillSet(addInvalidTopics, invalidTopics, shouldRetainTopic);
+        Set<String> newInternalTopics = fillSet(addInternalTopics, internalTopics, shouldRetainTopic);
+
+        return new MetadataCache(newClusterId, newNodes, newPartitions, newUnauthorizedTopics,
+                newInvalidTopics, newInternalTopics, newController);
+    }
+
+    /**
+     * Copies {@code baseSet} and adds all non-existent elements in {@code fillSet} such that {@code predicate} is true.
+     * In other words, all elements of {@code baseSet} will be contained in the result, with additional non-overlapping
+     * elements in {@code fillSet} where the predicate is true.
+     *
+     * @param baseSet the base elements for the resulting set
+     * @param fillSet elements to be filled into the resulting set
+     * @param predicate tested against the fill set to determine whether elements should be added to the base set
+     */
+    private static <T> Set<T> fillSet(Set<T> baseSet, Set<T> fillSet, Predicate<T> predicate) {
+        Set<T> result = new HashSet<>(baseSet.size());
+        result.addAll(baseSet);
+        for (T element : fillSet) {
+            if (predicate.test(element)) {
+                result.add(element);
+            }
+        }
+        return result;
     }
 
     private void computeClusterView() {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -973,11 +973,11 @@ public class NetworkClient implements KafkaClient {
         private final Metadata metadata;
 
         // Defined if there is a request in progress, null otherwise
-        private Integer inProgressRequestVersion;
+        private InProgressData inProgress;
 
         DefaultMetadataUpdater(Metadata metadata) {
             this.metadata = metadata;
-            this.inProgressRequestVersion = null;
+            this.inProgress = null;
         }
 
         @Override
@@ -991,7 +991,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         private boolean hasFetchInProgress() {
-            return inProgressRequestVersion != null;
+            return inProgress != null;
         }
 
         @Override
@@ -1045,7 +1045,7 @@ public class NetworkClient implements KafkaClient {
         public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
             maybeFatalException.ifPresent(metadata::fatalError);
             metadata.failedUpdate(now);
-            inProgressRequestVersion = null;
+            inProgress = null;
         }
 
         @Override
@@ -1075,10 +1075,10 @@ public class NetworkClient implements KafkaClient {
                 log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                 this.metadata.failedUpdate(now);
             } else {
-                this.metadata.update(inProgressRequestVersion, response, now);
+                this.metadata.update(inProgress.requestVersion, response, inProgress.isPartialUpdate, now);
             }
 
-            inProgressRequestVersion = null;
+            inProgress = null;
         }
 
         @Override
@@ -1105,11 +1105,11 @@ public class NetworkClient implements KafkaClient {
             String nodeConnectionId = node.idString();
 
             if (canSendRequest(nodeConnectionId, now)) {
-                Metadata.MetadataRequestAndVersion requestAndVersion = metadata.newMetadataRequestAndVersion();
+                Metadata.MetadataRequestAndVersion requestAndVersion = metadata.newMetadataRequestAndVersion(now);
                 MetadataRequest.Builder metadataRequest = requestAndVersion.requestBuilder;
                 log.debug("Sending metadata request {} to node {}", metadataRequest, node);
                 sendInternalMetadataRequest(metadataRequest, nodeConnectionId, now);
-                this.inProgressRequestVersion = requestAndVersion.requestVersion;
+                inProgress = new InProgressData(requestAndVersion.requestVersion, requestAndVersion.isPartialUpdate);
                 return defaultRequestTimeoutMs;
             }
 
@@ -1134,6 +1134,16 @@ public class NetworkClient implements KafkaClient {
             // connection might be usable again.
             return Long.MAX_VALUE;
         }
+
+        public class InProgressData {
+            public final int requestVersion;
+            public final boolean isPartialUpdate;
+
+            private InProgressData(int requestVersion, boolean isPartialUpdate) {
+                this.requestVersion = requestVersion;
+                this.isPartialUpdate = isPartialUpdate;
+            }
+        };
 
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -51,7 +51,7 @@ public class ConsumerMetadata extends Metadata {
     }
 
     @Override
-    public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
+    public synchronized MetadataRequest.Builder newMetadataRequestBuilder(boolean isPartialUpdate) {
         if (subscription.hasPatternSubscription())
             return MetadataRequest.Builder.allTopics();
         List<String> topics = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -51,7 +51,7 @@ public class ConsumerMetadata extends Metadata {
     }
 
     @Override
-    public synchronized MetadataRequest.Builder newMetadataRequestBuilder(boolean isPartialUpdate) {
+    public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
         if (subscription.hasPatternSubscription())
             return MetadataRequest.Builder.allTopics();
         List<String> topics = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1021,7 +1021,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 log.trace("Requesting metadata update for topic {}.", topic);
             }
             metadata.add(topic, nowMs + elapsed);
-            int version = metadata.requestUpdate();
+            int version = metadata.requestUpdateForTopic(topic);
             sender.wakeup();
             try {
                 metadata.awaitUpdate(version, remainingWaitMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -413,6 +413,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             } else {
                 this.metadata = new ProducerMetadata(retryBackoffMs,
                         config.getLong(ProducerConfig.METADATA_MAX_AGE_CONFIG),
+                        config.getLong(ProducerConfig.METADATA_MAX_IDLE_CONFIG),
                         logContext,
                         clusterResourceListeners,
                         Time.SYSTEM);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -62,6 +62,13 @@ public class ProducerConfig extends AbstractConfig {
     public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
     private static final String METADATA_MAX_AGE_DOC = CommonClientConfigs.METADATA_MAX_AGE_DOC;
 
+    /** <code>metadata.max.idle.ms</code> */
+    public static final String METADATA_MAX_IDLE_CONFIG = "metadata.max.idle.ms";
+    private static final String METADATA_MAX_IDLE_DOC =
+            "Controls how long the producer will cache metadata for a topic that's idle. If the elapsed " +
+            "time since a topic was last produced to exceeds the metadata idle duration, then the topic's " +
+            "metadata is forgotten and the next access to it will force a metadata fetch request.";
+
     /** <code>batch.size</code> */
     public static final String BATCH_SIZE_CONFIG = "batch.size";
     private static final String BATCH_SIZE_DOC = "The producer will attempt to batch records together into fewer requests whenever multiple records are being sent"
@@ -300,6 +307,12 @@ public class ProducerConfig extends AbstractConfig {
                                         Importance.MEDIUM,
                                         REQUEST_TIMEOUT_MS_DOC)
                                 .define(METADATA_MAX_AGE_CONFIG, Type.LONG, 5 * 60 * 1000, atLeast(0), Importance.LOW, METADATA_MAX_AGE_DOC)
+                                .define(METADATA_MAX_IDLE_CONFIG,
+                                        Type.LONG,
+                                        5 * 60 * 1000,
+                                        atLeast(5000),
+                                        Importance.LOW,
+                                        METADATA_MAX_IDLE_DOC)
                                 .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
                                         Type.LONG,
                                         30000,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -72,6 +72,14 @@ public class ProducerMetadata extends Metadata {
         }
     }
 
+    public synchronized int requestUpdateForTopic(String topic) {
+        if (newTopics.contains(topic)) {
+            return requestUpdateForNewTopics();
+        } else {
+            return requestUpdate();
+        }
+    }
+
     // Visible for testing
     synchronized Set<String> topics() {
         return topics.keySet();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -27,36 +27,42 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class ProducerMetadata extends Metadata {
-    static final long TOPIC_EXPIRY_MS = 5 * 60 * 1000;
+    // If a topic hasn't been accessed for this many milliseconds, it is removed from the cache.
+    private final long metadataIdleMs;
 
     /* Topics with expiry time */
     private final Map<String, Long> topics = new HashMap<>();
+    private final Set<String> newTopics = new HashSet<>();
     private final Logger log;
     private final Time time;
 
     public ProducerMetadata(long refreshBackoffMs,
                             long metadataExpireMs,
+                            long metadataIdleMs,
                             LogContext logContext,
                             ClusterResourceListeners clusterResourceListeners,
                             Time time) {
         super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners);
+        this.metadataIdleMs = metadataIdleMs;
         this.log = logContext.logger(ProducerMetadata.class);
         this.time = time;
     }
 
     @Override
-    public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
-        return new MetadataRequest.Builder(new ArrayList<>(topics.keySet()), true);
+    public synchronized MetadataRequest.Builder newMetadataRequestBuilder(boolean isPartialUpdate) {
+        return new MetadataRequest.Builder(new ArrayList<>(isPartialUpdate ? newTopics : topics.keySet()), true);
     }
 
     public synchronized void add(String topic, long nowMs) {
         Objects.requireNonNull(topic, "topic cannot be null");
-        if (topics.put(topic, nowMs + TOPIC_EXPIRY_MS) == null) {
+        if (topics.put(topic, nowMs + metadataIdleMs) == null) {
+            newTopics.add(topic);
             requestUpdateForNewTopics();
         }
     }
@@ -64,6 +70,11 @@ public class ProducerMetadata extends Metadata {
     // Visible for testing
     synchronized Set<String> topics() {
         return topics.keySet();
+    }
+
+    // Visible for testing
+    synchronized Set<String> newTopics() {
+        return newTopics;
     }
 
     public synchronized boolean containsTopic(String topic) {
@@ -75,6 +86,8 @@ public class ProducerMetadata extends Metadata {
         Long expireMs = topics.get(topic);
         if (expireMs == null) {
             return false;
+        } else if (newTopics.contains(topic)) {
+            return true;
         } else if (expireMs <= nowMs) {
             log.debug("Removing unused topic {} from the metadata list, expiryMs {} now {}", topic, expireMs, nowMs);
             topics.remove(topic);
@@ -101,8 +114,17 @@ public class ProducerMetadata extends Metadata {
     }
 
     @Override
-    public synchronized void update(int requestVersion, MetadataResponse response, long now) {
-        super.update(requestVersion, response, now);
+    public synchronized void update(int requestVersion, MetadataResponse response, boolean isPartialUpdate, long nowMs) {
+        super.update(requestVersion, response, isPartialUpdate, nowMs);
+
+        // Remove any new topics in the response from the new topic set. Note that if an error was encountered for a
+        // new topic, then any work to resolve the error will include the topic in a full metadata update.
+        if (!newTopics.isEmpty()) {
+            for (MetadataResponse.TopicMetadata metadata : response.topicMetadata()) {
+                newTopics.remove(metadata.topic());
+            }
+        }
+
         notifyAll();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -55,8 +55,13 @@ public class ProducerMetadata extends Metadata {
     }
 
     @Override
-    public synchronized MetadataRequest.Builder newMetadataRequestBuilder(boolean isPartialUpdate) {
-        return new MetadataRequest.Builder(new ArrayList<>(isPartialUpdate ? newTopics : topics.keySet()), true);
+    public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
+        return new MetadataRequest.Builder(new ArrayList<>(topics.keySet()), true);
+    }
+
+    @Override
+    public synchronized MetadataRequest.Builder newMetadataRequestBuilderForNewTopics() {
+        return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
     }
 
     public synchronized void add(String topic, long nowMs) {
@@ -117,8 +122,8 @@ public class ProducerMetadata extends Metadata {
     public synchronized void update(int requestVersion, MetadataResponse response, boolean isPartialUpdate, long nowMs) {
         super.update(requestVersion, response, isPartialUpdate, nowMs);
 
-        // Remove any new topics in the response from the new topic set. Note that if an error was encountered for a
-        // new topic, then any work to resolve the error will include the topic in a full metadata update.
+        // Remove all topics in the response that are in the new topic set. Note that if an error was encountered for a
+        // new topic's metadata, then any work to resolve the error will include the topic in a full metadata update.
         if (!newTopics.isEmpty()) {
             for (MetadataResponse.TopicMetadata metadata : response.topicMetadata()) {
                 newTopics.remove(metadata.topic());

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.test.TestUtils.assertOptional;
 import static org.junit.Assert.assertEquals;
@@ -722,15 +721,15 @@ public class MetadataTest {
                 .setIsrNodes(Arrays.asList(1, 2))
                 .setOfflineReplicas(Collections.singletonList(0));
 
-        metadata.update(new MetadataResponse(new MetadataResponseData()
+        metadata.updateWithCurrentRequestVersion(new MetadataResponse(new MetadataResponseData()
                         .setTopics(buildTopicCollection(tp.topic(), firstPartitionMetadata))
                         .setBrokers(buildBrokerCollection(Arrays.asList(node0, node1, node2)))),
-                10L);
+                false, 10L);
 
-        metadata.update(new MetadataResponse(new MetadataResponseData()
+        metadata.updateWithCurrentRequestVersion(new MetadataResponse(new MetadataResponseData()
                         .setTopics(buildTopicCollection(tp.topic(), secondPartitionMetadata))
                         .setBrokers(buildBrokerCollection(Arrays.asList(node1, node2)))),
-                20L);
+                false, 20L);
 
         assertNull(metadata.fetch().leaderFor(tp));
         assertEquals(Optional.of(10), metadata.lastSeenLeaderEpoch(tp));

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -573,6 +573,21 @@ public class MetadataTest {
         metadata.update(versionAndBuilder.requestVersion,
                 TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic", 1)), true, refreshTimeMs);
         assertFalse(metadata.updateRequested());
+
+        // Request two partial metadata updates that are overlapping.
+        metadata.requestUpdateForNewTopics();
+        versionAndBuilder = metadata.newMetadataRequestAndVersion(time.milliseconds());
+        assertTrue(versionAndBuilder.isPartialUpdate);
+        metadata.requestUpdateForNewTopics();
+        Metadata.MetadataRequestAndVersion overlappingVersionAndBuilder = metadata.newMetadataRequestAndVersion(time.milliseconds());
+        assertTrue(overlappingVersionAndBuilder.isPartialUpdate);
+        assertTrue(metadata.updateRequested());
+        metadata.update(versionAndBuilder.requestVersion,
+                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-1", 1)), true, refreshTimeMs);
+        assertTrue(metadata.updateRequested());
+        metadata.update(overlappingVersionAndBuilder.requestVersion,
+                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-2", 1)), true, refreshTimeMs);
+        assertFalse(metadata.updateRequested());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -583,10 +583,10 @@ public class MetadataTest {
         assertTrue(overlappingVersionAndBuilder.isPartialUpdate);
         assertTrue(metadata.updateRequested());
         metadata.update(versionAndBuilder.requestVersion,
-                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-1", 1)), true, refreshTimeMs);
+                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-1", 1)), true, time.milliseconds());
         assertTrue(metadata.updateRequested());
         metadata.update(overlappingVersionAndBuilder.requestVersion,
-                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-2", 1)), true, refreshTimeMs);
+                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic-2", 1)), true, time.milliseconds());
         assertFalse(metadata.updateRequested());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -725,19 +725,17 @@ public class MetadataTest {
         oldTopicPartitionCounts.put("oldValidTopic", 2);
         oldTopicPartitionCounts.put("keepValidTopic", 3);
 
-        Set<String> oldRetainTopics = new HashSet<>();
-        oldRetainTopics.add("oldInvalidTopic");
-        oldRetainTopics.add("keepInvalidTopic");
-        oldRetainTopics.add("oldUnauthorizedTopic");
-        oldRetainTopics.add("keepUnauthorizedTopic");
-        oldRetainTopics.add("oldValidTopic");
-        oldRetainTopics.add("keepValidTopic");
-
-        retainTopics.set(oldRetainTopics);
+        retainTopics.set(new HashSet<>(Arrays.asList(
+            "oldInvalidTopic",
+            "keepInvalidTopic",
+            "oldUnauthorizedTopic",
+            "keepUnauthorizedTopic",
+            "oldValidTopic",
+            "keepValidTopic")));
 
         MetadataResponse metadataResponse =
                 TestUtils.metadataUpdateWith(oldClusterId, oldNodes, oldTopicErrors, oldTopicPartitionCounts, _tp -> 100);
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.update(metadataResponse, true, time.milliseconds());
 
         // Update the metadata to add a new topic variant, "new", which will be retained with "keep". Note this
         // means that all of the "old" topics should be dropped.
@@ -759,18 +757,16 @@ public class MetadataTest {
         newTopicPartitionCounts.put("keepValidTopic", 2);
         newTopicPartitionCounts.put("newValidTopic", 4);
 
-        Set<String> newRetainTopics = new HashSet<>();
-        newRetainTopics.add("keepInvalidTopic");
-        newRetainTopics.add("newInvalidTopic");
-        newRetainTopics.add("keepUnauthorizedTopic");
-        newRetainTopics.add("newUnauthorizedTopic");
-        newRetainTopics.add("keepValidTopic");
-        newRetainTopics.add("newValidTopic");
-
-        retainTopics.set(newRetainTopics);
+        retainTopics.set(new HashSet<>(Arrays.asList(
+            "keepInvalidTopic",
+            "newInvalidTopic",
+            "keepUnauthorizedTopic",
+            "newUnauthorizedTopic",
+            "keepValidTopic",
+            "newValidTopic")));
 
         metadataResponse = TestUtils.metadataUpdateWith(newClusterId, newNodes, newTopicErrors, newTopicPartitionCounts, _tp -> 200);
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.update(metadataResponse, true, time.milliseconds());
 
         cluster = metadata.fetch();
         assertEquals(cluster.clusterResource().clusterId(), newClusterId);
@@ -785,7 +781,7 @@ public class MetadataTest {
         retainTopics.set(Collections.emptySet());
 
         metadataResponse = TestUtils.metadataUpdateWith(newClusterId, newNodes, newTopicErrors, newTopicPartitionCounts, _tp -> 300);
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.update(metadataResponse, true, time.milliseconds());
 
         cluster = metadata.fetch();
         assertEquals(cluster.clusterResource().clusterId(), newClusterId);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopi
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -530,6 +531,13 @@ public class MetadataTest {
     public void testPartialMetadataUpdate() {
         Time time = new MockTime();
 
+        metadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(), new ClusterResourceListeners()) {
+                @Override
+                protected MetadataRequest.Builder newMetadataRequestBuilderForNewTopics() {
+                    return newMetadataRequestBuilder();
+                }
+            };
+
         assertFalse(metadata.updateRequested());
 
         // Request a metadata update. This must force a full metadata update request.
@@ -554,7 +562,7 @@ public class MetadataTest {
         versionAndBuilder = metadata.newMetadataRequestAndVersion(time.milliseconds());
         assertFalse(versionAndBuilder.isPartialUpdate);
         metadata.update(versionAndBuilder.requestVersion,
-                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic", 1)), true, time.milliseconds());
+                TestUtils.metadataUpdateWith(1, Collections.singletonMap("topic", 1)), false, time.milliseconds());
         assertFalse(metadata.updateRequested());
 
         // Request only a partial metadata update, but elapse enough time such that a full refresh is needed.

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -644,7 +644,7 @@ public class MockClient implements KafkaClient {
         public void update(Time time, MetadataUpdate update) {
             MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
             maybeCheckExpectedTopics(update, builder);
-            metadata.update(update.updateResponse, time.milliseconds());
+            metadata.updateWithCurrentRequestVersion(update.updateResponse, false, time.milliseconds());
             this.lastUpdate = update;
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -642,7 +642,7 @@ public class MockClient implements KafkaClient {
 
         @Override
         public void update(Time time, MetadataUpdate update) {
-            MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
+            MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
             maybeCheckExpectedTopics(update, builder);
             metadata.update(update.updateResponse, time.milliseconds());
             this.lastUpdate = update;

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -642,7 +642,7 @@ public class MockClient implements KafkaClient {
 
         @Override
         public void update(Time time, MetadataUpdate update) {
-            MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
+            MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
             maybeCheckExpectedTopics(update, builder);
             metadata.update(update.updateResponse, time.milliseconds());
             this.lastUpdate = update;

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -397,7 +397,7 @@ public class NetworkClientTest {
 
         // ApiVersionsRequest has been sent
         assertEquals(1, selector.completedSends().size());
-        
+
         buffer = selector.completedSendBuffers().get(0).buffer();
         header = parseHeader(buffer);
         assertEquals(ApiKeys.API_VERSIONS, header.apiKey());
@@ -608,7 +608,7 @@ public class NetworkClientTest {
 
         MetadataResponse metadataResponse = TestUtils.metadataUpdateWith(2, Collections.emptyMap());
         Metadata metadata = new Metadata(refreshBackoffMs, 5000, new LogContext(), new ClusterResourceListeners());
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
 
         Cluster cluster = metadata.fetch();
         Node node1 = cluster.nodes().get(0);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1175,7 +1175,7 @@ public class ConsumerCoordinatorTest {
         assertFalse(coordinator.rejoinNeededOrPending());
 
         // a new partition is added to the topic
-        metadata.update(TestUtils.metadataUpdateWith(1, singletonMap(topic1, 2)), time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith(1, singletonMap(topic1, 2)), false, time.milliseconds());
         coordinator.maybeUpdateSubscriptionMetadata();
 
         // we should detect the change and ask for reassignment

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -77,7 +77,7 @@ public class ConsumerMetadataTest {
 
         MetadataResponse response = MetadataResponse.prepareResponse(singletonList(node),
             "clusterId", node.id(), topics);
-        metadata.update(response, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(response, false, time.milliseconds());
 
         if (includeInternalTopics)
             assertEquals(Utils.mkSet("__matching_topic", "__consumer_offsets"), metadata.fetch().topics());
@@ -113,7 +113,7 @@ public class ConsumerMetadataTest {
     public void testTransientTopics() {
         subscription.subscribe(singleton("foo"), new NoOpConsumerRebalanceListener());
         ConsumerMetadata metadata = newConsumerMetadata(false);
-        metadata.update(TestUtils.metadataUpdateWith(1, singletonMap("foo", 1)), time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith(1, singletonMap("foo", 1)), false, time.milliseconds());
         assertFalse(metadata.updateRequested());
 
         metadata.addTransientTopics(singleton("foo"));
@@ -125,13 +125,13 @@ public class ConsumerMetadataTest {
         Map<String, Integer> topicPartitionCounts = new HashMap<>();
         topicPartitionCounts.put("foo", 1);
         topicPartitionCounts.put("bar", 1);
-        metadata.update(TestUtils.metadataUpdateWith(1, topicPartitionCounts), time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith(1, topicPartitionCounts), false, time.milliseconds());
         assertFalse(metadata.updateRequested());
 
         assertEquals(Utils.mkSet("foo", "bar"), new HashSet<>(metadata.fetch().topics()));
 
         metadata.clearTransientTopics();
-        metadata.update(TestUtils.metadataUpdateWith(1, topicPartitionCounts), time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith(1, topicPartitionCounts), false, time.milliseconds());
         assertEquals(singleton("foo"), new HashSet<>(metadata.fetch().topics()));
     }
 
@@ -153,7 +153,7 @@ public class ConsumerMetadataTest {
 
         MetadataResponse response = MetadataResponse.prepareResponse(singletonList(node),
             "clusterId", node.id(), topics);
-        metadata.update(response, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(response, false, time.milliseconds());
 
         assertEquals(allTopics, metadata.fetch().topics());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -67,7 +67,7 @@ public class ConsumerMetadataTest {
         subscription.subscribe(Pattern.compile("__.*"), new NoOpConsumerRebalanceListener());
         ConsumerMetadata metadata = newConsumerMetadata(includeInternalTopics);
 
-        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
+        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
         assertTrue(builder.isAllTopics());
 
         List<MetadataResponse.TopicMetadata> topics = new ArrayList<>();
@@ -142,7 +142,7 @@ public class ConsumerMetadataTest {
 
         ConsumerMetadata metadata = newConsumerMetadata(false);
 
-        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
+        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
         assertEquals(allTopics, new HashSet<>(builder.topics()));
 
         List<MetadataResponse.TopicMetadata> topics = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -67,7 +67,7 @@ public class ConsumerMetadataTest {
         subscription.subscribe(Pattern.compile("__.*"), new NoOpConsumerRebalanceListener());
         ConsumerMetadata metadata = newConsumerMetadata(includeInternalTopics);
 
-        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
+        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
         assertTrue(builder.isAllTopics());
 
         List<MetadataResponse.TopicMetadata> topics = new ArrayList<>();
@@ -142,7 +142,7 @@ public class ConsumerMetadataTest {
 
         ConsumerMetadata metadata = newConsumerMetadata(false);
 
-        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder(false);
+        MetadataRequest.Builder builder = metadata.newMetadataRequestBuilder();
         assertEquals(allTopics, new HashSet<>(builder.topics()));
 
         List<MetadataResponse.TopicMetadata> topics = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -249,7 +249,7 @@ public class ConsumerNetworkClientTest {
     public void testInvalidTopicExceptionPropagatedFromMetadata() {
         MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("clusterId", 1,
                 Collections.singletonMap("topic", Errors.INVALID_TOPIC_EXCEPTION), Collections.emptyMap());
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
         consumerClient.poll(time.timer(Duration.ZERO));
     }
 
@@ -257,7 +257,7 @@ public class ConsumerNetworkClientTest {
     public void testTopicAuthorizationExceptionPropagatedFromMetadata() {
         MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("clusterId", 1,
                 Collections.singletonMap("topic", Errors.TOPIC_AUTHORIZATION_FAILED), Collections.emptyMap());
-        metadata.update(metadataResponse, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
         consumerClient.poll(time.timer(Duration.ZERO));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -3465,7 +3465,7 @@ public class FetcherTest {
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put(tp0.topic(), 4);
         MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> 1);
-        metadata.update(metadataResponse, 0L);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
         // Seek
         subscriptions.seek(tp0, 0);
@@ -3495,8 +3495,8 @@ public class FetcherTest {
 
         final int epochOne = 1;
 
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
-                Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochOne), false, 0L);
 
         Node node = metadata.fetch().nodes().get(0);
         assertFalse(client.isConnected(node.idString()));
@@ -3542,8 +3542,8 @@ public class FetcherTest {
         final int epochTwo = 2;
 
         // Start with metadata, epoch=1
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
-                Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochOne), false, 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);
@@ -3556,8 +3556,8 @@ public class FetcherTest {
         subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(0, Optional.of(epochOne), leaderAndEpoch));
 
         // Update metadata to epoch=2, enter validation
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
-                Collections.emptyMap(), partitionCounts, tp -> epochTwo), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochTwo), false, 0L);
         fetcher.validateOffsetsIfNeeded();
 
         // Offset validation is skipped
@@ -3574,7 +3574,8 @@ public class FetcherTest {
 
         final int epochOne = 1;
 
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochOne), false, 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);
@@ -3616,7 +3617,8 @@ public class FetcherTest {
         final int epochThree = 3;
 
         // Start with metadata, epoch=1
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochOne), false, 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);
@@ -3627,7 +3629,8 @@ public class FetcherTest {
         subscriptions.seekValidated(tp0, new SubscriptionState.FetchPosition(0, Optional.of(epochOne), leaderAndEpoch));
 
         // Update metadata to epoch=2, enter validation
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochTwo), 0L);
+        metadata.updateWithCurrentRequestVersion(TestUtils.metadataUpdateWith("dummy", 1,
+                Collections.emptyMap(), partitionCounts, tp -> epochTwo), false, 0L);
         fetcher.validateOffsetsIfNeeded();
         assertTrue(subscriptions.awaitingValidation(tp0));
 
@@ -3686,7 +3689,7 @@ public class FetcherTest {
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put(tp0.topic(), 4);
         MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> 2);
-        metadata.update(metadataResponse, 0L);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -274,7 +274,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);
 
@@ -355,7 +355,7 @@ public class KafkaProducerTest {
             @Override
             Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
                 // give Sender its own Metadata instance so that we can isolate Metadata calls from KafkaProducer
-                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000));
+                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000, 100_000));
             }
         };
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
@@ -407,7 +407,7 @@ public class KafkaProducerTest {
             @Override
             Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
                 // give Sender its own Metadata instance so that we can isolate Metadata calls from KafkaProducer
-                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000));
+                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000, 100_000));
             }
         };
 
@@ -445,7 +445,7 @@ public class KafkaProducerTest {
             @Override
             Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
                 // give Sender its own Metadata instance so that we can isolate Metadata calls from KafkaProducer
-                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000));
+                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000, 100_000));
             }
         };
         // One request update if metadata is available but outdated for the given record
@@ -483,7 +483,7 @@ public class KafkaProducerTest {
             @Override
             Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
                 // give Sender its own Metadata instance so that we can isolate Metadata calls from KafkaProducer
-                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000));
+                return super.newSender(logContext, kafkaClient, newMetadata(0, 100_000, 100_000));
             }
         };
 
@@ -509,8 +509,9 @@ public class KafkaProducerTest {
         configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "600000");
         long refreshBackoffMs = 500L;
         long metadataExpireMs = 60000L;
+        long metadataIdleMs = 60000L;
         final Time time = new MockTime();
-        final ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, metadataExpireMs,
+        final ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, metadataExpireMs, metadataIdleMs,
                 new LogContext(), new ClusterResourceListeners(), time);
         final String topic = "topic";
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
@@ -558,7 +559,7 @@ public class KafkaProducerTest {
 
         long nowMs = Time.SYSTEM.milliseconds();
         String topic = "topic";
-        ProducerMetadata metadata = newMetadata(0, 90000);
+        ProducerMetadata metadata = newMetadata(0, 90000, 90000);
         metadata.add(topic, nowMs);
 
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap(topic, 1));
@@ -624,7 +625,7 @@ public class KafkaProducerTest {
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
 
         long nowMs = Time.SYSTEM.milliseconds();
-        ProducerMetadata metadata = newMetadata(0, 90000);
+        ProducerMetadata metadata = newMetadata(0, 90000, 90000);
         metadata.add(topic, nowMs);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap(topic, 1));
         metadata.update(initialUpdateResponse, nowMs);
@@ -662,7 +663,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -682,7 +683,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
 
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);
@@ -853,7 +854,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -877,7 +878,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -919,7 +920,7 @@ public class KafkaProducerTest {
         String topicName = "test";
         Time time = Time.SYSTEM;
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
-        ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE,
+        ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE,
                 new LogContext(), new ClusterResourceListeners(), time);
         metadata.update(initialUpdateResponse, time.milliseconds());
         MockClient client = new MockClient(time, metadata);
@@ -961,7 +962,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -980,7 +981,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("testTopic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -1008,7 +1009,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("testTopic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -1037,7 +1038,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime();
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("testTopic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
         metadata.update(initialUpdateResponse, time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
@@ -1058,8 +1059,8 @@ public class KafkaProducerTest {
         assertionDoneLatch.await(5000, TimeUnit.MILLISECONDS);
     }
 
-    private ProducerMetadata newMetadata(long refreshBackoffMs, long expirationMs) {
-        return new ProducerMetadata(refreshBackoffMs, expirationMs,
+    private ProducerMetadata newMetadata(long refreshBackoffMs, long expirationMs, long idleMs) {
+        return new ProducerMetadata(refreshBackoffMs, expirationMs, idleMs,
                 new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -709,7 +709,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
 
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);
@@ -746,7 +746,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
 
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);
@@ -802,7 +802,7 @@ public class KafkaProducerTest {
 
         Time time = new MockTime(1);
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
-        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE);
 
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -362,19 +362,19 @@ public class KafkaProducerTest {
         producer.send(record);
 
         // One request update for each empty cluster returned
-        verify(metadata, times(4)).requestUpdate();
+        verify(metadata, times(4)).requestUpdateForTopic(topic);
         verify(metadata, times(4)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(5)).fetch();
 
         // Should not request update for subsequent `send`
         producer.send(record, null);
-        verify(metadata, times(4)).requestUpdate();
+        verify(metadata, times(4)).requestUpdateForTopic(topic);
         verify(metadata, times(4)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(6)).fetch();
 
         // Should not request update for subsequent `partitionsFor`
         producer.partitionsFor(topic);
-        verify(metadata, times(4)).requestUpdate();
+        verify(metadata, times(4)).requestUpdateForTopic(topic);
         verify(metadata, times(4)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(7)).fetch();
 
@@ -414,7 +414,7 @@ public class KafkaProducerTest {
         // Four request updates where the topic isn't present, at which point the timeout expires and a
         // TimeoutException is thrown
         Future future = producer.send(record);
-        verify(metadata, times(4)).requestUpdate();
+        verify(metadata, times(4)).requestUpdateForTopic(topic);
         verify(metadata, times(4)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(5)).fetch();
         try {
@@ -450,7 +450,7 @@ public class KafkaProducerTest {
         };
         // One request update if metadata is available but outdated for the given record
         producer.send(record);
-        verify(metadata, times(2)).requestUpdate();
+        verify(metadata, times(2)).requestUpdateForTopic(topic);
         verify(metadata, times(2)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(3)).fetch();
 
@@ -490,7 +490,7 @@ public class KafkaProducerTest {
         // Four request updates where the requested partition is out of range, at which point the timeout expires
         // and a TimeoutException is thrown
         Future future = producer.send(record);
-        verify(metadata, times(4)).requestUpdate();
+        verify(metadata, times(4)).requestUpdateForTopic(topic);
         verify(metadata, times(4)).awaitUpdate(anyInt(), anyLong());
         verify(metadata, times(5)).fetch();
         try {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -125,12 +125,13 @@ public class SenderTest {
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
     private static final long RETRY_BACKOFF_MS = 50;
+    private static final long TOPIC_IDLE_MS = 60 * 1000;
 
     private TopicPartition tp0 = new TopicPartition("test", 0);
     private TopicPartition tp1 = new TopicPartition("test", 1);
     private MockTime time = new MockTime();
     private int batchSize = 16 * 1024;
-    private ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE,
+    private ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, TOPIC_IDLE_MS,
             new LogContext(), new ClusterResourceListeners(), time);
     private MockClient client = new MockClient(time, metadata);
     private ApiVersions apiVersions = new ApiVersions();
@@ -508,7 +509,7 @@ public class SenderTest {
         assertTrue("Request should be completed", future.isDone());
 
         assertTrue("Topic not retained in metadata list", metadata.containsTopic(tp0.topic()));
-        time.sleep(ProducerMetadata.TOPIC_EXPIRY_MS);
+        time.sleep(TOPIC_IDLE_MS);
         client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
         assertFalse("Unused topic has not been expired", metadata.containsTopic(tp0.topic()));
         future = appendToAccumulator(tp0);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -116,8 +116,8 @@ public class TransactionManagerTest {
     private final TopicPartition tp1 = new TopicPartition(topic, 1);
     private final LogContext logContext = new LogContext();
     private final MockTime time = new MockTime();
-    private final ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, logContext,
-            new ClusterResourceListeners(), time);
+    private final ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE,
+            logContext, new ClusterResourceListeners(), time);
     private final MockClient client = new MockClient(time, metadata);
     private final ApiVersions apiVersions = new ApiVersions();
 


### PR DESCRIPTION
Improves the producer's topic metadata fetching logic by maintaining a per-topic last refresh time, which is used to discriminate which topics' metadata should be fetched.

The improvement can be witnessed during producer startup, where many topics may be fetched serially. Previously, where N topics were being fetched serially, O(N^2) total topic metadata would be processed, whereas this improvement makes it O(N).

A simple test can show the differences fairly easily. Starting a producer on 500 existing topics with 64 partitions each, single-threaded:

Old: 1000 records sent, 32.446463 records/sec (0.00 MB/sec), 65.52 ms avg latency, 459.00 ms max latency, 23 ms 50th, 213 ms 95th, 360 ms 99th, 459 ms 99.9th.

New: 1000 records sent, 206.143063 records/sec (0.00 MB/sec), 10.55 ms avg latency, 187.00 ms max latency, 7 ms 50th, 29 ms 95th, 43 ms 99th, 187 ms 99.9th.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
