### PR TITLE
KAFKA-9287; Fix unneeded delay before failing pending transaction commit

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -770,10 +770,8 @@ public final class RecordAccumulator {
 
     /**
      * Abort any batches which have not been drained
-     * @return if one or more batches were aborted
      */
-    boolean abortUndrainedBatches(RuntimeException reason) {
-        boolean abortedSomeBatches = false;
+    void abortUndrainedBatches(RuntimeException reason) {
         for (ProducerBatch batch : incomplete.copyAll()) {
             Deque<ProducerBatch> dq = getDeque(batch.topicPartition);
             boolean aborted = false;
@@ -787,10 +785,8 @@ public final class RecordAccumulator {
             if (aborted) {
                 batch.abort(reason);
                 deallocate(batch);
-                abortedSomeBatches = true;
             }
         }
-        return abortedSomeBatches;
     }
 
     public void mutePartition(TopicPartition tp) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -770,8 +770,10 @@ public final class RecordAccumulator {
 
     /**
      * Abort any batches which have not been drained
+     * @return if one or more batches were aborted
      */
-    void abortUndrainedBatches(RuntimeException reason) {
+    boolean abortUndrainedBatches(RuntimeException reason) {
+        boolean abortedSomeBatches = false;
         for (ProducerBatch batch : incomplete.copyAll()) {
             Deque<ProducerBatch> dq = getDeque(batch.topicPartition);
             boolean aborted = false;
@@ -785,8 +787,10 @@ public final class RecordAccumulator {
             if (aborted) {
                 batch.abort(reason);
                 deallocate(batch);
+                abortedSomeBatches = true;
             }
         }
+        return abortedSomeBatches;
     }
 
     public void mutePartition(TopicPartition tp) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -321,10 +321,6 @@ public class Sender implements Runnable {
                         maybeAbortBatches(lastError);
                     client.poll(retryBackoffMs, time.milliseconds());
                     return;
-                } else if (transactionManager.hasAbortableError()) {
-                    if (accumulator.abortUndrainedBatches(transactionManager.lastError())) {
-                        return;
-                    }
                 }
             } catch (AuthenticationException e) {
                 // This is already logged as error, but propagated here to perform any clean ups.
@@ -429,15 +425,17 @@ public class Sender implements Runnable {
             return true;
         }
 
-        if (transactionManager.isCompleting() && accumulator.hasIncomplete()) {
-            if (transactionManager.isAborting())
+        if (transactionManager.hasAbortableError() || transactionManager.isAborting()) {
+            if (accumulator.hasIncomplete())
                 accumulator.abortUndrainedBatches(new KafkaException("Failing batch since transaction was aborted"));
+        }
+
+        if (transactionManager.isCompleting() && !accumulator.flushInProgress()) {
             // There may still be requests left which are being retried. Since we do not know whether they had
             // been successfully appended to the broker log, we must resend them until their final status is clear.
             // If they had been appended and we did not receive the error, then our sequence number would no longer
             // be correct which would lead to an OutOfSequenceException.
-            if (!accumulator.flushInProgress())
-                accumulator.beginFlush();
+            accumulator.beginFlush();
         }
 
         TransactionManager.TxnRequestHandler nextRequestHandler = transactionManager.nextRequestHandler(accumulator.hasIncomplete());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -322,7 +322,9 @@ public class Sender implements Runnable {
                     client.poll(retryBackoffMs, time.milliseconds());
                     return;
                 } else if (transactionManager.hasAbortableError()) {
-                    accumulator.abortUndrainedBatches(transactionManager.lastError());
+                    if (accumulator.abortUndrainedBatches(transactionManager.lastError())) {
+                        return;
+                    }
                 }
             } catch (AuthenticationException e) {
                 // This is already logged as error, but propagated here to perform any clean ups.

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1239,7 +1239,6 @@ public class TransactionManagerTest {
         TopicAuthorizationException exception = (TopicAuthorizationException) transactionManager.lastError();
         assertEquals(singleton(tp0.topic()), exception.unauthorizedTopics());
         assertAbortableError(TopicAuthorizationException.class);
-
         sender.runOnce();
 
         TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
@@ -1450,10 +1449,8 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, pid, epoch);
         sender.runOnce();
         assertFutureFailed(unauthorizedTopicProduceFuture);
-
-        sender.runOnce();
-        assertNotNull(authorizedTopicProduceFuture.get());
         assertTrue(authorizedTopicProduceFuture.isDone());
+        assertNotNull(authorizedTopicProduceFuture.get());
         assertTrue(authorizedTopicProduceFuture.isDone());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1288,17 +1288,10 @@ public class TransactionManagerTest {
         // The next call aborts the records, which have not yet been sent. It should
         // not block because there are no requests pending and we still need to cancel
         // the pending transaction commit.
-        client.enableBlockingUntilWakeup(1);
-        sender.runOnce();
-        client.wakeup();
-
-        assertFalse(commitResult.isCompleted());
-        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
-        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
-
-        // The last call errors the pending commit.
         sender.runOnce();
         assertTrue(commitResult.isCompleted());
+        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
+        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
         assertTrue(commitResult.error() instanceof TopicAuthorizationException);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1457,8 +1457,10 @@ public class TransactionManagerTest {
         prepareProduceResponse(Errors.NONE, pid, epoch);
         sender.runOnce();
         assertFutureFailed(unauthorizedTopicProduceFuture);
-        assertTrue(authorizedTopicProduceFuture.isDone());
+
+        sender.runOnce();
         assertNotNull(authorizedTopicProduceFuture.get());
+        assertTrue(authorizedTopicProduceFuture.isDone());
         assertTrue(authorizedTopicProduceFuture.isDone());
 
         prepareEndTxnResponse(Errors.NONE, TransactionResult.ABORT, pid, epoch);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1204,7 +1204,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testTopicAuthorizationFailureInAddPartitions() {
+    public void testTopicAuthorizationFailureInAddPartitions() throws InterruptedException {
         final long pid = 13131L;
         final short epoch = 1;
         final TopicPartition tp0 = new TopicPartition("foo", 0);
@@ -1217,6 +1217,10 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartitionToTransaction(tp0);
         transactionManager.failIfNotReadyForSend();
         transactionManager.maybeAddPartitionToTransaction(tp1);
+
+        FutureRecordMetadata firstPartitionAppend = appendToAccumulator(tp0);
+        FutureRecordMetadata secondPartitionAppend = appendToAccumulator(tp1);
+
         Map<TopicPartition, Errors> errors = new HashMap<>();
         errors.put(tp0, Errors.TOPIC_AUTHORIZATION_FAILED);
         errors.put(tp1, Errors.OPERATION_NOT_ATTEMPTED);
@@ -1234,8 +1238,68 @@ public class TransactionManagerTest {
 
         TopicAuthorizationException exception = (TopicAuthorizationException) transactionManager.lastError();
         assertEquals(singleton(tp0.topic()), exception.unauthorizedTopics());
-
         assertAbortableError(TopicAuthorizationException.class);
+
+        sender.runOnce();
+
+        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
+        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
+    }
+
+    @Test
+    public void testCommitWithTopicAuthorizationFailureInAddPartitionsInFlight() throws InterruptedException {
+        final long pid = 13131L;
+        final short epoch = 1;
+        final TopicPartition tp0 = new TopicPartition("foo", 0);
+        final TopicPartition tp1 = new TopicPartition("bar", 0);
+
+        doInitTransactions(pid, epoch);
+
+        // Begin a transaction, send two records, and begin commit
+        transactionManager.beginTransaction();
+        transactionManager.maybeAddPartitionToTransaction(tp0);
+        transactionManager.maybeAddPartitionToTransaction(tp1);
+        FutureRecordMetadata firstPartitionAppend = appendToAccumulator(tp0);
+        FutureRecordMetadata secondPartitionAppend = appendToAccumulator(tp1);
+        TransactionalRequestResult commitResult = transactionManager.beginCommit();
+
+        // We send the AddPartitionsToTxn request in the first sender call
+        sender.runOnce();
+        assertFalse(transactionManager.hasError());
+        assertFalse(commitResult.isCompleted());
+        assertFalse(firstPartitionAppend.isDone());
+
+        // The AddPartitionsToTxn response returns in the next call with the error
+        Map<TopicPartition, Errors> errors = new HashMap<>();
+        errors.put(tp0, Errors.TOPIC_AUTHORIZATION_FAILED);
+        errors.put(tp1, Errors.OPERATION_NOT_ATTEMPTED);
+        client.respond(body -> {
+            AddPartitionsToTxnRequest request = (AddPartitionsToTxnRequest) body;
+            assertEquals(new HashSet<>(request.partitions()), new HashSet<>(errors.keySet()));
+            return true;
+        }, new AddPartitionsToTxnResponse(0, errors));
+
+        sender.runOnce();
+        assertTrue(transactionManager.hasError());
+        assertFalse(commitResult.isCompleted());
+        assertFalse(firstPartitionAppend.isDone());
+        assertFalse(secondPartitionAppend.isDone());
+
+        // The next call aborts the records, which have not yet been sent. It should
+        // not block because there are no requests pending and we still need to cancel
+        // the pending transaction commit.
+        client.enableBlockingUntilWakeup(1);
+        sender.runOnce();
+        client.wakeup();
+
+        assertFalse(commitResult.isCompleted());
+        TestUtils.assertFutureThrows(firstPartitionAppend, KafkaException.class);
+        TestUtils.assertFutureThrows(secondPartitionAppend, KafkaException.class);
+
+        // The last call errors the pending commit.
+        sender.runOnce();
+        assertTrue(commitResult.isCompleted());
+        assertTrue(commitResult.error() instanceof TopicAuthorizationException);
     }
 
     @Test


### PR DESCRIPTION
It is possible for the user to call `commitTransaction` before a pending `AddPartitionsToTxn` call has returned. If the `AddPartitionsToTxn` call returns an abortable error, we need to cancel any pending batches in the accumulator and we need to fail the pending commit. The problem in this case is that `Sender.runOnce`, after failing the batches, enters `NetworkClient.poll` before it has a chance to cancel the commit. Since there are no pending requests at this time, this will block unnecessarily and prevent completion of the doomed commit. This patch fixes the problem by returning from `runOnce` if any batches have been aborted, which allows the commit to also fail without the delay.

Note that this was the cause of the delay executing `AuthorizerIntegrationTest.testTransactionalProducerTopicAuthorizationExceptionInCommit` compared to other tests in this class. After fixing the bug, the delay is gone and the test time is similar to other test cases in the class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
