### PR TITLE
MINOR: add UPGRADE_FROM to 2.4 config docs

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -284,6 +284,11 @@
             <td colspan="2">Timestamp extractor class that implements the <code class="docutils literal"><span class="pre">TimestampExtractor</span></code> interface.</td>
             <td>See <a class="reference internal" href="#streams-developer-guide-timestamp-extractor"><span class="std std-ref">Timestamp Extractor</span></a></td>
           </tr>
+          <tr class="row-odd"><td>upgrade.from</td>
+            <td>Medium</td>
+            <td colspan="2">The version you are upgrading from during a rolling upgrade.</td>
+            <td>See <a class="reference internal" href="#streams-developer-guide-upgrade-from"><span class="std std-ref">Upgrade From</span></a></td>
+          </tr>
           <tr class="row-even"><td>value.serde</td>
             <td>Medium</td>
             <td colspan="2">Default serializer/deserializer class for record values, implements the <code class="docutils literal"><span class="pre">Serde</span></code> interface (see also key.serde).</td>
@@ -566,6 +571,17 @@
 </pre></div>
               </div>
             </div></blockquote>
+        </div>
+        <div class="section" id="upgrade-from">
+          <h4><a class="toc-backref" href="#id14">upgrade.from</a><a class="headerlink" href="#upgrade-from" title="Permalink to this headline"></a></h4>
+          <blockquote>
+            <div>
+              The version you are upgrading from. It is important to set this config when performing a rolling upgrade to certain versions, as described in the upgrade guide.
+              You should set this config to the appropriate version before bouncing your instances and upgrading them to the newer version. Once everyone is on the
+              newer version, you should remove this config and do a second rolling bounce. It is only necessary to set this config and follow the two-bounce upgrade path
+              when upgrading from below version 2.0, or when upgrading to 2.4+ from any version lower than 2.4.
+            </div>
+          </blockquote>
         </div>
       </div>
       <div class="section" id="kafka-consumers-and-producer-configuration-parameters">


### PR DESCRIPTION
This config is among those missing from the "Configuring a Streams Application" docs, and since it is once again required for safe upgrade in 2.4 we should really make sure it's included.

This should only be cherry-picked to 2.4 since it references the new version (2.4)

Separate PR for the 2.0 - 2.3 docs: https://github.com/apache/kafka/pull/7831