### PR TITLE
(DO NOT MERGE) KAFKA-9284: Zookeeper TLS docs and system tests

### DIFF
--- a/bin/windows/zookeeper-shell.bat
+++ b/bin/windows/zookeeper-shell.bat
@@ -15,7 +15,7 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
 IF [%1] EQU [] (
-	echo USAGE: %0 zookeeper_host:port[/path] [args...]
+	echo USAGE: %0 zookeeper_host:port[/path] [-zk-tls-config-file file] [args...]
 	EXIT /B 1
 )
 

--- a/bin/windows/zookeeper-shell.bat
+++ b/bin/windows/zookeeper-shell.bat
@@ -19,4 +19,4 @@ IF [%1] EQU [] (
 	EXIT /B 1
 )
 
-"%~dp0kafka-run-class.bat" org.apache.zookeeper.ZooKeeperMain -server %*
+"%~dp0kafka-run-class.bat" org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server %*

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -20,4 +20,4 @@ then
 	exit 1
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMain -server "$@"
+exec $(dirname $0)/kafka-run-class.sh org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka -server "$@"

--- a/bin/zookeeper-shell.sh
+++ b/bin/zookeeper-shell.sh
@@ -16,7 +16,7 @@
 
 if [ $# -lt 1 ];
 then
-	echo "USAGE: $0 zookeeper_host:port[/path] [args...]"
+	echo "USAGE: $0 zookeeper_host:port[/path] [-zk-tls-config-file file] [args...]"
 	exit 1
 fi
 

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -50,6 +50,9 @@ public final class JaasUtils {
     }
 
     public static boolean isZkSecurityEnabled() {
+        // Technically a client must also check if TLS mutual authentication has been configured,
+        // but we will leave that up to the client code to determine since direct connectivity to ZooKeeper
+        // has been deprecated in many clients and we don't wish to re-introduce a ZooKeeper jar dependency here.
         boolean zkSaslEnabled = Boolean.parseBoolean(System.getProperty(ZK_SASL_CLIENT, DEFAULT_ZK_SASL_CLIENT));
         String zkLoginContextName = System.getProperty(ZK_LOGIN_CONTEXT_NAME_KEY, DEFAULT_ZK_LOGIN_CONTEXT_NAME);
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -555,6 +555,15 @@ public final class Utils {
      * @param filename The path of the file to read
      */
     public static Properties loadProps(String filename) throws IOException {
+        return loadProps(filename, null);
+    }
+
+    /**
+     * Read a properties file from the given path
+     * @param filename The path of the file to read
+     * @param onlyIncludeKeys When non-null, only return values associated with these keys and ignore all others
+     */
+    public static Properties loadProps(String filename, List<String> onlyIncludeKeys) throws IOException {
         Properties props = new Properties();
 
         if (filename != null) {
@@ -565,7 +574,15 @@ public final class Utils {
             System.out.println("Did not load any properties since the property file is not specified");
         }
 
-        return props;
+        if (onlyIncludeKeys == null || onlyIncludeKeys.size() == 0)
+            return props;
+        Properties requestedProps = new Properties();
+        onlyIncludeKeys.forEach(key -> {
+            String value = props.getProperty(key);
+            if (value != null)
+                requestedProps.setProperty(key, value);
+        });
+        return requestedProps;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -30,9 +30,11 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -450,6 +452,25 @@ public class UtilsTest {
         assertEquals(fileChannelContent.length(), buffer.position());
         assertTrue(buffer.hasRemaining());
         verify(channelMock, atLeastOnce()).read(any(), anyLong());
+    }
+
+    @Test
+    public void testLoadProps() throws IOException {
+        File tempFile = TestUtils.tempFile();
+        try {
+            String testContent = "a=1\nb=2\n#a comment\n\nc=3";
+            Files.write(tempFile.toPath(), testContent.getBytes());
+            Properties props = Utils.loadProps(tempFile.getPath());
+            assertEquals(3, props.size());
+            assertEquals("1", props.get("a"));
+            assertEquals("2", props.get("b"));
+            assertEquals("3", props.get("c"));
+            Properties restrictedProps = Utils.loadProps(tempFile.getPath(), Arrays.asList("b", "d"));
+            assertEquals(1, restrictedProps.size());
+            assertEquals("2", restrictedProps.get("b"));
+        } finally {
+            Files.deleteIfExists(tempFile.toPath());
+        }
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -458,16 +458,18 @@ public class UtilsTest {
     public void testLoadProps() throws IOException {
         File tempFile = TestUtils.tempFile();
         try {
-            String testContent = "a=1\nb=2\n#a comment\n\nc=3";
+            String testContent = "a=1\nb=2\n#a comment\n\nc=3\nd=";
             Files.write(tempFile.toPath(), testContent.getBytes());
             Properties props = Utils.loadProps(tempFile.getPath());
-            assertEquals(3, props.size());
+            assertEquals(4, props.size());
             assertEquals("1", props.get("a"));
             assertEquals("2", props.get("b"));
             assertEquals("3", props.get("c"));
-            Properties restrictedProps = Utils.loadProps(tempFile.getPath(), Arrays.asList("b", "d"));
-            assertEquals(1, restrictedProps.size());
+            assertEquals("", props.get("d"));
+            Properties restrictedProps = Utils.loadProps(tempFile.getPath(), Arrays.asList("b", "d", "e"));
+            assertEquals(2, restrictedProps.size());
             assertEquals("2", restrictedProps.get("b"));
+            assertEquals("", restrictedProps.get("d"));
         } finally {
             Files.deleteIfExists(tempFile.toPath());
         }

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -292,15 +292,27 @@ object AclCommand extends Logging {
   class JAuthorizerService(val authorizerClass: Class[_ <: JAuthorizer], val opts: AclCommandOptions) extends AclCommandService with Logging {
 
     private def withAuthorizer()(f: JAuthorizer => Unit): Unit = {
+      // It is possible that zookeeper.set.acl could be true without SASL if mutual certificate authentication is configured.
+      // We will default the value of zookeeper.set.acl to true or false based on whether SASL is configured,
+      // but if SASL is not configured and zookeeper.set.acl is supposed to be true due to mutual certificate authentication
+      // then it will be up to the user to explicitly specify zookeeper.set.acl=true in the authorizer-properties.
       val defaultProps = Map(KafkaConfig.ZkEnableSecureAclsProp -> JaasUtils.isZkSecurityEnabled)
-      val authorizerProperties =
+      val authorizerPropertiesWithoutTls =
         if (opts.options.has(opts.authorizerPropertiesOpt)) {
           val authorizerProperties = opts.options.valuesOf(opts.authorizerPropertiesOpt).asScala
           defaultProps ++ CommandLineUtils.parseKeyValueArgs(authorizerProperties, acceptMissingValue = false).asScala
         } else {
           defaultProps
         }
-
+    val authorizerProperties =
+      if (opts.options.has(opts.zkTlsConfigFile)) {
+        // load in TLS configs both with and without the "authorizer." prefix
+        // Tested via System Test kafkatest.tests.core.zookeeper_tls_test.ZookeeperTlsTest.test_zk_tls
+        val validKeys = (KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList ++ KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.map("authorizer." + _).toList).asJava
+        authorizerPropertiesWithoutTls ++ Utils.loadProps(opts.options.valueOf(opts.zkTlsConfigFile), validKeys).asInstanceOf[java.util.Map[String, Any]].asScala
+      }
+      else
+        authorizerPropertiesWithoutTls
       val authZ = Utils.newInstance(authorizerClass)
       try {
         authZ.configure(authorizerProperties.asJava)
@@ -689,6 +701,11 @@ object AclCommand extends Logging {
       "This will generate ACLs that allows READ,DESCRIBE on topic and READ on group.")
 
     val forceOpt = parser.accepts("force", "Assume Yes to all queries and do not prompt.")
+
+    val zkTlsConfigFile = parser.accepts("zk-tls-config-file",
+      "Identifies the file where ZooKeeper client TLS connectivity properties for the authorizer are defined.  Any properties other than the following (with or without an \"authorizer.\" prefix) are ignored: " +
+        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.sorted.mkString(", "))
+      .withOptionalArg().describedAs("Authorizer ZooKeeper TLS configuration").ofType(classOf[String])
 
     options = parser.parse(args: _*)
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -102,7 +102,7 @@ object ConfigCommand extends Config {
 
   private def processCommandWithZk(zkConnectString: String, opts: ConfigCommandOptions): Unit = {
     val zkClient = KafkaZkClient(zkConnectString, JaasUtils.isZkSecurityEnabled, 30000, 30000,
-      Int.MaxValue, Time.SYSTEM)
+      Int.MaxValue, Time.SYSTEM, zkClientConfig = ZkSecurityMigrator.createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile))
     val adminZkClient = new AdminZkClient(zkClient)
     try {
       if (opts.options.has(opts.alterOpt))
@@ -585,6 +585,11 @@ object ConfigCommand extends Config {
     val brokerLogger = parser.accepts("broker-logger", "The broker's ID for its logger config.")
       .withRequiredArg
       .ofType(classOf[String])
+    // Tested via System Test kafkatest.tests.core.zookeeper_tls_test.ZookeeperTlsTest.test_zk_tls
+    val zkTlsConfigFile = parser.accepts("zk-tls-config-file",
+      "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
+        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.sorted.mkString(", ") + " are ignored.")
+      .withOptionalArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
 
     private val entityFlags = List((topic, ConfigType.Topic),

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -102,7 +102,7 @@ object ConfigCommand extends Config {
 
   private def processCommandWithZk(zkConnectString: String, opts: ConfigCommandOptions): Unit = {
     val zkClient = KafkaZkClient(zkConnectString, JaasUtils.isZkSecurityEnabled, 30000, 30000,
-      Int.MaxValue, Time.SYSTEM, zkClientConfig = ZkSecurityMigrator.createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile))
+      Int.MaxValue, Time.SYSTEM)
     val adminZkClient = new AdminZkClient(zkClient)
     try {
       if (opts.options.has(opts.alterOpt))
@@ -585,10 +585,6 @@ object ConfigCommand extends Config {
     val brokerLogger = parser.accepts("broker-logger", "The broker's ID for its logger config.")
       .withRequiredArg
       .ofType(classOf[String])
-    val zkTlsConfigFile = parser.accepts("zk-tls-config-file",
-      "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZkSslProps.mkString(", ") + " are ignored.")
-      .withOptionalArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
 
     private val entityFlags = List((topic, ConfigType.Topic),

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -102,7 +102,7 @@ object ConfigCommand extends Config {
 
   private def processCommandWithZk(zkConnectString: String, opts: ConfigCommandOptions): Unit = {
     val zkClient = KafkaZkClient(zkConnectString, JaasUtils.isZkSecurityEnabled, 30000, 30000,
-      Int.MaxValue, Time.SYSTEM)
+      Int.MaxValue, Time.SYSTEM, zkClientConfig = ZkSecurityMigrator.createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile))
     val adminZkClient = new AdminZkClient(zkClient)
     try {
       if (opts.options.has(opts.alterOpt))
@@ -585,6 +585,10 @@ object ConfigCommand extends Config {
     val brokerLogger = parser.accepts("broker-logger", "The broker's ID for its logger config.")
       .withRequiredArg
       .ofType(classOf[String])
+    val zkTlsConfigFile = parser.accepts("zk-tls-config-file",
+      "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
+        KafkaConfig.ZkSslProps.mkString(", ") + " are ignored.")
+      .withOptionalArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
 
     private val entityFlags = List((topic, ConfigType.Topic),

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.ExecutionException
 import kafka.common.AdminCommandFailedException
 import kafka.log.LogConfig
 import kafka.log.LogConfig._
-import kafka.server.{ConfigType, DynamicConfig, KafkaConfig}
+import kafka.server.{ConfigType, DynamicConfig}
 import kafka.utils._
 import kafka.utils.json.JsonValue
 import kafka.zk.{AdminZkClient, KafkaZkClient}
@@ -52,8 +52,7 @@ object ReassignPartitionsCommand extends Logging {
     val opts = validateAndParseArgs(args)
     val zkConnect = opts.options.valueOf(opts.zkConnectOpt)
     val time = Time.SYSTEM
-    val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 30000, 30000, Int.MaxValue, time,
-      zkClientConfig = ZkSecurityMigrator.createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile))
+    val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 30000, 30000, Int.MaxValue, time)
 
     val adminClientOpt = createAdminClient(opts)
 
@@ -498,10 +497,6 @@ object ReassignPartitionsCommand extends Logging {
                       .describedAs("timeout")
                       .ofType(classOf[Long])
                       .defaultsTo(10000)
-    val zkTlsConfigFile = parser.accepts("zk-tls-config-file",
-      "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZkSslProps.mkString(", ") + " are ignored.")
-      .withOptionalArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
   }
 }

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -140,7 +140,7 @@ object ZkSecurityMigrator extends Logging {
     zkClientConfig
   }
 
-  private def createZkClientConfigFromOption(options: OptionSet, option: ArgumentAcceptingOptionSpec[String]) : Option[ZKClientConfig] =
+  private[admin] def createZkClientConfigFromOption(options: OptionSet, option: ArgumentAcceptingOptionSpec[String]) : Option[ZKClientConfig] =
     if (!options.has(option))
       None
     else

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -75,15 +75,15 @@ object ZkSecurityMigrator extends Logging {
     // Instantiate the client config we will use so that we take into account config provided via the CLI option
     // and system properties passed via -D parameters if no CLI option is given.
     val zkClientConfig = createZkClientConfigFromOption(opts.options, opts.zkTlsConfigFile).getOrElse(new ZKClientConfig())
-    // For TLS client authentication to be enabled the client must (at a minimum) configure itself as being secure
+    // For TLS client authentication to be enabled the client must (at a minimum) configure itself as using TLS
     // with both a client connection socket and a key store location explicitly set.
-    val tlsClientAuthEnabled = zkClientConfig.getBoolean(KafkaConfig.ZkClientSecureProp) &&
-      zkClientConfig.getProperty(KafkaConfig.ZkClientCnxnSocketProp) != null &&
-      zkClientConfig.getProperty(KafkaConfig.ZkSslKeyStoreLocationProp) != null
+    val tlsClientAuthEnabled = KafkaConfig.getZooKeeperClientProperty(zkClientConfig, KafkaConfig.ZkSslClientEnableProp).getOrElse("false") == "true" &&
+      KafkaConfig.getZooKeeperClientProperty(zkClientConfig, KafkaConfig.ZkClientCnxnSocketProp).isDefined &&
+      KafkaConfig.getZooKeeperClientProperty(zkClientConfig, KafkaConfig.ZkSslKeyStoreLocationProp).isDefined
     if (jaasFile == null && !tlsClientAuthEnabled) {
       val errorMsg = "No JAAS configuration file and has been specified and no TLS client certificate has been specified. Please make sure that you have set " +
         "the system property %s or provide a ZooKeeper client TLS configuration via --%s <filename> identifying at least %s, %s, and %s".format(JaasUtils.JAVA_LOGIN_CONFIG_PARAM,
-          tlsConfigFileOption, KafkaConfig.ZkClientSecureProp, KafkaConfig.ZkClientCnxnSocketProp, KafkaConfig.ZkSslKeyStoreLocationProp)
+          tlsConfigFileOption, KafkaConfig.ZkSslClientEnableProp, KafkaConfig.ZkClientCnxnSocketProp, KafkaConfig.ZkSslKeyStoreLocationProp)
       System.out.println("ERROR: %s".format(errorMsg))
       throw new IllegalArgumentException("Incorrect configuration")
     }
@@ -127,7 +127,7 @@ object ZkSecurityMigrator extends Logging {
   }
 
   def createZkClientConfigFromFile(filename: String) : ZKClientConfig = {
-    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.ZkSslProps.asJava)
+    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.asJava)
     val zkClientConfig = new ZKClientConfig() // Initializes based on any system properties that have been set
     // Now override any set system properties with explicitly-provided values from the config file
     // Emit INFO logs due to camel-case property names encouraging mistakes -- help people see mistakes they make
@@ -135,7 +135,7 @@ object ZkSecurityMigrator extends Logging {
     zkTlsConfigFileProps.entrySet().asScala.foreach(entry => {
       val key = entry.getKey.toString
       info(s"Setting $key")
-      zkClientConfig.setProperty(key, entry.getValue.toString)
+      KafkaConfig.setZooKeeperClientProperty(zkClientConfig, key, entry.getValue.toString)
     })
     zkClientConfig
   }
@@ -160,7 +160,7 @@ object ZkSecurityMigrator extends Logging {
       "before migration. If not, exit the command.")
     val zkTlsConfigFile = parser.accepts(tlsConfigFileOption,
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZkSslProps.mkString(", ") + " are ignored.")
+        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.mkString(", ") + " are ignored.")
       .withOptionalArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
   }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -50,6 +50,11 @@ object Defaults {
   val ZkSyncTimeMs = 2000
   val ZkEnableSecureAcls = false
   val ZkMaxInFlightRequests = 10
+  val ZkClientSecure = false
+  val ZkSslProtocol = "TLSv1.2"
+  val ZkSslHostnameVerificationEnable = true
+  val ZkSslCrlEnable = false
+  val ZkSslOcspEnable = false
 
   /** ********* General Configuration ***********/
   val BrokerIdGenerationEnable = true
@@ -269,6 +274,26 @@ object KafkaConfig {
   val ZkSyncTimeMsProp = "zookeeper.sync.time.ms"
   val ZkEnableSecureAclsProp = "zookeeper.set.acl"
   val ZkMaxInFlightRequestsProp = "zookeeper.max.in.flight.requests"
+  val ZkClientSecureProp = "zookeeper.client.secure"
+  val ZkClientCnxnSocketProp = "zookeeper.clientCnxnSocket"
+  val ZkSslKeyStoreLocationProp = "zookeeper.ssl.keyStore.location"
+  val ZkSslKeyStorePasswordProp = "zookeeper.ssl.keyStore.password"
+  val ZkSslKeyStoreTypeProp = "zookeeper.ssl.keyStore.type"
+  val ZkSslTrustStoreLocationProp = "zookeeper.ssl.trustStore.location"
+  val ZkSslTrustStorePasswordProp = "zookeeper.ssl.trustStore.password"
+  val ZkSslTrustStoreTypeProp = "zookeeper.ssl.trustStore.type"
+  val ZkSslProtocolProp = "zookeeper.ssl.protocol"
+  val ZkSslEnabledProtocolsProp = "zookeeper.ssl.enabledProtocols"
+  val ZkSslCipherSuitesProp = "zookeeper.ssl.ciphersuites"
+  val ZkSslContextSupplierClassProp = "zookeeper.ssl.context.supplier.class"
+  val ZkSslHostnameVerificationEnableProp = "zookeeper.ssl.hostnameVerification"
+  val ZkSslCrlEnableProp = "zookeeper.ssl.crl"
+  val ZkSslOcspEnableProp = "zookeeper.ssl.ocsp"
+
+  private[kafka] val ZkSslProps = List(ZkClientSecureProp, ZkClientCnxnSocketProp, ZkSslKeyStoreLocationProp,
+    ZkSslKeyStorePasswordProp, ZkSslKeyStoreTypeProp, ZkSslTrustStoreLocationProp, ZkSslTrustStorePasswordProp,
+    ZkSslTrustStoreTypeProp, ZkSslProtocolProp, ZkSslEnabledProtocolsProp, ZkSslCipherSuitesProp,
+    ZkSslContextSupplierClassProp, ZkSslHostnameVerificationEnableProp, ZkSslCrlEnableProp, ZkSslOcspEnableProp)
   /** ********* General Configuration ***********/
   val BrokerIdGenerationEnableProp = "broker.id.generation.enable"
   val MaxReservedBrokerIdProp = "reserved.broker.max.id"
@@ -503,6 +528,28 @@ object KafkaConfig {
   val ZkSyncTimeMsDoc = "How far a ZK follower can be behind a ZK leader"
   val ZkEnableSecureAclsDoc = "Set client to use secure ACLs"
   val ZkMaxInFlightRequestsDoc = "The maximum number of unacknowledged requests the client will send to Zookeeper before blocking."
+  val ZkClientSecureDoc = "Set client to use TLS when connecting to ZooKeeper. When true, <code>" +
+    ZkClientCnxnSocketProp + "</code> must be set (typically to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code>); other values to set may include " +
+    ZkSslProps.filter(x => x != ZkClientSecureProp && x != ZkClientCnxnSocketProp).mkString("<code>", "</code>, <code>", "</code>)")
+  val ZkClientCnxnSocketDoc = "Typically set to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code> when using TLS connectivity to ZooKeeper"
+  val ZkSslKeyStoreLocationDoc = "Keystore location when using a client-side certificate with TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>keyStore</code>, which differs from Kafka."
+  val ZkSslKeyStorePasswordDoc = "Keystore password when using a client-side certificate with TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>keyStore</code>, which differs from Kafka."
+  val ZkSslKeyStoreTypeDoc = "Keystore type when using a client-side certificate with TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>keyStore</code>, which differs from Kafka." +
+    " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the keystore."
+  val ZkSslTrustStoreLocationDoc = "Truststore location when using TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>trustStore</code>, which differs from Kafka."
+  val ZkSslTrustStorePasswordDoc = "Truststore password when using TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>trustStore</code>, which differs from Kafka."
+  val ZkSslTrustStoreTypeDoc = "Truststore type when using TLS connectivity to ZooKeeper.  Note ZooKeeper's use of camel-case <code>trustStore</code>, which differs from Kafka." +
+    " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the truststore."
+  val ZkSslProtocolDoc = "Specifies the protocol to be used in ZooKeeper TLS negotiation"
+  val ZkSslEnabledProtocolsDoc = "Specifies the enabled protocol(s) in ZooKeeper TLS negotiation (csv).  Note ZooKeeper's use of camel-case <code>enabledProtocols</code>, which differs from Kafka." +
+    " The default value of <code>null</code> means the enabled protocol will be the value of the <code>" +
+    ZkSslProtocolProp + "</code> configuration property."
+  val ZkSslCipherSuitesDoc = "Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv)." +
+    " The default value of <code>null</code> means the list of enabled cipher suites is determined by the Java runtime being used."
+  val ZkSslContextSupplierClassDoc = "Specifies the class to be used for creating SSL context in ZooKeeper TLS communication"
+  val ZkSslHostnameVerificationEnableDoc = "Specifies whether to enable hostname verification in the ZooKeeper TLS negotiation process. Disabling it is only recommended for testing purposes."
+  val ZkSslCrlEnableDoc = "Specifies whether to enable Certificate Revocation List in the ZooKeeper TLS protocols"
+  val ZkSslOcspEnableDoc = "Specifies whether to enable Online Certificate Status Protocol in the ZooKeeper TLS protocols"
   /** ********* General Configuration ***********/
   val BrokerIdGenerationEnableDoc = s"Enable automatic broker id generation on the server. When enabled the value configured for $MaxReservedBrokerIdProp should be reviewed."
   val MaxReservedBrokerIdDoc = "Max number that can be used for a broker.id"
@@ -865,6 +912,21 @@ object KafkaConfig {
       .define(ZkSyncTimeMsProp, INT, Defaults.ZkSyncTimeMs, LOW, ZkSyncTimeMsDoc)
       .define(ZkEnableSecureAclsProp, BOOLEAN, Defaults.ZkEnableSecureAcls, HIGH, ZkEnableSecureAclsDoc)
       .define(ZkMaxInFlightRequestsProp, INT, Defaults.ZkMaxInFlightRequests, atLeast(1), HIGH, ZkMaxInFlightRequestsDoc)
+      .define(ZkClientSecureProp, BOOLEAN, Defaults.ZkClientSecure, MEDIUM, ZkClientSecureProp)
+      .define(ZkClientCnxnSocketProp, STRING, null, MEDIUM, ZkClientCnxnSocketDoc)
+      .define(ZkSslKeyStoreLocationProp, STRING, null, MEDIUM, ZkSslKeyStoreLocationDoc)
+      .define(ZkSslKeyStorePasswordProp, PASSWORD, null, MEDIUM, ZkSslKeyStorePasswordDoc)
+      .define(ZkSslKeyStoreTypeProp, STRING, null, MEDIUM, ZkSslKeyStoreTypeDoc)
+      .define(ZkSslTrustStoreLocationProp, STRING, null, MEDIUM, ZkSslTrustStoreLocationDoc)
+      .define(ZkSslTrustStorePasswordProp, PASSWORD, null, MEDIUM, ZkSslTrustStorePasswordDoc)
+      .define(ZkSslTrustStoreTypeProp, STRING, null, MEDIUM, ZkSslTrustStoreTypeDoc)
+      .define(ZkSslProtocolProp, STRING, Defaults.ZkSslProtocol, LOW, ZkSslProtocolDoc)
+      .define(ZkSslEnabledProtocolsProp, STRING, null, LOW, ZkSslEnabledProtocolsDoc)
+      .define(ZkSslCipherSuitesProp, STRING, null, LOW, ZkSslCipherSuitesDoc)
+      .define(ZkSslContextSupplierClassProp, STRING, null, LOW, ZkSslContextSupplierClassDoc)
+      .define(ZkSslHostnameVerificationEnableProp, BOOLEAN, Defaults.ZkSslHostnameVerificationEnable, LOW, ZkSslHostnameVerificationEnableDoc)
+      .define(ZkSslCrlEnableProp, BOOLEAN, Defaults.ZkSslCrlEnable, LOW, ZkSslCrlEnableDoc)
+      .define(ZkSslOcspEnableProp, BOOLEAN, Defaults.ZkSslOcspEnable, LOW, ZkSslOcspEnableDoc)
 
       /** ********* General Configuration ***********/
       .define(BrokerIdGenerationEnableProp, BOOLEAN, Defaults.BrokerIdGenerationEnable, MEDIUM, BrokerIdGenerationEnableDoc)
@@ -1159,6 +1221,21 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val zkSyncTimeMs: Int = getInt(KafkaConfig.ZkSyncTimeMsProp)
   val zkEnableSecureAcls: Boolean = getBoolean(KafkaConfig.ZkEnableSecureAclsProp)
   val zkMaxInFlightRequests: Int = getInt(KafkaConfig.ZkMaxInFlightRequestsProp)
+  val zkClientSecure: Boolean = getBoolean(KafkaConfig.ZkClientSecureProp)
+  val zkClientCnxnSocketClassName = Option(getString(KafkaConfig.ZkClientCnxnSocketProp))
+  val zkSslKeyStoreLocation = Option(getString(KafkaConfig.ZkSslKeyStoreLocationProp))
+  val zkSslKeyStorePassword = Option(getPassword(KafkaConfig.ZkSslKeyStorePasswordProp))
+  val zkSslKeyStoreType = Option(getString(KafkaConfig.ZkSslKeyStoreTypeProp))
+  val zkSslTrustStoreLocation = Option(getString(KafkaConfig.ZkSslTrustStoreLocationProp))
+  val zkSslTrustStorePassword = Option(getPassword(KafkaConfig.ZkSslTrustStorePasswordProp))
+  val zkSslTrustStoreType = Option(getString(KafkaConfig.ZkSslTrustStoreTypeProp))
+  val ZkSslProtocol = Option(getString(KafkaConfig.ZkSslProtocolProp))
+  val ZkSslEnabledProtocols = Option(getString(KafkaConfig.ZkSslEnabledProtocolsProp))
+  val ZkSslCipherSuites = Option(getString(KafkaConfig.ZkSslCipherSuitesProp))
+  val ZkSslContextSupplierClass = Option(getString(KafkaConfig.ZkSslContextSupplierClassProp))
+  val ZkSslHostnameVerificationEnable = Option(getBoolean(KafkaConfig.ZkSslHostnameVerificationEnableProp))
+  val ZkSslCrlEnable = Option(getBoolean(KafkaConfig.ZkSslCrlEnableProp))
+  val ZkSslOcspEnable = Option(getBoolean(KafkaConfig.ZkSslOcspEnableProp))
   /** ********* General Configuration ***********/
   val brokerIdGenerationEnable: Boolean = getBoolean(KafkaConfig.BrokerIdGenerationEnableProp)
   val maxReservedBrokerId: Int = getInt(KafkaConfig.MaxReservedBrokerIdProp)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -93,6 +93,7 @@ object KafkaServer {
   }
 
   def zkClientConfigFromKafkaConfig(config: KafkaConfig) =
+    // We have to take
     if (!config.zkSslClientEnable)
       None
     else {
@@ -105,13 +106,12 @@ object KafkaServer {
       config.zkSslTrustStoreLocation.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStoreLocationProp, _))
       config.zkSslTrustStorePassword.foreach(x => KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStorePasswordProp, x.value))
       config.zkSslTrustStoreType.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStoreTypeProp, _))
-      config.ZkSslProtocol.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslProtocolProp, _))
+      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslProtocolProp, config.ZkSslProtocol)
       config.ZkSslEnabledProtocols.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslEnabledProtocolsProp, _))
       config.ZkSslCipherSuites.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslCipherSuitesProp, _))
-      config.ZkSslContextSupplierClass.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslContextSupplierClassProp, _))
-      config.ZkSslEndpointIdentificationAlgorithm.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp, _))
-      config.ZkSslCrlEnable.foreach(x => KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslCrlEnableProp, x.toString))
-      config.ZkSslOcspEnable.foreach(x => KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslOcspEnableProp, x.toString))
+      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp, config.ZkSslEndpointIdentificationAlgorithm)
+      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslCrlEnableProp, config.ZkSslCrlEnable.toString)
+      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslOcspEnableProp, config.ZkSslOcspEnable.toString)
       Some(clientConfig)
     }
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.zookeeper.KeeperException.{Code, NodeExistsException}
 import org.apache.zookeeper.OpResult.{CreateResult, ErrorResult, SetDataResult}
+import org.apache.zookeeper.client.ZKClientConfig
 import org.apache.zookeeper.data.{ACL, Stat}
 import org.apache.zookeeper.{CreateMode, KeeperException, ZooKeeper}
 import scala.collection.{Map, Seq, mutable}
@@ -1853,9 +1854,10 @@ object KafkaZkClient {
             time: Time,
             metricGroup: String = "kafka.server",
             metricType: String = "SessionExpireListener",
-            name: Option[String] = None) = {
+            name: Option[String] = None,
+            zkClientConfig: Option[ZKClientConfig] = None) = {
     val zooKeeperClient = new ZooKeeperClient(connectString, sessionTimeoutMs, connectionTimeoutMs, maxInFlightRequests,
-      time, metricGroup, metricType, name)
+      time, metricGroup, metricType, name, zkClientConfig)
     new KafkaZkClient(zooKeeperClient, isSecure, time)
   }
 

