### PR TITLE
KAFKA-7251; Add support for TLS 1.3

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.SslAuthenticationException;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.Utils;
@@ -441,7 +442,15 @@ public class KafkaChannel implements AutoCloseable {
     }
 
     private long receive(NetworkReceive receive) throws IOException {
-        return receive.readFrom(transportLayer);
+        try {
+            return receive.readFrom(transportLayer);
+        } catch (SslAuthenticationException e) {
+            // With TLSv1.3, post-handshake messages may throw SSLExceptions, which are
+            // handled as authentication failures
+            String remoteDesc = remoteAddress != null ? remoteAddress.toString() : null;
+            state = new ChannelState(ChannelState.State.AUTHENTICATION_FAILED, e, remoteDesc);
+            throw e;
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -63,7 +63,7 @@ public class SslTransportLayer implements TransportLayer {
         HANDSHAKE,
         // SSL handshake failed, connection will be terminated
         HANDSHAKE_FAILED,
-        // SSLEngine has completed handshake, post-handshake messages may be pending for TLSv.3
+        // SSLEngine has completed handshake, post-handshake messages may be pending for TLSv1.3
         POST_HANDSHAKE,
         // SSLEngine has completed handshake, any post-handshake messages have been processed for TLSv1.3
         // For TLSv1.3, we move the channel to READY state when incoming data is processed after handshake

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -47,13 +47,28 @@ import org.slf4j.Logger;
 
 /*
  * Transport layer for SSL communication
+ *
+ *
+ * TLS v1.3 notes:
+ *   https://tools.ietf.org/html/rfc8446#section-4.6 : Post-Handshake Messages
+ *   "TLS also allows other messages to be sent after the main handshake.
+ *   These messages use a handshake content type and are encrypted under
+ *   the appropriate application traffic key."
  */
 public class SslTransportLayer implements TransportLayer {
     private enum State {
+        // Initial state
         NOT_INITALIZED,
+        // SSLEngine is in handshake mode
         HANDSHAKE,
+        // SSL handshake failed, connection will be terminated
         HANDSHAKE_FAILED,
+        // SSLEngine has completed handshake, post-handshake messages may be pending for TLSv.3
+        POST_HANDSHAKE,
+        // SSLEngine has completed handshake, any post-handshake messages have been processed for TLSv1.3
+        // For TLSv1.3, we move the channel to READY state when incoming data is processed after handshake
         READY,
+        // Channel is being closed
         CLOSING
     }
 
@@ -109,7 +124,7 @@ public class SslTransportLayer implements TransportLayer {
 
     @Override
     public boolean ready() {
-        return state == State.READY;
+        return state == State.POST_HANDSHAKE || state == State.READY;
     }
 
     /**
@@ -150,7 +165,6 @@ public class SslTransportLayer implements TransportLayer {
     public boolean isConnected() {
         return socketChannel.isConnected();
     }
-
 
     /**
     * Sends an SSL close message and closes socketChannel.
@@ -253,7 +267,7 @@ public class SslTransportLayer implements TransportLayer {
     public void handshake() throws IOException {
         if (state == State.NOT_INITALIZED)
             startHandshake();
-        if (state == State.READY)
+        if (ready())
             throw renegotiationException();
         if (state == State.CLOSING)
             throw closingException();
@@ -268,6 +282,8 @@ public class SslTransportLayer implements TransportLayer {
                 read = readFromSocketChannel();
 
             doHandshake();
+            if (ready())
+                updateBytesBuffered(true);
         } catch (SSLException e) {
             maybeProcessHandshakeFailure(e, true, null);
         } catch (IOException e) {
@@ -423,7 +439,7 @@ public class SslTransportLayer implements TransportLayer {
             if (netWriteBuffer.hasRemaining())
                 key.interestOps(key.interestOps() | SelectionKey.OP_WRITE);
             else {
-                state = State.READY;
+                state = sslEngine.getSession().getProtocol().equals("TLSv1.3") ? State.POST_HANDSHAKE : State.READY;
                 key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE);
                 SSLSession session = sslEngine.getSession();
                 log.debug("SSL handshake completed successfully with peerHost '{}' peerPort {} peerPrincipal '{}' cipherSuite '{}'",
@@ -526,7 +542,7 @@ public class SslTransportLayer implements TransportLayer {
     @Override
     public int read(ByteBuffer dst) throws IOException {
         if (state == State.CLOSING) return -1;
-        else if (state != State.READY) return 0;
+        else if (!ready()) return 0;
 
         //if we have unread decrypted data in appReadBuffer read that into dst buffer.
         int read = 0;
@@ -548,13 +564,29 @@ public class SslTransportLayer implements TransportLayer {
 
             while (netReadBuffer.position() > 0) {
                 netReadBuffer.flip();
-                SSLEngineResult unwrapResult = sslEngine.unwrap(netReadBuffer, appReadBuffer);
+                SSLEngineResult unwrapResult;
+                try {
+                    unwrapResult = sslEngine.unwrap(netReadBuffer, appReadBuffer);
+                    if (state == State.POST_HANDSHAKE && appReadBuffer.position() != 0) {
+                        // For TLSv1.3, we have finished processing post-handshake messages since we are now processing data
+                        state = State.READY;
+                    }
+                } catch (SSLException e) {
+                    // For TLSv1.3, handle SSL exceptions while processing post-handshake messages as authentication exceptions
+                    if (state == State.POST_HANDSHAKE) {
+                        state = State.HANDSHAKE_FAILED;
+                        throw new SslAuthenticationException("Failed to process post-handshake messages", e);
+                    } else
+                        throw e;
+                }
                 netReadBuffer.compact();
                 // handle ssl renegotiation.
-                if (unwrapResult.getHandshakeStatus() != HandshakeStatus.NOT_HANDSHAKING && unwrapResult.getStatus() == Status.OK) {
-                    log.trace("Renegotiation requested, but it is not supported, channelId {}, " +
-                        "appReadBuffer pos {}, netReadBuffer pos {}, netWriteBuffer pos {}", channelId,
-                        appReadBuffer.position(), netReadBuffer.position(), netWriteBuffer.position());
+                if (unwrapResult.getHandshakeStatus() != HandshakeStatus.NOT_HANDSHAKING &&
+                        unwrapResult.getHandshakeStatus() != HandshakeStatus.FINISHED &&
+                        unwrapResult.getStatus() == Status.OK) {
+                    log.error("Renegotiation requested, but it is not supported, channelId {}, " +
+                        "appReadBuffer pos {}, netReadBuffer pos {}, netWriteBuffer pos {} handshakeStatus {}", channelId,
+                        appReadBuffer.position(), netReadBuffer.position(), netWriteBuffer.position(), unwrapResult.getHandshakeStatus());
                     throw renegotiationException();
                 }
 
@@ -660,7 +692,7 @@ public class SslTransportLayer implements TransportLayer {
     public int write(ByteBuffer src) throws IOException {
         if (state == State.CLOSING)
             throw closingException();
-        if (state != State.READY)
+        if (!ready())
             return 0;
 
         int written = 0;
@@ -763,7 +795,7 @@ public class SslTransportLayer implements TransportLayer {
     public void addInterestOps(int ops) {
         if (!key.isValid())
             throw new CancelledKeyException();
-        else if (state != State.READY)
+        else if (!ready())
             throw new IllegalStateException("handshake is not completed");
 
         key.interestOps(key.interestOps() | ops);
@@ -777,7 +809,7 @@ public class SslTransportLayer implements TransportLayer {
     public void removeInterestOps(int ops) {
         if (!key.isValid())
             throw new CancelledKeyException();
-        else if (state != State.READY)
+        else if (!ready())
             throw new IllegalStateException("handshake is not completed");
 
         key.interestOps(key.interestOps() & ~ops);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -318,6 +318,8 @@ public class SslFactory implements Reconfigurable {
             while (true) {
                 switch (handshakeStatus) {
                     case NEED_WRAP:
+                        if (netBuffer.position() != 0) // Wait for peer to consume previously wrapped data
+                            return;
                         handshakeResult = sslEngine.wrap(EMPTY_BUF, netBuffer);
                         switch (handshakeResult.getStatus()) {
                             case OK: break;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -38,6 +38,7 @@ public final class Java {
 
     // Having these as static final provides the best opportunity for compilar optimization
     public static final boolean IS_JAVA9_COMPATIBLE = VERSION.isJava9Compatible();
+    public static final boolean IS_JAVA11_COMPATIBLE = VERSION.isJava11Compatible();
 
     public static boolean isIbmJdk() {
         return System.getProperty("java.vendor").contains("IBM");
@@ -62,6 +63,10 @@ public final class Java {
         // Package private for testing
         boolean isJava9Compatible() {
             return majorVersion >= 9;
+        }
+
+        boolean isJava11Compatible() {
+            return majorVersion >= 11;
         }
 
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -74,7 +74,7 @@ public class NetworkTestUtils {
         requests++;
         while (responses < messageCount) {
             selector.poll(0L);
-            assertEquals("No disconnects should have occurred.", 0, selector.disconnected().size());
+            assertEquals("No disconnects should have occurred ." + selector.disconnected(),  0, selector.disconnected().size());
 
             for (NetworkReceive receive : selector.completedReceives()) {
                 assertEquals(prefix + "-" + responses, new String(Utils.toArray(receive.payload()), StandardCharsets.UTF_8));

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -102,7 +102,8 @@ public class SslSelectorTest extends SelectorTest {
 
         Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(
                 TestKeyManagerFactory.ALGORITHM,
-                TestTrustManagerFactory.ALGORITHM
+                TestTrustManagerFactory.ALGORITHM,
+                TestSslUtils.DEFAULT_TLS_PROTOCOL_FOR_TESTS
         );
         sslServerConfigs.put(SecurityConfig.SECURITY_PROVIDERS_CONFIG, testProviderCreator.getClass().getName());
         EchoServer server = new EchoServer(SecurityProtocol.SSL, sslServerConfigs);
@@ -275,8 +276,12 @@ public class SslSelectorTest extends SelectorTest {
         selector.close();
         MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
         //the initial channel builder is for clients, we need a server one
+        String tlsProtocol = "TLSv1.2";
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
+        Map<String, Object> sslServerConfigs = new TestSslUtils.SslConfigsBuilder(Mode.SERVER)
+                .tlsProtocol(tlsProtocol)
+                .createNewTrustStore(trustStoreFile)
+                .build();
         channelBuilder = new SslChannelBuilder(Mode.SERVER, null, false);
         channelBuilder.configure(sslServerConfigs);
         selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
@@ -287,8 +292,8 @@ public class SslSelectorTest extends SelectorTest {
 
             InetSocketAddress serverAddress = (InetSocketAddress) ss.getLocalAddress();
 
-            SslSender sender1 = createSender(serverAddress, randomPayload(900));
-            SslSender sender2 = createSender(serverAddress, randomPayload(900));
+            SslSender sender1 = createSender(tlsProtocol, serverAddress, randomPayload(900));
+            SslSender sender2 = createSender(tlsProtocol, serverAddress, randomPayload(900));
             sender1.start();
             sender2.start();
 
@@ -357,8 +362,8 @@ public class SslSelectorTest extends SelectorTest {
         blockingConnect(node, serverAddr);
     }
 
-    private SslSender createSender(InetSocketAddress serverAddress, byte[] payload) {
-        return new SslSender(serverAddress, payload);
+    private SslSender createSender(String tlsProtocol, InetSocketAddress serverAddress, byte[] payload) {
+        return new SslSender(tlsProtocol, serverAddress, payload);
     }
 
     private static class TestSslChannelBuilder extends SslChannelBuilder {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSender.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSender.java
@@ -29,11 +29,13 @@ import java.util.concurrent.TimeUnit;
 
 public class SslSender extends Thread {
 
+    private final String tlsProtocol;
     private final InetSocketAddress serverAddress;
     private final byte[] payload;
     private final CountDownLatch handshaked = new CountDownLatch(1);
 
-    public SslSender(InetSocketAddress serverAddress, byte[] payload) {
+    public SslSender(String tlsProtocol, InetSocketAddress serverAddress, byte[] payload) {
+        this.tlsProtocol = tlsProtocol;
         this.serverAddress = serverAddress;
         this.payload = payload;
         setDaemon(true);
@@ -43,7 +45,7 @@ public class SslSender extends Thread {
     @Override
     public void run() {
         try {
-            SSLContext sc = SSLContext.getInstance("TLSv1.2");
+            SSLContext sc = SSLContext.getInstance(tlsProtocol);
             sc.init(null, new TrustManager[]{new NaiveTrustManager()}, new java.security.SecureRandom());
             try (SSLSocket connection = (SSLSocket) sc.getSocketFactory().createSocket(serverAddress.getAddress(), serverAddress.getPort())) {
                 OutputStream os = connection.getOutputStream();

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-import java.util.List;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
@@ -26,6 +25,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.ssl.SslFactory;
+import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -34,6 +34,8 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -46,7 +48,11 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,11 +66,13 @@ import static org.junit.Assert.fail;
 /**
  * Tests for the SSL transport layer. These use a test harness that runs a simple socket server that echos back responses.
  */
+@RunWith(value = Parameterized.class)
 public class SslTransportLayerTest {
 
     private static final int BUFFER_SIZE = 4 * 1024;
     private static Time time = Time.SYSTEM;
 
+    private final String tlsProtocol;
     private NioEchoServer server;
     private Selector selector;
     private ChannelBuilder channelBuilder;
@@ -72,14 +80,35 @@ public class SslTransportLayerTest {
     private CertStores clientCertStores;
     private Map<String, Object> sslClientConfigs;
     private Map<String, Object> sslServerConfigs;
+    private Map<String, Object> sslConfigOverrides;
+
+    @Parameterized.Parameters(name = "tlsProtocol={0}")
+    public static Collection<Object[]> data() {
+        List<Object[]> values = new ArrayList<>();
+        values.add(new Object[] {"TLSv1.2"});
+        if (Java.IS_JAVA11_COMPATIBLE) {
+            values.add(new Object[] {"TLSv1.3"});
+        }
+        return values;
+    }
+
+    public SslTransportLayerTest(String tlsProtocol) {
+        this.tlsProtocol = tlsProtocol;
+
+        sslConfigOverrides = new HashMap<>();
+        sslConfigOverrides.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
+        sslConfigOverrides.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
+    }
 
     @Before
     public void setup() throws Exception {
         // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
         serverCertStores = new CertStores(true, "server",  "localhost");
         clientCertStores = new CertStores(false, "client", "localhost");
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
+        sslServerConfigs.putAll(sslConfigOverrides);
+        sslClientConfigs.putAll(sslConfigOverrides);
         this.channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false);
         this.channelBuilder.configure(sslClientConfigs);
         this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
@@ -119,8 +148,8 @@ public class SslTransportLayerTest {
         String node = "0";
         serverCertStores = new CertStores(true, "server", InetAddress.getByName("127.0.0.1"));
         clientCertStores = new CertStores(false, "client", InetAddress.getByName("127.0.0.1"));
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
         server = createEchoServer(SecurityProtocol.SSL);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         createSelector(sslClientConfigs);
@@ -139,8 +168,8 @@ public class SslTransportLayerTest {
         String node = "0";
         serverCertStores = new CertStores(true, "localhost");
         clientCertStores = new CertStores(false, "localhost");
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
         server = createEchoServer(SecurityProtocol.SSL);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         createSelector(sslClientConfigs);
@@ -189,8 +218,8 @@ public class SslTransportLayerTest {
         // Create client certificate with an invalid hostname
         clientCertStores = new CertStores(false, "non-existent.com");
         serverCertStores = new CertStores(true, "localhost");
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
 
         // Create a server with endpoint validation enabled on the server SSL engine
         SslChannelBuilder serverChannelBuilder = new TestSslChannelBuilder(Mode.SERVER) {
@@ -224,8 +253,8 @@ public class SslTransportLayerTest {
         String node = "0";
         serverCertStores = new CertStores(true, "server", "notahost");
         clientCertStores = new CertStores(false, "client", "localhost");
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         server = createEchoServer(SecurityProtocol.SSL);
         createSelector(sslClientConfigs);
@@ -244,8 +273,8 @@ public class SslTransportLayerTest {
     public void testEndpointIdentificationDisabled() throws Exception {
         serverCertStores = new CertStores(true, "server", "notahost");
         clientCertStores = new CertStores(false, "client", "localhost");
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
 
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
         server = createEchoServer(SecurityProtocol.SSL);
@@ -338,6 +367,7 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationRequiredUntrustedProvided() throws Exception {
         String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
+        sslServerConfigs.putAll(sslConfigOverrides);
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         server = createEchoServer(SecurityProtocol.SSL);
         createSelector(sslClientConfigs);
@@ -377,6 +407,7 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationDisabledUntrustedProvided() throws Exception {
         String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
+        sslServerConfigs.putAll(sslConfigOverrides);
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
         server = createEchoServer(SecurityProtocol.SSL);
         createSelector(sslClientConfigs);
@@ -543,7 +574,7 @@ public class SslTransportLayerTest {
     @Test
     public void testUnsupportedCiphers() throws Exception {
         String node = "0";
-        SSLContext context = SSLContext.getInstance("TLSv1.2");
+        SSLContext context = SSLContext.getInstance(tlsProtocol);
         context.init(null, null, null);
         String[] cipherSuites = context.getDefaultSSLParameters().getCipherSuites();
         sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[0]));
@@ -807,6 +838,7 @@ public class SslTransportLayerTest {
             KafkaChannel channel = selector.channel(node);
             if (channel != null)
                 assertTrue("Channel not ready or disconnected:" + channel.state().state(), channel.ready());
+            selector.close();
         }
         assertTrue("Too many invocations of read/write during SslTransportLayer.handshake()", done);
     }
@@ -819,6 +851,7 @@ public class SslTransportLayerTest {
     @Test
     public void testPeerNotifiedOfHandshakeFailure() throws Exception {
         sslServerConfigs = serverCertStores.getUntrustingConfig();
+        sslServerConfigs.putAll(sslConfigOverrides);
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
 
         // Test without delay and a couple of delay counts to ensure delay applies to handshake failure
@@ -963,7 +996,7 @@ public class SslTransportLayerTest {
         NetworkTestUtils.waitForChannelClose(oldClientSelector, "1", ChannelState.State.AUTHENTICATION_FAILED);
 
         // Verify that new client with new truststore can authenticate, send and receive
-        sslClientConfigs = clientCertStores.getTrustingConfig(newServerCertStores);
+        sslClientConfigs = getTrustingConfig(clientCertStores, newServerCertStores);
         Selector newClientSelector = createSelector(sslClientConfigs);
         newClientSelector.connect("2", addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(newClientSelector, "2", 100, 10);
@@ -972,7 +1005,7 @@ public class SslTransportLayerTest {
         NetworkTestUtils.checkClientConnection(oldClientSelector, oldNode, 100, 10);
 
         CertStores invalidCertStores = new CertStores(true, "server", "127.0.0.1");
-        Map<String, Object>  invalidConfigs = invalidCertStores.getTrustingConfig(clientCertStores);
+        Map<String, Object>  invalidConfigs = getTrustingConfig(invalidCertStores, clientCertStores);
         verifyInvalidReconfigure(reconfigurableBuilder, invalidConfigs, "keystore with different SubjectAltName");
 
         Map<String, Object>  missingStoreConfigs = new HashMap<>();
@@ -1011,7 +1044,7 @@ public class SslTransportLayerTest {
         NetworkTestUtils.checkClientConnection(selector, oldNode, 100, 10);
 
         CertStores newClientCertStores = new CertStores(true, "client", "localhost");
-        sslClientConfigs = newClientCertStores.getTrustingConfig(serverCertStores);
+        sslClientConfigs = getTrustingConfig(newClientCertStores, serverCertStores);
         Map<String, Object> newTruststoreConfigs = newClientCertStores.trustStoreProps();
         assertTrue("SslChannelBuilder not reconfigurable", serverChannelBuilder instanceof ListenerReconfigurable);
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
@@ -1072,7 +1105,7 @@ public class SslTransportLayerTest {
         channelBuilder.configureBufferSizes(netReadBufSize, netWriteBufSize, appBufSize);
         this.channelBuilder = channelBuilder;
         this.channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
+        this.selector = new Selector(100 * 5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
         return selector;
     }
 
@@ -1082,6 +1115,12 @@ public class SslTransportLayerTest {
 
     private NioEchoServer createEchoServer(SecurityProtocol securityProtocol) throws Exception {
         return createEchoServer(ListenerName.forSecurityProtocol(securityProtocol), securityProtocol);
+    }
+
+    private Map<String, Object> getTrustingConfig(CertStores certStores, CertStores peerCertStores) {
+        Map<String, Object> configs = certStores.getTrustingConfig(peerCertStores);
+        configs.putAll(sslConfigOverrides);
+        return configs;
     }
 
     @FunctionalInterface

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -62,15 +62,17 @@ import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Map;
 
 public class TestSslUtils {
 
     public static final String TRUST_STORE_PASSWORD = "TrustStorePassword";
+    public static final String DEFAULT_TLS_PROTOCOL_FOR_TESTS = "TLSv1.2";
 
     /**
      * Create a self-signed X.509 Certificate.
@@ -152,40 +154,15 @@ public class TestSslUtils {
         saveKeyStore(ks, filename, password);
     }
 
-    private static Map<String, Object> createSslConfig(Mode mode, File keyStoreFile, Password password, Password keyPassword,
-                                                       File trustStoreFile, Password trustStorePassword) {
+    public static Map<String, Object> createSslConfig(String keyManagerAlgorithm, String trustManagerAlgorithm, String tlsProtocol) {
         Map<String, Object> sslConfigs = new HashMap<>();
-        sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2"); // protocol to create SSLContext
-
-        if (mode == Mode.SERVER || (mode == Mode.CLIENT && keyStoreFile != null)) {
-            sslConfigs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStoreFile.getPath());
-            sslConfigs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "JKS");
-            sslConfigs.put(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG, TrustManagerFactory.getDefaultAlgorithm());
-            sslConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, password);
-            sslConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword);
-        }
-
-        sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStoreFile.getPath());
-        sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
-        sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "JKS");
-        sslConfigs.put(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, TrustManagerFactory.getDefaultAlgorithm());
-
-        List<String> enabledProtocols  = new ArrayList<>();
-        enabledProtocols.add("TLSv1.2");
-        sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
-
-        return sslConfigs;
-    }
-
-    public static Map<String, Object> createSslConfig(String keyManagerAlgorithm, String trustManagerAlgorithm) {
-        Map<String, Object> sslConfigs = new HashMap<>();
-        sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2"); // protocol to create SSLContext
+        sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol); // protocol to create SSLContext
 
         sslConfigs.put(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG, keyManagerAlgorithm);
         sslConfigs.put(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, trustManagerAlgorithm);
 
         List<String> enabledProtocols  = new ArrayList<>();
-        enabledProtocols.add("TLSv1.2");
+        enabledProtocols.add(tlsProtocol);
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
 
         return sslConfigs;
@@ -202,37 +179,19 @@ public class TestSslUtils {
         return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, cn, new CertificateBuilder());
     }
 
-    public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore,
+    public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean createTrustStore,
             Mode mode, File trustStoreFile, String certAlias, String cn, CertificateBuilder certBuilder)
             throws IOException, GeneralSecurityException {
-        Map<String, X509Certificate> certs = new HashMap<>();
-        File keyStoreFile = null;
-        Password password = mode == Mode.SERVER ? new Password("ServerPassword") : new Password("ClientPassword");
-
-        Password trustStorePassword = new Password(TRUST_STORE_PASSWORD);
-
-        if (mode == Mode.CLIENT && useClientCert) {
-            keyStoreFile = File.createTempFile("clientKS", ".jks");
-            KeyPair cKP = generateKeyPair("RSA");
-            X509Certificate cCert = certBuilder.generate("CN=" + cn + ", O=A client", cKP);
-            createKeyStore(keyStoreFile.getPath(), password, "client", cKP.getPrivate(), cCert);
-            certs.put(certAlias, cCert);
-            keyStoreFile.deleteOnExit();
-        } else if (mode == Mode.SERVER) {
-            keyStoreFile = File.createTempFile("serverKS", ".jks");
-            KeyPair sKP = generateKeyPair("RSA");
-            X509Certificate sCert = certBuilder.generate("CN=" + cn + ", O=A server", sKP);
-            createKeyStore(keyStoreFile.getPath(), password, password, "server", sKP.getPrivate(), sCert);
-            certs.put(certAlias, sCert);
-            keyStoreFile.deleteOnExit();
-        }
-
-        if (trustStore) {
-            createTrustStore(trustStoreFile.getPath(), trustStorePassword, certs);
-            trustStoreFile.deleteOnExit();
-        }
-
-        return createSslConfig(mode, keyStoreFile, password, password, trustStoreFile, trustStorePassword);
+        SslConfigsBuilder builder = new SslConfigsBuilder(mode)
+                .useClientCert(useClientCert)
+                .certAlias(certAlias)
+                .cn(cn)
+                .certBuilder(certBuilder);
+        if (createTrustStore)
+            builder = builder.createNewTrustStore(trustStoreFile);
+        else
+            builder = builder.useExistingTrustStore(trustStoreFile);
+        return builder.build();
     }
 
     public static class CertificateBuilder {
@@ -282,6 +241,123 @@ public class TestSslUtils {
             } catch (Exception e) {
                 throw new CertificateException(e);
             }
+        }
+    }
+
+    public static class SslConfigsBuilder {
+        final Mode mode;
+        String tlsProtocol;
+        boolean useClientCert;
+        boolean createTrustStore;
+        File trustStoreFile;
+        Password trustStorePassword;
+        File keyStoreFile;
+        Password keyStorePassword;
+        Password keyPassword;
+        String certAlias;
+        String cn;
+        CertificateBuilder certBuilder;
+
+        public SslConfigsBuilder(Mode mode) {
+            this.mode = mode;
+            this.tlsProtocol = DEFAULT_TLS_PROTOCOL_FOR_TESTS;
+            trustStorePassword = new Password(TRUST_STORE_PASSWORD);
+            keyStorePassword = mode == Mode.SERVER ? new Password("ServerPassword") : new Password("ClientPassword");
+            keyPassword = keyStorePassword;
+            this.certBuilder = new CertificateBuilder();
+            this.cn = "localhost";
+            this.certAlias = mode.name().toLowerCase(Locale.ROOT);
+        }
+
+        public SslConfigsBuilder tlsProtocol(String tlsProtocol) {
+            this.tlsProtocol = tlsProtocol;
+            return this;
+        }
+
+        public SslConfigsBuilder createNewTrustStore(File trustStoreFile) {
+            this.trustStoreFile = trustStoreFile;
+            this.createTrustStore = true;
+            return this;
+        }
+
+        public SslConfigsBuilder useExistingTrustStore(File trustStoreFile) {
+            this.trustStoreFile = trustStoreFile;
+            this.createTrustStore = false;
+            return this;
+        }
+
+        public SslConfigsBuilder createNewKeyStore(File keyStoreFile) {
+            this.keyStoreFile = keyStoreFile;
+            return this;
+        }
+
+        public SslConfigsBuilder useClientCert(boolean useClientCert) {
+            this.useClientCert = useClientCert;
+            return this;
+        }
+
+        public SslConfigsBuilder certAlias(String certAlias) {
+            this.certAlias = certAlias;
+            return this;
+        }
+
+        public SslConfigsBuilder cn(String cn) {
+            this.cn = cn;
+            return this;
+        }
+
+        public SslConfigsBuilder certBuilder(CertificateBuilder certBuilder) {
+            this.certBuilder = certBuilder;
+            return this;
+        }
+
+        public  Map<String, Object> build() throws IOException, GeneralSecurityException {
+            Map<String, X509Certificate> certs = new HashMap<>();
+            File keyStoreFile = null;
+
+            if (mode == Mode.CLIENT && useClientCert) {
+                keyStoreFile = File.createTempFile("clientKS", ".jks");
+                KeyPair cKP = generateKeyPair("RSA");
+                X509Certificate cCert = certBuilder.generate("CN=" + cn + ", O=A client", cKP);
+                createKeyStore(keyStoreFile.getPath(), keyStorePassword, "client", cKP.getPrivate(), cCert);
+                certs.put(certAlias, cCert);
+                keyStoreFile.deleteOnExit();
+            } else if (mode == Mode.SERVER) {
+                keyStoreFile = File.createTempFile("serverKS", ".jks");
+                KeyPair sKP = generateKeyPair("RSA");
+                X509Certificate sCert = certBuilder.generate("CN=" + cn + ", O=A server", sKP);
+                createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyStorePassword, "server", sKP.getPrivate(), sCert);
+                certs.put(certAlias, sCert);
+                keyStoreFile.deleteOnExit();
+            }
+
+            if (createTrustStore) {
+                createTrustStore(trustStoreFile.getPath(), trustStorePassword, certs);
+                trustStoreFile.deleteOnExit();
+            }
+
+            Map<String, Object> sslConfigs = new HashMap<>();
+
+            sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol); // protocol to create SSLContext
+
+            if (mode == Mode.SERVER || (mode == Mode.CLIENT && keyStoreFile != null)) {
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStoreFile.getPath());
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "JKS");
+                sslConfigs.put(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG, TrustManagerFactory.getDefaultAlgorithm());
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword);
+                sslConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword);
+            }
+
+            sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStoreFile.getPath());
+            sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword);
+            sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "JKS");
+            sslConfigs.put(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, TrustManagerFactory.getDefaultAlgorithm());
+
+            List<String> enabledProtocols  = new ArrayList<>();
+            enabledProtocols.add(tlsProtocol);
+            sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
+
+            return sslConfigs;
         }
     }
 }

--- a/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
@@ -54,19 +54,13 @@ class SslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   import kafka.api.SslEndToEndAuthorizationTest.TestPrincipalBuilder
 
   override protected def securityProtocol = SecurityProtocol.SSL
-  // Since there are other E2E tests that enable SSL, running this test with TLSv1.3 if possible
+  // Since there are other E2E tests that enable SSL, running this test with TLSv1.3 if supported
   private  val tlsProtocol = if (Java.IS_JAVA11_COMPATIBLE) "TLSv1.3" else "TLSv1.2"
 
   this.serverConfig.setProperty(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required")
   this.serverConfig.setProperty(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, classOf[TestPrincipalBuilder].getName)
   this.serverConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
   this.serverConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
-  this.consumerConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
-  this.consumerConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
-  this.producerConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
-  this.producerConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
-  this.adminClientConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
-  this.adminClientConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
   // Escaped characters in DN attribute values: from http://www.ietf.org/rfc/rfc2253.txt
   // - a space or "#" character occurring at the beginning of the string
   // - a space character occurring at the end of the string
@@ -84,7 +78,8 @@ class SslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   }
 
   override def clientSecurityProps(certAlias: String): Properties = {
-    val props = TestUtils.securityConfigs(Mode.CLIENT, securityProtocol, trustStoreFile, certAlias, clientCn, clientSaslProperties)
+    val props = TestUtils.securityConfigs(Mode.CLIENT, securityProtocol, trustStoreFile,
+      certAlias, clientCn, clientSaslProperties, tlsProtocol)
     props.remove(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG)
     props
   }

--- a/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.network.Mode
 import org.apache.kafka.common.security.auth._
+import org.apache.kafka.common.utils.Java
 import org.junit.Before
 
 object SslEndToEndAuthorizationTest {
@@ -53,9 +54,19 @@ class SslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   import kafka.api.SslEndToEndAuthorizationTest.TestPrincipalBuilder
 
   override protected def securityProtocol = SecurityProtocol.SSL
+  // Since there are other E2E tests that enable SSL, running this test with TLSv1.3 if possible
+  private  val tlsProtocol = if (Java.IS_JAVA11_COMPATIBLE) "TLSv1.3" else "TLSv1.2"
 
   this.serverConfig.setProperty(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required")
   this.serverConfig.setProperty(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, classOf[TestPrincipalBuilder].getName)
+  this.serverConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
+  this.serverConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
+  this.consumerConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
+  this.consumerConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
+  this.producerConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
+  this.producerConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
+  this.adminClientConfig.setProperty(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol)
+  this.adminClientConfig.setProperty(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, tlsProtocol)
   // Escaped characters in DN attribute values: from http://www.ietf.org/rfc/rfc2253.txt
   // - a space or "#" character occurring at the beginning of the string
   // - a space character occurring at the end of the string

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -44,6 +44,7 @@ import org.apache.kafka.common.requests.{AbstractRequest, ProduceRequest, Reques
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.utils.{LogContext, MockTime, Time}
+import org.apache.kafka.test.TestSslUtils
 import org.apache.log4j.Level
 import org.junit.Assert._
 import org.junit._
@@ -686,7 +687,7 @@ class SocketServerTest {
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), serverMetrics, Time.SYSTEM, credentialProvider)
     try {
       overrideServer.startup()
-      val sslContext = SSLContext.getInstance("TLSv1.2")
+      val sslContext = SSLContext.getInstance(TestSslUtils.DEFAULT_TLS_PROTOCOL_FOR_TESTS)
       sslContext.init(null, Array(TestUtils.trustAllCerts), new java.security.SecureRandom())
       val socketFactory = sslContext.getSocketFactory
       val sslSocket = socketFactory.createSocket("localhost",


### PR DESCRIPTION
Adds support for TLSv1.3 in SslTransportLayer. Note that TLSv1.3 is only enabled from Java 11 onwards, so we test the code only when running with Java11 and above.

Tests run on this PR:
  - SslTransportLayerTest: This covers testing of our SslTransportLayer and all tests are run with TLSv1.3 when running with Java 11. These tests are also run with TLSv1.2 for all Java versions
  - SslFactoryTest: Also run with TLSv1.3 on Java 11 onwards in addition to TLSv1.2 for all Java versions
  - SslEndToEndAuthorizationTest - Run only with TLSv1.3 on Java 11 onwards and only with TLSv1.2 on earlier Java versions. We have other versions of this test which use SSL that continue to be with TLSv1.2 on Java 11 to avoid reducing test coverage for TLSv1.2
 
Additional testing for TLSv1.3:
  - Most tests that use SSL use TestSslUtils.DEFAULT_TLS_PROTOCOL_FOR_TESTS which is set to TLSv1.2. I have run all `clients` and `core` tests with `DEFAULT_TLS_PROTOCOL_FOR_TESTS=TLSv1.3` with Java 11.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
