### PR TITLE
MINOR: Removed accidental double negation in error message.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1620,7 +1620,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 statusBackingStore.flush();
                 log.info("Finished flushing status backing store in preparation for rebalance");
             } else {
-                log.info("Wasn't unable to resume work after last rebalance, can skip stopping connectors and tasks");
+                log.info("Wasn't able to resume work after last rebalance, can skip stopping connectors and tasks");
             }
         }
     }


### PR DESCRIPTION
I believe the error message changed in this commit is displayed when tasks or connectors are revoked while an unresolved rebalance is in progress. 
As during such a time the connectors and tasks are stopped anyway that step is skipped and this info message displayed, which in that case due to the double negation is incorrect.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