--- a/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
+++ b/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper
+
+import kafka.admin.ZkSecurityMigrator
+import org.apache.zookeeper.admin.ZooKeeperAdmin
+import org.apache.zookeeper.client.ZKClientConfig
+
+object ZooKeeperMainWithTlsSupportForKafka {
+  val zkTlsConfigFileOption = "-zk-tls-config-file"
+  def main(args: Array[String]): Unit = {
+    val zkTlsConfigFileIndex = args.indexOf(zkTlsConfigFileOption)
+    val zooKeeperMain: ZooKeeperMain =
+      if (zkTlsConfigFileIndex < 0)
+        // no TLS config, so just pass args directly
+        new ZooKeeperMainWithTlsSupportForKafka(args, None)
+      else if (zkTlsConfigFileIndex == args.length - 1)
+        throw new IllegalArgumentException(s"Error: no filename provided with option $zkTlsConfigFileOption")
+      else
+        // found TLS config, so instantiate it and pass args without the two TLS config-related arguments
+        new ZooKeeperMainWithTlsSupportForKafka(
+          args.slice(0, zkTlsConfigFileIndex) ++ args.slice(zkTlsConfigFileIndex + 2, args.length),
+          Some(ZkSecurityMigrator.createZkClientConfigFromFile(args(zkTlsConfigFileIndex + 1))))
+    // The run method of ZooKeeperMain is package-private,
+    // therefore this code unfortunately must reside in the same org.apache.zookeeper package.
+    zooKeeperMain.run
+  }
+}
+
+class ZooKeeperMainWithTlsSupportForKafka(args: Array[String], val zkClientConfig: Option[ZKClientConfig])
+  extends ZooKeeperMain(args) with Watcher {
+  override def connectToZK(newHost: String) = {
+    // ZooKeeperAdmin has no constructor that supports passing in both readOnly and ZkClientConfig,
+    // and readOnly ends up being set to false when passing in a ZkClientConfig instance;
+    // therefore it is currently not possible for us to construct a ZooKeeperAdmin instance with
+    // both an explicit ZkClientConfig instance and a readOnly value of true.
+    val readOnlyRequested = cl.getOption("readonly") != null
+    if (readOnlyRequested && zkClientConfig.isDefined)
+      throw new IllegalArgumentException(
+        s"read-only mode (-r) is not supported with an explicit TLS config (${ZooKeeperMainWithTlsSupportForKafka.zkTlsConfigFileOption})")
+    if (zk != null && zk.getState.isAlive) zk.close()
+    host = newHost
+    zk = if (zkClientConfig.isDefined)
+      new ZooKeeperAdmin(host, cl.getOption("timeout").toInt, this, zkClientConfig.get)
+    else
+      new ZooKeeperAdmin(host, cl.getOption("timeout").toInt, this, readOnlyRequested)
+  }
+
+  override def process(event: WatchedEvent): Unit = {
+    if (getPrintWatches) {
+      ZooKeeperMain.printMessage("WATCHER::")
+      ZooKeeperMain.printMessage(event.toString)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
+++ b/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
@@ -25,6 +25,10 @@ import org.apache.zookeeper.client.ZKClientConfig
 
 import scala.collection.JavaConverters._
 
+/*
+ * This code is tested via the following system test:
+ * kafkatest.tests.core.zookeeper_tls_test.ZookeeperTlsTest.test_zk_tls
+ */
 object ZooKeeperMainWithTlsSupportForKafka {
   val zkTlsConfigFileOption = "-zk-tls-config-file"
   def main(args: Array[String]): Unit = {

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -112,146 +112,352 @@ class KafkaTest {
   }
 
   @Test
-  def testZkSslClientEnableDefault(): Unit = {
+  def testZkSslClientEnable(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslClientEnableProp
+    assertEquals("zookeeper.ssl.client.enable", kafkaProp)
+    val sysProp = "zookeeper.client.secure"
     val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertFalse(config.values.get(KafkaConfig.ZkSslClientEnableProp).asInstanceOf[Boolean])
-  }
-
-  @Test
-  def testZkSslClientEnableExplicit(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
+    // first make sure there is the correct "default" value
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertFalse(emptyConfig.zkSslClientEnable) // but still has the correct "default" value
+    // next set system property alone
     val expected = true
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.client.enable=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslClientEnableProp).asInstanceOf[Boolean])
+    try {
+      System.setProperty(sysProp, s"$expected")
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(expected, config.zkSslClientEnable) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(expected, config.zkSslClientEnable)
   }
 
   @Test
   def testZkSslKeyStoreLocation(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslKeyStoreLocationProp
+    assertEquals("zookeeper.ssl.keystore.location", kafkaProp)
+    val sysProp = "zookeeper.ssl.keyStore.location"
+    val expected = "/the/location"
     val propertiesFile = prepareDefaultConfig()
-    val expected = "/keyStore/location"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keystore.location=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreLocationProp).asInstanceOf[String])
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslKeyStoreLocation) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected), config.zkSslKeyStoreLocation) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected), config.zkSslKeyStoreLocation)
   }
 
   @Test
   def testZkSslTrustStoreLocation(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslTrustStoreLocationProp
+    assertEquals("zookeeper.ssl.truststore.location", kafkaProp)
+    val sysProp = "zookeeper.ssl.trustStore.location"
+    val expected = "/the/location"
     val propertiesFile = prepareDefaultConfig()
-    val expected = "/trustStore/location"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.truststore.location=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreLocationProp).asInstanceOf[String])
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslTrustStoreLocation) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected), config.zkSslTrustStoreLocation) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected), config.zkSslTrustStoreLocation)
   }
 
   @Test
