### PR TITLE
MINOR: JavaDoc cleanup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
@@ -55,7 +55,7 @@ public interface SessionWindowedCogroupedKStream<K, V> {
 
     /**
      * Aggregate the values of records in these streams by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
@@ -99,7 +99,7 @@ public interface SessionWindowedCogroupedKStream<K, V> {
 
     /**
      * Aggregate the values of records in these streams by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
@@ -14,46 +14,64 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.kstream;
 
-
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.SessionStore;
+
+import java.time.Duration;
+
 /**
- * {@code SessionWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link org.apache.kafka.streams.KeyValue} pairs.
- * It is an intermediate representation of a {@link CogroupedKStream} in order to apply a windowed aggregation operation on the original
- * {@link KGroupedStream} records.
+ * {@code SessionWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link KeyValue} pairs.
+ * It is an intermediate representation of a {@link CogroupedKStream} in order to apply a windowed aggregation operation
+ * on the original {@link KGroupedStream} records resulting in a windowed {@link KTable} (a <emph>windowed</emph>
+ * {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}).
  * <p>
- * The specified {@link SessionWindows} defines how the windows are created.
+ * {@link SessionWindows} are dynamic data driven windows.
+ * They have no fixed time boundaries, rather the size of the window is determined by the records.
+ * <p>
  * The result is written into a local {@link SessionStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
  * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
  * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
- * A {@code SessionWindowedCogroupedKStream} must be obtained from a {@link CogroupedKStream} via {@link CogroupedKStream#windowedBy(SessionWindows)} .
+ * New events are added to sessions until their grace period ends (see {@link SessionWindows#grace(Duration)}).
+ * <p>
+ * A {@code SessionWindowedCogroupedKStream} must be obtained from a {@link CogroupedKStream} via
+ * {@link CogroupedKStream#windowedBy(SessionWindows)}.
  *
  * @param <K> Type of keys
  * @param <V> Type of values
  * @see KStream
  * @see KGroupedStream
+ * @see SessionWindows
  * @see CogroupedKStream
  */
-
 public interface SessionWindowedCogroupedKStream<K, V> {
 
     /**
-     * Aggregate the values of records in these streams by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in these streams by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Merger)} can be used to compute aggregate functions like count or sum ect...
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
-     * The default key serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@code #aggregate(Initializer, Merger, Materialized)}.
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #aggregate(Initializer, Merger, Materialized)}.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -62,98 +80,186 @@ public interface SessionWindowedCogroupedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * @param initializer    the instance of {@link Initializer}. Cannot be {@code null}.
-     * @param sessionMerger  the instance of {@link Merger}. Cannot be {@code null}.
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Merger<? super K, V> sessionMerger);
+
     /**
-     * Aggregate the values of records in these streams by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in these streams by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Merger, Materialized)} can be used to compute
-     * aggregate functions like count or sum ect...
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
+     * <p>
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use
+     * {@link #aggregate(Initializer, Merger, Named, Materialized)}.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
-     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * The rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
+     * @param named          a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key per session
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                     final Merger<? super K, V> sessionMerger,
+                                     final Named named);
+
+    /**
+     * Aggregate the values of records in these streams by the grouped key and defined sessions.
+     * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * <p>
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the session (per key).
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
+     * they are merged into a single session and the old sessions are discarded.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * @param initializer    the instance of {@link Initializer}. Cannot be {@code null}.
-     * @param sessionMerger  the instance of {@link Merger}. Cannot be {@code null}.
-     * @param materialized   an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlySessionStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>sessionStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
+     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Merger<? super K, V> sessionMerger,
                                      final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
+
     /**
-     * Aggregate the values of records in these streams by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in these streams by the grouped key and defined sessions.
      * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the session (per key).
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Named, Merger)} can be used to compute
-     * aggregate functions like count or sum ect...
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
-     * The default key serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@code #aggregate(Initializer, Named, Merger, Materialized)}.
-     * <p>
-     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same window and key.
-     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * @param initializer    the instance of {@link Initializer}. Cannot be {@code null}.
-     * @param sessionMerger  the instance of {@link Merger}. Cannot be {@code null}.
-     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // some windowed aggregation on value type double
+     * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlySessionStore<String, Long> sessionStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>sessionStore());
+     * String key = "some-key";
+     * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
+     * @param named          a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
-     */
-    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
-                                     final Merger<? super K, V> sessionMerger,
-                                     final Named named);
-    /**
-     * Aggregate the values of records in these streams by the grouped key and defined {@link SessionWindows}.
-     * Records with {@code null} key or value are ignored.
-     * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
-     * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Named, Merger, Materialized)} can be used to compute
-     * aggregate functions like count or sum ect...
-     * <p>
-     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same window and key.
-     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
-     * <p>
-     * @param initializer    the instance of {@link Initializer}. Cannot be {@code null}.
-     * @param sessionMerger  the instance of {@link Merger}. Cannot be {@code null}.
-     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
-     * @param materialized   an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Merger<? super K, V> sessionMerger,
                                      final Named named,
                                      final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.streams.kstream;
 
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.SessionStore;
 
@@ -38,10 +36,12 @@ import java.time.Duration;
  * They have no fixed time boundaries, rather the size of the window is determined by the records.
  * Please see {@link SessionWindows} for more details.
  * <p>
- * New events are added to {@link SessionWindows} until their grace period ends (see {@link SessionWindows#grace(Duration)}).
- *
- * Furthermore, updates are sent downstream into a windowed {@link KTable} changelog stream, where
+ * The result is written into a local {@link SessionStore} (which is basically an ever-updating
+ * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
+ * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
  * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
+ * Furthermore, updates are sent downstream into a windowed {@link KTable} changelog stream, where
+ * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.* New events are added to {@link SessionWindows} until their grace period ends (see {@link SessionWindows#grace(Duration)}).
  * <p>
  * A {@code SessionWindowedKStream} must be obtained from a {@link KGroupedStream} via {@link KGroupedStream#windowedBy(SessionWindows)} .
  *
@@ -54,44 +54,67 @@ import java.time.Duration;
 public interface SessionWindowedKStream<K, V> {
 
     /**
-     * Count the number of records in this stream by the grouped key into {@link SessionWindows}.
+     * Count the number of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
-     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+     * that represent the latest (rolling) count (i.e., number of records) for each key per session
      */
     KTable<Windowed<K>, Long> count();
 
     /**
-     * Count the number of records in this stream by the grouped key into {@link SessionWindows}.
+     * Count the number of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param named       a {@link Named} config used for the filter processor
-     *
+     * @param named  a {@link Named} config used to name the processor in the topology
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
-     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+     * that represent the latest (rolling) count (i.e., number of records) for each key per session
      */
     KTable<Windowed<K>, Long> count(final Named named);
 
     /**
-     * Count the number of records in this stream by the grouped key into {@link SessionWindows}.
+     * Count the number of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view) that can be queried using the name provided with {@link Materialized}.
+     * <p>
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the name provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
@@ -100,8 +123,8 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // compute sum
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -111,7 +134,6 @@ public interface SessionWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -120,21 +142,24 @@ public interface SessionWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     *                      Note: the valueSerde will be automatically set to {@link Serdes#Long()} if there is no valueSerde provided
+     *                      Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
+     *                      if there is no valueSerde provided
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
-     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+     * that represent the latest (rolling) count (i.e., number of records) for each key per session
      */
     KTable<Windowed<K>, Long> count(final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Count the number of records in this stream by the grouped key into {@link SessionWindows}.
+     * Count the number of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view) that can be queried using the name provided with {@link Materialized}.
+     * <p>
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the name provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
@@ -143,8 +168,8 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // compute sum
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -154,7 +179,6 @@ public interface SessionWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -163,23 +187,26 @@ public interface SessionWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param named         a {@link Named} config used to name the processor in the topology
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     *                      Note: the valueSerde will be automatically set to {@link Serdes#Long()} if there is no valueSerde provided
+     *                      Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
+     *                      if there is no valueSerde provided
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
-     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+     * that represent the latest (rolling) count (i.e., number of records) for each key per session
      */
     KTable<Windowed<K>, Long> count(final Named named,
                                     final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
-     * Aggregating is a generalization of {@link #reduce(Reducer) combining via
-     * reduce(...)} as it, for example, allows the result to have a different type than the input values.
+     * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
+     * allows the result to have a different type than the input values.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Initializer} is applied once per session directly before the first input record is
      * processed to provide an initial intermediate aggregation result that is used to process the first record.
@@ -188,11 +215,7 @@ public interface SessionWindowedKStream<K, V> {
      * {@link Initializer}) and the record's value.
      * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Aggregator, Merger)} can be used to compute
