### PR TITLE
KAFKA-9254: Overridden topic configs are reset after dynamic default change

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -619,7 +619,7 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaServer) extends Brok
       props ++= newBrokerDefaults
       props ++= log.config.originals.asScala.filterKeys(log.config.overriddenConfigs.contains)
 
-      val logConfig = LogConfig(props.asJava)
+      val logConfig = LogConfig(props.asJava, log.config.overriddenConfigs)
       log.updateConfig(logConfig)
     }
   }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -512,7 +512,7 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     TestUtils.createTopic(zkClient, topic2, 1, replicationFactor = numServers, servers, topicProps)
     var log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
     assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals(log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString, "2")
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString)
 
     val props = new Properties
     props.put(KafkaConfig.MinInSyncReplicasProp, "3")
@@ -521,13 +521,13 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     // Verify that all broker defaults have been updated again
     servers.foreach { server =>
       props.asScala.foreach { case (k, v) =>
-        assertEquals(s"Not reconfigured $k", server.config.originals.get(k).toString, v)
+        assertEquals(s"Not reconfigured $k", v, server.config.originals.get(k).toString)
       }
     }
 
     log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
     assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals(log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString, "2") // Verify topic-level config survives
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config survives
 
     // Make a second broker-default change
     props.clear()
@@ -535,7 +535,7 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogRetentionTimeMillisProp, "604800000"))
     log = servers.head.logManager.getLog(new TopicPartition(topic2, 0)).getOrElse(throw new IllegalStateException("Log not found"))
     assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals(log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString, "2") // Verify topic-level config still survives
+    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config still survives
   }
 
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9254

Currently, when dynamic broker config is updated, the log config will be recreated with an empty overridden configs. In such case, when updating dynamic broker configs a second round, the topic-level configs will lost.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
