### PR TITLE
HOTFIX: fix system test race condition

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -97,7 +97,7 @@ public class StreamsBrokerDownResilienceTest {
                 public void apply(final String key, final String value) {
                     System.out.println("received key " + key + " and value " + value);
                     messagesProcessed++;
-                    System.out.println("processed" + messagesProcessed + "messages");
+                    System.out.println("processed " + messagesProcessed + " messages");
                     System.out.flush();
                 }
             }).to(SINK_TOPIC);

--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -102,5 +102,5 @@ class BaseStreamsTest(KafkaTest):
           return int(result)
         except ValueError:
           self.logger.warn("Command failed with " + result)
-          return false
+          return False
 

--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -98,5 +98,9 @@ class BaseStreamsTest(KafkaTest):
     @staticmethod
     def verify_from_file(processor, message, file):
         result = processor.node.account.ssh_output("grep -E '%s' %s | wc -l" % (message, file), allow_fail=False)
-        return int(result)
+        try:
+          return int(result)
+        except ValueError:
+          self.logger.warn("Command failed with " + result)
+          return false
 

--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -101,6 +101,6 @@ class BaseStreamsTest(KafkaTest):
         try:
           return int(result)
         except ValueError:
-          self.logger.warn("Command failed with " + result)
-          return False
+          self.logger.warn("Command failed with ValueError: " + result)
+          return 0
 

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -28,7 +28,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
     outputTopic = "streamsResilienceSink"
     client_id = "streams-broker-resilience-verify-consumer"
     num_messages = 10000
-    message = "processed[0-9]*messages"
+    message = "processed [0-9]* messages"
     connected_message = "Discovered group coordinator"
 
     def __init__(self, test_context):


### PR DESCRIPTION
In some system tests a Streams app is started and then prints a message to stdout, which the system test waits for to confirm the node has successfully been brought up. It then greps for certain log messages in a retriable loop. 

But waiting on the Streams app to start/print to stdout does not mean the log file has been created yet, so the `grep` may return an error. Although this occurs in a retriable loop it is assumed that grep will not fail, and the result is piped to `wc` and then blindly converted to an int in the python function, which fails since the error message is a string (throws `ValueError`)

We should catch the `ValueError` and return a 0 so it can try again rather than immediately crash