-     * aggregate functions like count (c.f. {@link #count()})
-     * <p>
-     * The default value serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@link #aggregate(Initializer, Aggregator, Merger, Materialized)}.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -201,23 +224,33 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * @param initializer    the instance of {@link Initializer}
-     * @param aggregator     the instance of {@link Aggregator}
-     * @param sessionMerger  the instance of {@link Merger}
-     * @param <VR>            the value type of the resulting {@link KTable}
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
+     * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
                                            final Merger<? super K, VR> sessionMerger);
 
-
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in this stream by the grouped key and defined and defined session.
      * Records with {@code null} key or value are ignored.
-     * Aggregating is a generalization of {@link #reduce(Reducer) combining via
-     * reduce(...)} as it, for example, allows the result to have a different type than the input values.
+     * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
+     * allows the result to have a different type than the input values.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Initializer} is applied once per session directly before the first input record is
      * processed to provide an initial intermediate aggregation result that is used to process the first record.
@@ -226,11 +259,7 @@ public interface SessionWindowedKStream<K, V> {
      * {@link Initializer}) and the record's value.
      * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Aggregator, Merger)} can be used to compute
-     * aggregate functions like count (c.f. {@link #count()})
-     * <p>
-     * The default value serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@link #aggregate(Initializer, Aggregator, Merger, Materialized)}.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -239,13 +268,22 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * @param initializer    the instance of {@link Initializer}
-     * @param aggregator     the instance of {@link Aggregator}
-     * @param sessionMerger  the instance of {@link Merger}
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
      * @param named          a {@link Named} config used to name the processor in the topology
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
@@ -253,31 +291,32 @@ public interface SessionWindowedKStream<K, V> {
                                            final Named named);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view) that can be queried using the name provided with {@link Materialized}.
-     * Aggregating is a generalization of {@link #reduce(Reducer) combining via
-     * reduce(...)} as it, for example, allows the result to have a different type than the input values.
+     * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
+     * allows the result to have a different type than the input values.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Initializer} is applied once per session directly before the first input record is
      * processed to provide an initial intermediate aggregation result that is used to process the first record.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Aggregator, Merger)} can be used to compute
-     * aggregate functions like count (c.f. {@link #count()})
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
      * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // some windowed aggregation on value type double
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -285,49 +324,49 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer    the instance of {@link Initializer}
-     * @param aggregator     the instance of {@link Aggregator}
-     * @param sessionMerger  the instance of {@link Merger}
-     * @param materialized   an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
+     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
                                            final Merger<? super K, VR> sessionMerger,
                                            final Materialized<K, VR, SessionStore<Bytes, byte[]>> materialized);
 
-
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined {@link SessionWindows}.
+     * Aggregate the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view) that can be queried using the name provided with {@link Materialized}.
-     * Aggregating is a generalization of {@link #reduce(Reducer) combining via
-     * reduce(...)} as it, for example, allows the result to have a different type than the input values.
+     * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
+     * allows the result to have a different type than the input values.
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Initializer} is applied once per session directly before the first input record is
      * processed to provide an initial intermediate aggregation result that is used to process the first record.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
