### PR TITLE
KAFKA-9322: Add `tail -n` feature for ConsoleConsumer

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -24,7 +24,7 @@ import kafka.common.MessageFormatter
 import kafka.tools.ConsoleConsumer.ConsumerWrapper
 import kafka.utils.{Exit, TestUtils}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, MockConsumer, OffsetResetStrategy}
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{Node, PartitionInfo, TopicPartition}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.test.MockDeserializer
 import org.mockito.Mockito._
@@ -145,7 +145,7 @@ class ConsoleConsumerTest {
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
     assertEquals(0, config.partitionArg.get)
-    assertEquals(3, config.offsetArg)
+    assertEquals("3", config.offsetArg)
     assertEquals(false, config.fromBeginning)
 
   }
@@ -186,7 +186,7 @@ class ConsoleConsumerTest {
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
     assertEquals(0, config.partitionArg.get)
-    assertEquals(-1, config.offsetArg)
+    assertEquals("latest", config.offsetArg)
     assertEquals(false, config.fromBeginning)
     assertEquals(false, config.formatter.asInstanceOf[DefaultMessageFormatter].printValue)
   }
@@ -444,7 +444,7 @@ class ConsoleConsumerTest {
     var config = new ConsoleConsumer.ConsumerConfig(args)
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
-    assertEquals(-2, config.offsetArg)
+    assertEquals("earliest", config.offsetArg)
     assertEquals(true, config.fromBeginning)
 
     // Start from latest
@@ -457,7 +457,7 @@ class ConsoleConsumerTest {
     config = new ConsoleConsumer.ConsumerConfig(args)
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
-    assertEquals(-1, config.offsetArg)
+    assertEquals("latest", config.offsetArg)
     assertEquals(false, config.fromBeginning)
   }
 
@@ -494,5 +494,32 @@ class ConsoleConsumerTest {
     } finally {
       Exit.resetExitProcedure()
     }
+  }
+
+
+  @Test
+  def testReadLastNMessages(): Unit = {
+    val topic = "test"
+    val tp1 = new TopicPartition(topic, 0)
+    val startOffset: java.lang.Long = 0L
+    val totalMessages: java.lang.Long = 10L
+    val lastN = -3
+
+    val mockConsumer = new MockConsumer[Array[Byte], Array[Byte]](OffsetResetStrategy.EARLIEST)
+    val partitionInfo = new PartitionInfo(topic, 0, null, new Array[Node](0), new Array[Node](0))
+
+    mockConsumer.updatePartitions(topic, List(partitionInfo).asJava)
+    mockConsumer.updateBeginningOffsets(Map(tp1 -> startOffset).asJava)
+    mockConsumer.updateEndOffsets(Map(tp1 -> totalMessages).asJava)
+
+    val consumer = new ConsumerWrapper(Some(topic), Some(0), Some(lastN.toString), None, mockConsumer)
+
+    0 until totalMessages.intValue foreach { i =>
+      mockConsumer.addRecord(new ConsumerRecord[Array[Byte], Array[Byte]](topic, 0, i, "key".getBytes, "value".getBytes))
+    }
+
+    val formatter = mock(classOf[MessageFormatter])
+    ConsoleConsumer.process(-1, formatter, consumer, System.out, skipMessageOnError = false)
+    verify(formatter, times(Math.abs(lastN))).writeTo(any(), any())
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9322

When debugging, it will be convenient to quickly check the last N messages for a partition using ConsoleConsumer. Currently `offset` could not be negative except -1 and -2. However, we could simply break this rule to support `tail -n` feature.

Slightly different, with this patch applied, -1 means the last one message instead of the latest offset, -2 means the last two messages intead of the earliest offset. You could use `latest` and `earliest` explicitly if you really start reading from those positions.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
