### PR TITLE
KAFKA-9228: Force reconfiguration of tasks if converter or Kafka client configs are changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1690,6 +1690,7 @@ project(':connect:runtime') {
     compile project(':connect:api')
     compile project(':clients')
     compile project(':tools')
+    compile project(':connect:file')
     compile project(':connect:json')
     compile project(':connect:transforms')
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -756,6 +756,7 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
+        herder.connectorClientAndConverterConfigs.put(CONN1, Collections.emptyMap());
 
         // And delete the connector
         member.wakeup();
@@ -795,6 +796,7 @@ public class DistributedHerderTest {
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
         PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
+        herder.connectorClientAndConverterConfigs.put(CONN1, Collections.emptyMap());
 
         // now handle the connector restart
         member.wakeup();
@@ -1475,6 +1477,8 @@ public class DistributedHerderTest {
         time.sleep(1000L);
         assertStatistics("leaderUrl", true, 3, 0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
 
+        herder.connectorClientAndConverterConfigs.put(CONN1, Collections.emptyMap());
+
         herder.tick();
         time.sleep(2000L);
         assertStatistics("leaderUrl", false, 3, 1, 100, 2000L);
@@ -1551,6 +1555,7 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
+        herder.connectorClientAndConverterConfigs.put(CONN1, Collections.emptyMap());
 
         // list connectors, get connector info, get connector config, get task configs
         member.wakeup();


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9228)

There's a subtle bug in the Connect framework that hasn't been a common issue due to the patterns many connector developers follow for their `Connector::taskConfigs` method (more on the cause of this is outlined in the Jira issue). It's possible that reconfiguring a connector but only altering its converters and/or Kafka clients will fail to propagate to the connector's tasks.

This change should fix that bug by caching the client and converter configs for running connectors in the herder and, if a change is detected to any of those configs, force a restart of the connector's tasks. This is done in both the standalone and distributed herder.

A unit test is added for the shared converter/client config extraction logic, and an integration test is added to confirm the fix which fails on the current `trunk` but passes on the source branch of this PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