-  def testZookeeperKeyStoreTrustStorePasswords(): Unit = {
+  def testZookeeperKeyStorePassword(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslKeyStorePasswordProp
+    assertEquals("zookeeper.ssl.keystore.password", kafkaProp)
+    val sysProp = "zookeeper.ssl.keyStore.password"
+    val expected = "ThePa$$word!"
     val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "zookeeper.ssl.keystore.password=keystore_password",
-      "--override", "zookeeper.ssl.truststore.password=truststore_password")))
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslKeyStorePasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslTrustStorePasswordProp).toString)
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslKeyStorePassword) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(new Password(expected)), config.zkSslKeyStorePassword) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(new Password(expected), config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(new Password(expected)), config.zkSslKeyStorePassword)
+  }
 
-    assertEquals("keystore_password", config.getPassword(KafkaConfig.ZkSslKeyStorePasswordProp).value)
-    assertEquals("truststore_password", config.getPassword(KafkaConfig.ZkSslTrustStorePasswordProp).value)
+  @Test
+  def testZookeeperTrustStorePassword(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslTrustStorePasswordProp
+    assertEquals("zookeeper.ssl.truststore.password", kafkaProp)
+    val sysProp = "zookeeper.ssl.trustStore.password"
+    val expected = "ThePa$$word!"
+    val propertiesFile = prepareDefaultConfig()
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslTrustStorePassword) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(new Password(expected)), config.zkSslTrustStorePassword) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(new Password(expected), config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(new Password(expected)), config.zkSslTrustStorePassword)
   }
 
   @Test
   def testZkSslKeyStoreType(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
+    val kafkaProp = KafkaConfig.ZkSslKeyStoreTypeProp
+    assertEquals("zookeeper.ssl.keystore.type", kafkaProp)
+    val sysProp = "zookeeper.ssl.keyStore.type"
     val expected = "PEM"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keystore.type=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreTypeProp).asInstanceOf[String])
