### PR TITLE
KAFKA-9330: Skip `join` when `AdminClient.close` is called in callback thread

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -556,7 +556,7 @@ public class KafkaAdminClient extends AdminClient {
             // cause deadlock, so check for that condition.
             if (Thread.currentThread() != thread) {
                 // Wait for the thread to be joined.
-                thread.join();
+                thread.join(waitTimeMs);
             }
             log.debug("Kafka admin client closed.");
         } catch (InterruptedException e) {


### PR DESCRIPTION
The close method calls `Thread.join` to wait for AdminClient thread to
die, but if the close is called in the api completion callback, `join`
waits forever, as the thread calling `join` is same as the thread it
wants to wait to die.

This change checks for this condition and skips the join. The thread
will then return to main loop, where it will check for this condition
and exit.

Added a new unit test to invoke this condition. The test fails with
timeout if the thread is joined in callback, passes otherwise.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