-     * Thus, {@code aggregate(Initializer, Aggregator, Merger)} can be used to compute
-     * aggregate functions like count (c.f. {@link #count()})
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
@@ -336,7 +375,8 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // some windowed aggregation on value type double
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -344,26 +384,27 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer    the instance of {@link Initializer}
-     * @param aggregator     the instance of {@link Aggregator}
-     * @param sessionMerger  the instance of {@link Merger}
+     * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
      * @param named          a {@link Named} config used to name the processor in the topology
-     * @param materialized   an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}
+     * @param materialized   a {@link Materialized} configused to materialize a state store. Cannot be {@code null}.
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
@@ -372,19 +413,26 @@ public interface SessionWindowedKStream<K, V> {
                                            final Materialized<K, VR, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Combine values of this stream by the grouped key into {@link SessionWindows}.
+     * Combine the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view).
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer)} can be used to compute aggregate functions like sum, min,
-     * or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -392,28 +440,42 @@ public interface SessionWindowedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param reducer           a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param reducer  a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer);
 
-
     /**
-     * Combine values of this stream by the grouped key into {@link SessionWindows}.
+     * Combine the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
-     * The result is written into a local {@link SessionStore} (which is basically an ever-updating
-     * materialized view).
+     * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer)} can be used to compute aggregate functions like sum, min,
-     * or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -421,21 +483,30 @@ public interface SessionWindowedKStream<K, V> {
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
-     * @param named         a {@link Named} config used to name the processor in the topology
+     * @param reducer  a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param named    a {@link Named} config used to name the processor in the topology
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer, final Named named);
 
     /**
-     * Combine values of this stream by the grouped key into {@link SessionWindows}.
+     * Combine the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
-     * provided by the given {@link Materialized} instance.
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
      * aggregate (first argument) and the record's value (second argument):
@@ -447,11 +518,9 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * <p>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, Materialized)} can be used to compute aggregate functions like
-     * sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
@@ -460,8 +529,8 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // compute sum
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -471,7 +540,6 @@ public interface SessionWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -480,25 +548,26 @@ public interface SessionWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     *
-     * @param reducer a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
-     * @param materializedAs an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}
+     * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
-                                  final Materialized<K, V, SessionStore<Bytes, byte[]>> materializedAs);
-
+                                  final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Combine values of this stream by the grouped key into {@link SessionWindows}.
+     * Combine the values of records in this stream by the grouped key and defined session.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
+     * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
-     * provided by the given {@link Materialized} instance.
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
      * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
      * aggregate (first argument) and the record's value (second argument):
@@ -510,11 +579,9 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * <p>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, Materialized)} can be used to compute aggregate functions like
-     * sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
@@ -523,8 +590,8 @@ public interface SessionWindowedKStream<K, V> {
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}.
+     * To query the local {@link SessionStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // compute sum
      * Sting queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
@@ -534,7 +601,6 @@ public interface SessionWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -542,17 +608,17 @@ public interface SessionWindowedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     *
-     * @param reducer a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
-     * @param named   a {@link Named} config used to name the processor in the topology
-     * @param materializedAs an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}
+     * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param named         a {@link Named} config used to name the processor in the topology
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
-     * the latest (rolling) aggregate for each key within a window
+     * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                   final Named named,
-                                  final Materialized<K, V, SessionStore<Bytes, byte[]>> materializedAs);
+                                  final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -54,7 +54,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Count the number of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
@@ -84,7 +84,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Count the number of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
@@ -115,7 +115,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Count the number of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
@@ -161,7 +161,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Count the number of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
@@ -209,7 +209,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Aggregate the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -258,7 +258,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Aggregate the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -309,7 +309,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Aggregate the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -370,7 +370,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Aggregate the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -433,7 +433,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Combine the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
@@ -478,7 +478,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Combine the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
@@ -524,7 +524,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Combine the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
@@ -584,7 +584,7 @@ public interface SessionWindowedKStream<K, V> {
 
     /**
      * Combine the values of records in this stream by the grouped key and defined sessions.
-     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
+     * Note that sessions are generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -28,22 +28,21 @@ import java.time.Duration;
 
 /**
  * {@code SessionWindowedKStream} is an abstraction of a <i>windowed</i> record stream of {@link KeyValue} pairs.
- * It is an intermediate representation after a grouping and windowing of a {@link KStream} before an aggregation is applied to the
- * new (partitioned) windows resulting in a windowed {@link KTable}
- * (a <emph>windowed</emph> {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}.
+ * It is an intermediate representation after a grouping and windowing of a {@link KStream} before an aggregation is
+ * applied to the new (partitioned) windows resulting in a windowed {@link KTable} (a <emph>windowed</emph>
+ * {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}).
  * <p>
  * {@link SessionWindows} are dynamic data driven windows.
  * They have no fixed time boundaries, rather the size of the window is determined by the records.
- * Please see {@link SessionWindows} for more details.
  * <p>
  * The result is written into a local {@link SessionStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
  * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
  * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
- * Furthermore, updates are sent downstream into a windowed {@link KTable} changelog stream, where
- * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.* New events are added to {@link SessionWindows} until their grace period ends (see {@link SessionWindows#grace(Duration)}).
+ * New events are added to sessions until their grace period ends (see {@link SessionWindows#grace(Duration)}).
  * <p>
- * A {@code SessionWindowedKStream} must be obtained from a {@link KGroupedStream} via {@link KGroupedStream#windowedBy(SessionWindows)} .
+ * A {@code SessionWindowedKStream} must be obtained from a {@link KGroupedStream} via
+ * {@link KGroupedStream#windowedBy(SessionWindows)}.
  *
  * @param <K> Type of keys
  * @param <V> Type of values
@@ -54,13 +53,16 @@ import java.time.Duration;
 public interface SessionWindowedKStream<K, V> {
 
     /**
-     * Count the number of records in this stream by the grouped key and defined session.
+     * Count the number of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * The default key serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #count(Materialized)}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same window and key.
+     * the same session and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
@@ -81,13 +83,16 @@ public interface SessionWindowedKStream<K, V> {
     KTable<Windowed<K>, Long> count();
 
     /**
-     * Count the number of records in this stream by the grouped key and defined session.
+     * Count the number of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
+     * The default key serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #count(Named, Materialized)}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same window and key.
+     * the same session and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
@@ -102,26 +107,27 @@ public interface SessionWindowedKStream<K, V> {
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param named  a {@link Named} config used to name the processor in the topology
+     * @param named  a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
      * that represent the latest (rolling) count (i.e., number of records) for each key per session
      */
     KTable<Windowed<K>, Long> count(final Named named);
 
     /**
-     * Count the number of records in this stream by the grouped key and defined session.
+     * Count the number of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
      * that can be queried using the name provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link SessionStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
@@ -136,12 +142,12 @@ public interface SessionWindowedKStream<K, V> {
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot
+     * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -154,19 +160,20 @@ public interface SessionWindowedKStream<K, V> {
     KTable<Windowed<K>, Long> count(final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Count the number of records in this stream by the grouped key and defined session.
+     * Count the number of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
      * that can be queried using the name provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link SessionStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
@@ -181,16 +188,16 @@ public interface SessionWindowedKStream<K, V> {
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot
+     * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param named         a {@link Named} config used to name the processor in the topology
+     * @param named         a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
      *                      Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
      *                      if there is no valueSerde provided
@@ -201,21 +208,26 @@ public interface SessionWindowedKStream<K, V> {
                                     final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined session.
+     * Aggregate the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
+     * <p>
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use
+     * {@link #aggregate(Initializer, Aggregator, Merger, Materialized)}.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
@@ -245,27 +257,32 @@ public interface SessionWindowedKStream<K, V> {
                                            final Merger<? super K, VR> sessionMerger);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined and defined session.
+     * Aggregate the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use
+     * {@link #aggregate(Initializer, Aggregator, Merger, Named, Materialized)}.
+     * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
-     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * The rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -280,7 +297,7 @@ public interface SessionWindowedKStream<K, V> {
      * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
      * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
      * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
-     * @param named          a {@link Named} config used to name the processor in the topology
+     * @param named          a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key per session
@@ -291,7 +308,8 @@ public interface SessionWindowedKStream<K, V> {
                                            final Named named);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined session.
+     * Aggregate the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -299,12 +317,12 @@ public interface SessionWindowedKStream<K, V> {
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
@@ -340,7 +358,7 @@ public interface SessionWindowedKStream<K, V> {
      * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
      * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
      * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
-     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}
+     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key per session
@@ -351,7 +369,8 @@ public interface SessionWindowedKStream<K, V> {
                                            final Materialized<K, VR, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined session.
+     * Aggregate the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
@@ -359,21 +378,21 @@ public interface SessionWindowedKStream<K, V> {
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once per session directly before the first input record is
-     * processed to provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied directly before the first input record per session is processed to
+     * provide an initial intermediate aggregation result that is used to process the first record per session.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * The specified {@link Merger} is used to merge 2 existing sessions into one, i.e., when the windows overlap,
+     * The specified {@link Merger} is used to merge two existing sessions into one, i.e., when the windows overlap,
      * they are merged into a single session and the old sessions are discarded.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link SessionStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
@@ -400,8 +419,8 @@ public interface SessionWindowedKStream<K, V> {
      * @param initializer    an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
      * @param aggregator     an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
      * @param sessionMerger  a {@link Merger} that combines two aggregation results. Cannot be {@code null}.
-     * @param named          a {@link Named} config used to name the processor in the topology
-     * @param materialized   a {@link Materialized} configused to materialize a state store. Cannot be {@code null}.
+     * @param named          a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @param materialized   a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key per session
@@ -413,15 +432,19 @@ public interface SessionWindowedKStream<K, V> {
                                            final Materialized<K, VR, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Combine the values of records in this stream by the grouped key and defined session.
+     * Combine the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #reduce(Reducer, Materialized)} .
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate (first argument) and the record's value (second argument):
+     * The value of the first record per session initialized the session result.
+     * The specified {@link Reducer} is applied for each additional input record per session and computes a new
+     * aggregate using the current aggregate (first argument) and the record's value (second argument):
      * <pre>{@code
      * // At the example of a Reducer<Long>
      * new Reducer<Long>() {
@@ -430,8 +453,6 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
-     * value as-is.
      * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
@@ -456,15 +477,19 @@ public interface SessionWindowedKStream<K, V> {
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer);
 
     /**
-     * Combine the values of records in this stream by the grouped key and defined session.
+     * Combine the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #reduce(Reducer, Named, Materialized)} .
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate (first argument) and the record's value (second argument):
+     * The value of the first record per session initialized the session result.
+     * The specified {@link Reducer} is applied for each additional input record per session and computes a new
+     * aggregate using the current aggregate (first argument) and the record's value (second argument):
      * <pre>{@code
      * // At the example of a Reducer<Long>
      * new Reducer<Long>() {
@@ -473,8 +498,6 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
-     * value as-is.
      * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
@@ -493,14 +516,15 @@ public interface SessionWindowedKStream<K, V> {
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param reducer  a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
-     * @param named    a {@link Named} config used to name the processor in the topology
+     * @param named    a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key per session
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer, final Named named);
 
     /**
-     * Combine the values of records in this stream by the grouped key and defined session.
+     * Combine the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
@@ -508,8 +532,9 @@ public interface SessionWindowedKStream<K, V> {
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate (first argument) and the record's value (second argument):
+     * The value of the first record per session initialized the session result.
+     * The specified {@link Reducer} is applied for each additional input record per session and computes a new
+     * aggregate using the current aggregate (first argument) and the record's value (second argument):
      * <pre>{@code
      * // At the example of a Reducer<Long>
      * new Reducer<Long>() {
@@ -518,16 +543,14 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
-     * value as-is.
      * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link SessionStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
@@ -542,12 +565,12 @@ public interface SessionWindowedKStream<K, V> {
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot
+     * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -560,17 +583,18 @@ public interface SessionWindowedKStream<K, V> {
                                   final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized);
 
     /**
-     * Combine the values of records in this stream by the grouped key and defined session.
+     * Combine the values of records in this stream by the grouped key and defined sessions.
+     * Note that sessions a generated on a per-key basis and records with different keys create independent sessions.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value
      * (c.f. {@link #aggregate(Initializer, Aggregator, Merger)}).
-     * <p>
      * The result is written into a local {@link SessionStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate (first argument) and the record's value (second argument):
+     * The value of the first record per session initialized the session result.
+     * The specified {@link Reducer} is applied for each additional input record per session and computes a new
+     * aggregate using the current aggregate (first argument) and the record's value (second argument):
      * <pre>{@code
      * // At the example of a Reducer<Long>
      * new Reducer<Long>() {
@@ -579,16 +603,14 @@ public interface SessionWindowedKStream<K, V> {
      *   }
      * }
      * }</pre>
-     * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
-     * value as-is.
      * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link SessionStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
@@ -603,17 +625,17 @@ public interface SessionWindowedKStream<K, V> {
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot
+     * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
-     * @param named         a {@link Named} config used to name the processor in the topology
+     * @param named         a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
      * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key per session

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -14,28 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.kstream;
-
 
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.WindowStore;
 
+import java.time.Duration;
+
 /**
- * {@code TimeWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link org.apache.kafka.streams.KeyValue} pairs.
- * It is an intermediate representation of a {@link CogroupedKStream} in order to apply a windowed aggregation operation on the original
- * {@link KGroupedStream} records resulting in a windowed {@link KTable}.
+ * {@code TimeWindowedCogroupKStream} is an abstraction of a <i>windowed</i> record stream of {@link KeyValue} pairs.
+ * It is an intermediate representation of a {@link CogroupedKStream} in order to apply a windowed aggregation operation
+ * on the original {@link KGroupedStream} records resulting in a windowed {@link KTable} (a <emph>windowed</emph>
+ * {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}).
  * <p>
  * The specified {@code windows} define either hopping time windows that can be overlapping or tumbling (c.f.
  * {@link TimeWindows}) or they define landmark windows (c.f. {@link UnlimitedWindows}).
+ * <p>
  * The result is written into a local {@link WindowStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
- *
- * A {@code WindowedCogroupKStream} must be obtained from a {@link CogroupedKStream} via {@link CogroupedKStream#windowedBy(Windows)} .
+ * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
+ * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
+ * New events are added to windows until their grace period ends (see {@link TimeWindows#grace(Duration)}).
+ * <p>
+ * A {@code TimeWindowedCogroupedKStream} must be obtained from a {@link CogroupedKStream} via
+ * {@link CogroupedKStream#windowedBy(Windows)} .
  *
  * @param <K> Type of keys
  * @param <V> Type of values
@@ -46,172 +53,157 @@ import org.apache.kafka.streams.state.WindowStore;
 public interface TimeWindowedCogroupedKStream<K, V> {
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and defined window.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the store name as provided with {@link Materialized}.
-     * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record
-     * for each key in each window is processed to provide an initial intermediate aggregation result
-     * that is used to process the first record for each key in each window.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
-     * a new aggregate using the current aggregate (or for the very first record using the intermediate
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per window and
+     * computes a new aggregate using the current aggregate (or for the very first record using the intermediate
      * aggregation result provided via the {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer)} can be used to compute aggregate functions like
-     * count or sum etc...
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
+     * the same window and key.
+     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     * <p>
-     * To query the local {@link WindowStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
-     * <pre>{@code
-     * KafkaStreams streams = ... // counting words
-     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
-     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     * String key = "some-word";
-     * long fromTime = ...;
-     * long toTime = ...;
-     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
-     * }</pre>
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param initializer  an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer);
 
     /**
      * Aggregate the values of records in this stream by the grouped key.
      * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the store name as provided with {@link Materialized}.
-     * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record
-     * for each key in each window is processed to provide an initial intermediate aggregation result
-     * that is used to process the first record for each key in each window.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
-     * a new aggregate using the current aggregate (or for the very first record using the intermediate
-     * aggregation result provided via the {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Materialized)} can be used to compute aggregate functions like
-     * count or sum etc...
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
+     * window and computes a new aggregate using the current aggregate (or for the very first record using the
+     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
      * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     * <p>
-     * To query the local {@link WindowStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
-     * <pre>{@code
-     * KafkaStreams streams = ... // counting words
-     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
-     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     * String key = "some-word";
-     * long fromTime = ...;
-     * long toTime = ...;
-     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
-     * }</pre>
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
-     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * The changelog topic will be named "${applicationId}-${internalStoreName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
+     * and "-changelog" is a fixed suffix.
+     * Note that the internal store name may not be queriable through Interactive Queries.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
-     */
-    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
-                                     final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
-
-    /**
-     * Aggregate the values of records in this stream by the grouped key.
-     * Records with {@code null} key or value are ignored.
-     * <p>
-     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the store name as provided with {@link Materialized}.
-     * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record
-     * for each key in each window is processed to provide an initial intermediate aggregation
-     * result that is used to process the first record for each key in each window.
-     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
-     * a new aggregate using the current aggregate (or for the very first record using the intermediate
-     * aggregation result provided via the {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Named)} can be used to compute aggregate functions like
-     * count or sum etc...
-     * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     * <p>
-     * To query the local {@link WindowStore} it must be obtained via
-     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
-     * <pre>{@code
-     * KafkaStreams streams = ... // counting words
-     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
-     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
-     * String key = "some-word";
-     * long fromTime = ...;
-     * long toTime = ...;
-     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
-     * }</pre>
-     * <p>
-     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * <p>
-     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
-     *
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
-     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param initializer  an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param named        a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Named named);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
+     * Records with {@code null} key or value are ignored.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * <p>
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
+     * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
+     * window and computes a new aggregate using the current aggregate (or for the very first record using the
+     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
+     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
+     * <p>
+     * To query the local {@link WindowStore} it must be obtained via
+     * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
+     * String key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
+     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
+     * latest (rolling) aggregate for each key within a window
+     */
+    KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
+                                     final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+
+    /**
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * <p>
      * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record for each key in each window is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record for each key in each window.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per window and computes
-     * a new aggregate using the current aggregate (or for the very first record using the intermediate
-     * aggregation result provided via the {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Named, Materialized)} can be used to compute aggregate functions like
-     * count or sum etc...
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
+     * window and computes a new aggregate using the current aggregate (or for the very first record using the
+     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
@@ -222,15 +214,18 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * KafkaStreams streams = ... // counting words
      * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
      * ReadOnlyWindowStore<String,Long> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<String, Long>windowStore());
+     *
      * String key = "some-word";
      * long fromTime = ...;
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
@@ -239,13 +234,12 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
-     * @param named  an instance of {@link Named} used to Named the processors. Cannot be {@code null}.
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param named         a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Named named,
                                      final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -42,7 +42,7 @@ import java.time.Duration;
  * New events are added to windows until their grace period ends (see {@link TimeWindows#grace(Duration)}).
  * <p>
  * A {@code TimeWindowedCogroupedKStream} must be obtained from a {@link CogroupedKStream} via
- * {@link CogroupedKStream#windowedBy(Windows)} .
+ * {@link CogroupedKStream#windowedBy(Windows)}.
  *
  * @param <K> Type of keys
  * @param <V> Type of values
@@ -53,20 +53,22 @@ import java.time.Duration;
 public interface TimeWindowedCogroupedKStream<K, V> {
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and the defined windows.
+     * Aggregate the values of records in this stream by the grouped key and defined windows.
      * Records with {@code null} key or value are ignored.
      * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
-     * window is processed to provide an initial intermediate aggregation result that is used to process the first
-     * record for each key in each window.
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the window (per key).
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per window and
-     * computes a new aggregate using the current aggregate (or for the very first record using the intermediate
-     * aggregation result provided via the {@link Initializer}) and the record's value.
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #aggregate(Initializer, Materialized)}.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
@@ -90,25 +92,27 @@ public interface TimeWindowedCogroupedKStream<K, V> {
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and defined windows.
      * Records with {@code null} key or value are ignored.
      * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
-     * window is processed to provide an initial intermediate aggregation result that is used to process the first
-     * record for each key in each window.
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the window (per key).
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
-     * window and computes a new aggregate using the current aggregate (or for the very first record using the
-     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
+     * The default key and value serde from the config will be used for serializing the result.
+     * If a different serde is required then you should use {@link #aggregate(Initializer, Named, Materialized)}.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * the same window and key.
+     * The rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -129,26 +133,26 @@ public interface TimeWindowedCogroupedKStream<K, V> {
                                      final Named named);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and the defined windows.
+     * Aggregate the values of records in this stream by the grouped key and defined windows.
      * Records with {@code null} key or value are ignored.
      * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
-     * window is processed to provide an initial intermediate aggregation result that is used to process the first
-     * record for each key in each window.
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the window (per key).
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
-     * window and computes a new aggregate using the current aggregate (or for the very first record using the
-     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link WindowStore} it must be obtained via
@@ -178,35 +182,34 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      *
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
      * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key within a window
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> aggregate(final Initializer<V> initializer,
                                      final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key and the defined windows.
+     * Aggregate the values of records in this stream by the grouped key and defined windows.
      * Records with {@code null} key or value are ignored.
-     * <p>
      * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
-     * window is processed to provide an initial intermediate aggregation result that is used to process the first
-     * record for each key in each window.
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the window (per key).
      * The specified {@link Aggregator} (as specified in {@link KGroupedStream#cogroup(Aggregator)} or
-     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record per key and per
-     * window and computes a new aggregate using the current aggregate (or for the very first record using the
-     * intermediate aggregation result provided via the {@link Initializer}) and the record's value.
+     * {@link CogroupedKStream#cogroup(KGroupedStream, Aggregator)}) is applied for each input record and computes a new
+     * aggregate using the current aggregate (or for the very first record using the intermediate aggregation result
+     * provided via the {@link Initializer}) and the record's value.
      * Thus, {@code aggregate()} can be used to compute aggregate functions like count or sum etc.
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
-     * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
-     * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
-     * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
      * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -21,7 +21,6 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.WindowStore;
 
@@ -29,24 +28,21 @@ import java.time.Duration;
 
 /**
  * {@code TimeWindowedKStream} is an abstraction of a <i>windowed</i> record stream of {@link KeyValue} pairs.
- * It is an intermediate representation of a {@link KStream} in order to apply a windowed aggregation operation on the original
- * {@link KStream} records.
- * <p>
- * It is an intermediate representation after a grouping and windowing of a {@link KStream} before an aggregation is applied to the
- * new (partitioned) windows resulting in a windowed {@link KTable}
- * (a <emph>windowed</emph> {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}.
+ * It is an intermediate representation of a {@link KStream} in order to apply a windowed aggregation operation
+ * on the original {@link KStream} records resulting in a windowed {@link KTable} (a <emph>windowed</emph>
+ * {@code KTable} is a {@link KTable} with key type {@link Windowed Windowed<K>}).
  * <p>
  * The specified {@code windows} define either hopping time windows that can be overlapping or tumbling (c.f.
  * {@link TimeWindows}) or they define landmark windows (c.f. {@link UnlimitedWindows}).
- * The result is written into a local windowed {@link KeyValueStore} (which is basically an ever-updating
+ * <p>
+ * The result is written into a local {@link WindowStore} (which is basically an ever-updating
  * materialized view) that can be queried using the name provided in the {@link Materialized} instance.
- *
- * New events are added to windows until their grace period ends (see {@link TimeWindows#grace(Duration)}).
- *
  * Furthermore, updates to the store are sent downstream into a windowed {@link KTable} changelog stream, where
  * "windowed" implies that the {@link KTable} key is a combined key of the original record key and a window ID.
-
- * A {@code WindowedKStream} must be obtained from a {@link KGroupedStream} via {@link KGroupedStream#windowedBy(Windows)} .
+ * New events are added to windows until their grace period ends (see {@link TimeWindows#grace(Duration)}).
+ * <p>
+ * A {@code TimeWindowedKStream} must be obtained from a {@link KGroupedStream} via
+ * {@link KGroupedStream#windowedBy(Windows)} .
  *
  * @param <K> Type of keys
  * @param <V> Type of values
@@ -59,6 +55,8 @@ public interface TimeWindowedKStream<K, V> {
      * Count the number of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
@@ -72,11 +70,11 @@ public interface TimeWindowedKStream<K, V> {
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
      * Note that the internal store name may not be queriable through Interactive Queries.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
-     * represent the latest (rolling) count (i.e., number of records) for each key
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
+     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
      */
     KTable<Windowed<K>, Long> count();
 
