### PR TITLE
MINOR: upgrade system test should check for ISR rejoin on each roll

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -720,8 +720,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 	""" Checks for common protocol exceptions due to invalid inter broker protocol handling.
         While such errors can and should be checked in other ways, checking the logs is a worthwhile failsafe.
         """
-        return 1 == node.account.ssh("grep -e 'java.lang.IllegalArgumentException: Invalid version' -e SchemaException %s/*"
-		% KafkaService.OPERATIONAL_LOG_DEBUG_DIR, allow_fail=True)
+        for node in self.nodes:
+            exit_code = node.account.ssh("grep -e 'java.lang.IllegalArgumentException: Invalid version' -e SchemaException %s/*"
+                    % KafkaService.OPERATIONAL_LOG_DEBUG_DIR, allow_fail=True)
+            if exit_code != 1:
+                return False
+        return True
 
     def list_consumer_groups(self, node=None, command_config=None):
         """ Get list of consumer groups.

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -559,7 +559,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         cmd += "&& sleep 1 && rm -f %s" % json_file
 
         # send command
-        self.logger.info("Verifying parition reassignment...")
+        self.logger.info("Verifying partition reassignment...")
         self.logger.debug(cmd)
         output = ""
         for line in node.account.ssh_capture(cmd):
@@ -674,15 +674,15 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         """
         self.logger.debug("Querying zookeeper to find assigned replicas for topic %s and partition %d" % (topic, partition))
         zk_path = "/brokers/topics/%s" % (topic)
-        assignemnt = self.zk.query(zk_path, chroot=self.zk_chroot)
+        assignment = self.zk.query(zk_path, chroot=self.zk_chroot)
 
-        if assignemnt is None:
+        if assignment is None:
             raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
 
-        assignemnt = json.loads(assignemnt)
-        self.logger.info(assignemnt)
+        assignment = json.loads(assignment)
+        self.logger.info(assignment)
 
-        replicas = assignemnt["partitions"][str(partition)]
+        replicas = assignment["partitions"][str(partition)]
 
         self.logger.info("Assigned replicas for topic %s and partition %d is now: %s" % (topic, partition, replicas))
         return [self.get_node(replica) for replica in replicas]
@@ -715,6 +715,13 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         except:
             self.logger.debug("Data in /cluster/id znode could not be parsed. Data = %s" % cluster)
             raise
+
+    def check_protocol_errors(self, node):
+	""" Checks for common protocol exceptions due to invalid inter broker protocol handling.
+        While such errors can and should be checked in other ways, checking the logs is a worthwhile failsafe.
+        """
+        return 1 == node.account.ssh("grep -e 'java.lang.IllegalArgumentException: Invalid version' -e SchemaException %s/*"
+		% KafkaService.OPERATIONAL_LOG_DEBUG_DIR, allow_fail=True)
 
     def list_consumer_groups(self, node=None, command_config=None):
         """ Get list of consumer groups.

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -15,7 +15,7 @@
 
 from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
-
+from ducktape.utils.util import wait_until
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.kafka import config_property
@@ -32,6 +32,8 @@ class TestUpgrade(ProduceConsumeValidateTest):
 
     def setUp(self):
         self.topic = "test_topic"
+        self.partitions = 3
+        self.replication_factor = 3
         self.zk = ZookeeperService(self.test_context, num_nodes=1)
         self.zk.start()
 
@@ -39,6 +41,11 @@ class TestUpgrade(ProduceConsumeValidateTest):
         self.producer_throughput = 1000
         self.num_producers = 1
         self.num_consumers = 1
+
+    def wait_until_rejoin(self):
+        for partition in range(0, self.partitions):
+            wait_until(lambda: len(self.kafka.isr_idx_list(self.topic, partition)) == self.replication_factor, timeout_sec=60,
+                    backoff_sec=1, err_msg="Replicas did not rejoin the ISR in a reasonable amount of time")
 
     def perform_upgrade(self, from_kafka_version, to_message_format_version=None):
         self.logger.info("First pass bounce - rolling upgrade")
@@ -48,6 +55,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
             node.config[config_property.INTER_BROKER_PROTOCOL_VERSION] = from_kafka_version
             node.config[config_property.MESSAGE_FORMAT_VERSION] = from_kafka_version
             self.kafka.start_node(node)
+            self.wait_until_rejoin()
 
         self.logger.info("Second pass bounce - remove inter.broker.protocol.version config")
         for node in self.kafka.nodes:
@@ -58,6 +66,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
             else:
                 node.config[config_property.MESSAGE_FORMAT_VERSION] = to_message_format_version
             self.kafka.start_node(node)
+            self.wait_until_rejoin()
 
     @cluster(num_nodes=6)
     @parametrize(from_kafka_version=str(LATEST_2_3), to_message_format_version=None, compression_types=["none"])
@@ -114,7 +123,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
         """
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk,
                                   version=KafkaVersion(from_kafka_version),
-                                  topics={self.topic: {"partitions": 3, "replication-factor": 3,
+                                  topics={self.topic: {"partitions": self.partitions, "replication-factor": self.replication_factor,
                                                        'configs': {"min.insync.replicas": 2}}})
         self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
@@ -145,3 +154,6 @@ class TestUpgrade(ProduceConsumeValidateTest):
         cluster_id = self.kafka.cluster_id()
         assert cluster_id is not None
         assert len(cluster_id) == 22
+
+        for node in self.kafka.nodes:
+            assert self.kafka.check_protocol_errors(node)

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -123,8 +123,9 @@ class TestUpgrade(ProduceConsumeValidateTest):
         """
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk,
                                   version=KafkaVersion(from_kafka_version),
-                                  topics={self.topic: {"partitions": self.partitions, "replication-factor": self.replication_factor,
-                                                       'configs': {"min.insync.replicas": 2}}})
+                                  topics={self.topic: {"partitions": self.partitions,
+				      "replication-factor": self.replication_factor,
+				      'configs': {"min.insync.replicas": 2}}})
         self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
         self.kafka.start()

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -156,5 +156,4 @@ class TestUpgrade(ProduceConsumeValidateTest):
         assert cluster_id is not None
         assert len(cluster_id) == 22
 
-        for node in self.kafka.nodes:
-            assert self.kafka.check_protocol_errors(node)
+        assert self.kafka.check_protocol_errors(self)


### PR DESCRIPTION
The upgrade system test correctly rolls by upgrading the broker and 
leaving the IBP, and then rolling again with the latest IBP version.
Unfortunately, this is not sufficient to pick up many problems in our IBP
gating as we charge through the rolls and after the second roll all of
the brokers will rejoin the ISR and the test will be treated as a
success.

I have tested this theory by testing the upgrade test with single roll
IBP bumps. "java.lang.IllegalArgumentException: Invalid version" exceptions
were encountered on brokers, but the test still passed.

This test adds two new checks:
1. We wait for the ISR to stabilize for all partitions. This is best
practice during rolls, and is enough to tell us if a broker hasn't
rejoined after each roll.
2. We check the broker logs for some common protocol errors. This is a
fail safe as it's possible for the test to be successful even if some
protocols are incompatible and the ISR is rejoined.