### PR TITLE
MINOR: Increase the timeout in one of Connect's distributed system tests

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -314,7 +314,7 @@ class ConnectDistributedTest(Test):
         if connect_protocol == 'compatible':
             timeout_sec = 120
         else:
-            timeout_sec = 30
+            timeout_sec = 70
 
         # we should still be paused after restarting
         for node in self.cc.nodes:


### PR DESCRIPTION
System test fails sometimes because Connect restarts around 30 seconds, so increasing timeout to 70 seconds (similar to other tests in same class).

Can be backported to `2.4`, `2.3`; see #7790 for similar change for `2.2` and `2.1`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