@@ -84,6 +82,8 @@ public interface TimeWindowedKStream<K, V> {
      * Count the number of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
@@ -97,12 +97,12 @@ public interface TimeWindowedKStream<K, V> {
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
      * Note that the internal store name may not be queriable through Interactive Queries.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param named         a {@link Named} config used to name the processor in the topology
-     * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
-     * represent the latest (rolling) count (i.e., number of records) for each key
+     * @param named  a {@link Named} config used to name the processor in the topology
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
+     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
      */
     KTable<Windowed<K>, Long> count(final Named named);
 
@@ -110,15 +110,18 @@ public interface TimeWindowedKStream<K, V> {
      * Count the number of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the name provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
      * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -132,7 +135,6 @@ public interface TimeWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -141,31 +143,33 @@ public interface TimeWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     *                       Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
-     *                       if there is no valueSerde provided
-     * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
-     * represent the latest (rolling) count (i.e., number of records) for each key
+     *                      Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
+     *                      if there is no valueSerde provided
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
+     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
      */
     KTable<Windowed<K>, Long> count(final Materialized<K, Long, WindowStore<Bytes, byte[]>> materialized);
-
 
     /**
      * Count the number of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the name provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
      * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -179,7 +183,6 @@ public interface TimeWindowedKStream<K, V> {
      * }</pre>
      * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
-     *
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -188,40 +191,37 @@ public interface TimeWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
      * @param named         a {@link Named} config used to name the processor in the topology
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     *                       Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
-     *                       if there is no valueSerde provided
-     * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
-     * represent the latest (rolling) count (i.e., number of records) for each key
+     *                      Note: the valueSerde will be automatically set to {@link org.apache.kafka.common.serialization.Serdes#Long() Serdes#Long()}
+     *                      if there is no valueSerde provided
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
+     * that represent the latest (rolling) count (i.e., number of records) for each key within a window
      */
-    KTable<Windowed<K>, Long> count(final Named named, final Materialized<K, Long, WindowStore<Bytes, byte[]>> materialized);
+    KTable<Windowed<K>, Long> count(final Named named,
+                                    final Materialized<K, Long, WindowStore<Bytes, byte[]>> materialized);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the provided {@code queryableStoreName}.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
+     * The specified {@link Aggregator} is applied for each input record per window and computes a new aggregate using
+     * the current aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Aggregator)} can be used to compute aggregate functions like
-     * count (c.f. {@link #count()}).
-     * <p>
-     * The default value serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@link #aggregate(Initializer, Aggregator, Materialized)}.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same key.
+     * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
@@ -233,43 +233,37 @@ public interface TimeWindowedKStream<K, V> {
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
      * Note that the internal store name may not be queriable through Interactive Queries.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     *
-     * @param <VR>          the value type of the resulting {@link KTable}
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
-     * @param aggregator    an {@link Aggregator} that computes a new aggregate result
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param initializer  an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator   an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param <VR>         the value type of the resulting {@link KTable}
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator);
 
-
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the provided {@code queryableStoreName}.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Aggregator)} can be used to compute aggregate functions like
-     * count (c.f. {@link #count()}).
-     * <p>
-     * The default value serde from config will be used for serializing the result.
-     * If a different serde is required then you should use {@link #aggregate(Initializer, Aggregator, Materialized)}.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same key.
-     * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
@@ -280,46 +274,45 @@ public interface TimeWindowedKStream<K, V> {
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
      * Note that the internal store name may not be queriable through Interactive Queries.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     *
-     * @param <VR>          the value type of the resulting {@link KTable}
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
-     * @param aggregator    an {@link Aggregator} that computes a new aggregate result
-     * @param named         a {@link Named} config used to name the processor in the topology
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param initializer  an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator   an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param named        a {@link Named} config used to name the processor in the topology
+     * @param <VR>         the value type of the resulting {@link KTable}
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
                                            final Named named);
 
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
      * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
      * aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Aggregator, Materialized)} can be used to compute aggregate functions like
-     * count (c.f. {@link #count()}).
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
-     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
+     * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
-     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}.
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -331,55 +324,55 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
-     * @param aggregator    an {@link Aggregator} that computes a new aggregate result
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator    an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * latest (rolling) aggregate for each key within a window
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
                                            final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized);
 
-
     /**
-     * Aggregate the values of records in this stream by the grouped key.
+     * Aggregate the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
      * allows the result to have a different type than the input values.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Initializer} is applied once directly before the first input record is processed to
-     * provide an initial intermediate aggregation result that is used to process the first record.
-     * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
-     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * The specified {@link Initializer} is applied once directly before the first input record for each key in each
+     * window is processed to provide an initial intermediate aggregation result that is used to process the first
+     * record for each key in each window.
+     * The specified {@link Aggregator} is applied for each input record per window and computes a new aggregate using
+     * the current aggregate (or for the very first record using the intermediate aggregation result provided via the
      * {@link Initializer}) and the record's value.
-     * Thus, {@code aggregate(Initializer, Aggregator, Materialized)} can be used to compute aggregate functions like
-     * count (c.f. {@link #count()}).
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
-     *
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -391,25 +384,26 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
-     * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
-     * alphanumerics, '.', '_' and '-'.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
-     * @param aggregator    an {@link Aggregator} that computes a new aggregate result
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator    an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
      * @param named         a {@link Named} config used to name the processor in the topology
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
      * @param <VR>          the value type of the resulting {@link KTable}
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
@@ -417,21 +411,28 @@ public interface TimeWindowedKStream<K, V> {
                                            final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized);
 
     /**
-     * Combine the values of records in this stream by the grouped key.
+     * Combine the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the provided {@code queryableStoreName}.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * The specified {@link Reducer} is applied for each input record per window and computes a new aggregate using the
+     * current aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, String)} can be used to compute aggregate functions like sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same key.
+     * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
@@ -442,32 +443,38 @@ public interface TimeWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param reducer   a {@link Reducer} that computes a new aggregate result
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param reducer  a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer);
 
-
     /**
-     * Combine the values of records in this stream by the grouped key.
+     * Combine the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
-     * that can be queried using the provided {@code queryableStoreName}.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view).
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * The specified {@link Reducer} is applied for each input record per window and computes a new aggregate using the current
+     * aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, String)} can be used to compute aggregate functions like sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache is used to deduplicate consecutive updates to
-     * the same key.
+     * the same window and key.
      * The rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
@@ -478,38 +485,46 @@ public interface TimeWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "internalStoreName" is an internal name
      * and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param named     a {@link Named} config used to name the processor in the topology
-     * @param reducer   a {@link Reducer} that computes a new aggregate result
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param reducer  a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param named    a {@link Named} config used to name the processor in the topology
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer, final Named named);
 
     /**
-     * Combine the values of records in this stream by the grouped key.
+     * Combine the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * The specified {@link Reducer} is applied for each input record per window and computes a new aggregate using the
+     * current aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, String)} can be used to compute aggregate functions like sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -521,7 +536,8 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<Long> reduceStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -530,40 +546,48 @@ public interface TimeWindowedKStream<K, V> {
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
      * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param reducer       a {@link Reducer} that computes a new aggregate result
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                   final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
 
-
     /**
-     * Combine the values of records in this stream by the grouped key.
+     * Combine the values of records in this stream by the grouped key and the defined windows.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value.
-     * The result is written into a local {@link KeyValueStore} (which is basically an ever-updating materialized view)
+     * <p>
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
      * that can be queried using the store name as provided with {@link Materialized}.
      * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
      * <p>
-     * The specified {@link Reducer} is applied for each input record and computes a new aggregate using the current
-     * aggregate and the record's value.
+     * The specified {@link Reducer} is applied for each input record per window and computes a new aggregate using the
+     * current aggregate (first argument) and the record's value (second argument):
+     * <pre>{@code
+     * // At the example of a Reducer<Long>
+     * new Reducer<Long>() {
+     *   public Long apply(Long aggValue, Long currValue) {
+     *     return aggValue + currValue;
+     *   }
+     * }
+     * }</pre>
      * If there is no current aggregate the {@link Reducer} is not applied and the new aggregate will be the record's
      * value as-is.
-     * Thus, {@code reduce(Reducer, String)} can be used to compute aggregate functions like sum, min, or max.
+     * Thus, {@code reduce()} can be used to compute aggregate functions like sum, min, or max.
      * <p>
      * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates to
      * the same window and key if caching is enabled on the {@link Materialized} instance.
-     * When caching is enable the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct keys, the number of
      * parallel running Kafka Streams instances, and the {@link StreamsConfig configuration} parameters for
      * {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
      * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
      * <p>
-     * To query the local windowed {@link KeyValueStore} it must be obtained via
+     * To query the local {@link WindowStore} it must be obtained via
      * {@link KafkaStreams#store(String, QueryableStoreType) KafkaStreams#store(...)}:
      * <pre>{@code
      * KafkaStreams streams = ... // counting words
@@ -575,7 +599,8 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<Long> reduceStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     *
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
      * Therefore, the store name defined by the Materialized instance must be a valid Kafka topic name and cannot contain characters other than ASCII
@@ -583,15 +608,15 @@ public interface TimeWindowedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@code Materialized}, and "-changelog" is a fixed suffix.
-     *
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
-     * @param reducer       a {@link Reducer} that computes a new aggregate result
+     * @param reducer       a {@link Reducer} that computes a new aggregate result. Cannot be {@code null}.
      * @param named         a {@link Named} config used to name the processor in the topology
-     * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
-     * latest (rolling) aggregate for each key
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                   final Named named,


### PR DESCRIPTION
During the work on KIP-150, we encountered a couple of JavaDoc inconsistencies:
 - different wording
 - typos; incorrect/missing markup
 - some classes/methods explain something, others don't
 - refined some JavaDocs to be more precise

This PR tries to cleanup the JavaDocs accordingly.

Call for review @vvcephei @wcarlson5 @bbejeck 