### PR TITLE
MINOR: Increase the timeout in one of Connect's distributed system tests

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -302,7 +302,7 @@ class ConnectDistributedTest(Test):
 
         # we should still be paused after restarting
         for node in self.cc.nodes:
-            wait_until(lambda: self.is_paused(self.source, node), timeout_sec=30,
+            wait_until(lambda: self.is_paused(self.source, node), timeout_sec=70,
                        err_msg="Failed to see connector startup in PAUSED state")
 
     @cluster(num_nodes=5)


### PR DESCRIPTION
System test fails sometimes because Connect restarts around 30 seconds, so increasing timeout to 70 seconds (similar to other tests in same class).

Can be backported to `2.1`; see #7789 for similar fix on `trunk`, `2.4`, and `2.3`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
