### PR TITLE
KAFKA-9246:Update Heartbeat timeout when ConsumerCoordinator commit offset

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1474,7 +1474,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
     }
 
-    // For testing only below
+    // For testing below and offset commit task
     final Heartbeat heartbeat() {
         return heartbeat;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
@@ -53,7 +53,7 @@ public class OffsetCommitResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public OffsetCommitResponse(int requestThrottleMs, Map<TopicPartition, Errors> responseData) {
+    public OffsetCommitResponse(int requestThrottleMs, Map<TopicPartition, Errors> responseData, boolean reblanceInProgress) {
         Map<String, OffsetCommitResponseTopic>
                 responseTopicDataMap = new HashMap<>();
 
@@ -72,7 +72,12 @@ public class OffsetCommitResponse extends AbstractResponse {
 
         data = new OffsetCommitResponseData()
                 .setTopics(new ArrayList<>(responseTopicDataMap.values()))
-                .setThrottleTimeMs(requestThrottleMs);
+                .setThrottleTimeMs(requestThrottleMs)
+                .setRebalanceInProgress(reblanceInProgress);
+    }
+
+    public OffsetCommitResponse(int requestThrottleMs, Map<TopicPartition, Errors> responseData) {
+        this(requestThrottleMs, responseData, false);
     }
 
     public OffsetCommitResponse(Map<TopicPartition, Errors> responseData) {

--- a/clients/src/main/resources/common/message/OffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/OffsetCommitRequest.json
@@ -30,7 +30,8 @@
   // version 7 adds a new field called groupInstanceId to indicate member identity across restarts.
   //
   // Version 8 is the first flexible version.
-  "validVersions": "0-8",
+  // From version 9 an OffsetCommitRequest will be treated as a HeartbeatRequest as well
+  "validVersions": "0-9",
   "flexibleVersions": "8+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/OffsetCommitResponse.json
+++ b/clients/src/main/resources/common/message/OffsetCommitResponse.json
@@ -28,7 +28,8 @@
   // Version 7 offsetCommitRequest supports a new field called groupInstanceId to indicate member identity across restarts.
   //
   // Version 8 is the first flexible version.
-  "validVersions": "0-8",
+  // From version 9 an OffsetCommitResponse will be treated as a HeartbeatResponse as well
+  "validVersions": "0-9",
   "flexibleVersions": "8+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
@@ -44,6 +45,7 @@
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no error." }
       ]}
-    ]}
+    ]},
+    {"name": "RebalanceInProgress", "type": "bool", "versions": "9+", "ignorable": true}
   ]
 }


### PR DESCRIPTION
I misoperated my git and need to reopen a PR(the original one is #7761).

the `GroupCoordinator` will renew HeartbeatExpiration after receiving `CommitOffsetReq`, so `ConsumerCoordinator` can also renew Heartbeat after sending `CommitOffsetReq`. 
However, the `ConsumerCoordinator` depends on heartbeats to detect `PreparingRebalance` and rejoin but the `commitOffsetReq` will generally not return an `Errors.ReblanceInProgress`  when `PreparingRebalance`.
So we just add a `ReblanceInProgress` field to the `CommitOffsetResponse` to indicate whether the `GroupCoordinator` is `PreparingRebalance`.

below is my implementation steps:
1. bump the protocol version of `CommitOffsetReq` and `CommitOffsetResp` and add a field to `ReblanceInProgress` field to the `CommitOffsetResp`.
2. add parameter to `GroupCoordinator.doCommitOffsets` to identify whether should we respond `ReblanceInProgress`;
3. when in `PreparingRebalance`, `GroupCoordinator` just act as before but add a `ReblanceInProgress` to the response;
4. client will interpret it intelligently.

and the interaction is as follows:
1. if an OLD client commits offset, it just acts as previous, and the broker will also act as previous;
2. if a new client commits offset, it will update heartbeat, the broker may respond a  `ReblanceInProgress`, the client also has the logic to handle it.

If this works well, we can also add `update Heartbeat logic` to `FetchOffsetReq` and `TxnOffsetCommitReq`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