+    val propertiesFile = prepareDefaultConfig()
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslKeyStoreType) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected), config.zkSslKeyStoreType) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected), config.zkSslKeyStoreType)
   }
 
   @Test
   def testZkSslTrustStoreType(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
+    val kafkaProp = KafkaConfig.ZkSslTrustStoreTypeProp
+    assertEquals("zookeeper.ssl.truststore.type", kafkaProp)
+    val sysProp = "zookeeper.ssl.trustStore.type"
     val expected = "PEM"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.truststore.type=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreTypeProp).asInstanceOf[String])
+    val propertiesFile = prepareDefaultConfig()
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.zkSslTrustStoreType) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"$expected")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected), config.zkSslTrustStoreType) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected), config.zkSslTrustStoreType)
   }
 
   @Test
   def testZkSslProtocol(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslProtocolProp
+    assertEquals("zookeeper.ssl.protocol", kafkaProp)
+    val sysProp = "zookeeper.ssl.protocol"
     val propertiesFile = prepareDefaultConfig()
-    val expected = "TLSv1.3"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.protocol=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslProtocolProp).asInstanceOf[String])
-  }
-
-  @Test
-  def testZkSslProtocolDefault(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertEquals("TLSv1.2", config.values.get(KafkaConfig.ZkSslProtocolProp))
+    // first make sure there is the correct "default" value
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals("TLSv1.2", emptyConfig.ZkSslProtocol) // but still has the correct "default" value
+    // next set system property alone
+    val expected = "TheProtocol"
+    try {
+      System.setProperty(sysProp, s"$expected")
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(expected, config.ZkSslProtocol) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(expected, config.ZkSslProtocol)
   }
 
   @Test
   def testZkSslEnabledProtocols(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslEnabledProtocolsProp
+    assertEquals("zookeeper.ssl.enabled.protocols", kafkaProp)
+    val sysProp = "zookeeper.ssl.enabledProtocols"
+    val expected = List("PROTOCOL_A", "PROTOCOL_B")
     val propertiesFile = prepareDefaultConfig()
-    val expected = List("A", "B")
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.enabled.protocols=${expected.mkString(",")}")))
-    assertEquals(expected.asJava, config.values.get(KafkaConfig.ZkSslEnabledProtocolsProp))
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.ZkSslEnabledProtocols) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"${expected.mkString(",")}")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected.asJava), config.ZkSslEnabledProtocols) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected.mkString(",")}")))
+    assertEquals(expected.asJava, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected.asJava), config.ZkSslEnabledProtocols)
   }
 
   @Test
   def testZkSslCipherSuites(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslCipherSuitesProp
+    assertEquals("zookeeper.ssl.cipher.suites", kafkaProp)
+    val sysProp = "zookeeper.ssl.ciphersuites"
+    val expected = List("CIPHER_A", "CIPHER_B")
     val propertiesFile = prepareDefaultConfig()
-    val expected = List("A", "B")
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.cipher.suites=${expected.mkString(",")}")))
-    assertEquals(expected.asJava, config.values.get(KafkaConfig.ZkSslCipherSuitesProp))
-  }
-
-  @Test
-  def testZkSslContextSupplierClass(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val expected = "foo"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.context.supplier.class=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslContextSupplierClassProp).asInstanceOf[String])
+    // first make sure there is no default
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals(None, emptyConfig.ZkSslCipherSuites) // has no default value
+    // next set system property alone
+    try {
+      System.setProperty(sysProp, s"${expected.mkString(",")}")
+      // need to create a new Kafka config for the system property to be recognized
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(Some(expected.asJava), config.ZkSslCipherSuites) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected.mkString(",")}")))
+    assertEquals(expected.asJava, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(Some(expected.asJava), config.ZkSslCipherSuites)
   }
 
   @Test
   def testZkSslEndpointIdentificationAlgorithm(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp
+    assertEquals("zookeeper.ssl.endpoint.identification.algorithm", kafkaProp)
+    val sysProp = "zookeeper.ssl.hostnameVerification"
     val propertiesFile = prepareDefaultConfig()
-    val expected = ""
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.endpoint.identification.algorithm=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp))
-  }
-
-  @Test
-  def testZkSslEndpointIdentificationAlgorithmDefault(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertEquals("HTTPS", config.values.get(KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp))
+    // first make sure there is the correct "default" value
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertEquals("HTTPS", emptyConfig.ZkSslEndpointIdentificationAlgorithm) // but still has the correct "default" value
+    // next set system property alone
+    Map("true" -> "HTTPS", "false" -> "").foreach { case (sysPropValue, expected) => {
+      try {
+        System.setProperty(sysProp, sysPropValue)
+        val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+        assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+        assertEquals(expected, config.ZkSslEndpointIdentificationAlgorithm) // but does impact the ultimate value of the property
+      } finally {
+        System.clearProperty(sysProp)
+      }
+    }}
+    // finally set Kafka config alone
+    List("https", "").foreach(expected => {
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+      assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+      assertEquals(expected, config.ZkSslEndpointIdentificationAlgorithm)
+    })
   }
 
   @Test
   def testZkSslCrlEnable(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslCrlEnableProp
+    assertEquals("zookeeper.ssl.crl.enable", kafkaProp)
+    val sysProp = "zookeeper.ssl.crl"
     val propertiesFile = prepareDefaultConfig()
-    val expected = "true"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.crl.enable=${expected}")))
-    assertTrue(config.values.get(KafkaConfig.ZkSslCrlEnableProp).asInstanceOf[Boolean])
-  }
-
-  @Test
-  def testZkSslCrlEnableDefault(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertFalse(config.values.get(KafkaConfig.ZkSslCrlEnableProp).asInstanceOf[Boolean])
+    // first make sure there is the correct "default" value
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertFalse(emptyConfig.ZkSslCrlEnable) // but still has the correct "default" value
+    // next set system property alone
+    val expected = true
+    try {
+      System.setProperty(sysProp, s"$expected")
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(expected, config.ZkSslCrlEnable) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(expected, config.ZkSslCrlEnable)
   }
 
   @Test
   def testZkSslOcspEnable(): Unit = {
+    val kafkaProp = KafkaConfig.ZkSslOcspEnableProp
+    assertEquals("zookeeper.ssl.ocsp.enable", kafkaProp)
+    val sysProp = "zookeeper.ssl.ocsp"
     val propertiesFile = prepareDefaultConfig()
-    val expected = "true"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ocsp.enable=${expected}")))
-    assertTrue(config.values.get(KafkaConfig.ZkSslOcspEnableProp).asInstanceOf[Boolean])
-  }
-
-  @Test
-  def testZkSslOcspEnableDefault(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertFalse(config.values.get(KafkaConfig.ZkSslOcspEnableProp).asInstanceOf[Boolean])
+    // first make sure there is the correct "default" value
+    val emptyConfig = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertNull(emptyConfig.values.get(kafkaProp)) // doesn't appear in the values
+    assertFalse(emptyConfig.ZkSslOcspEnable) // but still has the correct "default" value
+    // next set system property alone
+    val expected = true
+    try {
+      System.setProperty(sysProp, s"$expected")
+      val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+      assertNull(config.values.get(kafkaProp)) // doesn't appear in the values
+      assertEquals(expected, config.ZkSslOcspEnable) // but does impact the ultimate value of the property
+    } finally {
+      System.clearProperty(sysProp)
+    }
+    // finally set Kafka config alone
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"$kafkaProp=${expected}")))
+    assertEquals(expected, config.values.get(kafkaProp)) // appears in the values
+    assertEquals(expected, config.ZkSslOcspEnable)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -110,6 +110,169 @@ class KafkaTest {
   }
 
   @Test
