### PR TITLE
KAFKA-9332 change how to get joinGroupTimeoutMs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -519,7 +519,7 @@ public abstract class AbstractCoordinator implements Closeable {
         // Note that we override the request timeout using the rebalance timeout since that is the
         // maximum time that it may block on the coordinator. We add an extra 5 seconds for small delays.
 
-        int joinGroupTimeoutMs = Math.max(rebalanceTimeoutMs, rebalanceTimeoutMs + 5000);
+        int joinGroupTimeoutMs = rebalanceTimeoutMs + 5000;
         return client.send(coordinator, requestBuilder, joinGroupTimeoutMs)
                 .compose(new JoinGroupResponseHandler());
     }


### PR DESCRIPTION
rebalanceTimeoutMs + 5000 is always greater than rebalanceTimeoutMs，
  joinGroupTimeoutMs = rebalanceTimeoutMs + 5000，May reduce calculations

