### PR TITLE
KAFKA-6144: Allow state stores to serve stale reads during rebalance

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -450,12 +450,17 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public AlterConsumerGroupOffsetsResult alterConsumerGroupOffsets(String groupId, Map<TopicPartition, OffsetAndMetadata> offsets, AlterConsumerGroupOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implement yet");
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
     public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, ListOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implement yet");
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1020,7 +1020,7 @@ public class KafkaStreams implements AutoCloseable {
      */
     public Collection<StreamsMetadata> allMetadata() {
         validateIsRunning();
-        return streamsMetadataState.getAllMetadata();
+        return streamsMetadataState.getAllActiveMetadata();
     }
 
     /**
@@ -1073,7 +1073,7 @@ public class KafkaStreams implements AutoCloseable {
      * @param key           the key to find metadata for
      * @param keySerializer serializer for the key
      * @param <K>           key type
-     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provide {@code storeName} and
+     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provided {@code storeName} and
      * {@code key} of this application or {@link StreamsMetadata#NOT_AVAILABLE} if Kafka Streams is (re-)initializing
      */
     public <K> StreamsMetadata metadataForKey(final String storeName,
@@ -1104,7 +1104,7 @@ public class KafkaStreams implements AutoCloseable {
      * @param key         the key to find metadata for
      * @param partitioner the partitioner to be use to locate the host for the key
      * @param <K>         key type
-     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provide {@code storeName} and
+     * @return {@link StreamsMetadata} for the {@code KafkaStreams} instance with the provided {@code storeName} and
      * {@code key} of this application or {@link StreamsMetadata#NOT_AVAILABLE} if Kafka Streams is (re-)initializing
      */
     public <K> StreamsMetadata metadataForKey(final String storeName,
@@ -1112,6 +1112,23 @@ public class KafkaStreams implements AutoCloseable {
                                               final StreamPartitioner<? super K, ?> partitioner) {
         validateIsRunning();
         return streamsMetadataState.getMetadataWithKey(storeName, key, partitioner);
+    }
+
+    /**
+     * [TENTATIVE]  Provide metadata for all hosts that have this key.
+     *
+     * @param storeName     the {@code storeName} to find metadata for
+     * @param key           the key to find metadata for
+     * @param keySerializer serializer for the key
+     * @param <K>           key type
+     * @return {@link List<StreamsMetadata>} for the key ordered active first and then standby or
+     *         {@link StreamsMetadata#NOT_AVAILABLE} if Kafka Streams is (re-)initializing
+     */
+    public <K> List<StreamsMetadata> allMetadataWithKey(final String storeName,
+                                                        final K key,
+                                                        final Serializer<K> keySerializer) {
+        validateIsRunning();
+        return streamsMetadataState.getAllMetadataWithKey(storeName, key, keySerializer);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1230,7 +1230,7 @@ public class KafkaStreams implements AutoCloseable {
             localOffsetLags.put(storeName, partitionToOffsetLag);
         });
 
-        return localOffsetLags;
+        return Collections.unmodifiableMap(localOffsetLags);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1171,8 +1171,6 @@ public class KafkaStreams implements AutoCloseable {
 
         // Obtain the current positions, of all the active-restoring and standby tasks
         for (final StreamThread streamThread : this.threads) {
-            final Set<TaskId> restoringTaskIds = streamThread.restoringTaskIds();
-
             for (final StandbyTask standbyTask : streamThread.allStandbyTasks()) {
                 final Map<TopicPartition, Long> changelogPartitionLimits = standbyTask.checkpointedOffsets();
                 standbyTask.changelogPartitions().forEach(topicPartition ->
@@ -1180,6 +1178,7 @@ public class KafkaStreams implements AutoCloseable {
                         changelogPartitionLimits.getOrDefault(topicPartition, unknownPosition)));
             }
 
+            final Set<TaskId> restoringTaskIds = streamThread.restoringTaskIds();
             for (final StreamTask activeTask : streamThread.allStreamsTasks()) {
                 final boolean isRestoring = restoringTaskIds.contains(activeTask.id());
                 final Map<TopicPartition, Long> restoredOffsets = activeTask.restoredOffsets();

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * Represents all the metadata related to a key, where a particular key resides in a {@link KafkaStreams} application.
  * It contains the active {@link HostInfo} and a set of standby {@link HostInfo}s, denoting the instances where the key resides.
  * It also contains the partition number where the key belongs, which could be useful when used in conjunction with other APIs.
- * e.g: Relating with lags for that store partition using {@link KafkaStreams#allLocalOffsetLags()}
+ * e.g: Relating with lags for that store partition using {@link KafkaStreams#allLocalStorePartitionLags()}
  * NOTE: This is a point in time view. It may change as rebalances happen.
  */
 public class KeyQueryMetadata {
@@ -38,11 +38,10 @@ public class KeyQueryMetadata {
             Collections.emptySet(),
             -1);
 
-    // Active streams instance for key
     private final HostInfo activeHost;
-    // Streams instances that host the key as standbys
+
     private final Set<HostInfo> standbyHosts;
-    // Store partition corresponding to the key.
+
     private final int partition;
 
     public KeyQueryMetadata(final HostInfo activeHost, final Set<HostInfo> standbyHosts, final int partition) {
@@ -51,14 +50,29 @@ public class KeyQueryMetadata {
         this.partition = partition;
     }
 
+    /**
+     * Get the Active streams instance for given key
+     *
+     * @return active instance's {@link HostInfo}
+     */
     public HostInfo getActiveHost() {
         return activeHost;
     }
 
+    /**
+     * Get the Streams instances that host the key as standbys
+     *
+     * @return set of standby {@link HostInfo} or a empty set, if no standbys are configured
+     */
     public Set<HostInfo> getStandbyHosts() {
         return standbyHosts;
     }
 
+    /**
+     * Get the Store partition corresponding to the key.
+     *
+     * @return store partition number
+     */
     public int getPartition() {
         return partition;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -34,7 +34,7 @@ public class KeyQueryMetadata {
      * Sentinel to indicate that the KeyQueryMetadata is currently unavailable. This can occur during rebalance
      * operations.
      */
-    public final static KeyQueryMetadata NOT_AVAILABLE = new KeyQueryMetadata(new HostInfo("unavailable", -1),
+    public static final KeyQueryMetadata NOT_AVAILABLE = new KeyQueryMetadata(new HostInfo("unavailable", -1),
             Collections.emptySet(),
             -1);
 

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -23,11 +23,11 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents all the metadata where a particular key resides in a {@link KafkaStreams} application.
- * It contains the user supplied {@link HostInfo} and the Set of standby Hosts where the key would be found in case an application
- * has more than one standby. It also contains the partition number where the key belongs, this information would be useful in
- * developing another apis on top, to fetch Offset Lag or Time based lag for the partition where the key belongs.
- * NOTE: This is a point in time view. It may change when rebalances happen.
+ * Represents all the metadata related to a key, where a particular key resides in a {@link KafkaStreams} application.
+ * It contains the active {@link HostInfo} and a set of standby {@link HostInfo}s, denoting the instances where the key resides.
+ * It also contains the partition number where the key belongs, which could be useful when used in conjunction with other APIs.
+ * e.g: Relating with lags for that store partition using {@link KafkaStreams#allLocalOffsetLags()}
+ * NOTE: This is a point in time view. It may change as rebalances happen.
  */
 public class KeyQueryMetadata {
     /**
@@ -42,7 +42,6 @@ public class KeyQueryMetadata {
     private final HostInfo activeHost;
     // Streams instances that host the key as standbys
     private final Set<HostInfo> standbyHosts;
-
     // Store partition corresponding to the key.
     private final int partition;
 

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -83,12 +83,14 @@ public class KeyQueryMetadata {
             return false;
         }
         final KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
-        return Objects.equals(keyQueryMetadata.activeHost, activeHost) && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts) && Objects.equals(keyQueryMetadata.partition, partition);
+        return Objects.equals(keyQueryMetadata.activeHost, activeHost)
+            && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts)
+            && Objects.equals(keyQueryMetadata.partition, partition);
     }
 
     @Override
     public String toString() {
-        return "KeyQueryMetadata{" +
+        return "KeyQueryMetadata {" +
                 "activeHost=" + activeHost +
                 ", standbyHosts=" + standbyHosts +
                 ", partition=" + partition +

--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.processor.internals;
+package org.apache.kafka.streams;
 
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;
 
 import java.util.Collections;

--- a/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates information about lag, at a store partition replica (active or standby). This information is constantly changing as the
+ * tasks process records and thus, they should be treated as simply instantaenous measure of lag.
+ */
+public class LagInfo {
+
+    private final long currentOffsetPosition;
+
+    private final long endOffsetPosition;
+
+    private final long offsetLag;
+
+    LagInfo(final long currentOffsetPosition, final long endOffsetPosition) {
+        this.currentOffsetPosition = currentOffsetPosition;
+        this.endOffsetPosition = endOffsetPosition;
+        this.offsetLag = Math.max(0, endOffsetPosition - currentOffsetPosition);
+    }
+
+    /**
+     * Get the current maximum offset on the store partition's changelog topic, that has been successfully written into
+     * the store partition's state store.
+     *
+     * @return current consume offset for standby/restoring store partitions & simply endoffset for active store partition replicas
+     */
+    public long currentOffsetPosition() {
+        return this.currentOffsetPosition;
+    }
+
+    /**
+     * Get the end offset position for this store partition's changelog topic on the Kafka brokers.
+     *
+     * @return last offset written to the changelog topic partition
+     */
+    public long endOffsetPosition() {
+        return this.endOffsetPosition;
+    }
+
+    /**
+     * Get the measured lag between current and end offset positions, for this store partition replica
+     *
+     * @return lag as measured by message offsets
+     */
+    public long offsetLag() {
+        return this.offsetLag;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof LagInfo)) {
+            return false;
+        }
+        final LagInfo other = (LagInfo) obj;
+        return currentOffsetPosition == other.currentOffsetPosition
+            && endOffsetPosition == other.endOffsetPosition
+            && this.offsetLag == other.offsetLag;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentOffsetPosition, endOffsetPosition, offsetLag);
+    }
+
+    @Override
+    public String toString() {
+        return "LagInfo {" +
+            " currentOffsetPosition=" + currentOffsetPosition +
+            ", endOffsetPosition=" + endOffsetPosition +
+            ", offsetLag=" + offsetLag +
+            '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -305,7 +305,7 @@ public class StreamsConfig extends AbstractConfig {
     /**{@code application.server} */
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_SERVER_CONFIG = "application.server";
-    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to an embedded user defined endpoint that can be used for state store discovery and interactive queries within a single KafkaStreams application";
+    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to a user-defined endpoint that can be used for state store discovery and interactive queries on this KafkaStreams instance.";
 
     /** {@code bootstrap.servers} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -302,10 +302,10 @@ public class StreamsConfig extends AbstractConfig {
     public static final String APPLICATION_ID_CONFIG = "application.id";
     private static final String APPLICATION_ID_DOC = "An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix.";
 
-    /**{@code user.endpoint} */
+    /**{@code application.server} */
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_SERVER_CONFIG = "application.server";
-    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single KafkaStreams application";
+    private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to an embedded user defined endpoint that can be used for state store discovery and interactive queries within a single KafkaStreams application";
 
     /** {@code bootstrap.servers} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Map;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -32,7 +33,6 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractTask implements Task {
@@ -99,10 +99,6 @@ public abstract class AbstractTask implements Task {
     public TaskId id() {
         return id;
     }
-
-    public abstract long offsetLimit(final TopicPartition partition);
-
-    public abstract Map<TopicPartition, Long> checkpointedOffsets();
 
     @Override
     public String applicationId() {
@@ -260,4 +256,7 @@ public abstract class AbstractTask implements Task {
         return stateMgr.changelogPartitions();
     }
 
+    public Map<TopicPartition, Long> restoredOffsets() {
+        return stateMgr.changelogReader().restoredOffsets();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractTask implements Task {
@@ -100,6 +101,8 @@ public abstract class AbstractTask implements Task {
     }
 
     public abstract long offsetLimit(final TopicPartition partition);
+
+    public abstract Map<TopicPartition, Long> checkpointedOffsets();
 
     @Override
     public String applicationId() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -99,6 +99,8 @@ public abstract class AbstractTask implements Task {
         return id;
     }
 
+    public abstract long offsetLimit(final TopicPartition partition);
+
     @Override
     public String applicationId() {
         return applicationId;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -34,8 +35,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements RestoringTasks {
-    private final Map<TaskId, StreamTask> suspended = new HashMap<>();
-    private final Map<TaskId, StreamTask> restoring = new HashMap<>();
+    private final Map<TaskId, StreamTask> suspended = new ConcurrentHashMap<>();
+    private final Map<TaskId, StreamTask> restoring = new ConcurrentHashMap<>();
     private final Set<TopicPartition> restoredPartitions = new HashSet<>();
     private final Map<TopicPartition, StreamTask> restoringByPartition = new HashMap<>();
     private final Set<TaskId> prevActiveTasks = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 abstract class AssignedTasks<T extends Task> {
     final Logger log;
     final String taskTypeName;
-    final Map<TaskId, T> created = new HashMap<>();
+    final Map<TaskId, T> created = new ConcurrentHashMap<>();
 
     // IQ may access this map.
     final Map<TaskId, T> running = new ConcurrentHashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -251,7 +251,7 @@ abstract class AssignedTasks<T extends Task> {
     void shutdown(final boolean clean) {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
 
-        for (final T task : allTasks()) {
+        for (final T task: allTasks()) {
             try {
                 closeTask(task, clean);
             } catch (final TaskMigratedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -251,7 +251,7 @@ abstract class AssignedTasks<T extends Task> {
     void shutdown(final boolean clean) {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
 
-        for (final T task: allTasks()) {
+        for (final T task : allTasks()) {
             try {
                 closeTask(task, clean);
             } catch (final TaskMigratedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -599,6 +599,10 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
+    public Map<String, String> getStoreToChangelogTopic() {
+        return storeToChangelogTopic;
+    }
+
     public void connectSourceStoreAndTopic(final String sourceStoreName,
                                             final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -102,6 +102,9 @@ public class InternalTopologyBuilder {
     // map from state store names to this state store's corresponding changelog topic if possible
     private final Map<String, String> storeToChangelogTopic = new HashMap<>();
 
+    // map from changelog topic name to its corresponding state store.
+    private final Map<String, String> changelogTopicToStore = new HashMap<>();
+
     // all global topics
     private final Set<String> globalTopics = new HashSet<>();
 
@@ -603,12 +606,17 @@ public class InternalTopologyBuilder {
         return storeToChangelogTopic;
     }
 
+    public Map<String, String> getChangelogTopicToStore() {
+        return changelogTopicToStore;
+    }
+
     public void connectSourceStoreAndTopic(final String sourceStoreName,
                                             final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {
             throw new TopologyException("Source store " + sourceStoreName + " is already added.");
         }
         storeToChangelogTopic.put(sourceStoreName, topic);
+        changelogTopicToStore.put(topic, sourceStoreName);
     }
 
     public final void addInternalTopic(final String topicName) {
@@ -944,6 +952,7 @@ public class InternalTopologyBuilder {
                     if (stateStoreFactory.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
                         final String changelogTopic = ProcessorStateManager.storeChangelogTopic(applicationId, stateStoreName);
                         storeToChangelogTopic.put(stateStoreName, changelogTopic);
+                        changelogTopicToStore.put(changelogTopic, stateStoreName);
                     }
                     stateStoreMap.put(stateStoreName, stateStoreFactory.build());
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
@@ -16,14 +16,23 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
+/**
+ * Represents all the metadata where a particular key resides in a {@link KafkaStreams} application.
+ * It contains the user supplied {@link HostInfo} and the Set of standby Hosts where the key would be found in case an application
+ * has more than one standby. It also contains the partition number where the key belongs, this information would be useful in
+ * developing another apis on top, to fetch Offset Lag or Time based lag for the partition where the key belongs.
+ * NOTE: This is a point in time view. It may change when rebalances happen.
+ */
 public class KeyQueryMetadata {
     /**
-     * Sentinel to indicate that the StreamsMetadata is currently unavailable. This can occur during rebalance
+     * Sentinel to indicate that the KeyQueryMetadata is currently unavailable. This can occur during rebalance
      * operations.
      */
     public final static KeyQueryMetadata NOT_AVAILABLE = new KeyQueryMetadata(new HostInfo("unavailable", -1),
@@ -58,20 +67,11 @@ public class KeyQueryMetadata {
 
     @Override
     public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof KeyQueryMetadata)) {
             return false;
         }
-        final KeyQueryMetadata that = (KeyQueryMetadata) obj;
-        if (activeHost != that.activeHost) {
-            return false;
-        }
-        if (!standbyHosts.equals(that.standbyHosts)) {
-            return false;
-        }
-        return partition == that.partition;
+        KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
+        return Objects.equals(keyQueryMetadata.activeHost, activeHost) && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts) && Objects.equals(keyQueryMetadata.partition, partition);
     }
 
     @Override
@@ -85,9 +85,6 @@ public class KeyQueryMetadata {
 
     @Override
     public int hashCode() {
-        int result = activeHost.hashCode();
-        result = 31 * result + standbyHosts.hashCode();
-        result = 31 * result + partition;
-        return result;
+      return Objects.hash(activeHost, standbyHosts, partition);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
@@ -70,7 +70,7 @@ public class KeyQueryMetadata {
         if (!(obj instanceof KeyQueryMetadata)) {
             return false;
         }
-        KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
+        final KeyQueryMetadata keyQueryMetadata = (KeyQueryMetadata) obj;
         return Objects.equals(keyQueryMetadata.activeHost, activeHost) && Objects.equals(keyQueryMetadata.standbyHosts, standbyHosts) && Objects.equals(keyQueryMetadata.partition, partition);
     }
 
@@ -85,6 +85,6 @@ public class KeyQueryMetadata {
 
     @Override
     public int hashCode() {
-      return Objects.hash(activeHost, standbyHosts, partition);
+        return Objects.hash(activeHost, standbyHosts, partition);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/KeyQueryMetadata.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.state.HostInfo;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class KeyQueryMetadata {
+    /**
+     * Sentinel to indicate that the StreamsMetadata is currently unavailable. This can occur during rebalance
+     * operations.
+     */
+    public final static KeyQueryMetadata NOT_AVAILABLE = new KeyQueryMetadata(new HostInfo("unavailable", -1),
+            Collections.emptySet(),
+            -1);
+
+    // Active streams instance for key
+    private final HostInfo activeHost;
+    // Streams instances that host the key as standbys
+    private final Set<HostInfo> standbyHosts;
+
+    // Store partition corresponding to the key.
+    private final int partition;
+
+    public KeyQueryMetadata(final HostInfo activeHost, final Set<HostInfo> standbyHosts, final int partition) {
+        this.activeHost = activeHost;
+        this.standbyHosts = standbyHosts;
+        this.partition = partition;
+    }
+
+    public HostInfo getActiveHost() {
+        return activeHost;
+    }
+
+    public Set<HostInfo> getStandbyHosts() {
+        return standbyHosts;
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final KeyQueryMetadata that = (KeyQueryMetadata) obj;
+        if (activeHost != that.activeHost) {
+            return false;
+        }
+        if (!standbyHosts.equals(that.standbyHosts)) {
+            return false;
+        }
+        return partition == that.partition;
+    }
+
+    @Override
+    public String toString() {
+        return "KeyQueryMetadata{" +
+                "activeHost=" + activeHost +
+                ", standbyHosts=" + standbyHosts +
+                ", partition=" + partition +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        int result = activeHost.hashCode();
+        result = 31 * result + standbyHosts.hashCode();
+        result = 31 * result + partition;
+        return result;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.FixedOrderMap;
@@ -73,7 +74,7 @@ public class ProcessorStateManager implements StateManager {
     private final boolean eosEnabled;
     private final File baseDir;
     private OffsetCheckpoint checkpointFile;
-    private final Map<TopicPartition, Long> checkpointFileCache = new HashMap<>();
+    private final Map<TopicPartition, Long> checkpointFileCache = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Long> initialLoadedCheckpoints;
 
     /**
@@ -102,7 +103,7 @@ public class ProcessorStateManager implements StateManager {
         offsetLimits = new HashMap<>();
         standbyRestoredOffsets = new HashMap<>();
         this.isStandby = isStandby;
-        restoreCallbacks = isStandby ? new HashMap<>() : null;
+        restoreCallbacks = isStandby ? new ConcurrentHashMap<>() : null;
         recordConverters = isStandby ? new HashMap<>() : null;
         this.storeToChangelogTopic = new HashMap<>(storeToChangelogTopic);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -409,6 +409,10 @@ public class ProcessorStateManager implements StateManager {
         return unmodifiableList(changelogPartitions);
     }
 
+    ChangelogReader changelogReader() {
+        return changelogReader;
+    }
+
     void ensureStoresRegistered() {
         for (final Map.Entry<String, Optional<StateStore>> entry : registeredStores.entrySet()) {
             if (!entry.getValue().isPresent()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -195,7 +195,8 @@ public class StandbyTask extends AbstractTask {
         return remainingRecords;
     }
 
-    Map<TopicPartition, Long> checkpointedOffsets() {
+    @Override
+    public Map<TopicPartition, Long> checkpointedOffsets() {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -213,7 +213,6 @@ public class StandbyTask extends AbstractTask {
                 throw new IllegalStateException("Offset limit should monotonically increase, but was reduced. " +
                     "New limit: " + newlimit.getValue() + ". Previous limit: " + previousLimit);
             }
-
         }
 
         offsetLimits.putAll(newLimits);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -221,6 +221,11 @@ public class StandbyTask extends AbstractTask {
         return offsetLimits.get(partition);
     }
 
+    public long offsetLimit(final TopicPartition partition) {
+        final Long limit = offsetLimits.get(partition);
+        return limit != null ? limit : Long.MAX_VALUE;
+    }
+
     private Map<TopicPartition, Long> committedOffsetForPartitions(final Set<TopicPartition> partitions) {
         try {
             // those do not have a committed offset would default to 0

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -195,7 +195,6 @@ public class StandbyTask extends AbstractTask {
         return remainingRecords;
     }
 
-    @Override
     public Map<TopicPartition, Long> checkpointedOffsets() {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
@@ -219,12 +218,6 @@ public class StandbyTask extends AbstractTask {
         updateOffsetLimits = false;
 
         return offsetLimits.get(partition);
-    }
-
-    @Override
-    public long offsetLimit(final TopicPartition partition) {
-        final Long limit = offsetLimits.get(partition);
-        return limit != null ? limit : Long.MAX_VALUE;
     }
 
     private Map<TopicPartition, Long> committedOffsetForPartitions(final Set<TopicPartition> partitions) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -221,6 +221,7 @@ public class StandbyTask extends AbstractTask {
         return offsetLimits.get(partition);
     }
 
+    @Override
     public long offsetLimit(final TopicPartition partition) {
         final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -46,7 +47,7 @@ public class StoreChangelogReader implements ChangelogReader {
     private final StateRestoreListener userStateRestoreListener;
     private final Map<TopicPartition, Long> restoreToOffsets = new HashMap<>();
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
-    private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
+    private final Map<TopicPartition, StateRestorer> stateRestorers = new ConcurrentHashMap<>();
     private final Set<TopicPartition> needsRestoring = new HashSet<>();
     private final Set<TopicPartition> needsInitializing = new HashSet<>();
     private final Set<TopicPartition> completedRestorers = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -249,6 +249,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         offsetLimits.putAll(committedOffsetsForChangelogs);
     }
 
+    @Override
     public long offsetLimit(final TopicPartition partition) {
         final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -248,17 +247,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
         stateMgr.putOffsetLimits(committedOffsetsForChangelogs);
         offsetLimits.putAll(committedOffsetsForChangelogs);
-    }
-
-    @Override
-    public long offsetLimit(final TopicPartition partition) {
-        final Long limit = offsetLimits.get(partition);
-        return limit != null ? limit : Long.MAX_VALUE;
-    }
-
-    @Override
-    public Map<TopicPartition, Long> checkpointedOffsets() {
-        return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
     private void initializeTaskTime(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -97,7 +97,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     private boolean transactionInFlight = false;
 
     private final String threadId;
-    private final Map<TopicPartition, Long> offsetLimits = new HashMap<>();
 
     public interface ProducerSupplier {
         Producer<byte[], byte[]> get();
@@ -246,7 +245,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         stateMgr.putOffsetLimits(committedOffsetsForChangelogs);
-        offsetLimits.putAll(committedOffsetsForChangelogs);
     }
 
     private void initializeTaskTime(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -97,6 +97,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     private boolean transactionInFlight = false;
 
     private final String threadId;
+    private final Map<TopicPartition, Long> offsetLimits = new HashMap<>();
 
     public interface ProducerSupplier {
         Producer<byte[], byte[]> get();
@@ -245,6 +246,12 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
 
         stateMgr.putOffsetLimits(committedOffsetsForChangelogs);
+        offsetLimits.putAll(committedOffsetsForChangelogs);
+    }
+
+    public long offsetLimit(final TopicPartition partition) {
+        final Long limit = offsetLimits.get(partition);
+        return limit != null ? limit : Long.MAX_VALUE;
     }
 
     private void initializeTaskTime(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -253,6 +254,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     public long offsetLimit(final TopicPartition partition) {
         final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;
+    }
+
+    @Override
+    public Map<TopicPartition, Long> checkpointedOffsets() {
+        return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
     private void initializeTaskTime(final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1276,4 +1276,8 @@ public class StreamThread extends Thread {
     int currentNumIterations() {
         return numIterations;
     }
+
+    public StreamThread.StateListener stateListener() {
+        return stateListener;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -235,11 +235,6 @@ public class StreamThread extends Thread {
         return oldState;
     }
 
-    public boolean isRunningAndNotRebalancing() {
-        // we do not need to grab stateLock since it is a single read
-        return state == State.RUNNING;
-    }
-
     public boolean isRunning() {
         synchronized (stateLock) {
             return state.isRunning();
@@ -1199,6 +1194,18 @@ public class StreamThread extends Thread {
         return taskManager.standbyTasks();
     }
 
+    public List<StreamTask> allStreamsTasks() {
+        return taskManager.allStreamsTasks();
+    }
+
+    public List<StandbyTask> allStandbyTasks() {
+        return taskManager.allStandbyTasks();
+    }
+
+    public Set<TaskId> restoringTaskIds() {
+        return taskManager.restoringTaskIds();
+    }
+
     /**
      * Produces a string representation containing useful information about a StreamThread.
      * This is useful in debugging scenarios.
@@ -1268,9 +1275,5 @@ public class StreamThread extends Thread {
 
     int currentNumIterations() {
         return numIterations;
-    }
-
-    public StreamThread.StateListener stateListener() {
-        return stateListener;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1195,6 +1195,10 @@ public class StreamThread extends Thread {
         return taskManager.activeTasks();
     }
 
+    public Map<TaskId, StandbyTask> standbyTasks() {
+        return taskManager.standbyTasks();
+    }
+
     /**
      * Produces a string representation containing useful information about a StreamThread.
      * This is useful in debugging scenarios.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
 
@@ -372,6 +373,15 @@ public class StreamsMetadataState {
             } else if (standbyStateStoreNames.contains(storeName)
                     && !topicPartitions.isEmpty()) {
                 standbyHosts.add(streamsMetadata.hostInfo());
+            }
+        }
+
+        // would need these below changes to send TopicGroupId instead of partition in KeyQueryMetadata
+        int myTopicGroupId;
+        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        for (Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> topicGroup : topicGroups.entrySet()) {
+                if (topicGroup.getValue().sourceTopics.contains(sourceTopicsInfo.sourceTopics)) {
+                    myTopicGroupId = topicGroup.getKey();
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -338,8 +338,8 @@ public class StreamsMetadataState {
                 final StreamsMetadata metadata = new StreamsMetadata(key,
                                                                      activeStoresOnHost,
                                                                      activePartitionsOnHost,
-                                                                     standbyPartitionsOnHost,
-                                                                     standbyStoresOnHost);
+                                                                     standbyStoresOnHost,
+                                                                     standbyPartitionsOnHost);
                 allMetadata.add(metadata);
                 if (key.equals(thisHost)) {
                     myMetadata = metadata;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -116,7 +116,6 @@ public class StreamsMetadataState {
      * Find the {@link StreamsMetadata}s for a given storeName and key. This method will use the
      * {@link DefaultStreamPartitioner} to locate the store. If a custom partitioner has been used
      * please use {@link StreamsMetadataState#getMetadataWithKey(String, Object, StreamPartitioner)}
-     * <p>
      * Note: the key may not exist in the {@link org.apache.kafka.streams.processor.StateStore},
      * this method provides a way of finding which {@link StreamsMetadata} it would exist on.
      *
@@ -161,7 +160,7 @@ public class StreamsMetadataState {
 
     /**
      * Find the {@link KeyQueryMetadata}s for a given storeName and key.
-     * <p>
+     *
      * Note: the key may not exist in the {@link StateStore},
      * this method provides a way of finding which {@link StreamsMetadata} it would exist on.
      *
@@ -187,9 +186,9 @@ public class StreamsMetadataState {
             // global stores are on every node. if we dont' have the host info
             // for this host then just pick the first metadata
             if (thisHost == UNKNOWN_HOST) {
-                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), null, 0);
+                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), Collections.emptySet(), -1);
             }
-            return new KeyQueryMetadata(myMetadata.hostInfo(), null, 0);
+            return new KeyQueryMetadata(myMetadata.hostInfo(), Collections.emptySet(), -1);
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -203,7 +202,7 @@ public class StreamsMetadataState {
      * Find the {@link KeyQueryMetadata}s for a given storeName and key. This method will use the
      * {@link DefaultStreamPartitioner} to locate the store. If a custom partitioner has been used
      * please use {@link StreamsMetadataState#getKeyQueryMetadataWithKey(String, Object, Serializer)}
-     * <p>
+     *
      * Note: the key may not exist in the {@link org.apache.kafka.streams.processor.StateStore},
      * this method provides a way of finding which {@link KeyQueryMetadata} it would exist on.
      *
@@ -229,9 +228,9 @@ public class StreamsMetadataState {
             // global stores are on every node. if we dont' have the host info
             // for this host then just pick the first metadata
             if (thisHost == UNKNOWN_HOST) {
-                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), null, 0);
+                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), Collections.emptySet(), -1);
             }
-            return new KeyQueryMetadata(myMetadata.hostInfo(), null, 0);
+            return new KeyQueryMetadata(myMetadata.hostInfo(), Collections.emptySet(), -1);
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -333,13 +332,13 @@ public class StreamsMetadataState {
             final Set<TopicPartition> activepartitionsForHost = new HashSet<>(entry.getValue());
             final Set<String> activeStoresOnHost = getStoresOnHost(stores, activepartitionsForHost);
             activeStoresOnHost.addAll(globalStores);
-            final Set<TopicPartition> standbypartitionsForHost = new HashSet<>();
+            final Set<TopicPartition> standbyPartitionsForHost = new HashSet<>();
             final Set<String> standbyStoresOnHost = new HashSet<>();
-            if (standbyPartitionHostMap != null && standbyPartitionHostMap.containsKey(key)) {
-                standbypartitionsForHost.addAll(standbyPartitionHostMap.get(key));
-                standbyStoresOnHost.addAll(getStoresOnHost(stores, standbypartitionsForHost));
+            if (!standbyPartitionHostMap.isEmpty() && standbyPartitionHostMap.containsKey(key)) {
+                standbyPartitionsForHost.addAll(standbyPartitionHostMap.get(key));
+                standbyStoresOnHost.addAll(getStoresOnHost(stores, standbyPartitionsForHost));
             }
-            final StreamsMetadata metadata = new StreamsMetadata(key, activeStoresOnHost, activepartitionsForHost, standbypartitionsForHost, standbyStoresOnHost);
+            final StreamsMetadata metadata = new StreamsMetadata(key, activeStoresOnHost, activepartitionsForHost, standbyPartitionsForHost, standbyStoresOnHost);
             if (activepartitionsForHost != null) {
                 allMetadata.add(metadata);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -74,8 +74,7 @@ public class StreamsMetadataState {
     }
 
     /**
-     * Get the {@link StreamsMetadata}s for local instance in a
-     * {@link KafkaStreams application}
+     * Get the {@link StreamsMetadata}s for the local instance in a {@link KafkaStreams application}
      *
      * @return the {@link StreamsMetadata}s for the local instance in a {@link KafkaStreams} application
      */
@@ -165,9 +164,9 @@ public class StreamsMetadataState {
         }
 
         return getStreamsMetadataForKey(storeName,
-                key,
-                new DefaultStreamPartitioner<>(keySerializer, clusterMetadata),
-                sourceTopicsInfo);
+                                        key,
+                                        new DefaultStreamPartitioner<>(keySerializer, clusterMetadata),
+                                        sourceTopicsInfo);
     }
 
     /**
@@ -190,15 +189,15 @@ public class StreamsMetadataState {
                                                                        final Serializer<K> keySerializer) {
         Objects.requireNonNull(keySerializer, "keySerializer can't be null");
         return getKeyQueryMetadataForKey(storeName,
-            key,
-            new DefaultStreamPartitioner<>(keySerializer, clusterMetadata));
+                                         key,
+                                         new DefaultStreamPartitioner<>(keySerializer, clusterMetadata));
     }
 
     /**
      * Find the {@link KeyQueryMetadata}s for a given storeName and key
      *
-     * Note: the key may not exist in the {@link StateStore},
-     * this method provides a way of finding which {@link StreamsMetadata} it would exist on.
+     * Note: the key may not exist in the {@link StateStore},this method provides a way of finding which
+     * {@link StreamsMetadata} it would exist on.
      *
      * @param storeName   Name of the store
      * @param key         Key to use
@@ -208,8 +207,8 @@ public class StreamsMetadataState {
      * if streams is (re-)initializing
      */
     public synchronized <K> KeyQueryMetadata getKeyQueryMetadataForKey(final String storeName,
-                                                                        final K key,
-                                                                        final StreamPartitioner<? super K, ?> partitioner) {
+                                                                       final K key,
+                                                                       final StreamPartitioner<? super K, ?> partitioner) {
         Objects.requireNonNull(storeName, "storeName can't be null");
         Objects.requireNonNull(key, "key can't be null");
         Objects.requireNonNull(partitioner, "partitioner can't be null");
@@ -284,7 +283,8 @@ public class StreamsMetadataState {
      * @param clusterMetadata         the current clusterMetadata {@link Cluster}
      */
     synchronized void onChange(final Map<HostInfo, Set<TopicPartition>> activePartitionHostMap,
-                               final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap, final Cluster clusterMetadata) {
+                               final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap,
+                               final Cluster clusterMetadata) {
         this.clusterMetadata = clusterMetadata;
         rebuildMetadata(activePartitionHostMap, standbyPartitionHostMap);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.HostInfo;
@@ -115,7 +116,7 @@ public class StreamsMetadataState {
 
         final ArrayList<StreamsMetadata> results = new ArrayList<>();
         for (final StreamsMetadata metadata : allMetadata) {
-            if (metadata.stateStoreNames().contains(storeName) || metadata.getStandbyStateStoreNames().contains(storeName)) {
+            if (metadata.stateStoreNames().contains(storeName) || metadata.standbyStateStoreNames().contains(storeName)) {
                 results.add(metadata);
             }
         }
@@ -373,19 +374,17 @@ public class StreamsMetadataState {
         final Set<HostInfo> standbyHosts = new HashSet<>();
         for (final StreamsMetadata streamsMetadata : allMetadata) {
             final Set<String> activeStateStoreNames = streamsMetadata.stateStoreNames();
-            final Set<String> standbyStateStoreNames = streamsMetadata.getStandbyStateStoreNames();
+            final Set<String> standbyStateStoreNames = streamsMetadata.standbyStateStoreNames();
             final Set<TopicPartition> topicPartitions = new HashSet<>(streamsMetadata.topicPartitions());
             topicPartitions.retainAll(matchingPartitions);
-            if (activeStateStoreNames.contains(storeName)
-                    && !topicPartitions.isEmpty()) {
+            if (activeStateStoreNames.contains(storeName) && !topicPartitions.isEmpty()) {
                 activeHost = streamsMetadata.hostInfo();
-            } else if (standbyStateStoreNames.contains(storeName)
-                    && !topicPartitions.isEmpty()) {
+            } else if (standbyStateStoreNames.contains(storeName) && !topicPartitions.isEmpty()) {
                 standbyHosts.add(streamsMetadata.hostInfo());
             }
         }
 
-        return new KeyQueryMetadata(activeHost, standbyHosts, partition.intValue());
+        return new KeyQueryMetadata(activeHost, standbyHosts, partition);
     }
 
     @Deprecated

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
 
@@ -70,6 +69,16 @@ public class StreamsMetadataState {
         builder.append(indent).append(clusterMetadata).append("\n");
 
         return builder.toString();
+    }
+
+    /**
+     * Get the {@link StreamsMetadata}s for local instance in a
+     * {@link KafkaStreams application}
+     *
+     * @return the {@link StreamsMetadata}s for the local instance in a {@link KafkaStreams} application
+     */
+    public synchronized StreamsMetadata getMyMetadata() {
+        return myMetadata;
     }
 
     /**
@@ -376,15 +385,6 @@ public class StreamsMetadataState {
             }
         }
 
-        // would need these below changes to send TopicGroupId instead of partition in KeyQueryMetadata
-        int myTopicGroupId;
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
-        for (Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> topicGroup : topicGroups.entrySet()) {
-                if (topicGroup.getValue().sourceTopics.contains(sourceTopicsInfo.sourceTopics)) {
-                    myTopicGroupId = topicGroup.getKey();
-            }
-        }
-
         return new KeyQueryMetadata(activeHost, standbyHosts, partition.intValue());
     }
 
@@ -418,6 +418,10 @@ public class StreamsMetadataState {
             return null;
         }
         return new SourceTopicsInfo(sourceTopics);
+    }
+
+    public String getChangelogTopicForStore(final String storeName) {
+      return builder.getStoreToChangelogTopic().get(storeName);
     }
 
     private boolean isInitialized() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -421,7 +421,7 @@ public class StreamsMetadataState {
     }
 
     public String getChangelogTopicForStore(final String storeName) {
-      return builder.getStoreToChangelogTopic().get(storeName);
+        return builder.getStoreToChangelogTopic().get(storeName);
     }
 
     private boolean isInitialized() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1143,6 +1143,10 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 3:
             case 4:
             case 5:
+                processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
+                partitionsByHost = info.partitionsByHost();
+                standbyPartitionsByHost = Collections.emptyMap();
+                break;
             case 6:
                 processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
                 partitionsByHost = info.partitionsByHost();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -637,7 +637,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                         topicPartitions.addAll(partitionsForTask.get(id));
                     }
 
-                    // TODO: why do we have standby tasks even for non stateful sub topologies?
                     for (final TaskId id : state.standbyTasks()) {
                         standbyPartitions.addAll(partitionsForTask.get(id));
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -283,6 +283,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                         Collections.emptyList(),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
+                        Collections.emptyMap(),
                         errorCode).encode()
                 ));
             }
@@ -620,7 +621,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // ---------------- Step Three ---------------- //
 
         // construct the global partition assignment per host map
-        final Map<HostInfo, Set<TopicPartition>> partitionsByHostState = new HashMap<>();
+        final Map<HostInfo, Set<TopicPartition>> partitionsByHost = new HashMap<>();
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost = new HashMap<>();
         if (minReceivedMetadataVersion >= 2) {
             for (final Map.Entry<UUID, ClientMetadata> entry : clientMetadataMap.entrySet()) {
                 final HostInfo hostInfo = entry.getValue().hostInfo;
@@ -628,24 +630,32 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 // if application server is configured, also include host state map
                 if (hostInfo != null) {
                     final Set<TopicPartition> topicPartitions = new HashSet<>();
+                    final Set<TopicPartition> standbyPartitions = new HashSet<>();
                     final ClientState state = entry.getValue().state;
 
                     for (final TaskId id : state.activeTasks()) {
                         topicPartitions.addAll(partitionsForTask.get(id));
                     }
 
-                    partitionsByHostState.put(hostInfo, topicPartitions);
+                    // TODO: why do we have standby tasks even for non stateful sub topologies?
+                    for (final TaskId id : state.standbyTasks()) {
+                        standbyPartitions.addAll(partitionsForTask.get(id));
+                    }
+
+                    partitionsByHost.put(hostInfo, topicPartitions);
+                    standbyPartitionsByHost.put(hostInfo, standbyPartitions);
                 }
             }
         }
-        taskManager.setPartitionsByHostState(partitionsByHostState);
+        taskManager.setHostPartitionMappings(partitionsByHost, standbyPartitionsByHost);
 
         final Map<String, Assignment> assignment;
         if (versionProbing) {
             assignment = versionProbingAssignment(
                 clientMetadataMap,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 minReceivedMetadataVersion,
                 minSupportedMetadataVersion
@@ -654,7 +664,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             assignment = computeNewAssignment(
                 clientMetadataMap,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 minReceivedMetadataVersion,
                 minSupportedMetadataVersion
@@ -667,6 +678,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private Map<String, Assignment> computeNewAssignment(final Map<UUID, ClientMetadata> clientsMetadata,
                                                          final Map<TaskId, Set<TopicPartition>> partitionsForTask,
                                                          final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                                         final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                                          final Set<TopicPartition> allOwnedPartitions,
                                                          final int minUserMetadataVersion,
                                                          final int minSupportedMetadataVersion) {
@@ -700,6 +712,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 clientMetadata,
                 partitionsForTask,
                 partitionsByHostState,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 activeTaskAssignments,
                 interleavedStandby,
@@ -712,7 +725,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     private Map<String, Assignment> versionProbingAssignment(final Map<UUID, ClientMetadata> clientsMetadata,
                                                              final Map<TaskId, Set<TopicPartition>> partitionsForTask,
-                                                             final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                                             final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                                                             final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                                              final Set<TopicPartition> allOwnedPartitions,
                                                              final int minUserMetadataVersion,
                                                              final int minSupportedMetadataVersion) {
@@ -734,7 +748,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 assignment,
                 clientMetadata,
                 partitionsForTask,
-                partitionsByHostState,
+                partitionsByHost,
+                standbyPartitionsByHost,
                 allOwnedPartitions,
                 interleavedActive,
                 interleavedStandby,
@@ -749,6 +764,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                       final ClientMetadata clientMetadata,
                                       final Map<TaskId, Set<TopicPartition>> partitionsForTask,
                                       final Map<HostInfo, Set<TopicPartition>> partitionsByHostState,
+                                      final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                       final Set<TopicPartition> allOwnedPartitions,
                                       final Map<String, List<TaskId>> activeTaskAssignments,
                                       final Map<String, List<TaskId>> standbyTaskAssignments,
@@ -785,6 +801,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                         assignedActiveList,
                         standbyTaskMap,
                         partitionsByHostState,
+                        standbyPartitionsByHost,
                         AssignorError.NONE.code()
                     ).encode()
                 )
@@ -1113,6 +1130,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // version 2 fields
         final Map<TopicPartition, PartitionInfo> topicToPartitionInfo = new HashMap<>();
         final Map<HostInfo, Set<TopicPartition>> partitionsByHost;
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost;
 
         final Map<TopicPartition, TaskId> partitionsToTaskId = new HashMap<>();
 
@@ -1120,6 +1138,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 1:
                 processVersionOneAssignment(logPrefix, info, partitions, activeTasks, partitionsToTaskId);
                 partitionsByHost = Collections.emptyMap();
+                standbyPartitionsByHost = Collections.emptyMap();
                 break;
             case 2:
             case 3:
@@ -1127,6 +1146,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 5:
                 processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
                 partitionsByHost = info.partitionsByHost();
+                standbyPartitionsByHost = info.standbyPartitionByHost();
                 break;
             default:
                 throw new IllegalStateException(
@@ -1136,7 +1156,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
 
         taskManager.setClusterMetadata(Cluster.empty().withPartitions(topicToPartitionInfo));
-        taskManager.setPartitionsByHostState(partitionsByHost);
+        taskManager.setHostPartitionMappings(partitionsByHost, standbyPartitionsByHost);
         taskManager.setPartitionsToTaskId(partitionsToTaskId);
         taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
         taskManager.updateSubscriptionsFromAssignment(partitions);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1144,6 +1144,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             case 3:
             case 4:
             case 5:
+            case 6:
                 processVersionTwoAssignment(logPrefix, info, partitions, activeTasks, topicToPartitionInfo, partitionsToTaskId);
                 partitionsByHost = info.partitionsByHost();
                 standbyPartitionsByHost = info.standbyPartitionByHost();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -360,6 +360,18 @@ public class TaskManager {
         return standby.runningTaskMap();
     }
 
+    List<StreamTask> allStreamsTasks() {
+        return active.allTasks();
+    }
+
+    Set<TaskId> restoringTaskIds() {
+        return active.restoringTaskIds();
+    }
+
+    List<StandbyTask> allStandbyTasks() {
+        return standby.allTasks();
+    }
+
     void setConsumer(final Consumer<byte[], byte[]> consumer) {
         this.consumer = consumer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -440,8 +440,9 @@ public class TaskManager {
         this.cluster = cluster;
     }
 
-    public void setPartitionsByHostState(final Map<HostInfo, Set<TopicPartition>> partitionsByHostState) {
-        this.streamsMetadataState.onChange(partitionsByHostState, cluster);
+    public void setHostPartitionMappings(final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost) {
+        this.streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, cluster);
     }
 
     public void setPartitionsToTaskId(final Map<TopicPartition, TaskId> partitionsToTaskId) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -453,7 +453,7 @@ public class TaskManager {
     }
 
     public void setHostPartitionMappings(final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
-        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost) {
+                                         final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost) {
         this.streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, cluster);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -57,12 +57,12 @@ public class AssignmentInfo {
     public AssignmentInfo(final int version,
                           final int commonlySupportedVersion) {
         this(version,
-                commonlySupportedVersion,
-                Collections.emptyList(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                0);
+             commonlySupportedVersion,
+             Collections.emptyList(),
+             Collections.emptyMap(),
+             Collections.emptyMap(),
+             Collections.emptyMap(),
+            0);
     }
 
     public AssignmentInfo(final int version,
@@ -91,7 +91,7 @@ public class AssignmentInfo {
 
         if (version < 1 || version > LATEST_SUPPORTED_VERSION) {
             throw new IllegalArgumentException("version must be between 1 and " + LATEST_SUPPORTED_VERSION
-                    + "; was: " + version);
+                + "; was: " + version);
         }
     }
 
@@ -125,7 +125,7 @@ public class AssignmentInfo {
 
     /**
      * @throws TaskAssignmentException if method fails to encode the data, e.g., if there is an
-     *                                 IO exception during encoding
+     * IO exception during encoding
      */
     public ByteBuffer encode() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -335,7 +335,7 @@ public class AssignmentInfo {
                     break;
                 default:
                     final TaskAssignmentException fatalException = new TaskAssignmentException("Unable to decode assignment data: " +
-                            "used version: " + usedVersion + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
+                        "used version: " + usedVersion + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
                     log.error(fatalException.getMessage(), fatalException);
                     throw fatalException;
             }
@@ -439,12 +439,12 @@ public class AssignmentInfo {
         if (o instanceof AssignmentInfo) {
             final AssignmentInfo other = (AssignmentInfo) o;
             return usedVersion == other.usedVersion &&
-                    commonlySupportedVersion == other.commonlySupportedVersion &&
-                    errCode == other.errCode &&
-                    activeTasks.equals(other.activeTasks) &&
-                    standbyTasks.equals(other.standbyTasks) &&
-                    partitionsByHost.equals(other.partitionsByHost) &&
-                    standbyPartitionsByHost.equals(other.standbyPartitionsByHost);
+                   commonlySupportedVersion == other.commonlySupportedVersion &&
+                   errCode == other.errCode &&
+                   activeTasks.equals(other.activeTasks) &&
+                   standbyTasks.equals(other.standbyTasks) &&
+                   partitionsByHost.equals(other.partitionsByHost) &&
+                   standbyPartitionsByHost.equals(other.standbyPartitionsByHost);
         } else {
             return false;
         }
@@ -453,11 +453,11 @@ public class AssignmentInfo {
     @Override
     public String toString() {
         return "[version=" + usedVersion
-                + ", supported version=" + commonlySupportedVersion
-                + ", active tasks=" + activeTasks
-                + ", standby tasks=" + standbyTasks
-                + ", partitions by host=" + partitionsByHost
-                + ", standbyPartitions by host=" + standbyPartitionsByHost
-                + "]";
+            + ", supported version=" + commonlySupportedVersion
+            + ", active tasks=" + activeTasks
+            + ", standby tasks=" + standbyTasks
+            + ", partitions by host=" + partitionsByHost
+            + ", standbyPartitions by host=" + standbyPartitionsByHost
+            + "]";
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -55,12 +55,12 @@ public class AssignmentInfo {
     public AssignmentInfo(final int version,
                           final int commonlySupportedVersion) {
         this(version,
-            commonlySupportedVersion,
-            Collections.emptyList(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            0);
+                commonlySupportedVersion,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                0);
     }
 
     public AssignmentInfo(final int version,
@@ -89,7 +89,7 @@ public class AssignmentInfo {
 
         if (version < 1 || version > LATEST_SUPPORTED_VERSION) {
             throw new IllegalArgumentException("version must be between 1 and " + LATEST_SUPPORTED_VERSION
-                + "; was: " + version);
+                    + "; was: " + version);
         }
     }
 
@@ -123,7 +123,7 @@ public class AssignmentInfo {
 
     /**
      * @throws TaskAssignmentException if method fails to encode the data, e.g., if there is an
-     * IO exception during encoding
+     *                                 IO exception during encoding
      */
     public ByteBuffer encode() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -157,12 +157,19 @@ public class AssignmentInfo {
                     out.writeInt(commonlySupportedVersion);
                     encodeActiveAndStandbyTaskAssignment(out);
                     encodePartitionsByHostAsDictionary(out);
+                    out.writeInt(errCode);
+                    break;
+                case 6:
+                    out.writeInt(usedVersion);
+                    out.writeInt(commonlySupportedVersion);
+                    encodeActiveAndStandbyTaskAssignment(out);
+                    encodePartitionsByHostAsDictionary(out);
                     encodeStandbyPartitionsByHostAsDictionary(out);
                     out.writeInt(errCode);
                     break;
                 default:
                     throw new IllegalStateException("Unknown metadata version: " + usedVersion
-                        + "; latest commonly supported version: " + commonlySupportedVersion);
+                            + "; latest commonly supported version: " + commonlySupportedVersion);
             }
 
             out.flush();
@@ -202,7 +209,7 @@ public class AssignmentInfo {
     }
 
     private void encodeHostPartitionMapAsDictionary(final DataOutputStream out,
-        final Map<HostInfo, Set<TopicPartition>> hostPartitionMap) throws IOException {
+                                                    final Map<HostInfo, Set<TopicPartition>> hostPartitionMap) throws IOException {
 
         // Build a dictionary to encode topicNames
         int topicIndex = 0;
@@ -304,12 +311,20 @@ public class AssignmentInfo {
                     decodeActiveTasks(assignmentInfo, in);
                     decodeStandbyTasks(assignmentInfo, in);
                     decodePartitionsByHostUsingDictionary(assignmentInfo, in);
+                    assignmentInfo.errCode = in.readInt();
+                    break;
+                case 6:
+                    commonlySupportedVersion = in.readInt();
+                    assignmentInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion);
+                    decodeActiveTasks(assignmentInfo, in);
+                    decodeStandbyTasks(assignmentInfo, in);
+                    decodePartitionsByHostUsingDictionary(assignmentInfo, in);
                     decodeStandbyPartitionsByHostUsingDictionary(assignmentInfo, in);
                     assignmentInfo.errCode = in.readInt();
                     break;
                 default:
                     final TaskAssignmentException fatalException = new TaskAssignmentException("Unable to decode assignment data: " +
-                        "used version: " + usedVersion + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
+                            "used version: " + usedVersion + "; latest supported version: " + LATEST_SUPPORTED_VERSION);
                     log.error(fatalException.getMessage(), fatalException);
                     throw fatalException;
             }
@@ -340,7 +355,7 @@ public class AssignmentInfo {
     }
 
     private static void decodePartitionsByHost(final AssignmentInfo assignmentInfo,
-                                                   final DataInputStream in) throws IOException {
+                                               final DataInputStream in) throws IOException {
         assignmentInfo.partitionsByHost = new HashMap<>();
         final int numEntries = in.readInt();
         for (int i = 0; i < numEntries; i++) {
@@ -359,7 +374,7 @@ public class AssignmentInfo {
     }
 
     private static Map<HostInfo, Set<TopicPartition>> decodeHostPartitionMapUsingDictionary(final AssignmentInfo assignmentInfo,
-        final DataInputStream in) throws IOException {
+                                                                                            final DataInputStream in) throws IOException {
         final Map<HostInfo, Set<TopicPartition>> hostPartitionMap = new HashMap<>();
         final int dictSize = in.readInt();
         final Map<Integer, String> topicIndexDict = new HashMap<>(dictSize);
@@ -376,17 +391,17 @@ public class AssignmentInfo {
     }
 
     private static void decodePartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
-        final DataInputStream in) throws IOException {
+                                                              final DataInputStream in) throws IOException {
         assignmentInfo.partitionsByHost = decodeHostPartitionMapUsingDictionary(assignmentInfo, in);
     }
 
     private static void decodeStandbyPartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
-        final DataInputStream in) throws IOException {
+                                                                     final DataInputStream in) throws IOException {
         assignmentInfo.standbyPartitionsByHost = decodeHostPartitionMapUsingDictionary(assignmentInfo, in);
     }
 
     private static Set<TopicPartition> readTopicPartitions(final DataInputStream in,
-        final Map<Integer, String> topicIndexDict) throws IOException {
+                                                           final Map<Integer, String> topicIndexDict) throws IOException {
         final int numPartitions = in.readInt();
         final Set<TopicPartition> partitions = new HashSet<>(numPartitions);
         for (int j = 0; j < numPartitions; j++) {
@@ -399,7 +414,7 @@ public class AssignmentInfo {
     public int hashCode() {
         final int hostMapHashCode = partitionsByHost.hashCode() ^ standbyPartitionsByHost.hashCode();
         return usedVersion ^ commonlySupportedVersion ^ activeTasks.hashCode() ^ standbyTasks.hashCode()
-            ^ hostMapHashCode ^ errCode;
+                ^ hostMapHashCode ^ errCode;
     }
 
     @Override
@@ -421,11 +436,11 @@ public class AssignmentInfo {
     @Override
     public String toString() {
         return "[version=" + usedVersion
-            + ", supported version=" + commonlySupportedVersion
-            + ", active tasks=" + activeTasks
-            + ", standby tasks=" + standbyTasks
-            + ", partitions by host=" + partitionsByHost
-            + ", standbyPartitions by host=" + standbyPartitionsByHost
-            + "]";
+                + ", supported version=" + commonlySupportedVersion
+                + ", active tasks=" + activeTasks
+                + ", standby tasks=" + standbyTasks
+                + ", partitions by host=" + partitionsByHost
+                + ", standbyPartitions by host=" + standbyPartitionsByHost
+                + "]";
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -62,7 +62,7 @@ public class AssignmentInfo {
              Collections.emptyMap(),
              Collections.emptyMap(),
              Collections.emptyMap(),
-            0);
+             0);
     }
 
     public AssignmentInfo(final int version,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -49,6 +49,7 @@ public class AssignmentInfo {
     private List<TaskId> activeTasks;
     private Map<TaskId, Set<TopicPartition>> standbyTasks;
     private Map<HostInfo, Set<TopicPartition>> partitionsByHost;
+    private Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost;
 
     // used for decoding and "future consumer" assignments during version probing
     public AssignmentInfo(final int version,
@@ -58,6 +59,7 @@ public class AssignmentInfo {
             Collections.emptyList(),
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             0);
     }
 
@@ -65,8 +67,9 @@ public class AssignmentInfo {
                           final List<TaskId> activeTasks,
                           final Map<TaskId, Set<TopicPartition>> standbyTasks,
                           final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                          final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                           final int errCode) {
-        this(version, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, partitionsByHost, errCode);
+        this(version, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, partitionsByHost, standbyPartitionsByHost, errCode);
     }
 
     public AssignmentInfo(final int version,
@@ -74,12 +77,14 @@ public class AssignmentInfo {
                           final List<TaskId> activeTasks,
                           final Map<TaskId, Set<TopicPartition>> standbyTasks,
                           final Map<HostInfo, Set<TopicPartition>> partitionsByHost,
+                          final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                           final int errCode) {
         this.usedVersion = version;
         this.commonlySupportedVersion = commonlySupportedVersion;
         this.activeTasks = activeTasks;
         this.standbyTasks = standbyTasks;
         this.partitionsByHost = partitionsByHost;
+        this.standbyPartitionsByHost = standbyPartitionsByHost;
         this.errCode = errCode;
 
         if (version < 1 || version > LATEST_SUPPORTED_VERSION) {
@@ -110,6 +115,10 @@ public class AssignmentInfo {
 
     public Map<HostInfo, Set<TopicPartition>> partitionsByHost() {
         return partitionsByHost;
+    }
+
+    public Map<HostInfo, Set<TopicPartition>> standbyPartitionByHost() {
+        return standbyPartitionsByHost;
     }
 
     /**
@@ -148,6 +157,7 @@ public class AssignmentInfo {
                     out.writeInt(commonlySupportedVersion);
                     encodeActiveAndStandbyTaskAssignment(out);
                     encodePartitionsByHostAsDictionary(out);
+                    encodeStandbyPartitionsByHostAsDictionary(out);
                     out.writeInt(errCode);
                     break;
                 default:
@@ -191,12 +201,13 @@ public class AssignmentInfo {
         }
     }
 
-    private void encodePartitionsByHostAsDictionary(final DataOutputStream out) throws IOException {
+    private void encodeHostPartitionMapAsDictionary(final DataOutputStream out,
+        final Map<HostInfo, Set<TopicPartition>> hostPartitionMap) throws IOException {
 
         // Build a dictionary to encode topicNames
         int topicIndex = 0;
         final Map<String, Integer> topicNameDict = new HashMap<>();
-        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : partitionsByHost.entrySet()) {
+        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : hostPartitionMap.entrySet()) {
             for (final TopicPartition topicPartition : entry.getValue()) {
                 if (!topicNameDict.containsKey(topicPartition.topic())) {
                     topicNameDict.put(topicPartition.topic(), topicIndex++);
@@ -212,10 +223,10 @@ public class AssignmentInfo {
         }
 
         // encode partitions by host
-        out.writeInt(partitionsByHost.size());
+        out.writeInt(hostPartitionMap.size());
 
         // Write the topic index, partition
-        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : partitionsByHost.entrySet()) {
+        for (final Map.Entry<HostInfo, Set<TopicPartition>> entry : hostPartitionMap.entrySet()) {
             writeHostInfo(out, entry.getKey());
             out.writeInt(entry.getValue().size());
             for (final TopicPartition partition : entry.getValue()) {
@@ -223,6 +234,14 @@ public class AssignmentInfo {
                 out.writeInt(partition.partition());
             }
         }
+    }
+
+    private void encodePartitionsByHostAsDictionary(final DataOutputStream out) throws IOException {
+        encodeHostPartitionMapAsDictionary(out, partitionsByHost);
+    }
+
+    private void encodeStandbyPartitionsByHostAsDictionary(final DataOutputStream out) throws IOException {
+        encodeHostPartitionMapAsDictionary(out, standbyPartitionsByHost);
     }
 
     private void writeHostInfo(final DataOutputStream out, final HostInfo hostInfo) throws IOException {
@@ -285,6 +304,7 @@ public class AssignmentInfo {
                     decodeActiveTasks(assignmentInfo, in);
                     decodeStandbyTasks(assignmentInfo, in);
                     decodePartitionsByHostUsingDictionary(assignmentInfo, in);
+                    decodeStandbyPartitionsByHostUsingDictionary(assignmentInfo, in);
                     assignmentInfo.errCode = in.readInt();
                     break;
                 default:
@@ -338,9 +358,9 @@ public class AssignmentInfo {
         return partitions;
     }
 
-    private static void decodePartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
+    private static Map<HostInfo, Set<TopicPartition>> decodeHostPartitionMapUsingDictionary(final AssignmentInfo assignmentInfo,
         final DataInputStream in) throws IOException {
-        assignmentInfo.partitionsByHost = new HashMap<>();
+        final Map<HostInfo, Set<TopicPartition>> hostPartitionMap = new HashMap<>();
         final int dictSize = in.readInt();
         final Map<Integer, String> topicIndexDict = new HashMap<>(dictSize);
         for (int i = 0; i < dictSize; i++) {
@@ -350,8 +370,19 @@ public class AssignmentInfo {
         final int numEntries = in.readInt();
         for (int i = 0; i < numEntries; i++) {
             final HostInfo hostInfo = new HostInfo(in.readUTF(), in.readInt());
-            assignmentInfo.partitionsByHost.put(hostInfo, readTopicPartitions(in, topicIndexDict));
+            hostPartitionMap.put(hostInfo, readTopicPartitions(in, topicIndexDict));
         }
+        return hostPartitionMap;
+    }
+
+    private static void decodePartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
+        final DataInputStream in) throws IOException {
+        assignmentInfo.partitionsByHost = decodeHostPartitionMapUsingDictionary(assignmentInfo, in);
+    }
+
+    private static void decodeStandbyPartitionsByHostUsingDictionary(final AssignmentInfo assignmentInfo,
+        final DataInputStream in) throws IOException {
+        assignmentInfo.standbyPartitionsByHost = decodeHostPartitionMapUsingDictionary(assignmentInfo, in);
     }
 
     private static Set<TopicPartition> readTopicPartitions(final DataInputStream in,
@@ -366,8 +397,9 @@ public class AssignmentInfo {
 
     @Override
     public int hashCode() {
+        final int hostMapHashCode = partitionsByHost.hashCode() ^ standbyPartitionsByHost.hashCode();
         return usedVersion ^ commonlySupportedVersion ^ activeTasks.hashCode() ^ standbyTasks.hashCode()
-            ^ partitionsByHost.hashCode() ^ errCode;
+            ^ hostMapHashCode ^ errCode;
     }
 
     @Override
@@ -379,7 +411,8 @@ public class AssignmentInfo {
                     errCode == other.errCode &&
                     activeTasks.equals(other.activeTasks) &&
                     standbyTasks.equals(other.standbyTasks) &&
-                    partitionsByHost.equals(other.partitionsByHost);
+                    partitionsByHost.equals(other.partitionsByHost) &&
+                    standbyPartitionsByHost.equals(other.standbyPartitionsByHost);
         } else {
             return false;
         }
@@ -391,6 +424,8 @@ public class AssignmentInfo {
             + ", supported version=" + commonlySupportedVersion
             + ", active tasks=" + activeTasks
             + ", standby tasks=" + standbyTasks
-            + ", partitions by host=" + partitionsByHost + "]";
+            + ", partitions by host=" + partitionsByHost
+            + ", standbyPartitions by host=" + standbyPartitionsByHost
+            + "]";
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -16,8 +16,13 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.HostInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -34,13 +39,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.ByteBufferInputStream;
-import org.apache.kafka.streams.errors.TaskAssignmentException;
-import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.state.HostInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
+import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
 
 public class AssignmentInfo {
     private static final Logger log = LoggerFactory.getLogger(AssignmentInfo.class);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 public final class StreamsAssignmentProtocolVersions {
     public static final int UNKNOWN = -1;
     public static final int EARLIEST_PROBEABLE_VERSION = 3;
-    public static final int LATEST_SUPPORTED_VERSION = 5;
+    public static final int LATEST_SUPPORTED_VERSION = 6;
 
     private StreamsAssignmentProtocolVersions() {}
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -42,23 +42,14 @@ public class StreamsMetadata {
                                                                             Collections.emptySet());
 
     private final HostInfo hostInfo;
-    /**
-     * State stores owned by the instance as an active replica
-     */
-    private final Set<String> stateStoreNames;
-    /**
-     * Topic partitions consumed by the instance as an active replica
-     */
-    private final Set<TopicPartition> topicPartitions;
-    /**
-     * State stores owned by the instance as a standby replica
-     */
-    private final Set<String> standbyStateStoreNames;
-    /**
-     * (Source) Topic partitions for which the instance acts as standby.
-     */
-    private final Set<TopicPartition> standbyTopicPartitions;
 
+    private final Set<String> stateStoreNames;
+
+    private final Set<TopicPartition> topicPartitions;
+
+    private final Set<String> standbyStateStoreNames;
+
+    private final Set<TopicPartition> standbyTopicPartitions;
 
     public StreamsMetadata(final HostInfo hostInfo,
                            final Set<String> stateStoreNames,
@@ -73,24 +64,50 @@ public class StreamsMetadata {
         this.standbyStateStoreNames = standbyStateStoreNames;
     }
 
-    public Set<TopicPartition> standbyTopicPartitions() {
-        return standbyTopicPartitions;
-    }
-
-    public Set<String> standbyStateStoreNames() {
-        return standbyStateStoreNames;
-    }
-
+    /**
+     * The value of {@link org.apache.kafka.streams.StreamsConfig#APPLICATION_SERVER_CONFIG} configured for the streams
+     * instance, which is typically host/port
+     *
+     * @return {@link HostInfo} corresponding to the streams instance
+     */
     public HostInfo hostInfo() {
         return hostInfo;
     }
 
+    /**
+     * State stores owned by the instance as an active replica
+     *
+     * @return set of active state store names
+     */
     public Set<String> stateStoreNames() {
         return stateStoreNames;
     }
 
+    /**
+     * Topic partitions consumed by the instance as an active replica
+     *
+     * @return set of active topic partitions
+     */
     public Set<TopicPartition> topicPartitions() {
         return topicPartitions;
+    }
+
+    /**
+     * (Source) Topic partitions for which the instance acts as standby.
+     *
+     * @return set of standby topic partitions
+     */
+    public Set<TopicPartition> standbyTopicPartitions() {
+        return standbyTopicPartitions;
+    }
+
+    /**
+     * State stores owned by the instance as a standby replica
+     *
+     * @return set of standby state store names
+     */
+    public Set<String> standbyStateStoreNames() {
+        return standbyStateStoreNames;
     }
 
     public String host() {
@@ -110,21 +127,13 @@ public class StreamsMetadata {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final StreamsMetadata that = (StreamsMetadata) o;
-        if (!hostInfo.equals(that.hostInfo)) {
-            return false;
-        }
-        if (!stateStoreNames.equals(that.stateStoreNames)) {
-            return false;
-        }
-        if (!topicPartitions.equals(that.topicPartitions)) {
-            return false;
-        }
-        if (!standbyStateStoreNames.equals(that.standbyStateStoreNames)) {
-            return false;
-        }
 
-        return standbyTopicPartitions.equals(that.standbyTopicPartitions);
+        final StreamsMetadata that = (StreamsMetadata) o;
+        return Objects.equals(hostInfo, that.hostInfo)
+            && Objects.equals(stateStoreNames, that.stateStoreNames)
+            && Objects.equals(topicPartitions, that.topicPartitions)
+            && Objects.equals(standbyStateStoreNames, that.standbyStateStoreNames)
+            && Objects.equals(standbyTopicPartitions, that.standbyTopicPartitions);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state;
 
+import java.util.Objects;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.KafkaStreams;
 
@@ -41,10 +42,23 @@ public class StreamsMetadata {
                                                                             Collections.emptySet());
 
     private final HostInfo hostInfo;
+    /**
+     * State stores owned by the instance as an active replica
+     */
     private final Set<String> stateStoreNames;
+    /**
+     * Topic partitions consumed by the instance as an active replica
+     */
     private final Set<TopicPartition> topicPartitions;
-    private final Set<TopicPartition> standbyTopicPartitions;
+    /**
+     * State stores owned by the instance as a standby replica
+     */
     private final Set<String> standbyStateStoreNames;
+    /**
+     * (Source) Topic partitions for which the instance acts as standby.
+     */
+    private final Set<TopicPartition> standbyTopicPartitions;
+
 
     public StreamsMetadata(final HostInfo hostInfo,
                            final Set<String> stateStoreNames,
@@ -103,16 +117,19 @@ public class StreamsMetadata {
         if (!stateStoreNames.equals(that.stateStoreNames)) {
             return false;
         }
-        return topicPartitions.equals(that.topicPartitions);
+        if (!topicPartitions.equals(that.topicPartitions)) {
+            return false;
+        }
+        if (!standbyStateStoreNames.equals(that.standbyStateStoreNames)) {
+            return false;
+        }
 
+        return standbyTopicPartitions.equals(that.standbyTopicPartitions);
     }
 
     @Override
     public int hashCode() {
-        int result = hostInfo.hashCode();
-        result = 31 * result + stateStoreNames.hashCode();
-        result = 31 * result + topicPartitions.hashCode();
-        return result;
+        return Objects.hash(hostInfo, stateStoreNames, topicPartitions, standbyStateStoreNames, standbyTopicPartitions);
     }
 
     @Override
@@ -121,6 +138,8 @@ public class StreamsMetadata {
                 "hostInfo=" + hostInfo +
                 ", stateStoreNames=" + stateStoreNames +
                 ", topicPartitions=" + topicPartitions +
+                ", standbyStateStoreNames=" + standbyStateStoreNames +
+                ", standbyTopicPartitions=" + standbyTopicPartitions +
                 '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -63,8 +63,8 @@ public class StreamsMetadata {
     public StreamsMetadata(final HostInfo hostInfo,
                            final Set<String> stateStoreNames,
                            final Set<TopicPartition> topicPartitions,
-                           final Set<TopicPartition> standbyTopicPartitions,
-                           final Set<String> standbyStateStoreNames) {
+                           final Set<String> standbyStateStoreNames,
+                           final Set<TopicPartition> standbyTopicPartitions) {
 
         this.hostInfo = hostInfo;
         this.stateStoreNames = stateStoreNames;

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -59,11 +59,11 @@ public class StreamsMetadata {
         this.standbyStateStoreNames = standbyStateStoreNames;
     }
 
-    public Set<TopicPartition> getStandbyTopicPartitions() {
+    public Set<TopicPartition> standbyTopicPartitions() {
         return standbyTopicPartitions;
     }
 
-    public Set<String> getStandbyStateStoreNames() {
+    public Set<String> standbyStateStoreNames() {
         return standbyStateStoreNames;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -36,19 +36,35 @@ public class StreamsMetadata {
      */
     public final static StreamsMetadata NOT_AVAILABLE = new StreamsMetadata(new HostInfo("unavailable", -1),
                                                                             Collections.emptySet(),
+                                                                            Collections.emptySet(),
+                                                                            Collections.emptySet(),
                                                                             Collections.emptySet());
 
     private final HostInfo hostInfo;
     private final Set<String> stateStoreNames;
     private final Set<TopicPartition> topicPartitions;
+    private final Set<TopicPartition> standbyTopicPartitions;
+    private final Set<String> standbyStateStoreNames;
 
     public StreamsMetadata(final HostInfo hostInfo,
                            final Set<String> stateStoreNames,
-                           final Set<TopicPartition> topicPartitions) {
+                           final Set<TopicPartition> topicPartitions,
+                           final Set<TopicPartition> standbyTopicPartitions,
+                           final Set<String> standbyStateStoreNames) {
 
         this.hostInfo = hostInfo;
         this.stateStoreNames = stateStoreNames;
         this.topicPartitions = topicPartitions;
+        this.standbyTopicPartitions = standbyTopicPartitions;
+        this.standbyStateStoreNames = standbyStateStoreNames;
+    }
+
+    public Set<TopicPartition> getStandbyTopicPartitions() {
+        return standbyTopicPartitions;
+    }
+
+    public Set<String> getStandbyStateStoreNames() {
+        return standbyStateStoreNames;
     }
 
     public HostInfo hostInfo() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StreamsMetadata.java
@@ -134,7 +134,7 @@ public class StreamsMetadata {
 
     @Override
     public String toString() {
-        return "StreamsMetadata{" +
+        return "StreamsMetadata {" +
                 "hostInfo=" + hostInfo +
                 ", stateStoreNames=" + stateStoreNames +
                 ", topicPartitions=" + topicPartitions +

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -50,7 +50,7 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
         }
         if (!streamThread.isRunning()) {
             throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the stream thread is " +
-                streamThread.state() + ", not RUNNING");
+                streamThread.state() + ", not RUNNING or REBALANCING");
         }
         final List<T> stores = new ArrayList<>();
         final Set<Task> tasks = new HashSet<>(streamThread.tasks().values());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -55,7 +55,6 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
         final List<T> stores = new ArrayList<>();
         final Set<Task> tasks = new HashSet<>(streamThread.tasks().values());
 
-        //During rebalancing are standby tasks in running state?
         if (streamThread.standbyTasks() != null) {
             tasks.addAll(streamThread.standbyTasks().values());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -48,7 +48,6 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
-        // TODO: This needs to be rethought
         if (!streamThread.isRunning()) {
             throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the stream thread is " +
                 streamThread.state() + ", not RUNNING");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -55,6 +55,8 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
         }
         final List<T> stores = new ArrayList<>();
         final Set<Task> tasks = new HashSet<>(streamThread.tasks().values());
+
+        //During rebalancing are standby tasks in running state?
         if (streamThread.standbyTasks() != null) {
             tasks.addAll(streamThread.standbyTasks().values());
         }

--- a/streams/src/main/resources/common/message/SubscriptionInfo.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfo.json
@@ -15,7 +15,7 @@
 
 {
   "name": "SubscriptionInfo",
-  "validVersions": "1-5",
+  "validVersions": "1-6",
   "fields": [
     {
       "name": "version",

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -17,9 +17,14 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -313,6 +318,10 @@ public class KafkaStreamsTest {
                 Thread.sleep(50L);
                 return null;
             }).anyTimes();
+
+        EasyMock.expect(thread.allStandbyTasks()).andStubReturn(Collections.emptyList());
+        EasyMock.expect(thread.restoringTaskIds()).andStubReturn(Collections.emptySet());
+        EasyMock.expect(thread.allStreamsTasks()).andStubReturn(Collections.emptyList());
     }
 
     @Test
@@ -675,6 +684,27 @@ public class KafkaStreamsTest {
     public void shouldNotGetQueryMetadataWithPartitionerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
         streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+    }
+
+    @Test
+    public void shouldReturnEmptyLocalOffsetLags() {
+        // Mock all calls made to compute the offset lags,
+        final ListOffsetsResult result = EasyMock.mock(ListOffsetsResult.class);
+        final KafkaFutureImpl<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = new KafkaFutureImpl<>();
+        allFuture.complete(Collections.emptyMap());
+
+        EasyMock.expect(result.all()).andReturn(allFuture);
+        final MockAdminClient mockAdminClient = EasyMock.partialMockBuilder(MockAdminClient.class)
+            .addMockedMethod("listOffsets", Map.class).createMock();
+        EasyMock.expect(mockAdminClient.listOffsets(anyObject())).andStubReturn(result);
+        final MockClientSupplier mockClientSupplier = EasyMock.partialMockBuilder(MockClientSupplier.class)
+            .addMockedMethod("getAdmin").createMock();
+        EasyMock.expect(mockClientSupplier.getAdmin(anyObject())).andReturn(mockAdminClient);
+        EasyMock.replay(result, mockAdminClient, mockClientSupplier);
+
+        final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, mockClientSupplier, time);
+        streams.start();
+        assertEquals(0, streams.allLocalOffsetLags().size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -661,13 +661,13 @@ public class KafkaStreamsTest {
     @Test(expected = IllegalStateException.class)
     public void shouldNotGetTaskWithKeyAndSerializerWhenNotRunning() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
-        streams.metadataForKey("store", "key", Serdes.String().serializer());
+        streams.queryMetadataForKey("store", "key", Serdes.String().serializer());
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldNotGetTaskWithKeyAndPartitionerWhenNotRunning() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
-        streams.metadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+        streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -687,7 +687,7 @@ public class KafkaStreamsTest {
     }
 
     @Test
-    public void shouldReturnEmptyLocalOffsetLags() {
+    public void shouldReturnEmptyLocalStorePartitionLags() {
         // Mock all calls made to compute the offset lags,
         final ListOffsetsResult result = EasyMock.mock(ListOffsetsResult.class);
         final KafkaFutureImpl<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = new KafkaFutureImpl<>();
@@ -704,7 +704,7 @@ public class KafkaStreamsTest {
 
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, mockClientSupplier, time);
         streams.start();
-        assertEquals(0, streams.allLocalOffsetLags().size());
+        assertEquals(0, streams.allLocalStorePartitionLags().size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -659,13 +659,20 @@ public class KafkaStreamsTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotGetTaskWithKeyAndSerializerWhenNotRunning() {
+    public void shouldNotGetQueryMetadataWithSerializerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
         streams.queryMetadataForKey("store", "key", Serdes.String().serializer());
     }
 
+    @Test
+    public void shouldGetQueryMetadataWithSerializerWhenRunningOrRebalancing() {
+        final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
+        streams.start();
+        assertEquals(KeyQueryMetadata.NOT_AVAILABLE, streams.queryMetadataForKey("store", "key", Serdes.String().serializer()));
+    }
+
     @Test(expected = IllegalStateException.class)
-    public void shouldNotGetTaskWithKeyAndPartitionerWhenNotRunning() {
+    public void shouldNotGetQueryMetadataWithPartitionerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
         streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -256,10 +256,10 @@ public class LagFetchIntegrationTest {
             assertThat(offsetLagInfoMap.size(), equalTo(1));
             assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
             assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
-            LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
-            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.offsetLag(), equalTo(0L));
+            final LagInfo zeroLagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(zeroLagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.offsetLag(), equalTo(0L));
 
             // Kill instance, delete state to force restoration.
             assertThat("Streams instance did not close within timeout", streams.close(Duration.ofSeconds(60)));
@@ -292,16 +292,12 @@ public class LagFetchIntegrationTest {
             restartedStreams.start();
             TestUtils.waitForCondition(() -> restartedStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
                 "Standby should eventually catchup and have zero lag.");
-            lagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
-            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
-            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.offsetLag(), equalTo(5L));
+            final LagInfo fullLagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
+            assertThat(fullLagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(fullLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(fullLagInfo.offsetLag(), equalTo(5L));
 
-            lagInfo = restoreEndLagInfo.get(stateStoreName).get(0);
-            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.offsetLag(), equalTo(0L));
-
+            assertThat(zeroLagInfo, equalTo(restoreEndLagInfo.get(stateStoreName).get(0)));
         } finally {
             streams.close();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import kafka.utils.MockTime;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreamsWrapper;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+@Category({IntegrationTest.class})
+public class LagFetchIntegrationTest {
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    private static final long CONSUMER_TIMEOUT_MS = 60000;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private final MockTime mockTime = CLUSTER.time;
+    private Properties streamsConfiguration;
+    private Properties consumerConfiguration;
+    private String inputTopicName;
+    private String outputTopicName;
+    private String stateStoreName;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Before
+    public void before() {
+        inputTopicName = "input-topic-" + name.getMethodName();
+        outputTopicName = "output-topic-" + name.getMethodName();
+        stateStoreName = "lagfetch-test-store" + name.getMethodName();
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "lag-fetch-" + name.getMethodName());
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+
+        consumerConfiguration = new Properties();
+        consumerConfiguration.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        consumerConfiguration.setProperty(ConsumerConfig.GROUP_ID_CONFIG, name.getMethodName() + "-consumer");
+        consumerConfiguration.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfiguration.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfiguration.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchValidLagsDuringRebalancing() throws Exception {
+        final CountDownLatch latchTillActiveIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyHasPartitionsAssigned = new CountDownLatch(1);
+        final CyclicBarrier lagCheckBarrier = new CyclicBarrier(2);
+        final List<KafkaStreamsWrapper> streamsList = new ArrayList<>();
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        for (int i = 0; i < 2; i++) {
+            final Properties props = (Properties) streamsConfiguration.clone();
+            final File stateDir = folder.newFolder("state-" + i);
+            props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
+            props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
+            props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+            props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+
+            final StreamsBuilder builder = new StreamsBuilder();
+            final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+            t1.toStream().to(outputTopicName);
+            final KafkaStreamsWrapper streams = new KafkaStreamsWrapper(builder.build(), props);
+            streamsList.add(streams);
+        }
+
+        final KafkaStreamsWrapper activeStreams = streamsList.get(0);
+        final KafkaStreamsWrapper standbyStreams = streamsList.get(1);
+        activeStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (newState == StreamThread.State.RUNNING) {
+                latchTillActiveIsRunning.countDown();
+            }
+        });
+        standbyStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (oldState == StreamThread.State.PARTITIONS_ASSIGNED && newState == StreamThread.State.RUNNING) {
+                latchTillStandbyHasPartitionsAssigned.countDown();
+                try {
+                    lagCheckBarrier.await(60, TimeUnit.SECONDS);
+                } catch (final Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (newState == StreamThread.State.RUNNING) {
+                latchTillStandbyIsRunning.countDown();
+            }
+        });
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+            activeStreams.start();
+            latchTillActiveIsRunning.await(60, TimeUnit.SECONDS);
+
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+            // Check the active reports proper lag values.
+            offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(0L));
+
+            // start up the standby & make it pause right after it has partition assigned
+            standbyStreams.start();
+            latchTillStandbyHasPartitionsAssigned.await(60, TimeUnit.SECONDS);
+            offsetLagInfoMap = standbyStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(5L));
+            // standby thread wont proceed to RUNNING before this barrier is crossed
+            lagCheckBarrier.await(60, TimeUnit.SECONDS);
+
+            // wait till the lag goes down to 0, on the standby
+            TestUtils.waitForCondition(() -> standbyStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+        } finally {
+            for (final KafkaStreams streams : streamsList) {
+                streams.close();
+            }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToFetchValidLagsDuringRestoration() throws Exception {
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        final Properties props = (Properties) streamsConfiguration.clone();
+        final File stateDir = folder.newFolder("state");
+        props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:0");
+        props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-0");
+        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+        t1.toStream().to(outputTopicName);
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+
+            // Get the instance to fully catch up and reach RUNNING state
+            startApplicationAndWaitUntilRunning(Collections.singletonList(streams), Duration.ofSeconds(60));
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+
+            // check for proper lag values.
+            offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(0L));
+
+            // Kill instance, delete state to force restoration.
+            assertThat("Streams instance did not close within timeout", streams.close(Duration.ofSeconds(60)));
+            IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+            Files.walk(stateDir.toPath()).sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(f -> assertTrue("Some state " + f + " could not be deleted", f.delete()));
+
+            // wait till the lag goes down to 0
+            final KafkaStreams restartedStreams = new KafkaStreams(builder.build(), props);
+            // set a state restoration listener to track progress of restoration
+            final Map<String, Map<Integer, LagInfo>> restoreStartLagInfo = new HashMap<>();
+            final Map<String, Map<Integer, LagInfo>> restoreEndLagInfo = new HashMap<>();
+            restartedStreams.setGlobalStateRestoreListener(new StateRestoreListener() {
+                @Override
+                public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {
+                    restoreStartLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+
+                @Override
+                public void onBatchRestored(final TopicPartition topicPartition, final String storeName, final long batchEndOffset, final long numRestored) {
+                }
+
+                @Override
+                public void onRestoreEnd(final TopicPartition topicPartition, final String storeName, final long totalRestored) {
+                    restoreEndLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+            });
+
+            restartedStreams.start();
+            TestUtils.waitForCondition(() -> restartedStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+            lagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(5L));
+
+            lagInfo = restoreEndLagInfo.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(0L));
+
+        } finally {
+            streams.close();
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -64,7 +65,7 @@ import org.junit.experimental.categories.Category;
 @Category(IntegrationTest.class)
 public class OptimizedKTableIntegrationTest {
     private static final int NUM_BROKERS = 1;
-
+    private static int port = 0;
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
 
@@ -157,7 +158,9 @@ public class OptimizedKTableIntegrationTest {
             .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
 
         final boolean kafkaStreams1WasFirstActive;
-        if (store1.get(key) != null) {
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+
+        if ((keyQueryMetadata.getActiveHost().port() % 2) == 1) {
             kafkaStreams1WasFirstActive = true;
         } else {
             // Assert that data from the job was sent to the store
@@ -254,6 +257,7 @@ public class OptimizedKTableIntegrationTest {
         final Properties config = new Properties();
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + String.valueOf(++port));
         config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(applicationId).getPath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -374,7 +374,6 @@ public class QueryableStateIntegrationTest {
 
                     if (store.fetch(key, ofEpochMilli(from), ofEpochMilli(to)) == null) {
                         nullValueKeys.add(key);
-                        continue;
                     }
                 } catch (final InvalidStateStoreException e) {
                     // there must have been at least one rebalance state

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -73,6 +73,7 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreamsTest;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -265,11 +266,11 @@ public class QueryableStateIntegrationTest {
                                       final Set<String> stores,
                                       final List<Integer> partitionsPerStreamsInstance) {
         for (int i = 0; i < streamsList.size(); i++) {
-            final Map<String, Map<Integer, Long>> localOffsetLags = streamsList.get(i).allLocalOffsetLags();
+            final Map<String, Map<Integer, LagInfo>> localLags = streamsList.get(i).allLocalStorePartitionLags();
             final int expectedPartitions = partitionsPerStreamsInstance.get(i);
-            assertThat(localOffsetLags.values().stream().mapToInt(Map::size).sum(), equalTo(expectedPartitions));
+            assertThat(localLags.values().stream().mapToInt(Map::size).sum(), equalTo(expectedPartitions));
             if (expectedPartitions > 0) {
-                assertThat(localOffsetLags.keySet(), equalTo(stores));
+                assertThat(localLags.keySet(), equalTo(stores));
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -53,7 +53,7 @@ import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.apache.kafka.streams.processor.internals.KeyQueryMetadata;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -53,12 +53,12 @@ import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.processor.internals.KeyQueryMetadata;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
-import org.apache.kafka.streams.state.StreamsMetadata;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockMapper;
@@ -270,14 +270,14 @@ public class QueryableStateIntegrationTest {
 
             for (final String key: keys) {
                 try {
-                    final StreamsMetadata metadata = streams
-                        .metadataForKey(storeName, key, new StringSerializer());
-                    if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
+                    final KeyQueryMetadata metadata = streams
+                        .queryMetadataForKey(storeName, key, new StringSerializer());
+                    if (metadata == null || metadata.equals(KeyQueryMetadata.NOT_AVAILABLE)) {
                         noMetadataKeys.add(key);
                         continue;
                     }
 
-                    final int index = metadata.hostInfo().port();
+                    final int index = metadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = streamsList.get(index);
                     final ReadOnlyKeyValueStore<String, Long> store =
                         streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore());
@@ -321,14 +321,14 @@ public class QueryableStateIntegrationTest {
 
             for (final String key: keys) {
                 try {
-                    final StreamsMetadata metadata = streams
-                        .metadataForKey(storeName, key, new StringSerializer());
-                    if (metadata == null || metadata.equals(StreamsMetadata.NOT_AVAILABLE)) {
+                    final KeyQueryMetadata metadata = streams
+                        .queryMetadataForKey(storeName, key, new StringSerializer());
+                    if (metadata == null || metadata.equals(KeyQueryMetadata.NOT_AVAILABLE)) {
                         noMetadataKeys.add(key);
                         continue;
                     }
 
-                    final int index = metadata.hostInfo().port();
+                    final int index = metadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = streamsList.get(index);
                     final ReadOnlyWindowStore<String, Long> store =
                         streamsWithKey.store(storeName, QueryableStoreTypes.windowStore());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -343,7 +343,7 @@ public class SuppressionIntegrationTest {
     }
 
     private static void verifyErrorShutdown(final KafkaStreams driver) throws InterruptedException {
-        waitForCondition(() -> !driver.state().isRunning(), DEFAULT_TIMEOUT, "Streams didn't shut down.");
+        waitForCondition(() -> !driver.state().isRunningOrRebalancing(), DEFAULT_TIMEOUT, "Streams didn't shut down.");
         assertThat(driver.state(), is(KafkaStreams.State.ERROR));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -219,7 +219,7 @@ public class AbstractTaskTest {
                                 config) {
 
             @Override
-            public long offsetLimit(TopicPartition partition) {
+            public long offsetLimit(final TopicPartition partition) {
                 return 0;
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -224,6 +224,11 @@ public class AbstractTaskTest {
             }
 
             @Override
+            public Map<TopicPartition, Long> checkpointedOffsets() {
+                return null;
+            }
+
+            @Override
             public void initializeMetadata() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -219,6 +219,11 @@ public class AbstractTaskTest {
                                 config) {
 
             @Override
+            public long offsetLimit(TopicPartition partition) {
+                return 0;
+            }
+
+            @Override
             public void initializeMetadata() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -219,16 +219,6 @@ public class AbstractTaskTest {
                                 config) {
 
             @Override
-            public long offsetLimit(final TopicPartition partition) {
-                return 0;
-            }
-
-            @Override
-            public Map<TopicPartition, Long> checkpointedOffsets() {
-                return null;
-            }
-
-            @Override
             public void initializeMetadata() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -126,7 +126,9 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldNotThrowExceptionWhenOnChangeNotCalled() {
-        new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne).getAllMetadataForStore("store");
+        final Collection<StreamsMetadata> metadata = new StreamsMetadataState(
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne).getAllMetadataForStore("store");
+        assertEquals(0, metadata.size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -140,11 +140,11 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldGetAllStreamInstances() {
         final StreamsMetadata one = new StreamsMetadata(hostOne, Utils.mkSet(globalTable, "table-one", "table-two", "merged-table"),
-                Utils.mkSet(topic1P0, topic2P1, topic4P0), null, null);
+                Utils.mkSet(topic1P0, topic2P1, topic4P0), Collections.emptySet(), Collections.emptySet());
         final StreamsMetadata two = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-one", "merged-table"),
-                Utils.mkSet(topic2P0, topic1P1), null, null);
+                Utils.mkSet(topic2P0, topic1P1), Collections.emptySet(), Collections.emptySet());
         final StreamsMetadata three = new StreamsMetadata(hostThree, Utils.mkSet(globalTable, "table-three"),
-                Collections.singleton(topic3P0), null, null);
+                Collections.singleton(topic3P0), Collections.emptySet(), Collections.emptySet());
 
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
         assertEquals(3, actual.size());
@@ -170,7 +170,7 @@ public class StreamsMetadataStateTest {
             cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostFour, Collections.singleton(globalTable),
-                Collections.singleton(tp5), null, null);
+                Collections.singleton(tp5), Collections.emptySet(), Collections.emptySet());
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
         assertTrue("expected " + actual + " to contain " + expected, actual.contains(expected));
     }
@@ -178,9 +178,9 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldGetInstancesForStoreName() {
         final StreamsMetadata one = new StreamsMetadata(hostOne, Utils.mkSet(globalTable, "table-one", "table-two", "merged-table"),
-                Utils.mkSet(topic1P0, topic2P1, topic4P0), null, null);
+                Utils.mkSet(topic1P0, topic2P1, topic4P0), Collections.emptySet(), Collections.emptySet());
         final StreamsMetadata two = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-one", "merged-table"),
-                Utils.mkSet(topic2P0, topic1P1), null, null);
+                Utils.mkSet(topic2P0, topic1P1), Collections.emptySet(), Collections.emptySet());
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadataForStore("table-one");
         assertEquals(2, actual.size());
         assertTrue("expected " + actual + " to contain " + one, actual.contains(one));
@@ -208,7 +208,7 @@ public class StreamsMetadataStateTest {
 
         final KeyQueryMetadata expected = new KeyQueryMetadata(hostThree, Collections.<HostInfo>emptySet(), 0);
 
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataWithKey("table-three",
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
                                                                     "the-key",
                                                                     Serdes.String().serializer());
 
@@ -225,7 +225,7 @@ public class StreamsMetadataStateTest {
 
         final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, Collections.<HostInfo>emptySet(), 1);
 
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataWithKey("table-three",
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("table-three",
                 "the-key",
                 partitioner);
         assertEquals(expected, actual);
@@ -234,7 +234,7 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldReturnNotAvailableWhenClusterIsEmpty() {
         metadataState.onChange(Collections.<HostInfo, Set<TopicPartition>>emptyMap(), Collections.emptyMap(), Cluster.empty());
-        final KeyQueryMetadata result = metadataState.getKeyQueryMetadataWithKey("table-one", "a", Serdes.String().serializer());
+        final KeyQueryMetadata result = metadataState.getKeyQueryMetadataForKey("table-one", "a", Serdes.String().serializer());
         assertEquals(KeyQueryMetadata.NOT_AVAILABLE, result);
     }
 
@@ -247,7 +247,7 @@ public class StreamsMetadataStateTest {
 
         final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, Collections.<HostInfo>emptySet(), 2);
 
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataWithKey("merged-table",  "the-key", new StreamPartitioner<String, Object>() {
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("merged-table",  "the-key", new StreamPartitioner<String, Object>() {
             @Override
             public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
                 return 2;
@@ -260,7 +260,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldReturnNullOnGetWithKeyWhenStoreDoesntExist() {
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataWithKey("not-a-store",
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("not-a-store",
                 "key",
                 Serdes.String().serializer());
         assertNull(actual);
@@ -268,23 +268,23 @@ public class StreamsMetadataStateTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenKeyIsNull() {
-        metadataState.getKeyQueryMetadataWithKey("table-three", null, Serdes.String().serializer());
+        metadataState.getKeyQueryMetadataForKey("table-three", null, Serdes.String().serializer());
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenSerializerIsNull() {
-        metadataState.getKeyQueryMetadataWithKey("table-three", "key", (Serializer<Object>) null);
+        metadataState.getKeyQueryMetadataForKey("table-three", "key", (Serializer<Object>) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowIfStoreNameIsNull() {
-        metadataState.getKeyQueryMetadataWithKey(null, "key", Serdes.String().serializer());
+        metadataState.getKeyQueryMetadataForKey(null, "key", Serdes.String().serializer());
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void shouldThrowIfStreamPartitionerIsNull() {
-        metadataState.getKeyQueryMetadataWithKey(null, "key", (StreamPartitioner) null);
+        metadataState.getKeyQueryMetadataForKey(null, "key", (StreamPartitioner) null);
     }
 
     @Test
@@ -298,7 +298,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetMyMetadataForGlobalStoreWithKey() {
-        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataWithKey(globalTable, "key", Serdes.String().serializer());
+        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataForKey(globalTable, "key", Serdes.String().serializer());
         assertEquals(hostOne, metadata.getActiveHost());
     }
 
@@ -306,12 +306,12 @@ public class StreamsMetadataStateTest {
     public void shouldGetAnyHostForGlobalStoreByKeyIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
         streamsMetadataState.onChange(hostToPartitions, Collections.emptyMap(), cluster);
-        assertNotNull(streamsMetadataState.getKeyQueryMetadataWithKey(globalTable, "key", Serdes.String().serializer()));
+        assertNotNull(streamsMetadataState.getKeyQueryMetadataForKey(globalTable, "key", Serdes.String().serializer()));
     }
 
     @Test
     public void shouldGetMyMetadataForGlobalStoreWithKeyAndPartitioner() {
-        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataWithKey(globalTable, "key", partitioner);
+        final KeyQueryMetadata metadata = metadataState.getKeyQueryMetadataForKey(globalTable, "key", partitioner);
         assertEquals(hostOne, metadata.getActiveHost());
     }
 
@@ -319,7 +319,7 @@ public class StreamsMetadataStateTest {
     public void shouldGetAnyHostForGlobalStoreByKeyAndPartitionerIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
         streamsMetadataState.onChange(hostToPartitions, Collections.emptyMap(), cluster);
-        assertNotNull(streamsMetadataState.getKeyQueryMetadataWithKey(globalTable, "key", partitioner));
+        assertNotNull(streamsMetadataState.getKeyQueryMetadataForKey(globalTable, "key", partitioner));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyWrapper;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -122,7 +122,7 @@ public class StreamsMetadataStateTest {
 
         cluster = new Cluster(null, Collections.<Node>emptyList(), partitionInfos, Collections.<String>emptySet(), Collections.<String>emptySet());
         metadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), hostOne);
-        metadataState.onChange(hostToPartitions, cluster);
+        metadataState.onChange(hostToPartitions, Collections.emptyMap(), cluster);
         partitioner = new StreamPartitioner<String, Object>() {
             @Override
             public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
@@ -145,7 +145,7 @@ public class StreamsMetadataStateTest {
         final StreamsMetadata three = new StreamsMetadata(hostThree, Utils.mkSet(globalTable, "table-three"),
                 Collections.singleton(topic3P0));
 
-        final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
+        final Collection<StreamsMetadata> actual = metadataState.getAllActiveMetadata();
         assertEquals(3, actual.size());
         assertTrue("expected " + actual + " to contain " + one, actual.contains(one));
         assertTrue("expected " + actual + " to contain " + two, actual.contains(two));
@@ -165,11 +165,12 @@ public class StreamsMetadataStateTest {
         final HostInfo hostFour = new HostInfo("host-four", 8080);
         hostToPartitions.put(hostFour, Utils.mkSet(tp5));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
+        metadataState.onChange(hostToPartitions, Collections.emptyMap(),
+            cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostFour, Collections.singleton(globalTable),
                 Collections.singleton(tp5));
-        final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
+        final Collection<StreamsMetadata> actual = metadataState.getAllActiveMetadata();
         assertTrue("expected " + actual + " to contain " + expected, actual.contains(expected));
     }
 
@@ -201,7 +202,8 @@ public class StreamsMetadataStateTest {
         final TopicPartition tp4 = new TopicPartition("topic-three", 1);
         hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, tp4));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
+        metadataState.onChange(hostToPartitions, Collections.emptyMap(),
+            cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostThree, Utils.mkSet(globalTable, "table-three"),
                 Collections.singleton(topic3P0));
@@ -218,7 +220,8 @@ public class StreamsMetadataStateTest {
         final TopicPartition tp4 = new TopicPartition("topic-three", 1);
         hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, tp4));
 
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
+        metadataState.onChange(hostToPartitions, Collections.emptyMap(),
+            cluster.withPartitions(Collections.singletonMap(tp4, new PartitionInfo("topic-three", 1, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostTwo, Utils.mkSet(globalTable, "table-two", "table-three", "merged-table"),
                 Utils.mkSet(topic2P0, tp4));
@@ -229,7 +232,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldReturnNotAvailableWhenClusterIsEmpty() {
-        metadataState.onChange(Collections.<HostInfo, Set<TopicPartition>>emptyMap(), Cluster.empty());
+        metadataState.onChange(Collections.<HostInfo, Set<TopicPartition>>emptyMap(), Collections.emptyMap(), Cluster.empty());
         final StreamsMetadata result = metadataState.getMetadataWithKey("table-one", "a", Serdes.String().serializer());
         assertEquals(StreamsMetadata.NOT_AVAILABLE, result);
     }
@@ -238,7 +241,8 @@ public class StreamsMetadataStateTest {
     public void shouldGetInstanceWithKeyWithMergedStreams() {
         final TopicPartition topic2P2 = new TopicPartition("topic-two", 2);
         hostToPartitions.put(hostTwo, Utils.mkSet(topic2P0, topic1P1, topic2P2));
-        metadataState.onChange(hostToPartitions, cluster.withPartitions(Collections.singletonMap(topic2P2, new PartitionInfo("topic-two", 2, null, null, null))));
+        metadataState.onChange(hostToPartitions, Collections.emptyMap(),
+            cluster.withPartitions(Collections.singletonMap(topic2P2, new PartitionInfo("topic-two", 2, null, null, null))));
 
         final StreamsMetadata expected = new StreamsMetadata(hostTwo, Utils.mkSet("global-table", "table-two", "table-one", "merged-table"),
                 Utils.mkSet(topic2P0, topic1P1, topic2P2));
@@ -301,7 +305,7 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
-        streamsMetadataState.onChange(hostToPartitions, cluster);
+        streamsMetadataState.onChange(hostToPartitions, Collections.emptyMap(), cluster);
         assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", Serdes.String().serializer()));
     }
 
@@ -314,7 +318,7 @@ public class StreamsMetadataStateTest {
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyAndPartitionerIfMyHostUnknown() {
         final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(TopologyWrapper.getInternalTopologyBuilder(builder.build()), StreamsMetadataState.UNKNOWN_HOST);
-        streamsMetadataState.onChange(hostToPartitions, cluster);
+        streamsMetadataState.onChange(hostToPartitions, Collections.emptyMap(), cluster);
         assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", partitioner));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.GroupSubscription;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.RebalanceProtocol;
@@ -883,15 +885,20 @@ public class StreamsPartitionAssignorTest {
         builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
         final List<String> topics = asList("topic1", "topic2");
+        final Set<TopicPartition> allTopicPartitions = topics.stream()
+            .map(topic -> asList(new TopicPartition(topic, 0), new TopicPartition(topic, 1), new TopicPartition(topic, 2)))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+
         final Set<TaskId> allTasks = mkSet(task0_0, task0_1, task0_2);
 
 
         final Set<TaskId> prevTasks00 = mkSet(task0_0);
         final Set<TaskId> prevTasks01 = mkSet(task0_1);
         final Set<TaskId> prevTasks02 = mkSet(task0_2);
+        final Set<TaskId> standbyTasks00 = mkSet(task0_0);
         final Set<TaskId> standbyTasks01 = mkSet(task0_1);
         final Set<TaskId> standbyTasks02 = mkSet(task0_2);
-        final Set<TaskId> standbyTasks00 = mkSet(task0_0);
 
         final UUID uuid1 = UUID.randomUUID();
         final UUID uuid2 = UUID.randomUUID();
@@ -906,11 +913,11 @@ public class StreamsPartitionAssignorTest {
         subscriptions.put("consumer10",
                           new ConsumerPartitionAssignor.Subscription(
                               topics,
-                              getInfo(uuid1, prevTasks00, standbyTasks01).encode()));
+                              getInfo(uuid1, prevTasks00, standbyTasks01, "any:9096").encode()));
         subscriptions.put("consumer11",
                           new ConsumerPartitionAssignor.Subscription(
                               topics,
-                              getInfo(uuid1, prevTasks01, standbyTasks02).encode()));
+                              getInfo(uuid1, prevTasks01, standbyTasks02, "any:9096").encode()));
         subscriptions.put("consumer20",
                           new ConsumerPartitionAssignor.Subscription(
                               topics,
@@ -941,12 +948,32 @@ public class StreamsPartitionAssignorTest {
         allStandbyTasks.addAll(info20.standbyTasks().keySet());
 
         // all task ids are in the active tasks and also in the standby tasks
-
         assertEquals(3, allActiveTasks.size());
         assertEquals(allTasks, allActiveTasks);
 
         assertEquals(3, allStandbyTasks.size());
         assertEquals(allTasks, allStandbyTasks);
+
+        // Check host partition assignments
+        final Map<HostInfo, Set<TopicPartition>> partitionsByHost = info10.partitionsByHost();
+        assertEquals(2, partitionsByHost.size());
+        assertEquals(allTopicPartitions, partitionsByHost.values().stream()
+            .flatMap(Collection::stream).collect(Collectors.toSet()));
+
+        final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost = info10.standbyPartitionByHost();
+        assertEquals(2, standbyPartitionsByHost.size());
+        assertEquals(allTopicPartitions, standbyPartitionsByHost.values().stream()
+            .flatMap(Collection::stream).collect(Collectors.toSet()));
+
+        for (final HostInfo hostInfo : partitionsByHost.keySet()) {
+            assertTrue(Collections.disjoint(partitionsByHost.get(hostInfo), standbyPartitionsByHost.get(hostInfo)));
+        }
+
+        // All consumers got the same host info
+        assertEquals(partitionsByHost, info11.partitionsByHost());
+        assertEquals(partitionsByHost, info20.partitionsByHost());
+        assertEquals(standbyPartitionsByHost, info11.standbyPartitionByHost());
+        assertEquals(standbyPartitionsByHost, info20.standbyPartitionByHost());
     }
 
     @Test
@@ -1331,12 +1358,17 @@ public class StreamsPartitionAssignorTest {
         final Map<String, ConsumerPartitionAssignor.Assignment> assign = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
         final ConsumerPartitionAssignor.Assignment consumer1Assignment = assign.get("consumer1");
         final AssignmentInfo assignmentInfo = AssignmentInfo.decode(consumer1Assignment.userData());
-        final Set<TopicPartition> consumer1partitions = assignmentInfo.partitionsByHost().get(new HostInfo("localhost", 8080));
-        final Set<TopicPartition> consumer2Partitions = assignmentInfo.partitionsByHost().get(new HostInfo("other", 9090));
-        final HashSet<TopicPartition> allAssignedPartitions = new HashSet<>(consumer1partitions);
-        allAssignedPartitions.addAll(consumer2Partitions);
-        assertThat(consumer1partitions, not(allPartitions));
-        assertThat(consumer2Partitions, not(allPartitions));
+
+        final Set<TopicPartition> consumer1ActivePartitions = assignmentInfo.partitionsByHost().get(new HostInfo("localhost", 8080));
+        final Set<TopicPartition> consumer2ActivePartitions = assignmentInfo.partitionsByHost().get(new HostInfo("other", 9090));
+        final Set<TopicPartition> consumer1StandbyPartitions = assignmentInfo.standbyPartitionByHost().get(new HostInfo("localhost", 8080));
+        final Set<TopicPartition> consumer2StandbyPartitions = assignmentInfo.standbyPartitionByHost().get(new HostInfo("other", 9090));
+        final HashSet<TopicPartition> allAssignedPartitions = new HashSet<>(consumer1ActivePartitions);
+        allAssignedPartitions.addAll(consumer2ActivePartitions);
+        assertThat(consumer1ActivePartitions, not(allPartitions));
+        assertThat(consumer2ActivePartitions, not(allPartitions));
+        assertThat(consumer1ActivePartitions, equalTo(consumer2StandbyPartitions));
+        assertThat(consumer2ActivePartitions, equalTo(consumer1StandbyPartitions));
         assertThat(allAssignedPartitions, equalTo(allPartitions));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -24,11 +24,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
 import static org.junit.Assert.assertEquals;
@@ -39,36 +41,31 @@ public class AssignmentInfoTest {
         new TaskId(0, 1),
         new TaskId(1, 0),
         new TaskId(1, 1));
-    private final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<TaskId, Set<TopicPartition>>() {
-        {
-            put(new TaskId(1, 0),
-                Utils.mkSet(new TopicPartition("t1", 0), new TopicPartition("t2", 0)));
-            put(new TaskId(1, 1),
-                Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)));
-        }
-    };
-    private final Map<HostInfo, Set<TopicPartition>> activeAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
-        {
-            put(new HostInfo("localhost", 8088), Utils.mkSet(
-                new TopicPartition("t0", 0),
+
+    private final Map<TaskId, Set<TopicPartition>> standbyTasks = mkMap(
+        mkEntry(new TaskId(1, 0), mkSet(new TopicPartition("t1", 0), new TopicPartition("t2", 0))),
+        mkEntry(new TaskId(1, 1), mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)))
+    );
+
+    private final Map<HostInfo, Set<TopicPartition>> activeAssignment = mkMap(
+        mkEntry(new HostInfo("localhost", 8088),
+            mkSet(new TopicPartition("t0", 0),
                 new TopicPartition("t1", 0),
-                new TopicPartition("t2", 0)));
-            put(new HostInfo("localhost", 8089), Utils.mkSet(
-                new TopicPartition("t0", 1),
+                new TopicPartition("t2", 0))),
+        mkEntry(new HostInfo("localhost", 8089),
+            mkSet(new TopicPartition("t0", 1),
                 new TopicPartition("t1", 1),
-                new TopicPartition("t2", 1)));
-        }
-    };
-    private final Map<HostInfo, Set<TopicPartition>> standbyAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
-        {
-            put(new HostInfo("localhost", 8088), Utils.mkSet(
-                new TopicPartition("t1", 0),
-                new TopicPartition("t2", 0)));
-            put(new HostInfo("localhost", 8089), Utils.mkSet(
-                new TopicPartition("t1", 1),
-                new TopicPartition("t2", 1)));
-        }
-    };
+                new TopicPartition("t2", 1)))
+    );
+
+    private final Map<HostInfo, Set<TopicPartition>> standbyAssignment = mkMap(
+        mkEntry(new HostInfo("localhost", 8088),
+            Utils.mkSet(new TopicPartition("t1", 0),
+                new TopicPartition("t2", 0))),
+        mkEntry(new HostInfo("localhost", 8089),
+            Utils.mkSet(new TopicPartition("t1", 1),
+                new TopicPartition("t2", 1)))
+    );
 
     @Test
     public void shouldUseLatestSupportedVersionByDefault() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -55,52 +55,52 @@ public class AssignmentInfoTest {
 
     @Test
     public void shouldUseLatestSupportedVersionByDefault() {
-        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
         assertEquals(LATEST_SUPPORTED_VERSION, info.version());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
-        new AssignmentInfo(0, activeTasks, standbyTasks, globalAssignment, 0);
+        new AssignmentInfo(0, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion2() {
-        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, globalAssignment, 0);
+        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion1() {
-        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(1, UNKNOWN, activeTasks, standbyTasks, Collections.<HostInfo, Set<TopicPartition>>emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(1, UNKNOWN, activeTasks, standbyTasks, Collections.emptyMap(), Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion2() {
-        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion3() {
-        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, globalAssignment, 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 0);
+        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion4() {
-        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion5() {
-        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
@@ -108,8 +108,8 @@ public class AssignmentInfoTest {
     public void shouldEncodeAndDecodeSmallerCommonlySupportedVersion() {
         final int usedVersion = LATEST_SUPPORTED_VERSION - 1;
         final int commonlySupportedVersion = LATEST_SUPPORTED_VERSION - 1;
-        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, 2);
+        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -105,6 +105,13 @@ public class AssignmentInfoTest {
     }
 
     @Test
+    public void shouldEncodeAndDecodeVersion6() {
+        final AssignmentInfo info = new AssignmentInfo(6, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(6, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
+    }
+
+    @Test
     public void shouldEncodeAndDecodeSmallerCommonlySupportedVersion() {
         final int usedVersion = LATEST_SUPPORTED_VERSION - 1;
         final int commonlySupportedVersion = LATEST_SUPPORTED_VERSION - 1;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -36,78 +36,99 @@ import static org.junit.Assert.assertEquals;
 public class AssignmentInfoTest {
     private final List<TaskId> activeTasks = Arrays.asList(
         new TaskId(0, 0),
-        new TaskId(0, 0),
-        new TaskId(0, 1), new TaskId(1, 0));
+        new TaskId(0, 1),
+        new TaskId(1, 0),
+        new TaskId(1, 1));
     private final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<TaskId, Set<TopicPartition>>() {
         {
+            put(new TaskId(1, 0),
+                Utils.mkSet(new TopicPartition("t1", 0), new TopicPartition("t2", 0)));
             put(new TaskId(1, 1),
                 Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)));
-            put(new TaskId(2, 0),
-                Utils.mkSet(new TopicPartition("t3", 0), new TopicPartition("t3", 0)));
         }
     };
-    private final Map<HostInfo, Set<TopicPartition>> globalAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
+    private final Map<HostInfo, Set<TopicPartition>> activeAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
         {
-            put(new HostInfo("localhost", 80),
-                Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t3", 3)));
+            put(new HostInfo("localhost", 8088), Utils.mkSet(
+                new TopicPartition("t0", 0),
+                new TopicPartition("t1", 0),
+                new TopicPartition("t2", 0)));
+            put(new HostInfo("localhost", 8089), Utils.mkSet(
+                new TopicPartition("t0", 1),
+                new TopicPartition("t1", 1),
+                new TopicPartition("t2", 1)));
+        }
+    };
+    private final Map<HostInfo, Set<TopicPartition>> standbyAssignment = new HashMap<HostInfo, Set<TopicPartition>>() {
+        {
+            put(new HostInfo("localhost", 8088), Utils.mkSet(
+                new TopicPartition("t1", 0),
+                new TopicPartition("t2", 0)));
+            put(new HostInfo("localhost", 8089), Utils.mkSet(
+                new TopicPartition("t1", 1),
+                new TopicPartition("t2", 1)));
         }
     };
 
     @Test
     public void shouldUseLatestSupportedVersionByDefault() {
-        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
         assertEquals(LATEST_SUPPORTED_VERSION, info.version());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
-        new AssignmentInfo(0, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        new AssignmentInfo(0, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion2() {
-        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion1() {
-        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(1, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
         final AssignmentInfo expectedInfo = new AssignmentInfo(1, UNKNOWN, activeTasks, standbyTasks, Collections.emptyMap(), Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion2() {
-        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(2, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(2, UNKNOWN, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion3() {
-        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 0);
+        final AssignmentInfo info = new AssignmentInfo(3, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 0);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(3, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 0);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion4() {
-        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo info = new AssignmentInfo(4, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(4, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion5() {
-        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo info = new AssignmentInfo(5, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(5, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion6() {
-        final AssignmentInfo info = new AssignmentInfo(6, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(6, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo info = new AssignmentInfo(6, activeTasks, standbyTasks, activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(6, LATEST_SUPPORTED_VERSION, activeTasks, standbyTasks,
+            activeAssignment, standbyAssignment, 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 
@@ -115,8 +136,10 @@ public class AssignmentInfoTest {
     public void shouldEncodeAndDecodeSmallerCommonlySupportedVersion() {
         final int usedVersion = LATEST_SUPPORTED_VERSION - 1;
         final int commonlySupportedVersion = LATEST_SUPPORTED_VERSION - 1;
-        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
-        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks, globalAssignment, Collections.emptyMap(), 2);
+        final AssignmentInfo info = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks,
+            activeAssignment, standbyAssignment, 2);
+        final AssignmentInfo expectedInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 2);
         assertEquals(expectedInfo, AssignmentInfo.decode(info.encode()));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/LegacySubscriptionInfoSerde.java
@@ -32,7 +32,7 @@ public class LegacySubscriptionInfoSerde {
 
     private static final Logger log = LoggerFactory.getLogger(LegacySubscriptionInfoSerde.class);
 
-    public static final int LATEST_SUPPORTED_VERSION = 5;
+    public static final int LATEST_SUPPORTED_VERSION = 6;
     static final int UNKNOWN = -1;
 
     private final int usedVersion;
@@ -95,7 +95,7 @@ public class LegacySubscriptionInfoSerde {
      * @throws TaskAssignmentException if method fails to encode the data
      */
     public ByteBuffer encode() {
-        if (usedVersion == 3 || usedVersion == 4 || usedVersion == 5) {
+        if (usedVersion == 3 || usedVersion == 4 || usedVersion == 5 || usedVersion == 6) {
             final byte[] endPointBytes = prepareUserEndPoint(this.userEndPoint);
 
             final ByteBuffer buf = ByteBuffer.allocate(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -233,8 +233,8 @@ public class SubscriptionInfoTest {
     }
 
     @Test
-    public void generatedVersion3To5ShouldDecodeLegacyFormat() {
-        for (int version = 3; version <= 5; version++) {
+    public void generatedVersion3To6ShouldDecodeLegacyFormat() {
+        for (int version = 3; version <= 6; version++) {
             final LegacySubscriptionInfoSerde info = new LegacySubscriptionInfoSerde(
                 version,
                 LATEST_SUPPORTED_VERSION,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -321,7 +321,7 @@ public class StreamThreadStateStoreProviderTest {
     }
 
     private void mockThread(final boolean initialized) {
-        EasyMock.expect(threadMock.isRunningAndNotRebalancing()).andReturn(initialized);
+        EasyMock.expect(threadMock.isRunning()).andReturn(initialized);
         EasyMock.expect(threadMock.tasks()).andStubReturn(tasks);
         EasyMock.replay(threadMock);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.tests;
 
-import java.util.Collections;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -226,7 +225,7 @@ public class StreamsUpgradeTest {
 
             final TaskManager taskManager = taskManger();
             taskManager.setClusterMetadata(Cluster.empty().withPartitions(topicToPartitionInfo));
-            taskManager.setHostPartitionMappings(partitionsByHost, Collections.emptyMap());
+            taskManager.setHostPartitionMappings(partitionsByHost, info.standbyPartitionByHost());
             taskManager.setPartitionsToTaskId(partitionsToTaskId);
             taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
             taskManager.updateSubscriptionsFromAssignment(partitions);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.tests;
 
+import java.util.Collections;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -225,7 +226,7 @@ public class StreamsUpgradeTest {
 
             final TaskManager taskManager = taskManger();
             taskManager.setClusterMetadata(Cluster.empty().withPartitions(topicToPartitionInfo));
-            taskManager.setPartitionsByHostState(partitionsByHost);
+            taskManager.setHostPartitionMappings(partitionsByHost, Collections.emptyMap());
             taskManager.setPartitionsToTaskId(partitionsToTaskId);
             taskManager.setAssignmentMetadata(activeTasks, info.standbyTasks());
             taskManager.updateSubscriptionsFromAssignment(partitions);


### PR DESCRIPTION
KIP-535 Implementation

*Summary of testing strategy*
- [x] Unit tests for standby metadata
- [x] Integration test for querying standbys, during rebalance
- [x] Local testing
- [x] Unit tests around APIs used for allLocalOffsetLags() API
- [x] Integration test for lag APIs; LagInfo class
- [x] Final test coverage good; all new methods; even some love for deprecated APIs
- [ ] Streams System tests passing (1 test failing; currently triaging)
- [ ] Special cases like source topic optimization; 
- [ ] Update KIP with latest 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
