### PR TITLE
MINOR: flush only the evicted dirty entry

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -134,14 +134,14 @@ class NamedCache {
         }
 
         dirtyKeys.clear();
-        flush(entries);
+        applyFlushListener(entries);
         for (final Bytes key : deleted) {
             delete(key);
         }
     }
 
     // Entries should be removed from dirtyKeys before the listener is applied as it may be re-entrant
-    private void flush(final List<ThreadCache.DirtyEntry> entries) {
+    private void applyFlushListener(final List<ThreadCache.DirtyEntry> entries) {
         if (listener == null) {
             throw new IllegalArgumentException("No listener for namespace " + name + " registered with cache");
         }
@@ -237,7 +237,7 @@ class NamedCache {
         cache.remove(eldest.key);
         if (eldest.entry.isDirty()) {
             dirtyKeys.remove(eldest.key);
-            flush(Collections.singletonList(
+            applyFlushListener(Collections.singletonList(
                 new ThreadCache.DirtyEntry(eldest.key, eldest.entry.value(), eldest.entry)));
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -238,7 +238,7 @@ class NamedCache {
         if (eldest.entry.isDirty()) {
             dirtyKeys.remove(eldest.key);
             flush(Collections.singletonList(
-                new ThreadCache.DirtyEntry(eldest.key,eldest.entry.value(), eldest.entry)));
+                new ThreadCache.DirtyEntry(eldest.key, eldest.entry.value(), eldest.entry)));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -106,7 +106,8 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
     @Test
     public void shouldAvoidFlushingDeletionsWithoutDirtyKeys() {
         final int added = addItemsToCache();
-        // all dirty entries should have been flushed
+        store.flush();
+
         assertEquals(added, underlyingStore.approximateNumEntries());
         assertEquals(added, cacheFlushListener.forwarded.size());
 
@@ -158,16 +159,16 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
     @Test
     public void shouldFlushEvictedItemsIntoUnderlyingStore() {
         final int added = addItemsToCache();
-        // all dirty entries should have been flushed
-        assertEquals(added, underlyingStore.approximateNumEntries());
-        assertEquals(added, store.approximateNumEntries());
+        // only the evicted entry should have been flushed
+        assertEquals(1, underlyingStore.approximateNumEntries());
+        assertEquals(1, store.approximateNumEntries()); // this delegates to the underlying store, and not the cache
         assertNotNull(underlyingStore.get(Bytes.wrap("0".getBytes())));
     }
 
     @Test
     public void shouldForwardDirtyItemToListenerWhenEvicted() {
-        final int numRecords = addItemsToCache();
-        assertEquals(numRecords, cacheFlushListener.forwarded.size());
+        addItemsToCache();
+        assertEquals(1, cacheFlushListener.forwarded.size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -335,7 +335,7 @@ public class CachingWindowStoreTest {
     @Test
     public void shouldFlushEvictedItemsIntoUnderlyingStore() {
         final int added = addItemsToCache();
-        // all dirty entries should have been flushed
+        // only the evicted entry should have been flushed
         final KeyValueIterator<Bytes, byte[]> iter = underlying.fetch(
             Bytes.wrap("0".getBytes(StandardCharsets.UTF_8)),
             DEFAULT_TIMESTAMP,
@@ -421,9 +421,9 @@ public class CachingWindowStoreTest {
     }
 
     @Test
-    public void shouldForwardDirtyItemToListenerWhenEvicted() {
-        final int numRecords = addItemsToCache();
-        assertEquals(numRecords, cacheListener.forwarded.size());
+    public void shouldForwardDirtyEvictedItemToListenerWhenEvicted() {
+        addItemsToCache();
+        assertEquals(1, cacheListener.forwarded.size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -181,7 +181,7 @@ public class NamedCacheTest {
 
     @Test
     public void shouldRemoveDeletedValuesOnFlush() {
-        cache.setListener((dirty) -> {}); //no-op
+        cache.setListener(dirty -> { }); //no-op
         cache.put(Bytes.wrap(new byte[]{0}), new LRUCacheEntry(null, headers, true, 0, 0, 0, ""));
         cache.put(Bytes.wrap(new byte[]{1}), new LRUCacheEntry(new byte[]{20}, null, true, 0, 0, 0, ""));
         cache.flush();
@@ -197,7 +197,7 @@ public class NamedCacheTest {
         cache.put(Bytes.wrap(new byte[]{1}), clean);
         cache.put(Bytes.wrap(new byte[]{2}), clean);
         assertEquals(3 * cache.head().size(), cache.sizeInBytes());
-        cache.setListener((d) -> {
+        cache.setListener(d -> {
                 cache.put(Bytes.wrap(new byte[]{3}), clean);
                 // evict key 1
                 cache.evict();
@@ -238,7 +238,7 @@ public class NamedCacheTest {
         final LRUCacheEntry dirty = new LRUCacheEntry(new byte[]{3}, null, true, 0, 0, 0, "");
         final LRUCacheEntry clean = new LRUCacheEntry(new byte[]{3});
         final Bytes key = Bytes.wrap(new byte[] {3});
-        cache.setListener((d) -> cache.put(key, clean));
+        cache.setListener(d -> cache.put(key, clean));
         cache.put(key, dirty);
         cache.evict();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -44,7 +44,7 @@ public class ThreadCacheTest {
     private final LogContext logContext = new LogContext("testCache ");
 
     @Test
-    public void basicPutGet() throws IOException {
+    public void basicPutGet() {
         final List<KeyValue<String, String>> toInsert = Arrays.asList(
                 new KeyValue<>("K1", "V1"),
                 new KeyValue<>("K2", "V2"),
@@ -65,7 +65,7 @@ public class ThreadCacheTest {
         for (final KeyValue<String, String> kvToInsert : toInsert) {
             final Bytes key = Bytes.wrap(kvToInsert.key.getBytes());
             final LRUCacheEntry entry = cache.get(namespace, key);
-            assertEquals(entry.isDirty(), true);
+            assertTrue(entry.isDirty());
             assertEquals(new String(entry.value()), kvToInsert.value);
         }
         assertEquals(cache.gets(), 5);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
In NamedCache we currently flush _all_ dirty entries in the cache any time an eviction occurs. Since we don't batch the writes, there's not much benefit to flushing everything. Modifying this behavior to only flush the LRU entry would improve the cache in two ways

1) Makes it more effective at what it does, namely: reducing downstream traffic and writes to the underlying store
2) Helps reduce a source of overcounting with _at_least_once_. Without a cache, all records will immediately go into the changelog. If you process N records and then crash before the next commit, on recovery all N records will be loaded into the state store but the task will be resumed from the previous commit, causing these records to be processed twice/overcounted. Buffering  entries in the cache for as long as possible before the next commit means fewer records at risk of being overcounted