### PR TITLE
KAFKA-9241: Some SASL Clients not forced to re-authenticate

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -414,8 +414,11 @@ public class SaslServerAuthenticator implements Authenticator {
     private void handleSaslToken(byte[] clientToken) throws IOException {
         if (!enableKafkaSaslAuthenticateHeaders) {
             byte[] response = saslServer.evaluateResponse(clientToken);
-            if (reauthInfo.reauthenticating() && saslServer.isComplete())
-                reauthInfo.ensurePrincipalUnchanged(principal());
+            if (saslServer.isComplete()) {
+                reauthInfo.calcCompletionTimesAndReturnSessionLifetimeMs();
+                if (reauthInfo.reauthenticating())
+                    reauthInfo.ensurePrincipalUnchanged(principal());
+            }
             if (response != null) {
                 netOutBuffer = new NetworkSend(connectionId, ByteBuffer.wrap(response));
                 flushNetOutBufferAndUpdateInterestOps();

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -759,15 +759,17 @@ class SocketServerTest {
       sendApiRequest(socket, saslHandshakeRequest, saslHandshakeHeader)
       receiveResponse(socket)
 
-      // now send credentials within a SaslAuthenticateRequest
+      // now send credentials
       val authBytes = "admin\u0000admin\u0000admin-secret".getBytes("UTF-8")
       if (leverageKip152SaslAuthenticateRequest) {
+        // send credentials within a SaslAuthenticateRequest
         val saslAuthenticateRequest = new SaslAuthenticateRequest.Builder(new SaslAuthenticateRequestData()
           .setAuthBytes(authBytes)).build()
         val saslAuthenticateHeader = new RequestHeader(ApiKeys.SASL_AUTHENTICATE, saslAuthenticateRequest.version,
           clientId, correlationId)
         sendApiRequest(socket, saslAuthenticateRequest, saslAuthenticateHeader)
       } else {
+        // send credentials directly, without a SaslAuthenticateRequest
         sendRequest(socket, authBytes)
       }
       receiveResponse(socket)


### PR DESCRIPTION
Brokers are supposed to force SASL clients to re-authenticate (and kill
such connections in the absence of a timely and successful
re-authentication) when KIP-368 SASL Re-Authentication is enabled via
a positive connections.max.reauth.ms configuration value. There was a
flaw in the logic that caused connections to not be killed in the
absence of a timely and successful re-authentication if the client did
not leverage the SaslAuthenticateRequest API (which was defined in
KIP-152).