### PR TITLE
[WIP]KAFKA-8733 Initial sketch of the solution mentioned in KIP-501.

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -165,6 +165,8 @@ object Defaults {
   val InterBrokerSecurityProtocol = SecurityProtocol.PLAINTEXT.toString
   val InterBrokerProtocolVersion = ApiVersion.latestVersion.toString
 
+  val FollowerFetchReadsInSyncEnable = true
+
   /** ********* Controlled shutdown configuration ***********/
   val ControlledShutdownMaxRetries = 3
   val ControlledShutdownRetryBackoffMs = 5000
@@ -468,6 +470,9 @@ object KafkaConfig {
   val InterBrokerProtocolVersionProp = "inter.broker.protocol.version"
   val InterBrokerListenerNameProp = "inter.broker.listener.name"
   val ReplicaSelectorClassProp = "replica.selector.class"
+  // may need to find a better name
+  val FollowerFetchReadsInSyncEnableProp = "follower.fetch.reads.insync.enable"
+
   /** ********* Controlled shutdown configuration ***********/
   val ControlledShutdownMaxRetriesProp = "controlled.shutdown.max.retries"
   val ControlledShutdownRetryBackoffMsProp = "controlled.shutdown.retry.backoff.ms"
@@ -889,6 +894,7 @@ object KafkaConfig {
   val TransactionsRemoveExpiredTransactionsIntervalMsDoc = "The interval at which to remove transactions that have expired due to <code>transactional.id.expiration.ms</code> passing"
 
   /** ********* Fetch Configuration **************/
+  val FollowerFetchReadsInsyncEnableDoc = "It allows the follower to be insync if there are any pending fetch requests to be processed having offsets >= log-end-offset value at the earlier fetch request."
   val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of incremental fetch sessions that we will maintain."
   val FetchMaxBytesDoc = "The maximum number of bytes we will return for a fetch request. Must be at least 1024."
 
@@ -1146,6 +1152,7 @@ object KafkaConfig {
       .define(InterBrokerProtocolVersionProp, STRING, Defaults.InterBrokerProtocolVersion, ApiVersionValidator, MEDIUM, InterBrokerProtocolVersionDoc)
       .define(InterBrokerListenerNameProp, STRING, null, MEDIUM, InterBrokerListenerNameDoc)
       .define(ReplicaSelectorClassProp, STRING, null, MEDIUM, ReplicaSelectorClassDoc)
+      .define(FollowerFetchReadsInSyncEnableProp, BOOLEAN, Defaults.FollowerFetchReadsInSyncEnable, HIGH, FollowerFetchReadsInsyncEnableDoc)
 
       /** ********* Controlled shutdown configuration ***********/
       .define(ControlledShutdownMaxRetriesProp, INT, Defaults.ControlledShutdownMaxRetries, MEDIUM, ControlledShutdownMaxRetriesDoc)
@@ -1621,6 +1628,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val leaderImbalancePerBrokerPercentage = getInt(KafkaConfig.LeaderImbalancePerBrokerPercentageProp)
   val leaderImbalanceCheckIntervalSeconds = getLong(KafkaConfig.LeaderImbalanceCheckIntervalSecondsProp)
   def uncleanLeaderElectionEnable: java.lang.Boolean = getBoolean(KafkaConfig.UncleanLeaderElectionEnableProp)
+  val followerFetchReadsInSyncEnable = getBoolean(KafkaConfig.FollowerFetchReadsInSyncEnableProp)
 
   // We keep the user-provided String as `ApiVersion.apply` can choose a slightly different version (eg if `0.10.0`
   // is passed, `0.10.0-IV0` may be picked)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -16,11 +16,6 @@
  */
 package kafka.server
 
-import java.io.File
-import java.util.Optional
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.locks.Lock
 import com.yammer.metrics.core.Meter
 import kafka.api._
 import kafka.cluster.{BrokerEndPoint, Partition}
@@ -28,25 +23,23 @@ import kafka.common.RecordValidationException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
 import kafka.metrics.KafkaMetricsGroup
-import kafka.server.{FetchMetadata => SFetchMetadata}
 import kafka.server.HostedPartition.Online
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile, OffsetCheckpoints}
 import kafka.server.metadata.ConfigRepository
-import kafka.utils._
+import kafka.server.{FetchMetadata => SFetchMetadata}
 import kafka.utils.Implicits._
+import kafka.utils._
 import kafka.zk.KafkaZkClient
-import org.apache.kafka.common.{ElectionType, IsolationLevel, Node, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
-import org.apache.kafka.common.message.{DescribeLogDirsResponseData, DescribeProducersResponseData, FetchResponseData, LeaderAndIsrResponseData}
-import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrTopicError
-import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrPartitionError
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
+import org.apache.kafka.common.message.LeaderAndIsrResponseData.{LeaderAndIsrPartitionError, LeaderAndIsrTopicError}
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEndOffset, OffsetForLeaderTopicResult}
 import org.apache.kafka.common.message.StopReplicaRequestData.StopReplicaPartitionState
+import org.apache.kafka.common.message.{DescribeLogDirsResponseData, DescribeProducersResponseData, FetchResponseData, LeaderAndIsrResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
@@ -59,10 +52,16 @@ import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common._
 
-import scala.jdk.CollectionConverters._
+import java.io.File
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.Lock
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.compat.java8.OptionConverters._
+import scala.jdk.CollectionConverters._
 
 /*
  * Result metadata of a log append operation on the log
@@ -192,6 +191,9 @@ object HostedPartition {
   final object Offline extends HostedPartition
 }
 
+case class FollowerPendingFetchAvailabilityConfig(enable: Boolean,
+                                                  replicaLagTimeMaxMs: Long)
+
 object ReplicaManager {
   val HighWatermarkFilename = "replication-offset-checkpoint"
 }
@@ -262,6 +264,9 @@ class ReplicaManager(val config: KafkaConfig,
   protected val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
   private var logDirFailureHandler: LogDirFailureHandler = null
+
+  val followerFetchAvailabilityConfig = FollowerPendingFetchAvailabilityConfig(config.followerFetchReadsInSyncEnable,
+    config.replicaLagTimeMaxMs)
 
   private class LogDirFailureHandler(name: String, haltBrokerOnDirFailure: Boolean) extends ShutdownableThread(name) {
     override def doWork(): Unit = {
@@ -1008,6 +1013,42 @@ class ReplicaManager(val config: KafkaConfig,
     partition.legacyFetchOffsetsForTimestamp(timestamp, maxNumOffsets, isFromConsumer, fetchOnlyFromLeader)
   }
 
+  private def updateFollowerFetchRequestPreRead(replicaId: Int, fetchInfos: Seq[(TopicPartition, PartitionData)]): Unit = {
+    fetchInfos.foreach { case (topicPartition, partitionData) =>
+      onlinePartition(topicPartition) match {
+        case Some(partition) =>
+          partition.getReplica(replicaId) match {
+            case Some(replica) =>
+              replica.updateFetchStatePreRead(partitionData.fetchOffset)
+            case None =>
+              warn(s"While setting follower fetch request state before read, Replica $replicaId is not available " +
+                s"for topic partition $topicPartition and message offset ${partitionData.fetchOffset} ")
+          }
+        case None =>
+          warn(s"While setting follower fetch request state before read, the partition $topicPartition " +
+            s"hasn't been created.")
+      }
+    }
+  }
+
+  private def updateFollowerFetchRequestPostRead(replicaId: Int, fetchInfos: Seq[(TopicPartition, PartitionData)]): Unit = {
+    fetchInfos.foreach { case (topicPartition, partitionData) =>
+      onlinePartition(topicPartition) match {
+        case Some(partition) =>
+          partition.getReplica(replicaId) match {
+            case Some(replica) =>
+              replica.updatePendingFetchMessageOffsetAsProcessed(partitionData.fetchOffset)
+            case None =>
+              warn(s"While setting follower fetch request state after read, Replica $replicaId is not available " +
+                s"for topic partition $topicPartition and message offset ${partitionData.fetchOffset} ")
+          }
+        case None =>
+          warn(s"While setting follower fetch request state after read, the partition $topicPartition " +
+            s"hasn't been created.")
+      }
+    }
+  }
+
   /**
    * Fetch messages from a replica, and wait until enough data can be fetched and return;
    * the callback function will be triggered either when timeout or required fetch info is satisfied.
@@ -1035,17 +1076,29 @@ class ReplicaManager(val config: KafkaConfig,
     // Restrict fetching to leader if request is from follower or from a client with older version (no ClientMetadata)
     val fetchOnlyFromLeader = isFromFollower || (isFromConsumer && clientMetadata.isEmpty)
     def readFromLog(): Seq[(TopicPartition, LogReadResult)] = {
-      val result = readFromLocalLog(
-        replicaId = replicaId,
-        fetchOnlyFromLeader = fetchOnlyFromLeader,
-        fetchIsolation = fetchIsolation,
-        fetchMaxBytes = fetchMaxBytes,
-        hardMaxBytesLimit = hardMaxBytesLimit,
-        readPartitionInfo = fetchInfos,
-        quota = quota,
-        clientMetadata = clientMetadata)
-      if (isFromFollower) updateFollowerFetchState(replicaId, result)
-      else result
+      try {
+        // Update pending requests information before reading from the log.
+        // It is done here instead of Partition#readRecords because if it takes longer in reading any of the
+        // partition reads then we do not want any of the replicas of this fetch request go out of sync.
+        if (isFromFollower && followerFetchAvailabilityConfig.enable) updateFollowerFetchRequestPreRead(replicaId,
+          fetchInfos)
+        val result = readFromLocalLog(
+          replicaId = replicaId,
+          fetchOnlyFromLeader = fetchOnlyFromLeader,
+          fetchIsolation = fetchIsolation,
+          fetchMaxBytes = fetchMaxBytes,
+          hardMaxBytesLimit = hardMaxBytesLimit,
+          readPartitionInfo = fetchInfos,
+          quota = quota,
+          clientMetadata = clientMetadata)
+
+        if (isFromFollower) updateFollowerFetchState(replicaId, result)
+        else result
+      } finally {
+        // always clear pending request of the respective fetch offsets
+        if (isFromFollower && followerFetchAvailabilityConfig.enable) updateFollowerFetchRequestPostRead(replicaId,
+          fetchInfos)
+      }
     }
 
     val logReadResults = readFromLog()

--- a/core/src/test/scala/kafka/utils/PendingRequestsTest.scala
+++ b/core/src/test/scala/kafka/utils/PendingRequestsTest.scala
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.utils
+
+import kafka.cluster.PendingRequests
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{Assertions, Test}
+
+class PendingRequestsTest {
+
+  @Test
+  def testPendingRequestsIllegalState(): Unit = {
+    val pendingRequests = new PendingRequests
+    val fns = (1 to 16).map(_ => () => doTestPendingRequestsIllegalState(pendingRequests))
+    val x = System.currentTimeMillis()
+    TestUtils.assertConcurrent("ConcurrentPendingRequests", fns, 30000)
+    val y = System.currentTimeMillis()
+    System.out.println(s"Took ${y - x} msecs")
+  }
+
+  private def doTestPendingRequestsIllegalState(pr: PendingRequests) = {
+    val x = 10L
+    (1 to 2000000).foreach { _ =>
+      pr.add(x)
+      pr.remove(x)
+      pr.remove(x)
+      pr.add(x)
+    }
+  }
+
+  @Test
+  def testAddRemoveContains(): Unit = {
+    // This test does not check for concurrent threads but checks operations for a single thread
+    val pendingRequests = new PendingRequests
+    val x = 100L
+    assertEquals(1, pendingRequests.add(x))
+    assertEquals(2, pendingRequests.add(x))
+    assertEquals(3, pendingRequests.add(x))
+
+    Assertions.assertTrue(pendingRequests.contains(x))
+
+    Assertions.assertTrue(pendingRequests.remove(x))
+    Assertions.assertTrue(pendingRequests.contains(x))
+
+    Assertions.assertTrue(pendingRequests.remove(x))
+    Assertions.assertTrue(pendingRequests.contains(x))
+
+    Assertions.assertTrue(pendingRequests.remove(x))
+    Assertions.assertFalse(pendingRequests.contains(x))
+
+    Assertions.assertFalse(pendingRequests.remove(x))
+    Assertions.assertTrue(pendingRequests.isEmpty())
+    assertEquals(1, pendingRequests.add(x))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -88,14 +88,13 @@ class IsrExpirationTest {
     // create one partition and all replicas
     val partition0 = getPartitionWithAllReplicasInIsr(topic, 0, time, configs.head, log)
     assertEquals(configs.map(_.brokerId).toSet, partition0.inSyncReplicaIds, "All replicas should be in ISR")
-
     // let the follower catch up to the Leader logEndOffset - 1
     for (replica <- partition0.remoteReplicas)
       replica.updateFetchState(
         followerFetchOffsetMetadata = LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset, time = time)
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
 
@@ -144,7 +143,7 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = LogOffsetMetadata(leaderLogEndOffset - 2),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset, time = time)
 
     // Simulate 2 fetch requests spanning more than 100 ms which do not read to the end of the log.
     // The replicas will no longer be in ISR. We do 2 fetches because we want to simulate the case where the replica is lagging but is not stuck
@@ -158,7 +157,7 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset, time = time)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -175,7 +174,7 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset, time = time)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -193,14 +192,13 @@ class IsrExpirationTest {
     // create one partition and all replicas
     val partition0 = getPartitionWithAllReplicasInIsr(topic, 0, time, configs.head, log)
     assertEquals(configs.map(_.brokerId).toSet, partition0.inSyncReplicaIds, "All replicas should be in ISR")
-
     // let the follower catch up to the Leader logEndOffset
     for (replica <- partition0.remoteReplicas)
       replica.updateFetchState(
         followerFetchOffsetMetadata = LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset, time = time)
 
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -227,14 +225,13 @@ class IsrExpirationTest {
       addingReplicas = Seq.empty,
       removingReplicas = Seq.empty
     )
-
     // set lastCaughtUpTime to current time
     for (replica <- partition.remoteReplicas)
       replica.updateFetchState(
         followerFetchOffsetMetadata = LogOffsetMetadata(0L),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = 0L)
+        leaderEndOffset = 0L, time = time)
 
     // set the leader and its hw and the hw update time
     partition.leaderReplicaIdOpt = Some(leaderId)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -693,6 +693,7 @@ class KafkaConfigTest {
         case KafkaConfig.NumQuotaSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.QuotaWindowSizeSecondsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.DeleteTopicEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
+        case KafkaConfig.FollowerFetchReadsInSyncEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
 
         case KafkaConfig.MetricNumSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")
         case KafkaConfig.MetricSampleWindowMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -157,9 +157,9 @@ public class ReplicaFetcherThreadBenchmark {
             OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterIsrManager isrChannelManager = Mockito.mock(AlterIsrManager.class);
-            Partition partition = new Partition(tp, 100, ApiVersion$.MODULE$.latestVersion(),
+            Partition partition = new Partition(tp, 100L, ApiVersion$.MODULE$.latestVersion(),
                     0, Time.SYSTEM, isrChangeListener, new DelayedOperationsMock(tp),
-                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager);
+                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager, Partition.defaultFollowerPendingFetchAvailabilityConfig());
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId);
             pool.put(tp, partition);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -126,7 +126,7 @@ public class PartitionMakeFollowerBenchmark {
         partition = new Partition(tp, 100,
             ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
             isrChangeListener, delayedOperations,
-            Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+            Mockito.mock(MetadataCache.class), logManager, alterIsrManager, Partition.defaultFollowerPendingFetchAvailabilityConfig());
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId);
         executorService.submit((Runnable) () -> {
             SimpleRecord[] simpleRecords = new SimpleRecord[] {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -123,7 +123,7 @@ public class UpdateFollowerFetchStateBenchmark {
         partition = new Partition(topicPartition, 100,
                 ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
                 isrChangeListener, delayedOperations,
-                Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+                Mockito.mock(MetadataCache.class), logManager, alterIsrManager, Partition.defaultFollowerPendingFetchAvailabilityConfig());
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);
     }
 


### PR DESCRIPTION
Leader partition maintains follower replica state which is added with pending fetch requests that are to be processed for fetch offsets >= log-end-offset in the
earlier fetch request. Follower replica is considered to be insync if there are any such pending fetch requests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
