### PR TITLE
KAFKA-9314: Apply RetryWithToleranceOperator to push() and poll()

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -261,13 +261,9 @@ class WorkerSourceTask extends WorkerTask {
     }
 
     protected List<SourceRecord> poll() throws InterruptedException {
-        try {
-            return task.poll();
-        } catch (RetriableException | org.apache.kafka.common.errors.RetriableException e) {
-            log.warn("{} failed to poll records from SourceTask. Will retry operation.", this, e);
-            // Do nothing. Let the framework poll whenever it's ready.
-            return null;
-        }
+        retryWithToleranceOperator.reset();
+        return retryWithToleranceOperator.execute(
+            () -> task.poll(), Stage.TASK_POLL, List.class);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
@@ -47,7 +47,9 @@ class ProcessingContext {
     /**
      * Reset the internal fields before executing operations on a new record.
      */
-    private void reset() {
+    public void reset() {
+        consumedMessage = null;
+        sourceRecord = null;
         attempt = 0;
         position = null;
         klass = null;
@@ -60,8 +62,8 @@ class ProcessingContext {
      * @param consumedMessage the record
      */
     public void consumerRecord(ConsumerRecord<byte[], byte[]> consumedMessage) {
-        this.consumedMessage = consumedMessage;
         reset();
+        this.consumedMessage = consumedMessage;
     }
 
     /**
@@ -84,8 +86,8 @@ class ProcessingContext {
      * @param record the source record
      */
     public void sourceRecord(SourceRecord record) {
-        this.sourceRecord = record;
         reset();
+        this.sourceRecord = record;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -63,6 +63,8 @@ public class RetryWithToleranceOperator {
         TOLERABLE_EXCEPTIONS.put(Stage.HEADER_CONVERTER, Exception.class);
         TOLERABLE_EXCEPTIONS.put(Stage.KEY_CONVERTER, Exception.class);
         TOLERABLE_EXCEPTIONS.put(Stage.VALUE_CONVERTER, Exception.class);
+        TOLERABLE_EXCEPTIONS.put(Stage.TASK_POLL, org.apache.kafka.common.errors.RetriableException.class);
+        TOLERABLE_EXCEPTIONS.put(Stage.TASK_POLL, org.apache.kafka.connect.errors.RetriableException.class);
     }
 
     private final long errorRetryTimeout;
@@ -262,6 +264,10 @@ public class RetryWithToleranceOperator {
      */
     public void consumerRecord(ConsumerRecord<byte[], byte[]> consumedMessage) {
         this.context.consumerRecord(consumedMessage);
+    }
+
+    public void reset() {
+        this.context.reset();
     }
 
     /**


### PR DESCRIPTION
This commit applies RetryWithToleranceOperator added as part of KIP-298 to be
used when retrying RetriableExceptions thrown from SinkTask::put() and
SourceTask::poll().

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
