### PR TITLE
KAFKA-9307: Make transaction metadata loading resilient to previous errors

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -310,7 +310,7 @@ class TransactionCoordinator(brokerId: Int,
     // The operations performed during immigration must be resilient to any previous errors we saw or partial state we
     // left off during the unloading phase. Ensure we remove all associated state for this partition before we continue
     // loading it.
-    completeEmigration(txnTopicPartitionId)
+    txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
 
     // Now load the partition.
     txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch, txnMarkerChannelManager.addTxnMarkersToSend)
@@ -318,10 +318,6 @@ class TransactionCoordinator(brokerId: Int,
 
   def handleTxnEmigration(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
     txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch)
-    completeEmigration(txnTopicPartitionId)
-  }
-
-  private def completeEmigration(txnTopicPartitionId: Int): Unit = {
     txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -307,12 +307,22 @@ class TransactionCoordinator(brokerId: Int,
   }
 
   def handleTxnImmigration(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
+    // The operations performed during immigration must be resilient to any previous errors we saw or partial state we
+    // left off during the unloading phase. Ensure we remove all associated state for this partition before we continue
+    // loading it.
+    completeEmigration(txnTopicPartitionId)
+
+    // Now load the partition.
     txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch, txnMarkerChannelManager.addTxnMarkersToSend)
   }
 
   def handleTxnEmigration(txnTopicPartitionId: Int, coordinatorEpoch: Int): Unit = {
-      txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch)
-      txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
+    txnManager.removeTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch)
+    completeEmigration(txnTopicPartitionId)
+  }
+
+  private def completeEmigration(txnTopicPartitionId: Int): Unit = {
+    txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
   }
 
   private def logInvalidStateTransitionAndReturnError(transactionalId: String,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -384,8 +384,9 @@ class TransactionStateManager(brokerId: Int,
   }
 
   /**
-   * When this broker becomes a leader for a transaction log partition, load this partition and
-   * populate the transaction metadata cache with the transactional ids.
+   * When this broker becomes a leader for a transaction log partition, load this partition and populate the transaction
+   * metadata cache with the transactional ids. This operation must be resilient to any partial state left off from
+   * the previous loading / unloading operation.
    */
   def loadTransactionsForTxnTopicPartition(partitionId: Int, coordinatorEpoch: Int, sendTxnMarkers: SendTxnMarkersCallback): Unit = {
     validateTransactionTopicPartitionCountIsStable()

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -25,8 +25,6 @@ import org.apache.kafka.common.utils.{LogContext, MockTime, ProducerIdAndEpoch}
 import org.easymock.{Capture, EasyMock, IAnswer}
 import org.junit.Assert._
 import org.junit.Test
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito._
 
 import scala.collection.mutable
 
@@ -858,34 +856,6 @@ class TransactionCoordinatorTest {
     coordinator.handleTxnEmigration(0, coordinatorEpoch)
 
     EasyMock.verify(transactionManager, transactionMarkerChannelManager)
-  }
-
-  @Test
-  def shouldRemoveTransactionsForPartitionOnImmigration(): Unit = {
-    val txnTopicPartitionId = 1
-    val transactionManager = mock(classOf[TransactionStateManager])
-    val transactionMarkerChannelManager = mock(classOf[TransactionMarkerChannelManager])
-    val coordinator = new TransactionCoordinator(brokerId,
-      new TransactionConfig(),
-      scheduler,
-      pidManager,
-      transactionManager,
-      transactionMarkerChannelManager,
-      time,
-      new LogContext)
-
-    doNothing().when(transactionMarkerChannelManager).removeMarkersForTxnTopicPartition(txnTopicPartitionId)
-    doNothing().when(transactionManager).loadTransactionsForTxnTopicPartition(ArgumentMatchers.eq(txnTopicPartitionId),
-      ArgumentMatchers.eq(coordinatorEpoch), ArgumentMatchers.any())
-
-    val inOrderVerifier = inOrder(transactionManager, transactionMarkerChannelManager)
-
-    coordinator.handleTxnImmigration(txnTopicPartitionId, coordinatorEpoch)
-
-    // first call must be to remove transaction markers, and then we start loading transactions
-    inOrderVerifier.verify(transactionMarkerChannelManager).removeMarkersForTxnTopicPartition(txnTopicPartitionId)
-    inOrderVerifier.verify(transactionManager).loadTransactionsForTxnTopicPartition(ArgumentMatchers.eq(txnTopicPartitionId),
-      ArgumentMatchers.eq(coordinatorEpoch), ArgumentMatchers.any())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -25,6 +25,8 @@ import org.apache.kafka.common.utils.{LogContext, MockTime, ProducerIdAndEpoch}
 import org.easymock.{Capture, EasyMock, IAnswer}
 import org.junit.Assert._
 import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
 
 import scala.collection.mutable
 
@@ -856,6 +858,34 @@ class TransactionCoordinatorTest {
     coordinator.handleTxnEmigration(0, coordinatorEpoch)
 
     EasyMock.verify(transactionManager, transactionMarkerChannelManager)
+  }
+
+  @Test
+  def shouldRemoveTransactionsForPartitionOnImmigration(): Unit = {
+    val txnTopicPartitionId = 1
+    val transactionManager = mock(classOf[TransactionStateManager])
+    val transactionMarkerChannelManager = mock(classOf[TransactionMarkerChannelManager])
+    val coordinator = new TransactionCoordinator(brokerId,
+      new TransactionConfig(),
+      scheduler,
+      pidManager,
+      transactionManager,
+      transactionMarkerChannelManager,
+      time,
+      new LogContext)
+
+    doNothing().when(transactionMarkerChannelManager).removeMarkersForTxnTopicPartition(txnTopicPartitionId)
+    doNothing().when(transactionManager).loadTransactionsForTxnTopicPartition(ArgumentMatchers.eq(txnTopicPartitionId),
+      ArgumentMatchers.eq(coordinatorEpoch), ArgumentMatchers.any())
+
+    val inOrderVerifier = inOrder(transactionManager, transactionMarkerChannelManager)
+
+    coordinator.handleTxnImmigration(txnTopicPartitionId, coordinatorEpoch)
+
+    // first call must be to remove transaction markers, and then we start loading transactions
+    inOrderVerifier.verify(transactionMarkerChannelManager).removeMarkersForTxnTopicPartition(txnTopicPartitionId)
+    inOrderVerifier.verify(transactionManager).loadTransactionsForTxnTopicPartition(ArgumentMatchers.eq(txnTopicPartitionId),
+      ArgumentMatchers.eq(coordinatorEpoch), ArgumentMatchers.any())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -470,7 +470,7 @@ class TransactionStateManagerTest {
   }
 
   @Test
-  def testImmigrationWithFailedEmigration(): Unit = {
+  def testSuccessfulReimmigration(): Unit = {
     txnMetadata1.state = PrepareCommit
     txnMetadata1.addPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
       new TopicPartition("topic1", 1)))
@@ -486,7 +486,7 @@ class TransactionStateManagerTest {
     assertEquals(0, transactionManager.loadingPartitions.size)
     assertEquals(0, transactionManager.leavingPartitions.size)
 
-    // simulate a failed emigration; immigrate partition at epoch 1
+    // Re-immigrate partition at epoch 1. This should be successful even though we didn't get to emigrate the partition.
     prepareTxnLog(topicPartition, 0, records)
     transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _, _) => ())
     assertEquals(0, transactionManager.loadingPartitions.size)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -38,7 +38,6 @@ import org.apache.kafka.common.utils.MockTime
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.{After, Before, Test}
 import org.easymock.{Capture, EasyMock, IAnswer}
-import org.scalatest.Assertions.assertThrows
 
 import scala.collection.Map
 import scala.collection.mutable
@@ -468,44 +467,6 @@ class TransactionStateManagerTest {
     setupAndRunTransactionalIdExpiration(Errors.NONE, PrepareCommit)
     verifyMetadataDoesExistAndIsUsable(transactionalId1)
     verifyMetadataDoesExistAndIsUsable(transactionalId2)
-  }
-
-  @Test
-  def testReloadMetadataAfterException(): Unit = {
-    txnMetadata1.state = PrepareCommit
-    txnMetadata1.addPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
-      new TopicPartition("topic1", 1)))
-
-    txnRecords += new SimpleRecord(txnMessageKeyBytes1, TransactionLog.valueToBytes(txnMetadata1.prepareNoTransit()))
-    val startOffset = 0L
-    val records = MemoryRecords.withRecords(startOffset, CompressionType.NONE, txnRecords.toArray: _*)
-
-    prepareTxnLog(topicPartition, 0, records)
-
-    // immigrate partition at epoch 0
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _, _) => ())
-    assertEquals(0, transactionManager.loadingPartitions.size)
-    assertEquals(0, transactionManager.leavingPartitions.size)
-
-    // emigrate partition; simulate ZK session timeout
-    EasyMock.reset(zkClient)
-    EasyMock.expect(zkClient.getTopicPartitionCount(TRANSACTION_STATE_TOPIC_NAME))
-      .andThrow(new RuntimeException)
-      .once()
-      .andReturn(Some(numPartitions))
-      .anyTimes()
-    EasyMock.replay(zkClient)
-
-    assertThrows[RuntimeException] {
-      transactionManager.removeTransactionsForTxnTopicPartition(partitionId, 0)
-    }
-
-    // immigrate partition at epoch 1
-    prepareTxnLog(topicPartition, 0, records)
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _, _) => ())
-    assertEquals(0, transactionManager.loadingPartitions.size)
-    assertEquals(0, transactionManager.leavingPartitions.size)
-    assertTrue(transactionManager.transactionMetadataCache.get(partitionId).isDefined)
   }
 
   private def verifyMetadataDoesExistAndIsUsable(transactionalId: String): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -469,6 +469,32 @@ class TransactionStateManagerTest {
     verifyMetadataDoesExistAndIsUsable(transactionalId2)
   }
 
