### PR TITLE
KAFKA-9315: The Kafka Metrics class should clear the mbeans map when closing

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -145,6 +145,7 @@ public class JmxReporter implements MetricsReporter {
         synchronized (LOCK) {
             for (KafkaMbean mbean : this.mbeans.values())
                 unregister(mbean);
+            this.mbeans.clear();
         }
     }
 


### PR DESCRIPTION
The JmxReporter should clear the mbeans map when closing. Otherwise,
metrics may be incorrectly re-registered if the JmxReporter class is
used after it is closed.

For example, calling JmxReporter#close followed by
JmxReporter#unregister could result in some of the mbeans that were
removed in the close operation being re-registered.