+  def testZkSslProps(): Unit = {
+    assertEquals(15, KafkaConfig.ZkSslProps.size)
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkClientSecureProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkClientCnxnSocketProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStoreLocationProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStorePasswordProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStoreTypeProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStoreLocationProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStorePasswordProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStoreTypeProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslProtocolProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslEnabledProtocolsProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslCipherSuitesProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslContextSupplierClassProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslHostnameVerificationEnableProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslCrlEnableProp))
+    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslOcspEnableProp))
+  }
+
+  @Test
+  def testZkClientSecureDefault(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertFalse(config.values.get(KafkaConfig.ZkClientSecureProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkClientSecureExplicit(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = true
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.client.secure=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkClientSecureProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslKeyStoreLocation(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "/keyStore/location"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keyStore.location=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreLocationProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslTrustStoreLocation(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "/trustStore/location"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.trustStore.location=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreLocationProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZookeeperKeyStoreTrustStorePasswords(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "zookeeper.ssl.keyStore.password=keystore_password",
+      "--override", "zookeeper.ssl.trustStore.password=truststore_password")))
+    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslKeyStorePasswordProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslTrustStorePasswordProp).toString)
+
+    assertEquals("keystore_password", config.getPassword(KafkaConfig.ZkSslKeyStorePasswordProp).value)
+    assertEquals("truststore_password", config.getPassword(KafkaConfig.ZkSslTrustStorePasswordProp).value)
+  }
+
+  @Test
+  def testZkSslKeyStoreType(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "PEM"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keyStore.type=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreTypeProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslTrustStoreType(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "PEM"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.trustStore.type=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreTypeProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslProtocol(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "TLSv1.3"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.protocol=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslProtocolProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslEnabledProtocols(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "A,B"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.enabledProtocols=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslEnabledProtocolsProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslProtocolDefault(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertEquals("TLSv1.2", config.values.get(KafkaConfig.ZkSslProtocolProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslCipherSuites(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "A,B"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ciphersuites=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslCipherSuitesProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslContextSupplierClass(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "foo"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.context.supplier.class=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslContextSupplierClassProp).asInstanceOf[String])
+  }
+
+  @Test
+  def testZkSslHostnameVerificationEnable(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "false"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.hostnameVerification=${expected}")))
+    assertFalse(config.values.get(KafkaConfig.ZkSslHostnameVerificationEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslHostnameVerificationEnableDefault(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertTrue(config.values.get(KafkaConfig.ZkSslHostnameVerificationEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslCrlEnable(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "true"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.crl=${expected}")))
+    assertTrue(config.values.get(KafkaConfig.ZkSslCrlEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslCrlEnableDefault(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertFalse(config.values.get(KafkaConfig.ZkSslCrlEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslOcspEnable(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = "true"
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ocsp=${expected}")))
+    assertTrue(config.values.get(KafkaConfig.ZkSslOcspEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
+  def testZkSslOcspEnableDefault(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
+    assertFalse(config.values.get(KafkaConfig.ZkSslOcspEnableProp).asInstanceOf[Boolean])
+  }
+
+  @Test
   def testConnectionsMaxReauthMsDefault(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -28,6 +28,8 @@ import org.junit.{After, Before, Test}
 import org.junit.Assert._
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 
+import scala.collection.JavaConverters._
+
 class KafkaTest {
 
   @Before
@@ -110,45 +112,25 @@ class KafkaTest {
   }
 
   @Test
-  def testZkSslProps(): Unit = {
-    assertEquals(15, KafkaConfig.ZkSslProps.size)
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkClientSecureProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkClientCnxnSocketProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStoreLocationProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStorePasswordProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslKeyStoreTypeProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStoreLocationProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStorePasswordProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslTrustStoreTypeProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslProtocolProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslEnabledProtocolsProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslCipherSuitesProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslContextSupplierClassProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslHostnameVerificationEnableProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslCrlEnableProp))
-    assertTrue(KafkaConfig.ZkSslProps.contains(KafkaConfig.ZkSslOcspEnableProp))
-  }
-
-  @Test
-  def testZkClientSecureDefault(): Unit = {
+  def testZkSslClientEnableDefault(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertFalse(config.values.get(KafkaConfig.ZkClientSecureProp).asInstanceOf[Boolean])
+    assertFalse(config.values.get(KafkaConfig.ZkSslClientEnableProp).asInstanceOf[Boolean])
   }
 
   @Test
-  def testZkClientSecureExplicit(): Unit = {
+  def testZkSslClientEnableExplicit(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = true
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.client.secure=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkClientSecureProp).asInstanceOf[Boolean])
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.client.enable=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslClientEnableProp).asInstanceOf[Boolean])
   }
 
   @Test
   def testZkSslKeyStoreLocation(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "/keyStore/location"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keyStore.location=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keystore.location=${expected}")))
     assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreLocationProp).asInstanceOf[String])
   }
 
@@ -156,15 +138,15 @@ class KafkaTest {
   def testZkSslTrustStoreLocation(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "/trustStore/location"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.trustStore.location=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.truststore.location=${expected}")))
     assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreLocationProp).asInstanceOf[String])
   }
 
   @Test
   def testZookeeperKeyStoreTrustStorePasswords(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "zookeeper.ssl.keyStore.password=keystore_password",
-      "--override", "zookeeper.ssl.trustStore.password=truststore_password")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "zookeeper.ssl.keystore.password=keystore_password",
+      "--override", "zookeeper.ssl.truststore.password=truststore_password")))
     assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslKeyStorePasswordProp).toString)
     assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.ZkSslTrustStorePasswordProp).toString)
 
@@ -176,7 +158,7 @@ class KafkaTest {
   def testZkSslKeyStoreType(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "PEM"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keyStore.type=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.keystore.type=${expected}")))
     assertEquals(expected, config.values.get(KafkaConfig.ZkSslKeyStoreTypeProp).asInstanceOf[String])
   }
 
@@ -184,7 +166,7 @@ class KafkaTest {
   def testZkSslTrustStoreType(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "PEM"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.trustStore.type=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.truststore.type=${expected}")))
     assertEquals(expected, config.values.get(KafkaConfig.ZkSslTrustStoreTypeProp).asInstanceOf[String])
   }
 
@@ -197,26 +179,26 @@ class KafkaTest {
   }
 
   @Test
-  def testZkSslEnabledProtocols(): Unit = {
-    val propertiesFile = prepareDefaultConfig()
-    val expected = "A,B"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.enabledProtocols=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslEnabledProtocolsProp).asInstanceOf[String])
-  }
-
-  @Test
   def testZkSslProtocolDefault(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertEquals("TLSv1.2", config.values.get(KafkaConfig.ZkSslProtocolProp).asInstanceOf[String])
+    assertEquals("TLSv1.2", config.values.get(KafkaConfig.ZkSslProtocolProp))
+  }
+
+  @Test
+  def testZkSslEnabledProtocols(): Unit = {
+    val propertiesFile = prepareDefaultConfig()
+    val expected = List("A", "B")
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.enabled.protocols=${expected.mkString(",")}")))
+    assertEquals(expected.asJava, config.values.get(KafkaConfig.ZkSslEnabledProtocolsProp))
   }
 
   @Test
   def testZkSslCipherSuites(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    val expected = "A,B"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ciphersuites=${expected}")))
-    assertEquals(expected, config.values.get(KafkaConfig.ZkSslCipherSuitesProp).asInstanceOf[String])
+    val expected = List("A", "B")
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.cipher.suites=${expected.mkString(",")}")))
+    assertEquals(expected.asJava, config.values.get(KafkaConfig.ZkSslCipherSuitesProp))
   }
 
   @Test
@@ -228,25 +210,25 @@ class KafkaTest {
   }
 
   @Test
-  def testZkSslHostnameVerificationEnable(): Unit = {
+  def testZkSslEndpointIdentificationAlgorithm(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    val expected = "false"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.hostnameVerification=${expected}")))
-    assertFalse(config.values.get(KafkaConfig.ZkSslHostnameVerificationEnableProp).asInstanceOf[Boolean])
+    val expected = ""
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.endpoint.identification.algorithm=${expected}")))
+    assertEquals(expected, config.values.get(KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp))
   }
 
   @Test
-  def testZkSslHostnameVerificationEnableDefault(): Unit = {
+  def testZkSslEndpointIdentificationAlgorithmDefault(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile)))
-    assertTrue(config.values.get(KafkaConfig.ZkSslHostnameVerificationEnableProp).asInstanceOf[Boolean])
+    assertEquals("HTTPS", config.values.get(KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp))
   }
 
   @Test
   def testZkSslCrlEnable(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "true"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.crl=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.crl.enable=${expected}")))
     assertTrue(config.values.get(KafkaConfig.ZkSslCrlEnableProp).asInstanceOf[Boolean])
   }
 
@@ -261,7 +243,7 @@ class KafkaTest {
   def testZkSslOcspEnable(): Unit = {
     val propertiesFile = prepareDefaultConfig()
     val expected = "true"
-    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ocsp=${expected}")))
+    val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", s"zookeeper.ssl.ocsp.enable=${expected}")))
     assertTrue(config.values.get(KafkaConfig.ZkSslOcspEnableProp).asInstanceOf[Boolean])
   }
 

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -25,7 +25,7 @@ import kafka.api.{ApiVersion, KAFKA_2_0_IV0, KAFKA_2_0_IV1}
 import kafka.security.auth.Resource
 import kafka.security.authorizer.AuthorizerUtils.{WildcardHost, WildcardPrincipal}
 import kafka.server.{Defaults, KafkaConfig}
-import kafka.utils.{CoreUtils, TestUtils}
+import kafka.utils.TestUtils
 import kafka.zk.{ZkAclStore, ZooKeeperTestHarness}
 import kafka.zookeeper.{GetChildrenRequest, GetDataRequest, ZooKeeperClient}
 import org.apache.kafka.common.acl._

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -601,7 +601,6 @@ class KafkaConfigTest {
         case KafkaConfig.ZkSslProtocolProp =>  //ignore string
         case KafkaConfig.ZkSslEnabledProtocolsProp =>  //ignore string
         case KafkaConfig.ZkSslCipherSuitesProp =>  //ignore string
-        case KafkaConfig.ZkSslContextSupplierClassProp =>  //ignore string
         case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => //ignore string
         case KafkaConfig.ZkSslCrlEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
         case KafkaConfig.ZkSslOcspEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -590,7 +590,7 @@ class KafkaConfigTest {
         case KafkaConfig.ZkSyncTimeMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ZkEnableSecureAclsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
         case KafkaConfig.ZkMaxInFlightRequestsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number", "0")
-        case KafkaConfig.ZkClientSecureProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
+        case KafkaConfig.ZkSslClientEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
         case KafkaConfig.ZkClientCnxnSocketProp =>  //ignore string
         case KafkaConfig.ZkSslKeyStoreLocationProp =>  //ignore string
         case KafkaConfig.ZkSslKeyStorePasswordProp =>  //ignore string
@@ -602,7 +602,7 @@ class KafkaConfigTest {
         case KafkaConfig.ZkSslEnabledProtocolsProp =>  //ignore string
         case KafkaConfig.ZkSslCipherSuitesProp =>  //ignore string
         case KafkaConfig.ZkSslContextSupplierClassProp =>  //ignore string
-        case KafkaConfig.ZkSslHostnameVerificationEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
+        case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => //ignore string
         case KafkaConfig.ZkSslCrlEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
         case KafkaConfig.ZkSslOcspEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -590,6 +590,21 @@ class KafkaConfigTest {
         case KafkaConfig.ZkSyncTimeMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ZkEnableSecureAclsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
         case KafkaConfig.ZkMaxInFlightRequestsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number", "0")
+        case KafkaConfig.ZkClientSecureProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
+        case KafkaConfig.ZkClientCnxnSocketProp =>  //ignore string
+        case KafkaConfig.ZkSslKeyStoreLocationProp =>  //ignore string
+        case KafkaConfig.ZkSslKeyStorePasswordProp =>  //ignore string
+        case KafkaConfig.ZkSslKeyStoreTypeProp =>  //ignore string
+        case KafkaConfig.ZkSslTrustStoreLocationProp =>  //ignore string
+        case KafkaConfig.ZkSslTrustStorePasswordProp =>  //ignore string
+        case KafkaConfig.ZkSslTrustStoreTypeProp =>  //ignore string
+        case KafkaConfig.ZkSslProtocolProp =>  //ignore string
+        case KafkaConfig.ZkSslEnabledProtocolsProp =>  //ignore string
+        case KafkaConfig.ZkSslCipherSuitesProp =>  //ignore string
+        case KafkaConfig.ZkSslContextSupplierClassProp =>  //ignore string
+        case KafkaConfig.ZkSslHostnameVerificationEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
+        case KafkaConfig.ZkSslCrlEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
+        case KafkaConfig.ZkSslOcspEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
 
         case KafkaConfig.BrokerIdProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.NumNetworkThreadsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number", "0")

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -94,14 +94,14 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     val clientConfig = new ZKClientConfig()
     val propKey = KafkaConfig.ZkClientCnxnSocketProp
     val propVal = "org.apache.zookeeper.ClientCnxnSocketNetty"
-    clientConfig.setProperty(propKey, propVal)
+    KafkaConfig.setZooKeeperClientProperty(clientConfig, propKey, propVal)
     val client = KafkaZkClient(zkConnect, zkAclsEnabled.getOrElse(JaasUtils.isZkSecurityEnabled), zkSessionTimeout,
       zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, zkClientConfig = Some(clientConfig))
     try {
-      assertEquals(propVal, client.currentZooKeeper.getClientConfig.getProperty(propKey))
+      assertEquals(Some(propVal), KafkaConfig.getZooKeeperClientProperty(client.currentZooKeeper.getClientConfig, propKey))
       // For a sanity check, make sure a bad client connection socket class name generates an exception
       val badClientConfig = new ZKClientConfig()
-      badClientConfig.setProperty(propKey, propVal + "BadClassName")
+      KafkaConfig.setZooKeeperClientProperty(badClientConfig, propKey, propVal + "BadClassName")
       intercept[Exception] {
         KafkaZkClient(zkConnect, zkAclsEnabled.getOrElse(JaasUtils.isZkSecurityEnabled), zkSessionTimeout,
           zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, zkClientConfig = Some(badClientConfig))

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -38,7 +38,6 @@ import org.junit.{After, Before, Test}
 import org.scalatest.Assertions.{fail, intercept}
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 class ZooKeeperClientTest extends ZooKeeperTestHarness {
   private val mockPath = "/foo"

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -39,6 +39,8 @@ LOG_CLEANER_ENABLE = "log.cleaner.enable"
 AUTO_CREATE_TOPICS_ENABLE = "auto.create.topics.enable"
 
 ZOOKEEPER_CONNECT = "zookeeper.connect"
+ZOOKEEPER_CLIENT_SECURE = "zookeeper.client.secure"
+ZOOKEEPER_CLIENT_CNXN_SOCKET = "zookeeper.clientCnxnSocket"
 ZOOKEEPER_CONNECTION_TIMEOUT_MS = "zookeeper.connection.timeout.ms"
 INTER_BROKER_PROTOCOL_VERSION = "inter.broker.protocol.version"
 MESSAGE_FORMAT_VERSION = "log.message.format.version"

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -39,7 +39,7 @@ LOG_CLEANER_ENABLE = "log.cleaner.enable"
 AUTO_CREATE_TOPICS_ENABLE = "auto.create.topics.enable"
 
 ZOOKEEPER_CONNECT = "zookeeper.connect"
-ZOOKEEPER_CLIENT_SECURE = "zookeeper.client.secure"
+ZOOKEEPER_SSL_CLIENT_ENABLE = "zookeeper.ssl.client.enable"
 ZOOKEEPER_CLIENT_CNXN_SOCKET = "zookeeper.clientCnxnSocket"
 ZOOKEEPER_CONNECTION_TIMEOUT_MS = "zookeeper.connection.timeout.ms"
 INTER_BROKER_PROTOCOL_VERSION = "inter.broker.protocol.version"

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -96,6 +96,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
                  authorizer_class_name=None, topics=None, version=DEV_BRANCH, jmx_object_names=None,
                  jmx_attributes=None, zk_connect_timeout=5000, zk_session_timeout=6000, server_prop_overides=None, zk_chroot=None,
+                 zk_client_secure=False,
                  listener_security_config=ListenerSecurityConfig(), per_node_server_prop_overrides=None, extra_kafka_opts=""):
         """
         :param context: test context
@@ -113,6 +114,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param int zk_session_timeout:
         :param dict server_prop_overides: overrides for kafka.properties file
         :param zk_chroot:
+        :param bool zk_client_secure: connect to Zookeeper over secure client port (TLS) when True
         :param ListenerSecurityConfig listener_security_config: listener config to use
         :param dict per_node_server_prop_overrides:
         :param str extra_kafka_opts: jvm args to add to KAFKA_OPTS variable
@@ -139,6 +141,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.per_node_server_prop_overrides = per_node_server_prop_overrides
         self.log_level = "DEBUG"
         self.zk_chroot = zk_chroot
+        self.zk_client_secure = zk_client_secure
         self.listener_security_config = listener_security_config
         self.extra_kafka_opts = extra_kafka_opts
 
@@ -206,7 +209,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     @property
     def security_config(self):
         config = SecurityConfig(self.context, self.security_protocol, self.interbroker_listener.security_protocol,
-                                zk_sasl=self.zk.zk_sasl,
+                                zk_sasl=self.zk.zk_sasl, zk_tls=self.zk_client_secure,
                                 client_sasl_mechanism=self.client_sasl_mechanism,
                                 interbroker_sasl_mechanism=self.interbroker_sasl_mechanism,
                                 listener_security_config=self.listener_security_config)
@@ -221,7 +224,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def close_port(self, listener_name):
         self.port_mappings[listener_name].open = False
 
-    def start_minikdc(self, add_principals=""):
+    def start_minikdc_if_necessary(self, add_principals=""):
         if self.security_config.has_sasl:
             if self.minikdc is None:
                 self.minikdc = MiniKdc(self.context, self.nodes, extra_principals = add_principals)
@@ -233,10 +236,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return len(self.pids(node)) > 0
 
     def start(self, add_principals=""):
+        if self.zk_client_secure and not self.zk.client_secure_port:
+            raise Exception("Unable to start Kafka: TLS to Zookeeper requested but Zookeeper secure port not enabled")
         self.open_port(self.security_protocol)
         self.interbroker_listener.open = True
 
-        self.start_minikdc(add_principals)
+        self.start_minikdc_if_necessary(add_principals)
         self._ensure_zk_chroot()
 
         Service.start(self)
@@ -300,6 +305,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         override_configs = KafkaConfig(**node.config)
         override_configs[config_property.ADVERTISED_HOSTNAME] = node.account.hostname
         override_configs[config_property.ZOOKEEPER_CONNECT] = self.zk_connect_setting()
+        if self.zk_client_secure:
+            override_configs[config_property.ZOOKEEPER_CLIENT_SECURE] = 'true'
+            override_configs[config_property.ZOOKEEPER_CLIENT_CNXN_SOCKET] = 'org.apache.zookeeper.ClientCnxnSocketNetty'
+        else:
+            override_configs[config_property.ZOOKEEPER_CLIENT_SECURE] = 'false'
 
         for prop in self.server_prop_overides:
             override_configs[prop[0]] = prop[1]
@@ -643,14 +653,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         return missing
 
-    def restart_cluster(self, clean_shutdown=True):
+    def restart_cluster(self, clean_shutdown=True, timeout_sec=60, after_each_broker_restart=None, *args):
         for node in self.nodes:
-            self.restart_node(node, clean_shutdown=clean_shutdown)
+            self.restart_node(node, clean_shutdown=clean_shutdown, timeout_sec=timeout_sec)
+            if after_each_broker_restart is not None:
+                after_each_broker_restart(*args)
 
-    def restart_node(self, node, clean_shutdown=True):
+    def restart_node(self, node, clean_shutdown=True, timeout_sec=60):
         """Restart the given node."""
-        self.stop_node(node, clean_shutdown)
-        self.start_node(node)
+        self.stop_node(node, clean_shutdown, timeout_sec)
+        self.start_node(node, timeout_sec)
 
     def isr_idx_list(self, topic, partition=0):
         """ Get in-sync replica list the given topic and partition.
@@ -777,7 +789,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         return output
 
     def zk_connect_setting(self):
-        return self.zk.connect_setting(self.zk_chroot)
+        return self.zk.connect_setting(self.zk_chroot, self.zk_client_secure)
 
     def __bootstrap_servers(self, port, validate=True, offline_nodes=[]):
         if validate and not port.open:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -306,10 +306,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         override_configs[config_property.ADVERTISED_HOSTNAME] = node.account.hostname
         override_configs[config_property.ZOOKEEPER_CONNECT] = self.zk_connect_setting()
         if self.zk_client_secure:
-            override_configs[config_property.ZOOKEEPER_CLIENT_SECURE] = 'true'
+            override_configs[config_property.ZOOKEEPER_SSL_CLIENT_ENABLE] = 'true'
             override_configs[config_property.ZOOKEEPER_CLIENT_CNXN_SOCKET] = 'org.apache.zookeeper.ClientCnxnSocketNetty'
         else:
-            override_configs[config_property.ZOOKEEPER_CLIENT_SECURE] = 'false'
+            override_configs[config_property.ZOOKEEPER_SSL_CLIENT_ENABLE] = 'false'
 
         for prop in self.server_prop_overides:
             override_configs[prop[0]] = prop[1]

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -47,12 +47,22 @@ listener.name.{{ interbroker_listener.name.lower() }}.{{ k }}={{ v }}
 
 ssl.keystore.location=/mnt/security/test.keystore.jks
 ssl.keystore.password=test-ks-passwd
-ssl.key.password=test-key-passwd
+ssl.key.password=test-ks-passwd
 ssl.keystore.type=JKS
 ssl.truststore.location=/mnt/security/test.truststore.jks
 ssl.truststore.password=test-ts-passwd
 ssl.truststore.type=JKS
 ssl.endpoint.identification.algorithm=HTTPS
+# Zookeeper TLS settings
+#
+# Note that zookeeper.client.secure will be set to true or false elsewhere, as appropriate.
+# If it is false then these ZK keyStore/trustStore settings will have no effect.  If it is true then
+# zookeeper.clientCnxnSocket will also be set elsewhere (to org.apache.zookeeper.ClientCnxnSocketNetty)
+zookeeper.ssl.keyStore.location=/mnt/security/test.keystore.jks
+zookeeper.ssl.keyStore.password=test-ks-passwd
+zookeeper.ssl.trustStore.location=/mnt/security/test.truststore.jks
+zookeeper.ssl.trustStore.password=test-ts-passwd
+#
 sasl.mechanism.inter.broker.protocol={{ security_config.interbroker_sasl_mechanism }}
 sasl.enabled.mechanisms={{ ",".join(security_config.enabled_sasl_mechanisms) }}
 sasl.kerberos.service.name=kafka

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -55,13 +55,13 @@ ssl.truststore.type=JKS
 ssl.endpoint.identification.algorithm=HTTPS
 # Zookeeper TLS settings
 #
-# Note that zookeeper.client.secure will be set to true or false elsewhere, as appropriate.
-# If it is false then these ZK keyStore/trustStore settings will have no effect.  If it is true then
+# Note that zookeeper.ssl.client.enable will be set to true or false elsewhere, as appropriate.
+# If it is false then these ZK keystore/truststore settings will have no effect.  If it is true then
 # zookeeper.clientCnxnSocket will also be set elsewhere (to org.apache.zookeeper.ClientCnxnSocketNetty)
-zookeeper.ssl.keyStore.location=/mnt/security/test.keystore.jks
-zookeeper.ssl.keyStore.password=test-ks-passwd
-zookeeper.ssl.trustStore.location=/mnt/security/test.truststore.jks
-zookeeper.ssl.trustStore.password=test-ts-passwd
+zookeeper.ssl.keystore.location=/mnt/security/test.keystore.jks
+zookeeper.ssl.keystore.password=test-ks-passwd
+zookeeper.ssl.truststore.location=/mnt/security/test.truststore.jks
+zookeeper.ssl.truststore.password=test-ts-passwd
 #
 sasl.mechanism.inter.broker.protocol={{ security_config.interbroker_sasl_mechanism }}
 sasl.enabled.mechanisms={{ ",".join(security_config.enabled_sasl_mechanisms) }}

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -78,11 +78,11 @@ class SslStores(object):
 
         # also generate ZooKeeper client TLS config file for mutual authentication use case
         str = """zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
-zookeeper.client.secure=true
-zookeeper.ssl.trustStore.location=%s
-zookeeper.ssl.trustStore.password=%s
-zookeeper.ssl.keyStore.location=%s
-zookeeper.ssl.keyStore.password=%s
+zookeeper.ssl.client.enable=true
+zookeeper.ssl.truststore.location=%s
+zookeeper.ssl.truststore.password=%s
+zookeeper.ssl.keystore.location=%s
+zookeeper.ssl.keystore.password=%s
 """ % (SecurityConfig.TRUSTSTORE_PATH, self.truststore_passwd, SecurityConfig.KEYSTORE_PATH, self.keystore_passwd)
         node.account.create_file(SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH, str)
 

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import subprocess
 from tempfile import mkdtemp
@@ -24,7 +25,8 @@ import itertools
 
 
 class SslStores(object):
-    def __init__(self, local_scratch_dir):
+    def __init__(self, local_scratch_dir, logger=None):
+        self.logger = logger
         self.ca_crt_path = os.path.join(local_scratch_dir, "test.ca.crt")
         self.ca_jks_path = os.path.join(local_scratch_dir, "test.ca.jks")
         self.ca_passwd = "test-ca-passwd"
@@ -32,7 +34,8 @@ class SslStores(object):
         self.truststore_path = os.path.join(local_scratch_dir, "test.truststore.jks")
         self.truststore_passwd = "test-ts-passwd"
         self.keystore_passwd = "test-ks-passwd"
-        self.key_passwd = "test-key-passwd"
+        # Zookeeper TLS (as of v3.5.6) does not support a key password different than the keystore password
+        self.key_passwd = self.keystore_passwd
         # Allow upto one hour of clock skew between host and VMs
         self.startdate = "-1H"
 
@@ -72,6 +75,17 @@ class SslStores(object):
         self.runcmd("keytool -importcert -keystore %s -storepass %s -storetype JKS -alias ca -file %s -noprompt" % (ks_path, self.keystore_passwd, self.ca_crt_path))
         self.runcmd("keytool -importcert -keystore %s -storepass %s -storetype JKS -keypass %s -alias kafka -file %s -noprompt" % (ks_path, self.keystore_passwd, self.key_passwd, crt_path))
         node.account.copy_to(ks_path, SecurityConfig.KEYSTORE_PATH)
+
+        # also generate ZooKeeper client TLS config file for mutual authentication use case
+        str = """zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+zookeeper.client.secure=true
+zookeeper.ssl.trustStore.location=%s
+zookeeper.ssl.trustStore.password=%s
+zookeeper.ssl.keyStore.location=%s
+zookeeper.ssl.keyStore.password=%s
+""" % (SecurityConfig.TRUSTSTORE_PATH, self.truststore_passwd, SecurityConfig.KEYSTORE_PATH, self.keystore_passwd)
+        node.account.create_file(SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH, str)
+
         rmtree(ks_dir)
 
     def hostname(self, node):
@@ -80,6 +94,8 @@ class SslStores(object):
         return node.account.hostname
 
     def runcmd(self, cmd):
+        if self.logger:
+            self.logger.log(logging.DEBUG, cmd)
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         stdout, stderr = proc.communicate()
 
@@ -104,6 +120,7 @@ class SecurityConfig(TemplateRenderer):
     CONFIG_DIR = "/mnt/security"
     KEYSTORE_PATH = "/mnt/security/test.keystore.jks"
     TRUSTSTORE_PATH = "/mnt/security/test.truststore.jks"
+    ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH = "/mnt/security/zk_client_mutual_auth_config.properties"
     JAAS_CONF_PATH = "/mnt/security/jaas.conf"
     KRB5CONF_PATH = "/mnt/security/krb5.conf"
     KEYTAB_PATH = "/mnt/security/keytab"
@@ -113,7 +130,7 @@ class SecurityConfig(TemplateRenderer):
 
     def __init__(self, context, security_protocol=None, interbroker_security_protocol=None,
                  client_sasl_mechanism=SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SASL_MECHANISM_GSSAPI,
-                 zk_sasl=False, template_props="", static_jaas_conf=True, jaas_override_variables=None,
+                 zk_sasl=False, zk_tls=False, template_props="", static_jaas_conf=True, jaas_override_variables=None,
                  listener_security_config=ListenerSecurityConfig()):
         """
         Initialize the security properties for the node and copy
@@ -128,7 +145,7 @@ class SecurityConfig(TemplateRenderer):
             # This generates keystore/trustore files in a local scratch directory which gets
             # automatically destroyed after the test is run
             # Creating within the scratch directory allows us to run tests in parallel without fear of collision
-            SecurityConfig.ssl_stores = SslStores(context.local_scratch_dir)
+            SecurityConfig.ssl_stores = SslStores(context.local_scratch_dir, context.logger)
             SecurityConfig.ssl_stores.generate_ca()
             SecurityConfig.ssl_stores.generate_truststore()
 
@@ -143,8 +160,9 @@ class SecurityConfig(TemplateRenderer):
             interbroker_security_protocol = security_protocol
         self.interbroker_security_protocol = interbroker_security_protocol
         self.has_sasl = self.is_sasl(security_protocol) or self.is_sasl(interbroker_security_protocol) or zk_sasl
-        self.has_ssl = self.is_ssl(security_protocol) or self.is_ssl(interbroker_security_protocol)
+        self.has_ssl = self.is_ssl(security_protocol) or self.is_ssl(interbroker_security_protocol) or zk_tls
         self.zk_sasl = zk_sasl
+        self.zk_tls = zk_tls
         self.static_jaas_conf = static_jaas_conf
         self.listener_security_config = listener_security_config
         self.properties = {

--- a/tests/kafkatest/services/templates/zookeeper.properties
+++ b/tests/kafkatest/services/templates/zookeeper.properties
@@ -14,7 +14,20 @@
 # limitations under the License.
 
 dataDir=/mnt/zookeeper/data
+{% if zk_client_port %}
 clientPort=2181
+{% endif %}
+{% if zk_client_secure_port %}
+secureClientPort=2182
+serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
+authProvider.2=org.apache.zookeeper.server.auth.X509AuthenticationProvider
+ssl.keyStore.location=/mnt/security/test.keystore.jks
+ssl.keyStore.password=test-ks-passwd
+ssl.keyStore.type=JKS
+ssl.trustStore.location=/mnt/security/test.truststore.jks
+ssl.trustStore.password=test-ts-passwd
+ssl.trustStore.type=JKS
+{% endif %}
 maxClientCnxns=0
 initLimit=5
 syncLimit=2

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -152,7 +152,6 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
     # the use of ZooKeeper ACLs.
     #
     def zookeeper_migration(self, node, zk_acl):
-        SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH
         la_migra_cmd = "export KAFKA_OPTS=\"%s\";" % \
                        self.security_system_properties if self.security_config.zk_sasl else ""
         la_migra_cmd += "%s --zookeeper.acl=%s --zookeeper.connect=%s %s" % \

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -207,6 +207,34 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         output = self.nodes[0].account.ssh_output(cmd)
         self.logger.debug(output)
 
+    def describe(self, topic):
+        """
+        Describe the given topic using the ConfigCommand CLI
+        """
+
+        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        cmd = "%s kafka.admin.ConfigCommand --zookeeper %s %s --describe --topic %s" % \
+              (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
+               "--zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               topic)
+        self.logger.debug(cmd)
+        output = self.nodes[0].account.ssh_output(cmd)
+        self.logger.debug(output)
+
+    def list_acls(self, topic):
+        """
+        List ACLs for the given topic using the AclCommand CLI
+        """
+
+        kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
+        cmd = "%s kafka.admin.AclCommand --authorizer kafka.security.authorizer.AclAuthorizer --authorizer-properties zookeeper.connect=%s %s --list --topic %s" % \
+              (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
+               "--zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               topic)
+        self.logger.debug(cmd)
+        output = self.nodes[0].account.ssh_output(cmd)
+        self.logger.debug(output)
+
     def java_class_name(self):
         """ The class name of the Zookeeper quorum peers. """
         return "org.apache.zookeeper.server.quorum.QuorumPeerMain"

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -44,17 +44,21 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
             "collect_default": True}
     }
 
-    def __init__(self, context, num_nodes, zk_sasl = False):
+    def __init__(self, context, num_nodes, zk_sasl = False, zk_client_port = True, zk_client_secure_port = False):
         """
         :type context
         """
         self.kafka_opts = ""
         self.zk_sasl = zk_sasl
+        if not zk_client_port and not zk_client_secure_port:
+            raise Exception("Cannot disable both ZK clientPort and clientSecurePort")
+        self.zk_client_port = zk_client_port
+        self.zk_client_secure_port = zk_client_secure_port
         super(ZookeeperService, self).__init__(context, num_nodes)
 
     @property
     def security_config(self):
-        return SecurityConfig(self.context, zk_sasl=self.zk_sasl)
+        return SecurityConfig(self.context, zk_sasl=self.zk_sasl, zk_tls=self.zk_client_secure_port)
 
     @property
     def security_system_properties(self):
@@ -66,6 +70,15 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
     @property
     def zk_principals(self):
         return " zkclient "  + ' '.join(['zookeeper/' + zk_node.account.hostname for zk_node in self.nodes])
+
+    def restart_cluster(self):
+        for node in self.nodes:
+            self.restart_node(node)
+
+    def restart_node(self, node):
+        """Restart the given node."""
+        self.stop_node(node)
+        self.start_node(node)
 
     def start_node(self, node):
         idx = self.idx(node)
@@ -92,9 +105,10 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
     def listening(self, node):
         try:
-            cmd = "nc -z %s %s" % (node.account.hostname, 2181)
+            port = 2181 if self.zk_client_port else 2182
+            cmd = "nc -z %s %s" % (node.account.hostname, port)
             node.account.ssh_output(cmd, allow_fail=False)
-            self.logger.debug("Zookeeper started accepting connections at: '%s:%s')", node.account.hostname, 2181)
+            self.logger.debug("Zookeeper started accepting connections at: '%s:%s')", node.account.hostname, port)
             return True
         except (RemoteCommandError, ValueError) as e:
             return False
@@ -124,20 +138,28 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         node.account.ssh("rm -rf -- %s" % ZookeeperService.ROOT, allow_fail=False)
 
 
-    def connect_setting(self, chroot=None):
+    # force_tls is a necessary option for the case where we define both encrypted and non-encrypted ports
+    def connect_setting(self, chroot=None, force_tls=False):
         if chroot and not chroot.startswith("/"):
             raise Exception("ZK chroot must start with '/', invalid chroot: %s" % chroot)
 
         chroot = '' if chroot is None else chroot
-        return ','.join([node.account.hostname + ':2181' + chroot for node in self.nodes])
+        return ','.join([node.account.hostname + (':2182' if not self.zk_client_port or force_tls else ':2181') + chroot
+                         for node in self.nodes])
 
     #
     # This call is used to simulate a rolling upgrade to enable/disable
     # the use of ZooKeeper ACLs.
     #
     def zookeeper_migration(self, node, zk_acl):
-        la_migra_cmd = "%s --zookeeper.acl=%s --zookeeper.connect=%s" % \
-                       (self.path.script("zookeeper-security-migration.sh", node), zk_acl, self.connect_setting())
+        SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH
+        la_migra_cmd = "export KAFKA_OPTS=\"%s\";" % \
+                       self.security_system_properties if self.security_config.zk_sasl else ""
+        la_migra_cmd += "%s --zookeeper.acl=%s --zookeeper.connect=%s %s" % \
+                       (self.path.script("zookeeper-security-migration.sh", node), zk_acl,
+                        self.connect_setting(force_tls=self.zk_client_secure_port),
+                        "--zk-tls-config-file=" + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH \
+                            if self.zk_client_secure_port else "")
         node.account.ssh(la_migra_cmd)
 
     def _check_chroot(self, chroot):
@@ -153,8 +175,10 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         chroot_path = ('' if chroot is None else chroot) + path
 
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
-        cmd = "%s %s -server %s get %s" % \
-              (kafka_run_class, self.java_cli_class_name(), self.connect_setting(), chroot_path)
+        cmd = "%s %s -server %s %s get %s" % \
+              (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
+               "-zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               chroot_path)
         self.logger.debug(cmd)
 
         node = self.nodes[0]
@@ -167,7 +191,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
                     result = match.groups()[0]
         return result
 
-    def create(self, path, chroot=None):
+    def create(self, path, chroot=None, value=""):
         """
         Create an znode at the given path
         """
@@ -176,8 +200,10 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         chroot_path = ('' if chroot is None else chroot) + path
 
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
-        cmd = "%s %s -server %s create %s ''" % \
-              (kafka_run_class, self.java_cli_class_name(), self.connect_setting(), chroot_path)
+        cmd = "%s %s -server %s %s create %s '%s'" % \
+              (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
+               "-zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               chroot_path, value)
         self.logger.debug(cmd)
         output = self.nodes[0].account.ssh_output(cmd)
         self.logger.debug(output)
@@ -188,4 +214,4 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
 
     def java_cli_class_name(self):
         """ The class name of the Zookeeper tool within Kafka. """
-        return "org.apache.zookeeper.ZooKeeperMain"
+        return "org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka"

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -58,11 +58,8 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.consumer.group_id = "group"
 
     def bounce(self):
-        self.kafka.start_minikdc()
-        for node in self.kafka.nodes:
-            self.kafka.stop_node(node)
-            self.kafka.start_node(node)
-            time.sleep(10)
+        self.kafka.start_minikdc_if_necessary()
+        self.kafka.restart_cluster(after_each_broker_restart = lambda: time.sleep(10))
 
     def roll_in_secured_settings(self, client_protocol, broker_protocol):
         # Roll cluster to include inter broker security protocol.
@@ -82,12 +79,12 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
     def open_secured_port(self, client_protocol):
         self.kafka.security_protocol = client_protocol
         self.kafka.open_port(client_protocol)
-        self.kafka.start_minikdc()
+        self.kafka.start_minikdc_if_necessary()
         self.bounce()
 
     def add_sasl_mechanism(self, new_client_sasl_mechanism):
         self.kafka.client_sasl_mechanism = new_client_sasl_mechanism
-        self.kafka.start_minikdc()
+        self.kafka.start_minikdc_if_necessary()
         self.bounce()
 
     def roll_in_sasl_mechanism(self, security_protocol, new_sasl_mechanism):

--- a/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
@@ -69,19 +69,14 @@ class ZooKeeperSecurityUpgradeTest(ProduceConsumeValidateTest):
 
     def run_zk_migration(self):
         # change zk config (auth provider + jaas login)
-        self.zk.kafka_opts = self.zk.security_system_properties
         self.zk.zk_sasl = True
         if self.no_sasl:
-            self.kafka.start_minikdc(self.zk.zk_principals)
+            self.kafka.start_minikdc_if_necessary(self.zk.zk_principals)
         # restart zk
-        for node in self.zk.nodes:
-            self.zk.stop_node(node)
-            self.zk.start_node(node)
+        self.zk.restart_cluster()
 
         # restart broker with jaas login
-        for node in self.kafka.nodes:
-            self.kafka.stop_node(node)
-            self.kafka.start_node(node)
+        self.kafka.restart_cluster()
 
         # run migration tool
         for node in self.zk.nodes:
@@ -89,9 +84,7 @@ class ZooKeeperSecurityUpgradeTest(ProduceConsumeValidateTest):
 
         # restart broker with zookeeper.set.acl=true and acls
         self.kafka.zk_set_acl = True
-        for node in self.kafka.nodes:
-            self.kafka.stop_node(node)
-            self.kafka.start_node(node)
+        self.kafka.restart_cluster()
 
     @cluster(num_nodes=9)
     @matrix(security_protocol=["PLAINTEXT", "SSL", "SASL_SSL", "SASL_PLAINTEXT"])

--- a/tests/kafkatest/tests/core/zookeeper_tls_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_test.py
@@ -116,6 +116,14 @@ class ZookeeperTlsTest(ProduceConsumeValidateTest):
         if self.zk.query(path) != value:
             raise Exception("Error creating and then querying a znode using the CLI with a TLS-enabled ZooKeeper quorum")
 
+        # Make sure the ConfigCommand CLI is able to talk to a TLS-enabled ZooKeeper quorum
+        # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
+        self.zk.describe(self.topic)
+
+        # Make sure the AclCommand CLI is able to talk to a TLS-enabled ZooKeeper quorum
+        # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
+        self.zk.list_acls(self.topic)
+
         #
         # Test zookeeper.set.acl with just TLS mutual authentication (no SASL)
         #

--- a/tests/kafkatest/tests/core/zookeeper_tls_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_test.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark import matrix, ignore
+from ducktape.mark.resource import cluster
+
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
+
+import logging
+
+class ZookeeperTlsTest(ProduceConsumeValidateTest):
+    """Tests TLS connectivity to zookeeper.
+    """
+
+    def __init__(self, test_context):
+        super(ZookeeperTlsTest, self).__init__(test_context=test_context)
+
+    def setUp(self):
+        self.topic = "test_topic"
+        self.group = "group"
+        self.producer_throughput = 100
+        self.num_producers = 1
+        self.num_consumers = 1
+
+        self.zk = ZookeeperService(self.test_context, num_nodes=3)
+
+        self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
+            "partitions": 3,
+            "replication-factor": 3,
+            'configs': {"min.insync.replicas": 2}}})
+
+    def create_producer_and_consumer(self):
+        self.producer = VerifiableProducer(
+            self.test_context, self.num_producers, self.kafka, self.topic,
+            throughput=self.producer_throughput)
+
+        self.consumer = ConsoleConsumer(
+            self.test_context, self.num_consumers, self.kafka, self.topic,
+            consumer_timeout_ms=60000, message_validator=is_int)
+
+        self.consumer.group_id = self.group
+
+    def perform_produce_consume_validation(self):
+        self.create_producer_and_consumer()
+        self.run_produce_consume_validate()
+        self.producer.free()
+        self.consumer.free()
+
+    def enable_zk_tls(self):
+        self.test_context.logger.debug("Enabling the TLS port in Zookeeper (we won't use it from Kafka yet)")
+        # change zk config (enable TLS, but also keep non-TLS)
+        self.zk.zk_client_secure_port = True
+        self.zk.restart_cluster()
+        # bounce a Kafka broker to force it to leverage Zookeeper -- a simple sanity check
+        self.kafka.stop_node(self.kafka.nodes[0])
+        self.kafka.start_node(self.kafka.nodes[0])
+
+    def enable_kafka_zk_tls(self):
+        self.test_context.logger.debug("Configuring Kafka to use the TLS port in Zookeeper")
+        # change Kafka config (enable TLS to Zookeeper)
+        self.kafka.zk_client_secure = True
+        self.kafka.restart_cluster()
+
+    def disable_zk_non_tls(self):
+        self.test_context.logger.debug("Disabling the non-TLS port in Zookeeper (as a simple sanity check)")
+        # change zk config (disable non-TLS, keep TLS)
+        self.zk.zk_client_port = False
+        self.zk.restart_cluster()
+        # bounce a Kafka broker to force it to leverage Zookeeper -- a simple sanity check
+        self.kafka.stop_node(self.kafka.nodes[0])
+        self.kafka.start_node(self.kafka.nodes[0])
+
+    @cluster(num_nodes=9)
+    def test_zk_tls(self):
+        self.zk.start()
+        self.kafka.security_protocol = self.kafka.interbroker_security_protocol = "PLAINTEXT"
+
+        self.kafka.start()
+
+        # Enable TLS port in Zookeeper in adition to the regular con-TLS port
+        self.enable_zk_tls()
+
+        # Leverage ZK TLS port in Kafka
+        self.enable_kafka_zk_tls()
+        self.perform_produce_consume_validation()
+
+        # Disable ZK non-TLS port to make sure we aren't using it
+        self.disable_zk_non_tls()
+
+        # Make sure the ZooKeeper command line is able to talk to a TLS-enabled ZooKeeepr quorum
+        # Test both create() and query(), each of which leverages the ZooKeeper command line
+        path="/foo"
+        value="{\"bar\": 0}" # must be
+        self.zk.create(path, value=value)
+        if self.zk.query(path) != value:
+            raise Exception("Error creating and then querying a znode using the CLI with a TLS-enabled ZooKeeper quorum")
+
+        # now enable ZK SASL authentication, but don't take advantage of it in Kafka yet
+        self.zk.zk_sasl = True
+        self.kafka.start_minikdc_if_necessary(self.zk.zk_principals)
+        self.zk.restart_cluster()
+        # bounce a Kafka broker to force it to leverage Zookeeper -- a simple sanity check
+        self.kafka.stop_node(self.kafka.nodes[0])
+        self.kafka.start_node(self.kafka.nodes[0])
+
+        # run migration tool
+        self.zk.zookeeper_migration(self.zk.nodes[0], "secure")
+
+        # restart brokers with zookeeper.set.acl=true and acls
+        self.kafka.zk_set_acl = True
+        self.kafka.restart_cluster()
+        self.perform_produce_consume_validation()


### PR DESCRIPTION
Initial commit, just a working system test for now, no docs.

I discovered that mutual authentication is required, so client needs
a key store in addition to a trust store.  Also, client key store
password must be the same as any password associated with the key in
that key store -- if the passwords don't match (or if the key store is
not specified at all) then the client wil be unable to connect to
Zookeeper on the TLS clientSecurePort.

Specifying the required parameters (e.g. key/trust store locations and
password, etc.) currently must be done via Java system properties, and
it is possible to define system properties via "-D" flags at the command
line.  This is less than desireable because command line arguments are
insecure.  A better approach would be to specify them in a .properties
file and have the JVM read them from there.  This might be doable by
alowing the bin/kafka-run-class.sh script to accept a pair of parameters
(e.g. -sysprops /path/to/system.properties) and invoke a wrapper class
when loading system properties from a file is requested; the wrapper
class could read and apply the system property definitions before
forwarding the invocation to the intended class.  Adding actual Kafka
configs is another option, but I think that would only apply to the
brokers -- command line tools (Zookeeper security migration tool, etc.)
would still need a separate solution.

If/how client certificate authentication can work with the Zookeeper
security migration tool (which adds ACLs to lock down znodes) is an
open question and requires more investigation.  For example, can SASL
authentication work on top of certificate authentication?  If so then
it is perhaps an acceptable first pass to leave things as they are --
only support applying Zookeeper ACLs on the SASL identity.  But if not,
or if we wish to support ACLs based on the certificate identity, then
we have to investigate how this can be done (maybe no change is needed)
and also if we can support adding ACLs multiple certificate identities.
If we can't support ading ACLs for multiple certificate identities then
we would be constrained to all brokers authenticating with the same
certificate.  So there is investigation to be done here.

KIP 515 was opened to address some of the above issues but it has been
dormant for a while (and the number 515 was actually already taken by
another KIP); this KIP might need to be revived (with a new KIP number).