+  @Test
+  def testImmigrationWithFailedEmigration(): Unit = {
+    txnMetadata1.state = PrepareCommit
+    txnMetadata1.addPartitions(Set[TopicPartition](new TopicPartition("topic1", 0),
+      new TopicPartition("topic1", 1)))
+
+    txnRecords += new SimpleRecord(txnMessageKeyBytes1, TransactionLog.valueToBytes(txnMetadata1.prepareNoTransit()))
+    val startOffset = 0L
+    val records = MemoryRecords.withRecords(startOffset, CompressionType.NONE, txnRecords.toArray: _*)
+
+    prepareTxnLog(topicPartition, 0, records)
+
+    // immigrate partition at epoch 0
+    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _, _) => ())
+    assertEquals(0, transactionManager.loadingPartitions.size)
+    assertEquals(0, transactionManager.leavingPartitions.size)
+
+    // simulate a failed emigration; immigrate partition at epoch 1
+    prepareTxnLog(topicPartition, 0, records)
+    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _, _) => ())
+    assertEquals(0, transactionManager.loadingPartitions.size)
+    assertEquals(0, transactionManager.leavingPartitions.size)
+    assertTrue(transactionManager.transactionMetadataCache.get(partitionId).isDefined)
+    assertEquals(1, transactionManager.transactionMetadataCache.get(partitionId).get.coordinatorEpoch)
+  }
+
   private def verifyMetadataDoesExistAndIsUsable(transactionalId: String): Unit = {
     transactionManager.getTransactionState(transactionalId) match {
       case Left(_) => fail("shouldn't have been any errors")


### PR DESCRIPTION
Allow transaction metadata to be reloaded, even if it already exists as of a previous epoch. This helps with cases where a previous become-follower transition failed to unload corresponding metadata.