### PR TITLE
KAFKA-9294: Add tests for Named parameter

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -677,6 +677,7 @@ public interface KStream<K, V> {
      */
     <VR> KStream<K, VR> flatMapValues(final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends VR>> mapper,
                                       final Named named);
+
     /**
      * Print the records of this KStream using the options provided by {@link Printed}
      * Note that this is mainly for debugging/testing purposes, and it will try to flush on each record print.
@@ -872,1195 +873,6 @@ public interface KStream<K, V> {
      */
     void to(final TopicNameExtractor<K, V> topicExtractor,
             final Produced<K, V> produced);
-
-    /**
-     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or one output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transform(new TransformerSupplier() { ... }, "myTransformState");
-     * }</pre>
-     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
-     * transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * in which case no record is emitted.
-     * <pre>{@code
-     * new TransformerSupplier() {
-     *     Transformer get() {
-     *         return new Transformer() {
-     *             private ProcessorContext context;
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.context = context;
-     *                 this.state = context.getStateStore("myTransformState");
-     *                 // punctuate each second; can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             KeyValue transform(K key, V value) {
-     *                 // can access this.state
-     *                 return new KeyValue(key, value); // can emit a single value via return -- can also be null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transform()}.
-     * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
-     * <p>
-     * Note that it is possible to emit multiple records for each input record by using
-     * {@link ProcessorContext#forward(Object, Object) context#forward()} in
-     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
-     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()}.
-     *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
-     * @param stateStoreNames     the names of the state stores used by the processor
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
-     * @see #map(KeyValueMapper)
-     * @see #flatTransform(TransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
-     * @see #process(ProcessorSupplier, String...)
-     */
-    <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
-                                       final String... stateStoreNames);
-
-    /**
-     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or one output record.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transform(new TransformerSupplier() { ... }, "myTransformState");
-     * }</pre>
-     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
-     * transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * in which case no record is emitted.
-     * <pre>{@code
-     * new TransformerSupplier() {
-     *     Transformer get() {
-     *         return new Transformer() {
-     *             private ProcessorContext context;
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.context = context;
-     *                 this.state = context.getStateStore("myTransformState");
-     *                 // punctuate each second; can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             KeyValue transform(K key, V value) {
-     *                 // can access this.state
-     *                 return new KeyValue(key, value); // can emit a single value via return -- can also be null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transform()}.
-     * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
-     * <p>
-     * Note that it is possible to emit multiple records for each input record by using
-     * {@link ProcessorContext#forward(Object, Object) context#forward()} in
-     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
-     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()}.
-     *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
-     * @param named               a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames     the names of the state stores used by the processor
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
-     * @see #map(KeyValueMapper)
-     * @see #flatTransform(TransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
-     * @see #process(ProcessorSupplier, String...)
-     */
-    <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
-                                       final Named named,
-                                       final String... stateStoreNames);
-
-    /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransform(new TransformerSupplier() { ... }, "myTransformState");
-     * }</pre>
-     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)
-     * punctuate()}, a schedule must be registered.
-     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
-     * type) in {@link Transformer#transform(Object, Object) transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
-     * <pre>{@code
-     * new TransformerSupplier() {
-     *     Transformer get() {
-     *         return new Transformer() {
-     *             private ProcessorContext context;
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.context = context;
-     *                 this.state = context.getStateStore("myTransformState");
-     *                 // punctuate each second; can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<KeyValue> transform(K key, V value) {
-     *                 // can access this.state
-     *                 List<KeyValue> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new KeyValue(key, value));
-     *                 }
-     *                 return result; // emits a list of key-value pairs via return
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransform()}.
-     * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
-     * <p>
-     * Note that it is possible to emit records by using {@link ProcessorContext#forward(Object, Object)
-     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
-     * @param stateStoreNames     the names of the state stores used by the processor
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
-     * @see #flatMap(KeyValueMapper)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
-     * @see #process(ProcessorSupplier, String...)
-     */
-    <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                           final String... stateStoreNames);
-
-    /**
-     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
-     * can be altered arbitrarily).
-     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
-     * returns zero or more output records.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransform(new TransformerSupplier() { ... }, "myTransformState");
-     * }</pre>
-     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)
-     * punctuate()}, a schedule must be registered.
-     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
-     * type) in {@link Transformer#transform(Object, Object) transform()}.
-     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
-     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
-     * <pre>{@code
-     * new TransformerSupplier() {
-     *     Transformer get() {
-     *         return new Transformer() {
-     *             private ProcessorContext context;
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.context = context;
-     *                 this.state = context.getStateStore("myTransformState");
-     *                 // punctuate each second; can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<KeyValue> transform(K key, V value) {
-     *                 // can access this.state
-     *                 List<KeyValue> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new KeyValue(key, value));
-     *                 }
-     *                 return result; // emits a list of key-value pairs via return
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransform()}.
-     * <p>
-     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
-     * or join) is applied to the result {@code KStream}.
-     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
-     * <p>
-     * Note that it is possible to emit records by using {@link ProcessorContext#forward(Object, Object)
-     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
-     * detected at runtime.
-     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
-     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
-     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
-     *
-     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
-     * @param named               a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames     the names of the state stores used by the processor
-     * @param <K1>                the key type of the new stream
-     * @param <V1>                the value type of the new stream
-     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
-     * @see #flatMap(KeyValueMapper)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerSupplier, String...)
-     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
-     * @see #process(ProcessorSupplier, String...)
-     */
-    <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                           final Named named,
-                                           final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
-     * connect global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is {@code null},
-     * no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
-     * pairs can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerSupplier() {
-     *     ValueTransformer get() {
-     *         return new ValueTransformer() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             NewValueType transform(V value) {
-     *                 // can access this.state
-     *                 return new NewValueType(); // or null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transformValues()}.
-     * <p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerSupplier} that generates a
-     *                                 {@link ValueTransformer}
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                        final String... stateStoreNames);
-    /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
-     * connect global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is {@code null}, no
-     * records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
-     * pairs can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerSupplier() {
-     *     ValueTransformer get() {
-     *         return new ValueTransformer() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             NewValueType transform(V value) {
-     *                 // can access this.state
-     *                 return new NewValueType(); // or null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transformValues()}.
-     * <p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerSupplier} that generates a
-     *                                 {@link ValueTransformer}
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                        final Named named,
-                                        final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
-     * connect global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return the new value in
-     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerWithKeySupplier() {
-     *     ValueTransformerWithKey get() {
-     *         return new ValueTransformerWithKey() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             NewValueType transform(K readOnlyKey, V value) {
-     *                 // can access this.state and use read-only key
-     *                 return new NewValueType(readOnlyKey); // or null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transformValues()}.
-     * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
-     *                                 {@link ValueTransformerWithKey}
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                        final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes a new value for it.
-     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
-     * connect global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.transformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return the new value in
-     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerWithKeySupplier() {
-     *     ValueTransformerWithKey get() {
-     *         return new ValueTransformerWithKey() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             NewValueType transform(K readOnlyKey, V value) {
-     *                 // can access this.state and use read-only key
-     *                 return new NewValueType(readOnlyKey); // or null
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code transformValues()}.
-     * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
-     *                                 {@link ValueTransformerWithKey}
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                        final Named named,
-                                        final String... stateStoreNames);
-    /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand:
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
-     * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
-     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerSupplier() {
-     *     ValueTransformer get() {
-     *         return new ValueTransformer() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<NewValueType> transform(V value) {
-     *                 // can access this.state
-     *                 List<NewValueType> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new NewValueType(value));
-     *                 }
-     *                 return result; // values
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()})
-     *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a
-     *                                 {@link ValueTransformer}
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #flatTransform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
-     * record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
-     * the processing progress can be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand:
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
-     * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
-     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
-     * emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerSupplier() {
-     *     ValueTransformer get() {
-     *         return new ValueTransformer() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<NewValueType> transform(V value) {
-     *                 // can access this.state
-     *                 List<NewValueType> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new NewValueType(value));
-     *                 }
-     *                 return result; // values
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
-     * Setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()})
-     *
-     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a
-     *                                 {@link ValueTransformer}
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #flatTransform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final Named named,
-                                            final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
-     * be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand:
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
-     * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerWithKeySupplier() {
-     *     ValueTransformerWithKey get() {
-     *         return new ValueTransformerWithKey() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<NewValueType> transform(K readOnlyKey, V value) {
-     *                 // can access this.state and use read-only key
-     *                 List<NewValueType> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new NewValueType(readOnlyKey));
-     *                 }
-     *                 return result; // values
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
-     *                                 {@link ValueTransformerWithKey}
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #flatTransform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final String... stateStoreNames);
-
-    /**
-     * Transform the value of each input record into zero or more new values (with possibly a new
-     * type) and emit for each new value a record with the same key of the input record and the value.
-     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
-     * each input record value and computes zero or more new values.
-     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
-     * be observed and additional periodic actions can be performed.
-     * <p>
-     * In order to assign a state store, the state store must be created and registered beforehand:
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
-     * }</pre>
-     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
-     * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
-     * transform()}.
-     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
-     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
-     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
-     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
-     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
-     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
-     * to emit a {@link KeyValue} pair.
-     * <pre>{@code
-     * new ValueTransformerWithKeySupplier() {
-     *     ValueTransformerWithKey get() {
-     *         return new ValueTransformerWithKey() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myValueTransformState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             Iterable<NewValueType> transform(K readOnlyKey, V value) {
-     *                 // can access this.state and use read-only key
-     *                 List<NewValueType> result = new ArrayList<>();
-     *                 for (int i = 0; i < 3; i++) {
-     *                     result.add(new NewValueType(readOnlyKey));
-     *                 }
-     *                 return result; // values
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
-     * {@code flatTransformValues()}.
-     * <p>
-     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
-     * So, setting a new value preserves data co-location with respect to the key.
-     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
-     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
-     * flatTransform()})
-     *
-     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
-     *                                 {@link ValueTransformerWithKey}
-     * @param named                    a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames          the names of the state stores used by the processor
-     * @param <VR>                     the value type of the result stream
-     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
-     * different type)
-     * @see #mapValues(ValueMapper)
-     * @see #mapValues(ValueMapperWithKey)
-     * @see #transform(TransformerSupplier, String...)
-     * @see #flatTransform(TransformerSupplier, String...)
-     */
-    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                            final Named named,
-                                            final String... stateStoreNames);
-
-    /**
-     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
-     * {@link ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * Note that this is a terminal operation that returns void.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myProcessorState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * inputStream.process(new ProcessorSupplier() { ... }, "myProcessorState");
-     * }</pre>
-     * Within the {@link Processor}, the state is obtained via the
-     * {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * <pre>{@code
-     * new ProcessorSupplier() {
-     *     Processor get() {
-     *         return new Processor() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myProcessorState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             void process(K key, V value) {
-     *                 // can access this.state
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String)} should be performed before {@code transform()}.
-     *
-     * @param processorSupplier a instance of {@link ProcessorSupplier} that generates a {@link Processor}
-     * @param stateStoreNames   the names of the state store used by the processor
-     * @see #foreach(ForeachAction)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
-                 final String... stateStoreNames);
-
-    /**
-     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
-     * {@link ProcessorSupplier}).
-     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
-     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
-     * but allows access to the {@code ProcessorContext} and record metadata.
-     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
-     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
-     * can be observed and additional periodic actions can be performed.
-     * Note that this is a terminal operation that returns void.
-     * <p>
-     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
-     * global state stores; read-only access to global state stores is available by default):
-     * <pre>{@code
-     * // create store
-     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
-     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myProcessorState"),
-     *                 Serdes.String(),
-     *                 Serdes.String());
-     * // register store
-     * builder.addStateStore(keyValueStoreBuilder);
-     *
-     * inputStream.process(new ProcessorSupplier() { ... }, "myProcessorState");
-     * }</pre>
-     * Within the {@link Processor}, the state is obtained via the
-     * {@link ProcessorContext}.
-     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
-     * a schedule must be registered.
-     * <pre>{@code
-     * new ProcessorSupplier() {
-     *     Processor get() {
-     *         return new Processor() {
-     *             private StateStore state;
-     *
-     *             void init(ProcessorContext context) {
-     *                 this.state = context.getStateStore("myProcessorState");
-     *                 // punctuate each second, can access this.state
-     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
-     *             }
-     *
-     *             void process(K key, V value) {
-     *                 // can access this.state
-     *             }
-     *
-     *             void close() {
-     *                 // can access this.state
-     *             }
-     *         }
-     *     }
-     * }
-     * }</pre>
-     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
-     * If repartitioning is required, a call to {@link #through(String)} should be performed before {@code transform()}.
-     *
-     * @param processorSupplier a instance of {@link ProcessorSupplier} that generates a {@link Processor}
-     * @param named             a {@link Named} config used to name the processor in the topology
-     * @param stateStoreNames   the names of the state store used by the processor
-     * @see #foreach(ForeachAction)
-     * @see #transform(TransformerSupplier, String...)
-     */
-    void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
-                 final Named named,
-                 final String... stateStoreNames);
 
     /**
      * Group the records by their current key into a {@link KGroupedStream} while preserving the original values
@@ -3446,4 +2258,1193 @@ public interface KStream<K, V> {
                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keyValueMapper,
                                          final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner,
                                          final Named named);
+
+    /**
+     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
+     * can be altered arbitrarily).
+     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
+     * returns zero or one output record.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transform(new TransformerSupplier() { ... }, "myTransformState");
+     * }</pre>
+     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
+     * transform()}.
+     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
+     * in which case no record is emitted.
+     * <pre>{@code
+     * new TransformerSupplier() {
+     *     Transformer get() {
+     *         return new Transformer() {
+     *             private ProcessorContext context;
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.context = context;
+     *                 this.state = context.getStateStore("myTransformState");
+     *                 // punctuate each second; can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             KeyValue transform(K key, V value) {
+     *                 // can access this.state
+     *                 return new KeyValue(key, value); // can emit a single value via return -- can also be null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transform()}.
+     * <p>
+     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}.
+     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
+     * <p>
+     * Note that it is possible to emit multiple records for each input record by using
+     * {@link ProcessorContext#forward(Object, Object) context#forward()} in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
+     * detected at runtime.
+     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
+     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
+     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()}.
+     *
+     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
+     * @param stateStoreNames     the names of the state stores used by the processor
+     * @param <K1>                the key type of the new stream
+     * @param <V1>                the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @see #map(KeyValueMapper)
+     * @see #flatTransform(TransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
+     * @see #process(ProcessorSupplier, String...)
+     */
+    <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
+                                       final String... stateStoreNames);
+
+    /**
+     * Transform each record of the input stream into zero or one record in the output stream (both key and value type
+     * can be altered arbitrarily).
+     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
+     * returns zero or one output record.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K':V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #map(KeyValueMapper) map()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #map(KeyValueMapper) map()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()},
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transform(new TransformerSupplier() { ... }, "myTransformState");
+     * }</pre>
+     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link Transformer} must return a {@link KeyValue} type in {@link Transformer#transform(Object, Object)
+     * transform()}.
+     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
+     * in which case no record is emitted.
+     * <pre>{@code
+     * new TransformerSupplier() {
+     *     Transformer get() {
+     *         return new Transformer() {
+     *             private ProcessorContext context;
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.context = context;
+     *                 this.state = context.getStateStore("myTransformState");
+     *                 // punctuate each second; can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             KeyValue transform(K key, V value) {
+     *                 // can access this.state
+     *                 return new KeyValue(key, value); // can emit a single value via return -- can also be null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transform()}.
+     * <p>
+     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}.
+     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()} )
+     * <p>
+     * Note that it is possible to emit multiple records for each input record by using
+     * {@link ProcessorContext#forward(Object, Object) context#forward()} in
+     * {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
+     * detected at runtime.
+     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
+     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * If in {@link Transformer#transform(Object, Object) Transformer#transform()} multiple records need to be emitted
+     * for each input record, it is recommended to use {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()}.
+     *
+     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
+     * @param named               a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames     the names of the state stores used by the processor
+     * @param <K1>                the key type of the new stream
+     * @param <V1>                the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @see #map(KeyValueMapper)
+     * @see #flatTransform(TransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
+     * @see #process(ProcessorSupplier, String...)
+     */
+    <K1, V1> KStream<K1, V1> transform(final TransformerSupplier<? super K, ? super V, KeyValue<K1, V1>> transformerSupplier,
+                                       final Named named,
+                                       final String... stateStoreNames);
+
+    /**
+     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+     * can be altered arbitrarily).
+     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
+     * returns zero or more output records.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransform(new TransformerSupplier() { ... }, "myTransformState");
+     * }</pre>
+     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)
+     * punctuate()}, a schedule must be registered.
+     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
+     * type) in {@link Transformer#transform(Object, Object) transform()}.
+     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
+     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
+     * <pre>{@code
+     * new TransformerSupplier() {
+     *     Transformer get() {
+     *         return new Transformer() {
+     *             private ProcessorContext context;
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.context = context;
+     *                 this.state = context.getStateStore("myTransformState");
+     *                 // punctuate each second; can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<KeyValue> transform(K key, V value) {
+     *                 // can access this.state
+     *                 List<KeyValue> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new KeyValue(key, value));
+     *                 }
+     *                 return result; // emits a list of key-value pairs via return
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransform()}.
+     * <p>
+     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}.
+     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
+     * <p>
+     * Note that it is possible to emit records by using {@link ProcessorContext#forward(Object, Object)
+     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
+     * detected at runtime.
+     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
+     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     *
+     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
+     * @param stateStoreNames     the names of the state stores used by the processor
+     * @param <K1>                the key type of the new stream
+     * @param <V1>                the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @see #flatMap(KeyValueMapper)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
+     * @see #process(ProcessorSupplier, String...)
+     */
+    <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
+                                           final String... stateStoreNames);
+
+    /**
+     * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+     * can be altered arbitrarily).
+     * A {@link Transformer} (provided by the given {@link TransformerSupplier}) is applied to each input record and
+     * returns zero or more output records.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K':V'>, <K'':V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMap(KeyValueMapper) flatMap()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMap(KeyValueMapper) flatMap()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransform(new TransformerSupplier() { ... }, "myTransformState");
+     * }</pre>
+     * Within the {@link Transformer}, the state is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)
+     * punctuate()}, a schedule must be registered.
+     * The {@link Transformer} must return an {@link java.lang.Iterable} type (e.g., any {@link java.util.Collection}
+     * type) in {@link Transformer#transform(Object, Object) transform()}.
+     * The return value of {@link Transformer#transform(Object, Object) Transformer#transform()} may be {@code null},
+     * which is equal to returning an empty {@link java.lang.Iterable Iterable}, i.e., no records are emitted.
+     * <pre>{@code
+     * new TransformerSupplier() {
+     *     Transformer get() {
+     *         return new Transformer() {
+     *             private ProcessorContext context;
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.context = context;
+     *                 this.state = context.getStateStore("myTransformState");
+     *                 // punctuate each second; can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<KeyValue> transform(K key, V value) {
+     *                 // can access this.state
+     *                 List<KeyValue> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new KeyValue(key, value));
+     *                 }
+     *                 return result; // emits a list of key-value pairs via return
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransform()}.
+     * <p>
+     * Transforming records might result in an internal data redistribution if a key based operator (like an aggregation
+     * or join) is applied to the result {@code KStream}.
+     * (cf. {@link #transformValues(ValueTransformerSupplier, String...) transformValues()})
+     * <p>
+     * Note that it is possible to emit records by using {@link ProcessorContext#forward(Object, Object)
+     * context#forward()} in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     * Be aware that a mismatch between the types of the emitted records and the type of the stream would only be
+     * detected at runtime.
+     * To ensure type-safety at compile-time, {@link ProcessorContext#forward(Object, Object) context#forward()} should
+     * not be used in {@link Transformer#transform(Object, Object) Transformer#transform()} and
+     * {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}.
+     *
+     * @param transformerSupplier an instance of {@link TransformerSupplier} that generates a {@link Transformer}
+     * @param named               a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames     the names of the state stores used by the processor
+     * @param <K1>                the key type of the new stream
+     * @param <V1>                the value type of the new stream
+     * @return a {@code KStream} that contains more or less records with new key and value (possibly of different type)
+     * @see #flatMap(KeyValueMapper)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerSupplier, String...)
+     * @see #transformValues(ValueTransformerWithKeySupplier, String...)
+     * @see #process(ProcessorSupplier, String...)
+     */
+    <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
+                                           final Named named,
+                                           final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
+     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
+     * connect global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
+     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is {@code null},
+     * no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
+     * pairs can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
+     * emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerSupplier() {
+     *     ValueTransformer get() {
+     *         return new ValueTransformer() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             NewValueType transform(V value) {
+     *                 // can access this.state
+     *                 return new NewValueType(); // or null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transformValues()}.
+     * <p>
+     * Setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerSupplier} that generates a
+     *                                 {@link ValueTransformer}
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
+                                        final String... stateStoreNames);
+    /**
+     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
+     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
+     * connect global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformer} must return the new value in {@link ValueTransformer#transform(Object) transform()}.
+     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is {@code null}, no
+     * records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()}, no additional {@link KeyValue}
+     * pairs can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
+     * emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerSupplier() {
+     *     ValueTransformer get() {
+     *         return new ValueTransformer() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             NewValueType transform(V value) {
+     *                 // can access this.state
+     *                 return new NewValueType(); // or null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transformValues()}.
+     * <p>
+     * Setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerSupplier} that generates a
+     *                                 {@link ValueTransformer}
+     * @param named                    a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
+                                        final Named named,
+                                        final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
+     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
+     * each input record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
+     * connect global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformerWithKey} must return the new value in
+     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
+     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
+     * to emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerWithKeySupplier() {
+     *     ValueTransformerWithKey get() {
+     *         return new ValueTransformerWithKey() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             NewValueType transform(K readOnlyKey, V value) {
+     *                 // can access this.state and use read-only key
+     *                 return new NewValueType(readOnlyKey); // or null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transformValues()}.
+     * <p>
+     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
+     * So, setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     *                                 {@link ValueTransformerWithKey}
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
+                                        final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into a new value (with possibly a new type) of the output record.
+     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
+     * each input record value and computes a new value for it.
+     * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapperWithKey) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapperWithKey) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand (it's not required to
+     * connect global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.transformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformerWithKey} must return the new value in
+     * {@link ValueTransformerWithKey#transform(Object, Object) transform()}.
+     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
+     * to emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerWithKeySupplier() {
+     *     ValueTransformerWithKey get() {
+     *         return new ValueTransformerWithKey() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             NewValueType transform(K readOnlyKey, V value) {
+     *                 // can access this.state and use read-only key
+     *                 return new NewValueType(readOnlyKey); // or null
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code transformValues()}.
+     * <p>
+     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
+     * So, setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #transform(TransformerSupplier, String...)})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     *                                 {@link ValueTransformerWithKey}
+     * @param named                    a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains records with unmodified key and new values (possibly of different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
+                                        final Named named,
+                                        final String... stateStoreNames);
+    /**
+     * Transform the value of each input record into zero or more new values (with possibly a new
+     * type) and emit for each new value a record with the same key of the input record and the value.
+     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes zero or more new values.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand:
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
+     * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
+     * transform()}.
+     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
+     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
+     * emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerSupplier() {
+     *     ValueTransformer get() {
+     *         return new ValueTransformer() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<NewValueType> transform(V value) {
+     *                 // can access this.state
+     *                 List<NewValueType> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new NewValueType(value));
+     *                 }
+     *                 return result; // values
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransformValues()}.
+     * <p>
+     * Setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()})
+     *
+     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a
+     *                                 {@link ValueTransformer}
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
+     * different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #flatTransform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
+                                            final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into zero or more new values (with possibly a new
+     * type) and emit for each new value a record with the same key of the input record and the value.
+     * A {@link ValueTransformer} (provided by the given {@link ValueTransformerSupplier}) is applied to each input
+     * record value and computes zero or more new values.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #mapValues(ValueMapper) mapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #mapValues(ValueMapper) mapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) Punctuator#punctuate()}
+     * the processing progress can be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand:
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerSupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformer}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformer} must return an {@link java.lang.Iterable} type (e.g., any
+     * {@link java.util.Collection} type) in {@link ValueTransformer#transform(Object)
+     * transform()}.
+     * If the return value of {@link ValueTransformer#transform(Object) ValueTransformer#transform()} is an empty
+     * {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformer} tries to
+     * emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerSupplier() {
+     *     ValueTransformer get() {
+     *         return new ValueTransformer() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<NewValueType> transform(V value) {
+     *                 // can access this.state
+     *                 List<NewValueType> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new NewValueType(value));
+     *                 }
+     *                 return result; // values
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransformValues()}.
+     * <p>
+     * Setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()})
+     *
+     * @param valueTransformerSupplier an instance of {@link ValueTransformerSupplier} that generates a
+     *                                 {@link ValueTransformer}
+     * @param named                    a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
+     * different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #flatTransform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
+                                            final Named named,
+                                            final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into zero or more new values (with possibly a new
+     * type) and emit for each new value a record with the same key of the input record and the value.
+     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
+     * each input record value and computes zero or more new values.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
+     * be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand:
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
+     * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
+     * transform()}.
+     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
+     * to emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerWithKeySupplier() {
+     *     ValueTransformerWithKey get() {
+     *         return new ValueTransformerWithKey() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<NewValueType> transform(K readOnlyKey, V value) {
+     *                 // can access this.state and use read-only key
+     *                 List<NewValueType> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new NewValueType(readOnlyKey));
+     *                 }
+     *                 return result; // values
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransformValues()}.
+     * <p>
+     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
+     * So, setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     *                                 {@link ValueTransformerWithKey}
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
+     * different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #flatTransform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
+                                            final String... stateStoreNames);
+
+    /**
+     * Transform the value of each input record into zero or more new values (with possibly a new
+     * type) and emit for each new value a record with the same key of the input record and the value.
+     * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to
+     * each input record value and computes zero or more new values.
+     * Thus, an input record {@code <K,V>} can be transformed into output records {@code <K:V'>, <K:V''>, ...}.
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #flatMapValues(ValueMapperWithKey) flatMapValues()}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can
+     * be observed and additional periodic actions can be performed.
+     * <p>
+     * In order to assign a state store, the state store must be created and registered beforehand:
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myValueTransformState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * KStream outputStream = inputStream.flatTransformValues(new ValueTransformerWithKeySupplier() { ... }, "myValueTransformState");
+     * }</pre>
+     * Within the {@link ValueTransformerWithKey}, the state store is obtained via the {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * The {@link ValueTransformerWithKey} must return an {@link java.lang.Iterable} type (e.g., any
+     * {@link java.util.Collection} type) in {@link ValueTransformerWithKey#transform(Object, Object)
+     * transform()}.
+     * If the return value of {@link ValueTransformerWithKey#transform(Object, Object) ValueTransformerWithKey#transform()}
+     * is an empty {@link java.lang.Iterable Iterable} or {@code null}, no records are emitted.
+     * In contrast to {@link #transform(TransformerSupplier, String...) transform()} and
+     * {@link #flatTransform(TransformerSupplier, String...) flatTransform()}, no additional {@link KeyValue} pairs
+     * can be emitted via {@link ProcessorContext#forward(Object, Object) ProcessorContext.forward()}.
+     * A {@link org.apache.kafka.streams.errors.StreamsException} is thrown if the {@link ValueTransformerWithKey} tries
+     * to emit a {@link KeyValue} pair.
+     * <pre>{@code
+     * new ValueTransformerWithKeySupplier() {
+     *     ValueTransformerWithKey get() {
+     *         return new ValueTransformerWithKey() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myValueTransformState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             Iterable<NewValueType> transform(K readOnlyKey, V value) {
+     *                 // can access this.state and use read-only key
+     *                 List<NewValueType> result = new ArrayList<>();
+     *                 for (int i = 0; i < 3; i++) {
+     *                     result.add(new NewValueType(readOnlyKey));
+     *                 }
+     *                 return result; // values
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String) through()} should be performed before
+     * {@code flatTransformValues()}.
+     * <p>
+     * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
+     * So, setting a new value preserves data co-location with respect to the key.
+     * Thus, <em>no</em> internal data redistribution is required if a key based operator (like an aggregation or join)
+     * is applied to the result {@code KStream}. (cf. {@link #flatTransform(TransformerSupplier, String...)
+     * flatTransform()})
+     *
+     * @param valueTransformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     *                                 {@link ValueTransformerWithKey}
+     * @param named                    a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames          the names of the state stores used by the processor
+     * @param <VR>                     the value type of the result stream
+     * @return a {@code KStream} that contains more or less records with unmodified key and new values (possibly of
+     * different type)
+     * @see #mapValues(ValueMapper)
+     * @see #mapValues(ValueMapperWithKey)
+     * @see #transform(TransformerSupplier, String...)
+     * @see #flatTransform(TransformerSupplier, String...)
+     */
+    <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
+                                            final Named named,
+                                            final String... stateStoreNames);
+
+    /**
+     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
+     * {@link ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * Note that this is a terminal operation that returns void.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myProcessorState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * inputStream.process(new ProcessorSupplier() { ... }, "myProcessorState");
+     * }</pre>
+     * Within the {@link Processor}, the state is obtained via the
+     * {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * <pre>{@code
+     * new ProcessorSupplier() {
+     *     Processor get() {
+     *         return new Processor() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myProcessorState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             void process(K key, V value) {
+     *                 // can access this.state
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String)} should be performed before {@code transform()}.
+     *
+     * @param processorSupplier a instance of {@link ProcessorSupplier} that generates a {@link Processor}
+     * @param stateStoreNames   the names of the state store used by the processor
+     * @see #foreach(ForeachAction)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
+                 final String... stateStoreNames);
+
+    /**
+     * Process all records in this stream, one record at a time, by applying a {@link Processor} (provided by the given
+     * {@link ProcessorSupplier}).
+     * Attaching a state store makes this a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
+     * If you choose not to attach one, this operation is similar to the stateless {@link #foreach(ForeachAction)}
+     * but allows access to the {@code ProcessorContext} and record metadata.
+     * This is essentially mixing the Processor API into the DSL, and provides all the functionality of the PAPI.
+     * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress
+     * can be observed and additional periodic actions can be performed.
+     * Note that this is a terminal operation that returns void.
+     * <p>
+     * In order to assign a state, the state must be created and registered beforehand (it's not required to connect
+     * global state stores; read-only access to global state stores is available by default):
+     * <pre>{@code
+     * // create store
+     * StoreBuilder<KeyValueStore<String,String>> keyValueStoreBuilder =
+     *         Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("myProcessorState"),
+     *                 Serdes.String(),
+     *                 Serdes.String());
+     * // register store
+     * builder.addStateStore(keyValueStoreBuilder);
+     *
+     * inputStream.process(new ProcessorSupplier() { ... }, "myProcessorState");
+     * }</pre>
+     * Within the {@link Processor}, the state is obtained via the
+     * {@link ProcessorContext}.
+     * To trigger periodic actions via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long) punctuate()},
+     * a schedule must be registered.
+     * <pre>{@code
+     * new ProcessorSupplier() {
+     *     Processor get() {
+     *         return new Processor() {
+     *             private StateStore state;
+     *
+     *             void init(ProcessorContext context) {
+     *                 this.state = context.getStateStore("myProcessorState");
+     *                 // punctuate each second, can access this.state
+     *                 context.schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, new Punctuator(..));
+     *             }
+     *
+     *             void process(K key, V value) {
+     *                 // can access this.state
+     *             }
+     *
+     *             void close() {
+     *                 // can access this.state
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     * Even if any upstream operation was key-changing, no auto-repartition is triggered.
+     * If repartitioning is required, a call to {@link #through(String)} should be performed before {@code transform()}.
+     *
+     * @param processorSupplier a instance of {@link ProcessorSupplier} that generates a {@link Processor}
+     * @param named             a {@link Named} config used to name the processor in the topology
+     * @param stateStoreNames   the names of the state store used by the processor
+     * @see #foreach(ForeachAction)
+     * @see #transform(TransformerSupplier, String...)
+     */
+    void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
+                 final Named named,
+                 final String... stateStoreNames);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.Collection;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.ValueMapper;
@@ -29,6 +28,7 @@ import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -60,7 +60,6 @@ import java.util.Set;
 
 public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K, V> {
 
-
     static final String JOINTHIS_NAME = "KSTREAM-JOINTHIS-";
 
     static final String JOINOTHER_NAME = "KSTREAM-JOINOTHER-";
@@ -130,13 +129,18 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public KStream<K, V> filter(final Predicate<? super K, ? super V> predicate, final Named named) {
+    public KStream<K, V> filter(final Predicate<? super K, ? super V> predicate,
+                                final Named named) {
         Objects.requireNonNull(predicate, "predicate can't be null");
         Objects.requireNonNull(named, "named can't be null");
+
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FILTER_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamFilter<>(predicate, false), name);
-        final ProcessorGraphNode<? super K, ? super V> filterProcessorNode = new ProcessorGraphNode<>(name, processorParameters);
-        builder.addGraphNode(this.streamsGraphNode, filterProcessorNode);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamFilter<>(predicate, false), name);
+        final ProcessorGraphNode<? super K, ? super V> filterProcessorNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, filterProcessorNode);
 
         return new KStreamImpl<>(
                 name,
@@ -154,14 +158,18 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public KStream<K, V> filterNot(final Predicate<? super K, ? super V> predicate, final Named named) {
+    public KStream<K, V> filterNot(final Predicate<? super K, ? super V> predicate,
+                                   final Named named) {
         Objects.requireNonNull(predicate, "predicate can't be null");
         Objects.requireNonNull(named, "named can't be null");
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FILTER_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamFilter<>(predicate, true), name);
-        final ProcessorGraphNode<? super K, ? super V> filterNotProcessorNode = new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(this.streamsGraphNode, filterNotProcessorNode);
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FILTER_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamFilter<>(predicate, true), name);
+        final ProcessorGraphNode<? super K, ? super V> filterNotProcessorNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, filterNotProcessorNode);
 
         return new KStreamImpl<>(
                 name,
@@ -179,24 +187,32 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <KR> KStream<KR, V> selectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper, final Named named) {
+    public <KR> KStream<KR, V> selectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper,
+                                         final Named named) {
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
 
         final ProcessorGraphNode<K, V> selectKeyProcessorNode = internalSelectKey(mapper, new NamedInternal(named));
-
         selectKeyProcessorNode.keyChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, selectKeyProcessorNode);
+
+        builder.addGraphNode(streamsGraphNode, selectKeyProcessorNode);
 
         // key serde cannot be preserved
-        return new KStreamImpl<>(selectKeyProcessorNode.nodeName(), null, valSerde, sourceNodes, true, selectKeyProcessorNode, builder);
+        return new KStreamImpl<>(
+            selectKeyProcessorNode.nodeName(),
+            null,
+            valSerde,
+            sourceNodes,
+            true,
+            selectKeyProcessorNode,
+            builder);
     }
 
     private <KR> ProcessorGraphNode<K, V> internalSelectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper,
                                                             final NamedInternal named) {
         final String name = named.orElseGenerateWithPrefix(builder, KEY_SELECT_NAME);
-        final KStreamMap<K, V, KR, V> kStreamMap = new KStreamMap<>((key, value) -> new KeyValue<>(mapper.apply(key, value), value));
-
+        final KStreamMap<K, V, KR, V> kStreamMap =
+            new KStreamMap<>((key, value) -> new KeyValue<>(mapper.apply(key, value), value));
         final ProcessorParameters<K, V> processorParameters = new ProcessorParameters<>(kStreamMap, name);
 
         return new ProcessorGraphNode<>(name, processorParameters);
@@ -208,16 +224,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <KR, VR> KStream<KR, VR> map(final KeyValueMapper<? super K, ? super V, ? extends KeyValue<? extends KR, ? extends VR>> mapper, final Named named) {
+    public <KR, VR> KStream<KR, VR> map(final KeyValueMapper<? super K, ? super V, ? extends KeyValue<? extends KR, ? extends VR>> mapper,
+                                        final Named named) {
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
+
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAP_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamMap<>(mapper), name);
-
-        final ProcessorGraphNode<? super K, ? super V> mapProcessorNode = new ProcessorGraphNode<>(name, processorParameters);
-
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamMap<>(mapper), name);
+        final ProcessorGraphNode<? super K, ? super V> mapProcessorNode =
+            new ProcessorGraphNode<>(name, processorParameters);
         mapProcessorNode.keyChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, mapProcessorNode);
+
+        builder.addGraphNode(streamsGraphNode, mapProcessorNode);
 
         // key and value serde cannot be preserved
         return new KStreamImpl<>(
@@ -231,30 +250,35 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper) {
-        return mapValues(withKey(mapper));
+    public <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> valueMapper) {
+        return mapValues(withKey(valueMapper));
     }
 
     @Override
-    public <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper, final Named named) {
+    public <VR> KStream<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper,
+                                         final Named named) {
         return mapValues(withKey(mapper), named);
     }
 
     @Override
-    public <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> mapper) {
-        return mapValues(mapper, NamedInternal.empty());
+    public <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> valueMapperWithKey) {
+        return mapValues(valueMapperWithKey, NamedInternal.empty());
     }
 
     @Override
-    public <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> mapper, final Named named) {
-        Objects.requireNonNull(mapper, "mapper can't be null");
-        Objects.requireNonNull(mapper, "named can't be null");
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAPVALUES_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamMapValues<>(mapper), name);
-        final ProcessorGraphNode<? super K, ? super V> mapValuesProcessorNode = new ProcessorGraphNode<>(name, processorParameters);
+    public <VR> KStream<K, VR> mapValues(final ValueMapperWithKey<? super K, ? super V, ? extends VR> valueMapperWithKey,
+                                         final Named named) {
+        Objects.requireNonNull(valueMapperWithKey, "valueMapperWithKey can't be null");
+        Objects.requireNonNull(named, "named can't be null");
 
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAPVALUES_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamMapValues<>(valueMapperWithKey), name);
+        final ProcessorGraphNode<? super K, ? super V> mapValuesProcessorNode =
+            new ProcessorGraphNode<>(name, processorParameters);
         mapValuesProcessorNode.setValueChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, mapValuesProcessorNode);
+
+        builder.addGraphNode(streamsGraphNode, mapValuesProcessorNode);
 
         // value serde cannot be preserved
         return new KStreamImpl<>(
@@ -268,17 +292,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public void print(final Printed<K, V> printed) {
-        Objects.requireNonNull(printed, "printed can't be null");
-        final PrintedInternal<K, V> printedInternal = new PrintedInternal<>(printed);
-        final String name = new NamedInternal(printedInternal.name()).orElseGenerateWithPrefix(builder, PRINTING_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(printedInternal.build(this.name), name);
-        final ProcessorGraphNode<? super K, ? super V> printNode = new ProcessorGraphNode<>(name, processorParameters);
-
-        builder.addGraphNode(this.streamsGraphNode, printNode);
-    }
-
-    @Override
     public <KR, VR> KStream<KR, VR> flatMap(final KeyValueMapper<? super K, ? super V, ? extends Iterable<? extends KeyValue<? extends KR, ? extends VR>>> mapper) {
         return flatMap(mapper, NamedInternal.empty());
     }
@@ -288,12 +301,15 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                             final Named named) {
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
+
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FLATMAP_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamFlatMap<>(mapper), name);
-        final ProcessorGraphNode<? super K, ? super V> flatMapNode = new ProcessorGraphNode<>(name, processorParameters);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamFlatMap<>(mapper), name);
+        final ProcessorGraphNode<? super K, ? super V> flatMapNode =
+            new ProcessorGraphNode<>(name, processorParameters);
         flatMapNode.keyChangingOperation(true);
 
-        builder.addGraphNode(this.streamsGraphNode, flatMapNode);
+        builder.addGraphNode(streamsGraphNode, flatMapNode);
 
         // key and value serde cannot be preserved
         return new KStreamImpl<>(name, null, null, sourceNodes, true, flatMapNode, builder);
@@ -316,19 +332,92 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public <VR> KStream<K, VR> flatMapValues(final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends VR>> mapper,
+    public <VR> KStream<K, VR> flatMapValues(final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends VR>> valueMapper,
                                              final Named named) {
-        Objects.requireNonNull(mapper, "mapper can't be null");
+        Objects.requireNonNull(valueMapper, "valueMapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FLATMAPVALUES_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new KStreamFlatMapValues<>(mapper), name);
-        final ProcessorGraphNode<? super K, ? super V> flatMapValuesNode = new ProcessorGraphNode<>(name, processorParameters);
 
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FLATMAPVALUES_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamFlatMapValues<>(valueMapper), name);
+        final ProcessorGraphNode<? super K, ? super V> flatMapValuesNode =
+            new ProcessorGraphNode<>(name, processorParameters);
         flatMapValuesNode.setValueChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, flatMapValuesNode);
+
+        builder.addGraphNode(streamsGraphNode, flatMapValuesNode);
 
         // value serde cannot be preserved
-        return new KStreamImpl<>(name, keySerde, null, sourceNodes, this.repartitionRequired, flatMapValuesNode, builder);
+        return new KStreamImpl<>(
+            name,
+            keySerde,
+            null,
+            sourceNodes,
+            repartitionRequired,
+            flatMapValuesNode,
+            builder);
+    }
+
+    @Override
+    public void print(final Printed<K, V> printed) {
+        Objects.requireNonNull(printed, "printed can't be null");
+
+        final PrintedInternal<K, V> printedInternal = new PrintedInternal<>(printed);
+        final String name = new NamedInternal(printedInternal.name()).orElseGenerateWithPrefix(builder, PRINTING_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(printedInternal.build(this.name), name);
+        final ProcessorGraphNode<? super K, ? super V> printNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, printNode);
+    }
+
+    @Override
+    public void foreach(final ForeachAction<? super K, ? super V> action) {
+        foreach(action, NamedInternal.empty());
+    }
+
+    @Override
+    public void foreach(final ForeachAction<? super K, ? super V> action,
+                        final Named named) {
+        Objects.requireNonNull(action, "action can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FOREACH_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamPeek<>(action, false), name);
+        final ProcessorGraphNode<? super K, ? super V> foreachNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, foreachNode);
+    }
+
+    @Override
+    public KStream<K, V> peek(final ForeachAction<? super K, ? super V> action) {
+        return peek(action, NamedInternal.empty());
+    }
+
+    @Override
+    public KStream<K, V> peek(final ForeachAction<? super K, ? super V> action,
+                              final Named named) {
+        Objects.requireNonNull(action, "action can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, PEEK_NAME);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new KStreamPeek<>(action, true), name);
+        final ProcessorGraphNode<? super K, ? super V> peekNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, peekNode);
+
+        return new KStreamImpl<>(
+            name,
+            keySerde,
+            valSerde,
+            sourceNodes,
+            repartitionRequired,
+            peekNode,
+            builder);
     }
 
     @Override
@@ -339,37 +428,42 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @Override
     @SuppressWarnings("unchecked")
-    public KStream<K, V>[] branch(final Named name, final Predicate<? super K, ? super V>... predicates) {
-        Objects.requireNonNull(name, "name can't be null");
-        return doBranch(new NamedInternal(name), predicates);
+    public KStream<K, V>[] branch(final Named named,
+                                  final Predicate<? super K, ? super V>... predicates) {
+        Objects.requireNonNull(named, "named can't be null");
+        return doBranch(new NamedInternal(named), predicates);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private KStream<K, V>[] doBranch(final NamedInternal named,
                                      final Predicate<? super K, ? super V>... predicates) {
+        Objects.requireNonNull(predicates, "predicates can't be a null array");
         if (predicates.length == 0) {
-            throw new IllegalArgumentException("you must provide at least one predicate");
+            throw new IllegalArgumentException("branch() requires at least one predicate");
         }
         for (final Predicate<? super K, ? super V> predicate : predicates) {
-            Objects.requireNonNull(predicate, "predicates can't have null values");
+            Objects.requireNonNull(predicate, "predicates can't be null");
         }
 
         final String branchName = named.orElseGenerateWithPrefix(builder, BRANCH_NAME);
-
         final String[] childNames = new String[predicates.length];
         for (int i = 0; i < predicates.length; i++) {
             childNames[i] = named.suffixWithOrElseGet("-predicate-" + i, builder, BRANCHCHILD_NAME);
         }
 
-        final ProcessorParameters processorParameters = new ProcessorParameters<>(new KStreamBranch(predicates.clone(), childNames), branchName);
-        final ProcessorGraphNode<K, V> branchNode = new ProcessorGraphNode<>(branchName, processorParameters);
-        builder.addGraphNode(this.streamsGraphNode, branchNode);
+        final ProcessorParameters processorParameters =
+            new ProcessorParameters<>(new KStreamBranch(predicates.clone(), childNames), branchName);
+        final ProcessorGraphNode<K, V> branchNode =
+            new ProcessorGraphNode<>(branchName, processorParameters);
+
+        builder.addGraphNode(streamsGraphNode, branchNode);
 
         final KStream<K, V>[] branchChildren = (KStream<K, V>[]) Array.newInstance(KStream.class, predicates.length);
-
         for (int i = 0; i < predicates.length; i++) {
-            final ProcessorParameters innerProcessorParameters = new ProcessorParameters<>(new PassThrough<K, V>(), childNames[i]);
-            final ProcessorGraphNode<K, V> branchChildNode = new ProcessorGraphNode<>(childNames[i], innerProcessorParameters);
+            final ProcessorParameters innerProcessorParameters =
+                new ProcessorParameters<>(new PassThrough<K, V>(), childNames[i]);
+            final ProcessorGraphNode<K, V> branchChildNode =
+                new ProcessorGraphNode<>(childNames[i], innerProcessorParameters);
 
             builder.addGraphNode(branchNode, branchChildNode);
             branchChildren[i] = new KStreamImpl<>(childNames[i], keySerde, valSerde, sourceNodes, repartitionRequired, branchChildNode, builder);
@@ -380,76 +474,45 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @Override
     public KStream<K, V> merge(final KStream<K, V> stream) {
-        Objects.requireNonNull(stream);
-        return merge(builder, stream, NamedInternal.empty());
+        return merge(stream, NamedInternal.empty());
     }
 
     @Override
-    public KStream<K, V> merge(final KStream<K, V> stream, final Named processorName) {
-        Objects.requireNonNull(stream);
-        return merge(builder, stream, new NamedInternal(processorName));
+    public KStream<K, V> merge(final KStream<K, V> stream,
+                               final Named named) {
+        Objects.requireNonNull(stream, "stream can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+
+        return merge(builder, stream, new NamedInternal(named));
     }
 
     private KStream<K, V> merge(final InternalStreamsBuilder builder,
                                 final KStream<K, V> stream,
-                                final NamedInternal processorName) {
+                                final NamedInternal named) {
         final KStreamImpl<K, V> streamImpl = (KStreamImpl<K, V>) stream;
-        final String name = processorName.orElseGenerateWithPrefix(builder, MERGE_NAME);
-        final Set<String> allSourceNodes = new HashSet<>();
-
         final boolean requireRepartitioning = streamImpl.repartitionRequired || repartitionRequired;
+        final String name = named.orElseGenerateWithPrefix(builder, MERGE_NAME);
+        final Set<String> allSourceNodes = new HashSet<>();
         allSourceNodes.addAll(sourceNodes);
         allSourceNodes.addAll(streamImpl.sourceNodes);
 
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(new PassThrough<>(), name);
-
-        final ProcessorGraphNode<? super K, ? super V> mergeNode = new ProcessorGraphNode<>(name, processorParameters);
+        final ProcessorParameters<? super K, ? super V> processorParameters =
+            new ProcessorParameters<>(new PassThrough<>(), name);
+        final ProcessorGraphNode<? super K, ? super V> mergeNode =
+            new ProcessorGraphNode<>(name, processorParameters);
         mergeNode.setMergeNode(true);
-        builder.addGraphNode(Arrays.asList(this.streamsGraphNode, streamImpl.streamsGraphNode), mergeNode);
+
+        builder.addGraphNode(Arrays.asList(streamsGraphNode, streamImpl.streamsGraphNode), mergeNode);
 
         // drop the serde as we cannot safely use either one to represent both streams
-        return new KStreamImpl<>(name, null, null, allSourceNodes, requireRepartitioning, mergeNode, builder);
-    }
-
-    @Override
-    public void foreach(final ForeachAction<? super K, ? super V> action) {
-        foreach(action, NamedInternal.empty());
-    }
-
-    @Override
-    public void foreach(final ForeachAction<? super K, ? super V> action, final Named named) {
-        Objects.requireNonNull(action, "action can't be null");
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FOREACH_NAME);
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(
-                new KStreamPeek<>(action, false),
-                name
-        );
-
-        final ProcessorGraphNode<? super K, ? super V> foreachNode = new ProcessorGraphNode<>(name, processorParameters);
-        builder.addGraphNode(this.streamsGraphNode, foreachNode);
-    }
-
-    @Override
-    public KStream<K, V> peek(final ForeachAction<? super K, ? super V> action) {
-        return peek(action, NamedInternal.empty());
-    }
-
-    @Override
-    public KStream<K, V> peek(final ForeachAction<? super K, ? super V> action, final Named named) {
-        Objects.requireNonNull(action, "action can't be null");
-        Objects.requireNonNull(named, "named can't be null");
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, PEEK_NAME);
-
-        final ProcessorParameters<? super K, ? super V> processorParameters = new ProcessorParameters<>(
-                new KStreamPeek<>(action, true),
-                name
-        );
-
-        final ProcessorGraphNode<? super K, ? super V> peekNode = new ProcessorGraphNode<>(name, processorParameters);
-
-        builder.addGraphNode(this.streamsGraphNode, peekNode);
-
-        return new KStreamImpl<>(name, keySerde, valSerde, sourceNodes, repartitionRequired, peekNode, builder);
+        return new KStreamImpl<>(
+            name,
+            null,
+            null,
+            allSourceNodes,
+            requireRepartitioning,
+            mergeNode,
+            builder);
     }
 
     @Override
@@ -458,9 +521,11 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public KStream<K, V> through(final String topic, final Produced<K, V> produced) {
+    public KStream<K, V> through(final String topic,
+                                 final Produced<K, V> produced) {
         Objects.requireNonNull(topic, "topic can't be null");
-        Objects.requireNonNull(produced, "Produced can't be null");
+        Objects.requireNonNull(produced, "produced can't be null");
+
         final ProducedInternal<K, V> producedInternal = new ProducedInternal<>(produced);
         if (producedInternal.keySerde() == null) {
             producedInternal.withKeySerde(keySerde);
@@ -469,6 +534,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             producedInternal.withValueSerde(valSerde);
         }
         to(topic, producedInternal);
+
         return builder.stream(
             Collections.singleton(topic),
             new ConsumedInternal<>(
@@ -486,9 +552,11 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public void to(final String topic, final Produced<K, V> produced) {
+    public void to(final String topic,
+                   final Produced<K, V> produced) {
         Objects.requireNonNull(topic, "topic can't be null");
-        Objects.requireNonNull(produced, "Produced can't be null");
+        Objects.requireNonNull(produced, "produced can't be null");
+
         final ProducedInternal<K, V> producedInternal = new ProducedInternal<>(produced);
         if (producedInternal.keySerde() == null) {
             producedInternal.withKeySerde(keySerde);
@@ -505,9 +573,11 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     }
 
     @Override
-    public void to(final TopicNameExtractor<K, V> topicExtractor, final Produced<K, V> produced) {
-        Objects.requireNonNull(topicExtractor, "topic extractor can't be null");
-        Objects.requireNonNull(produced, "Produced can't be null");
+    public void to(final TopicNameExtractor<K, V> topicExtractor,
+                   final Produced<K, V> produced) {
+        Objects.requireNonNull(topicExtractor, "topicExtractor can't be null");
+        Objects.requireNonNull(produced, "produced can't be null");
+
         final ProducedInternal<K, V> producedInternal = new ProducedInternal<>(produced);
         if (producedInternal.keySerde() == null) {
             producedInternal.withKeySerde(keySerde);
@@ -518,7 +588,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         to(topicExtractor, producedInternal);
     }
 
-    private void to(final TopicNameExtractor<K, V> topicExtractor, final ProducedInternal<K, V> produced) {
+    private void to(final TopicNameExtractor<K, V> topicExtractor,
+                    final ProducedInternal<K, V> produced) {
         final String name = new NamedInternal(produced.name()).orElseGenerateWithPrefix(builder, SINK_NAME);
         final StreamSinkNode<K, V> sinkNode = new StreamSinkNode<>(
             name,
@@ -526,181 +597,70 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             produced
         );
 
-        builder.addGraphNode(this.streamsGraphNode, sinkNode);
+        builder.addGraphNode(streamsGraphNode, sinkNode);
     }
 
     @Override
-    public <KR, VR> KStream<KR, VR> transform(final TransformerSupplier<? super K, ? super V, KeyValue<KR, VR>> transformerSupplier,
-                                              final String... stateStoreNames) {
-        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
-        final String name = builder.newProcessorName(TRANSFORM_NAME);
-        return flatTransform(new TransformerSupplierAdapter<>(transformerSupplier), Named.as(name), stateStoreNames);
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector) {
+        return groupBy(selector, Grouped.with(null, valSerde));
     }
 
     @Override
-    public <KR, VR> KStream<KR, VR> transform(final TransformerSupplier<? super K, ? super V, KeyValue<KR, VR>> transformerSupplier,
-                                              final Named named,
-                                              final String... stateStoreNames) {
-        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
-        return flatTransform(new TransformerSupplierAdapter<>(transformerSupplier), named, stateStoreNames);
+    @Deprecated
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
+                                              final org.apache.kafka.streams.kstream.Serialized<KR, V> serialized) {
+        Objects.requireNonNull(selector, "selector can't be null");
+        Objects.requireNonNull(serialized, "serialized can't be null");
+
+        final SerializedInternal<KR, V> serializedInternal = new SerializedInternal<>(serialized);
+
+        return groupBy(selector, Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
     }
 
     @Override
-    public <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                                  final String... stateStoreNames) {
-        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
-        final String name = builder.newProcessorName(TRANSFORM_NAME);
-        return flatTransform(transformerSupplier, Named.as(name), stateStoreNames);
+    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
+                                              final Grouped<KR, V> grouped) {
+        Objects.requireNonNull(selector, "selector can't be null");
+        Objects.requireNonNull(grouped, "grouped can't be null");
+
+        final GroupedInternal<KR, V> groupedInternal = new GroupedInternal<>(grouped);
+        final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(selector, new NamedInternal(groupedInternal.name()));
+        selectKeyMapNode.keyChangingOperation(true);
+
+        builder.addGraphNode(streamsGraphNode, selectKeyMapNode);
+
+        return new KGroupedStreamImpl<>(
+            selectKeyMapNode.nodeName(),
+            sourceNodes,
+            groupedInternal,
+            true,
+            selectKeyMapNode,
+            builder);
     }
 
     @Override
-    public <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
-                                                  final Named named,
-                                                  final String... stateStoreNames) {
-        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
-        Objects.requireNonNull(named, "named can't be null");
-
-        final String name = new NamedInternal(named).name();
-        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
-                name,
-                new ProcessorParameters<>(new KStreamFlatTransform<>(transformerSupplier), name),
-                stateStoreNames
-        );
-
-        transformNode.keyChangingOperation(true);
-        builder.addGraphNode(streamsGraphNode, transformNode);
-
-        // cannot inherit key and value serde
-        return new KStreamImpl<>(name, null, null, sourceNodes, true, transformNode, builder);
+    public KGroupedStream<K, V> groupByKey() {
+        return groupByKey(Grouped.with(keySerde, valSerde));
     }
 
     @Override
-    public <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                               final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-        return doTransformValues(toValueTransformerWithKeySupplier(valueTransformerSupplier), NamedInternal.empty(), stateStoreNames);
+    @Deprecated
+    public KGroupedStream<K, V> groupByKey(final org.apache.kafka.streams.kstream.Serialized<K, V> serialized) {
+        final SerializedInternal<K, V> serializedInternal = new SerializedInternal<>(serialized);
+        return groupByKey(Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
     }
 
     @Override
-    public <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
-                                               final Named named,
-                                               final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformSupplier can't be null");
-        Objects.requireNonNull(named, "named can't be null");
-        return doTransformValues(toValueTransformerWithKeySupplier(valueTransformerSupplier),
-                new NamedInternal(named), stateStoreNames);
-    }
+    public KGroupedStream<K, V> groupByKey(final Grouped<K, V> grouped) {
+        final GroupedInternal<K, V> groupedInternal = new GroupedInternal<>(grouped);
 
-    @Override
-    public <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                               final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-        return doTransformValues(valueTransformerSupplier, NamedInternal.empty(), stateStoreNames);
-    }
-
-    @Override
-    public <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
-                                               final Named named,
-                                               final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformSupplier can't be null");
-        Objects.requireNonNull(named, "named can't be null");
-        return doTransformValues(valueTransformerSupplier, new NamedInternal(named), stateStoreNames);
-    }
-
-    private <VR> KStream<K, VR> doTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerWithKeySupplier,
-                                                  final NamedInternal named,
-                                                  final String... stateStoreNames) {
-
-        final String name = named.orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
-        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
+        return new KGroupedStreamImpl<>(
             name,
-            new ProcessorParameters<>(new KStreamTransformValues<>(valueTransformerWithKeySupplier), name),
-            stateStoreNames
-        );
-
-        transformNode.setValueChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, transformNode);
-
-        // cannot inherit value serde
-        return new KStreamImpl<>(name, keySerde, null, sourceNodes, repartitionRequired, transformNode, builder);
-    }
-
-    @Override
-    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                                   final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-
-        return doFlatTransformValues(toValueTransformerWithKeySupplier(valueTransformerSupplier), NamedInternal.empty(), stateStoreNames);
-    }
-
-    @Override
-    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
-                                                   final Named named,
-                                                   final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-
-        return doFlatTransformValues(toValueTransformerWithKeySupplier(valueTransformerSupplier), named, stateStoreNames);
-    }
-
-    @Override
-    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                                   final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-
-        return doFlatTransformValues(valueTransformerSupplier, NamedInternal.empty(), stateStoreNames);
-    }
-
-    @Override
-    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
-                                                   final Named named,
-                                                   final String... stateStoreNames) {
-        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
-
-        return doFlatTransformValues(valueTransformerSupplier, named, stateStoreNames);
-    }
-
-    private <VR> KStream<K, VR> doFlatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerWithKeySupplier,
-                                                      final Named named,
-                                                      final String... stateStoreNames) {
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
-
-        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
-            name,
-            new ProcessorParameters<>(new KStreamFlatTransformValues<>(valueTransformerWithKeySupplier), name),
-            stateStoreNames
-        );
-
-        transformNode.setValueChangingOperation(true);
-        builder.addGraphNode(this.streamsGraphNode, transformNode);
-
-        // cannot inherit value serde
-        return new KStreamImpl<>(name, keySerde, null, sourceNodes, repartitionRequired, transformNode, builder);
-    }
-
-    @Override
-    public void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
-                        final String... stateStoreNames) {
-
-        Objects.requireNonNull(processorSupplier, "ProcessSupplier cant' be null");
-        final String name = builder.newProcessorName(PROCESSOR_NAME);
-        process(processorSupplier, Named.as(name), stateStoreNames);
-    }
-
-    @Override
-    public void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
-                        final Named named,
-                        final String... stateStoreNames) {
-        Objects.requireNonNull(processorSupplier, "ProcessSupplier cant' be null");
-        Objects.requireNonNull(named, "named cant' be null");
-
-        final String name = new NamedInternal(named).name();
-        final StatefulProcessorNode<? super K, ? super V> processNode = new StatefulProcessorNode<>(
-                name,
-                new ProcessorParameters<>(processorSupplier, name),
-                stateStoreNames
-        );
-
-        builder.addGraphNode(this.streamsGraphNode, processNode);
+            sourceNodes,
+            groupedInternal,
+            repartitionRequired,
+            streamsGraphNode,
+            builder);
     }
 
     @Override
@@ -716,10 +676,15 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                         final JoinWindows windows,
                                         final Joined<K, V, VO> joined) {
-        Objects.requireNonNull(joined, "Joined can't be null");
+        Objects.requireNonNull(joined, "joined can't be null");
+
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
-        final StreamJoined<K, V, VO> streamJoined =
-            StreamJoined.with(joinedInternal.keySerde(), joinedInternal.valueSerde(), joinedInternal.otherValueSerde()).withName(joinedInternal.name());
+        final StreamJoined<K, V, VO> streamJoined = StreamJoined
+            .with(
+                joinedInternal.keySerde(),
+                joinedInternal.valueSerde(),
+                joinedInternal.otherValueSerde())
+            .withName(joinedInternal.name());
 
         return join(otherStream, joiner, windows, streamJoined);
 
@@ -731,13 +696,12 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                         final JoinWindows windows,
                                         final StreamJoined<K, V, VO> streamJoined) {
 
-        return doJoin(otherStream,
-                      joiner,
-                      windows,
-                      streamJoined,
-                      new KStreamImplJoin(builder, false, false)
-                    );
-
+        return doJoin(
+            otherStream,
+            joiner,
+            windows,
+            streamJoined,
+            new KStreamImplJoin(builder, false, false));
     }
 
     @Override
@@ -754,9 +718,15 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                              final JoinWindows windows,
                                              final Joined<K, V, VO> joined) {
         Objects.requireNonNull(joined, "Joined can't be null");
+
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
-        final StreamJoined<K, V, VO> streamJoined =
-            StreamJoined.with(joinedInternal.keySerde(), joinedInternal.valueSerde(), joinedInternal.otherValueSerde()).withName(joinedInternal.name());
+        final StreamJoined<K, V, VO> streamJoined = StreamJoined
+            .with(
+                joinedInternal.keySerde(),
+                joinedInternal.valueSerde(),
+                joinedInternal.otherValueSerde())
+            .withName(joinedInternal.name());
+
         return outerJoin(other, joiner, windows, streamJoined);
     }
 
@@ -817,16 +787,24 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final Serde<V> repartitionValueSerde = valueSerdeOverride != null ? valueSerdeOverride : valSerde;
         final OptimizableRepartitionNodeBuilder<K, V> optimizableRepartitionNodeBuilder =
             OptimizableRepartitionNode.optimizableRepartitionNodeBuilder();
-        final String repartitionedSourceName = createRepartitionedSource(builder,
-                                                                         repartitionKeySerde,
-                                                                         repartitionValueSerde,
-                                                                         repartitionName,
-                                                                         optimizableRepartitionNodeBuilder);
+        final String repartitionedSourceName = createRepartitionedSource(
+            builder,
+            repartitionKeySerde,
+            repartitionValueSerde,
+            repartitionName,
+            optimizableRepartitionNodeBuilder);
 
         final OptimizableRepartitionNode<K, V> optimizableRepartitionNode = optimizableRepartitionNodeBuilder.build();
-        builder.addGraphNode(this.streamsGraphNode, optimizableRepartitionNode);
+        builder.addGraphNode(streamsGraphNode, optimizableRepartitionNode);
 
-        return new KStreamImpl<>(repartitionedSourceName, repartitionKeySerde, repartitionValueSerde, Collections.singleton(repartitionedSourceName), false, optimizableRepartitionNode, builder);
+        return new KStreamImpl<>(
+            repartitionedSourceName,
+            repartitionKeySerde,
+            repartitionValueSerde,
+            Collections.singleton(repartitionedSourceName),
+            false,
+            optimizableRepartitionNode,
+            builder);
     }
 
     static <K1, V1> String createRepartitionedSource(final InternalStreamsBuilder builder,
@@ -835,9 +813,9 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                      final String repartitionTopicNamePrefix,
                                                      final OptimizableRepartitionNodeBuilder<K1, V1> optimizableRepartitionNodeBuilder) {
 
-
         final String repartitionTopicName = repartitionTopicNamePrefix.endsWith(REPARTITION_TOPIC_SUFFIX) ?
-            repartitionTopicNamePrefix : repartitionTopicNamePrefix + REPARTITION_TOPIC_SUFFIX;
+            repartitionTopicNamePrefix :
+            repartitionTopicNamePrefix + REPARTITION_TOPIC_SUFFIX;
 
         // Always need to generate the names to burn index counter for compatibility
         final String genSinkName = builder.newProcessorName(SINK_NAME);
@@ -859,21 +837,21 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         }
 
         final Predicate<K1, V1> notNullKeyPredicate = (k, v) -> k != null;
-
-        final ProcessorParameters processorParameters = new ProcessorParameters<>(
+        final ProcessorParameters<K1, V1> processorParameters = new ProcessorParameters<>(
             new KStreamFilter<>(notNullKeyPredicate, false),
             nullKeyFilterProcessorName
         );
 
-        optimizableRepartitionNodeBuilder.withKeySerde(keySerde)
-                                         .withValueSerde(valSerde)
-                                         .withSourceName(sourceName)
-                                         .withRepartitionTopic(repartitionTopicName)
-                                         .withSinkName(sinkName)
-                                         .withProcessorParameters(processorParameters)
-                                         // reusing the source name for the graph node name
-                                         // adding explicit variable as it simplifies logic
-                                         .withNodeName(sourceName);
+        optimizableRepartitionNodeBuilder
+            .withKeySerde(keySerde)
+            .withValueSerde(valSerde)
+            .withSourceName(sourceName)
+            .withRepartitionTopic(repartitionTopicName)
+            .withSinkName(sinkName)
+            .withProcessorParameters(processorParameters)
+            // reusing the source name for the graph node name
+            // adding explicit variable as it simplifies logic
+            .withNodeName(sourceName);
 
         return sourceName;
     }
@@ -892,12 +870,16 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                             final JoinWindows windows,
                                             final Joined<K, V, VO> joined) {
         Objects.requireNonNull(joined, "Joined can't be null");
+
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
-        final StreamJoined<K, V, VO> streamJoined =
-            StreamJoined.with(joinedInternal.keySerde(), joinedInternal.valueSerde(), joinedInternal.otherValueSerde()).withName(joinedInternal.name());
+        final StreamJoined<K, V, VO> streamJoined = StreamJoined
+            .with(
+                joinedInternal.keySerde(),
+                joinedInternal.valueSerde(),
+                joinedInternal.otherValueSerde())
+            .withName(joinedInternal.name());
 
         return leftJoin(other, joiner, windows, streamJoined);
-
     }
 
     @Override
@@ -905,12 +887,12 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                             final JoinWindows windows,
                                             final StreamJoined<K, V, VO> streamJoined) {
-        return doJoin(other,
-                     joiner,
-                     windows,
-                     streamJoined,
-                     new KStreamImplJoin(builder, true, false)
-        );
+        return doJoin(
+            other,
+            joiner,
+            windows,
+            streamJoined,
+            new KStreamImplJoin(builder, true, false));
     }
 
     @Override
@@ -929,6 +911,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
+
         if (repartitionRequired) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                 name != null ? name : this.name,
@@ -953,8 +936,10 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(other, "other can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(joined, "joined can't be null");
+
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
         final String internalName = joinedInternal.name();
+
         if (repartitionRequired) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
                 internalName != null ? internalName : name,
@@ -997,7 +982,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         return globalTableJoin(globalTable, keyMapper, joiner, true, named);
     }
 
-
     private <KG, VG, VR> KStream<K, VR> globalTableJoin(final GlobalKTable<KG, VG> globalTable,
                                                         final KeyValueMapper<? super K, ? super V, ? extends KG> keyMapper,
                                                         final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
@@ -1008,25 +992,29 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(named, "named can't be null");
 
-        final KTableValueGetterSupplier<KG, VG> valueGetterSupplier = ((GlobalKTableImpl<KG, VG>) globalTable).valueGetterSupplier();
+        final KTableValueGetterSupplier<KG, VG> valueGetterSupplier =
+            ((GlobalKTableImpl<KG, VG>) globalTable).valueGetterSupplier();
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, LEFTJOIN_NAME);
-
         final ProcessorSupplier<K, V> processorSupplier = new KStreamGlobalKTableJoin<>(
             valueGetterSupplier,
             joiner,
             keyMapper,
-            leftJoin
-        );
+            leftJoin);
         final ProcessorParameters<K, V> processorParameters = new ProcessorParameters<>(processorSupplier, name);
+        final StreamTableJoinNode<K, V> streamTableJoinNode =
+            new StreamTableJoinNode<>(name, processorParameters, new String[] {}, null);
 
-        final StreamTableJoinNode<K, V> streamTableJoinNode = new StreamTableJoinNode<>(name,
-                                                                                        processorParameters,
-                                                                                        new String[] {},
-                                                                                        null);
-        builder.addGraphNode(this.streamsGraphNode, streamTableJoinNode);
+        builder.addGraphNode(streamsGraphNode, streamTableJoinNode);
 
         // do not have serde for joined result
-        return new KStreamImpl<>(name, keySerde, null, sourceNodes, repartitionRequired, streamTableJoinNode, builder);
+        return new KStreamImpl<>(
+            name,
+            keySerde,
+            null,
+            sourceNodes,
+            repartitionRequired,
+            streamTableJoinNode,
+            builder);
     }
 
     @SuppressWarnings("unchecked")
@@ -1046,83 +1034,237 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorSupplier<K, V> processorSupplier = new KStreamKTableJoin<>(
             ((KTableImpl<K, ?, VO>) other).valueGetterSupplier(),
             joiner,
-            leftJoin
-        );
+            leftJoin);
 
         final ProcessorParameters<K, V> processorParameters = new ProcessorParameters<>(processorSupplier, name);
         final StreamTableJoinNode<K, V> streamTableJoinNode = new StreamTableJoinNode<>(
             name,
             processorParameters,
-            ((KTableImpl) other).valueGetterSupplier().storeNames(),
+            ((KTableImpl<K, ?, VO>) other).valueGetterSupplier().storeNames(),
             this.name
         );
 
-        builder.addGraphNode(this.streamsGraphNode, streamTableJoinNode);
+        builder.addGraphNode(streamsGraphNode, streamTableJoinNode);
 
         // do not have serde for joined result
-        return new KStreamImpl<>(name, joined.keySerde() != null ? joined.keySerde() : keySerde, null, allSourceNodes, false, streamTableJoinNode, builder);
-
-    }
-
-    @Override
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector) {
-        return groupBy(selector, Grouped.with(null, valSerde));
-    }
-
-    @Override
-    @Deprecated
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
-                                              final org.apache.kafka.streams.kstream.Serialized<KR, V> serialized) {
-        Objects.requireNonNull(selector, "selector can't be null");
-        Objects.requireNonNull(serialized, "serialized can't be null");
-        final SerializedInternal<KR, V> serializedInternal = new SerializedInternal<>(serialized);
-
-        return groupBy(selector, Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
-    }
-
-    @Override
-    public <KR> KGroupedStream<KR, V> groupBy(final KeyValueMapper<? super K, ? super V, KR> selector,
-                                              final Grouped<KR, V> grouped) {
-        Objects.requireNonNull(selector, "selector can't be null");
-        Objects.requireNonNull(grouped, "grouped can't be null");
-        final GroupedInternal<KR, V> groupedInternal = new GroupedInternal<>(grouped);
-        final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(selector, new NamedInternal(groupedInternal.name()));
-        selectKeyMapNode.keyChangingOperation(true);
-
-        builder.addGraphNode(this.streamsGraphNode, selectKeyMapNode);
-
-        return new KGroupedStreamImpl<>(
-            selectKeyMapNode.nodeName(),
-            sourceNodes,
-            groupedInternal,
-            true,
-            selectKeyMapNode,
-            builder);
-    }
-
-    @Override
-    public KGroupedStream<K, V> groupByKey() {
-        return groupByKey(Grouped.with(keySerde, valSerde));
-    }
-
-    @Override
-    @Deprecated
-    public KGroupedStream<K, V> groupByKey(final org.apache.kafka.streams.kstream.Serialized<K, V> serialized) {
-        final SerializedInternal<K, V> serializedInternal = new SerializedInternal<>(serialized);
-        return groupByKey(Grouped.with(serializedInternal.keySerde(), serializedInternal.valueSerde()));
-    }
-
-    @Override
-    public KGroupedStream<K, V> groupByKey(final Grouped<K, V> grouped) {
-        final GroupedInternal<K, V> groupedInternal = new GroupedInternal<>(grouped);
-
-        return new KGroupedStreamImpl<>(
+        return new KStreamImpl<>(
             name,
-            sourceNodes,
-            groupedInternal,
-            repartitionRequired,
-            streamsGraphNode,
+            joined.keySerde() != null ? joined.keySerde() : keySerde,
+            null,
+            allSourceNodes,
+            false,
+            streamTableJoinNode,
             builder);
     }
 
+    @Override
+    public <KR, VR> KStream<KR, VR> transform(final TransformerSupplier<? super K, ? super V, KeyValue<KR, VR>> transformerSupplier,
+                                              final String... stateStoreNames) {
+        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
+        final String name = builder.newProcessorName(TRANSFORM_NAME);
+        return flatTransform(new TransformerSupplierAdapter<>(transformerSupplier), Named.as(name), stateStoreNames);
+    }
+
+    @Override
+    public <KR, VR> KStream<KR, VR> transform(final TransformerSupplier<? super K, ? super V, KeyValue<KR, VR>> transformerSupplier,
+                                              final Named named,
+                                              final String... stateStoreNames) {
+        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
+        return flatTransform(new TransformerSupplierAdapter<>(transformerSupplier), named, stateStoreNames);
+    }
+
+    @Override
+    public <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
+                                                  final String... stateStoreNames) {
+        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
+        final String name = builder.newProcessorName(TRANSFORM_NAME);
+        return flatTransform(transformerSupplier, Named.as(name), stateStoreNames);
+    }
+
+    @Override
+    public <K1, V1> KStream<K1, V1> flatTransform(final TransformerSupplier<? super K, ? super V, Iterable<KeyValue<K1, V1>>> transformerSupplier,
+                                                  final Named named,
+                                                  final String... stateStoreNames) {
+        Objects.requireNonNull(transformerSupplier, "transformerSupplier can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+        Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
+        for (final String stateStoreName : stateStoreNames) {
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+        }
+
+        final String name = new NamedInternal(named).name();
+        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
+            name,
+            new ProcessorParameters<>(new KStreamFlatTransform<>(transformerSupplier), name),
+            stateStoreNames);
+        transformNode.keyChangingOperation(true);
+
+        builder.addGraphNode(streamsGraphNode, transformNode);
+
+        // cannot inherit key and value serde
+        return new KStreamImpl<>(
+            name,
+            null,
+            null,
+            sourceNodes,
+            true,
+            transformNode,
+            builder);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
+                                               final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doTransformValues(
+            toValueTransformerWithKeySupplier(valueTransformerSupplier),
+            NamedInternal.empty(),
+            stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> transformValues(final ValueTransformerSupplier<? super V, ? extends VR> valueTransformerSupplier,
+                                               final Named named,
+                                               final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+        return doTransformValues(
+            toValueTransformerWithKeySupplier(valueTransformerSupplier),
+            new NamedInternal(named),
+            stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
+                                               final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doTransformValues(valueTransformerSupplier, NamedInternal.empty(), stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> transformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerSupplier,
+                                               final Named named,
+                                               final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+        return doTransformValues(valueTransformerSupplier, new NamedInternal(named), stateStoreNames);
+    }
+
+    private <VR> KStream<K, VR> doTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VR> valueTransformerWithKeySupplier,
+                                                  final NamedInternal named,
+                                                  final String... stateStoreNames) {
+        Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
+        for (final String stateStoreName : stateStoreNames) {
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+        }
+
+        final String name = named.orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
+        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
+            name,
+            new ProcessorParameters<>(new KStreamTransformValues<>(valueTransformerWithKeySupplier), name),
+            stateStoreNames);
+        transformNode.setValueChangingOperation(true);
+
+        builder.addGraphNode(streamsGraphNode, transformNode);
+
+        // cannot inherit value serde
+        return new KStreamImpl<>(
+            name,
+            keySerde,
+            null,
+            sourceNodes,
+            repartitionRequired,
+            transformNode,
+            builder);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
+                                                   final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doFlatTransformValues(
+            toValueTransformerWithKeySupplier(valueTransformerSupplier),
+            NamedInternal.empty(),
+            stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerSupplier<? super V, Iterable<VR>> valueTransformerSupplier,
+                                                   final Named named,
+                                                   final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doFlatTransformValues(
+            toValueTransformerWithKeySupplier(valueTransformerSupplier),
+            named,
+            stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
+                                                   final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doFlatTransformValues(valueTransformerSupplier, NamedInternal.empty(), stateStoreNames);
+    }
+
+    @Override
+    public <VR> KStream<K, VR> flatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerSupplier,
+                                                   final Named named,
+                                                   final String... stateStoreNames) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return doFlatTransformValues(valueTransformerSupplier, named, stateStoreNames);
+    }
+
+    private <VR> KStream<K, VR> doFlatTransformValues(final ValueTransformerWithKeySupplier<? super K, ? super V, Iterable<VR>> valueTransformerWithKeySupplier,
+                                                      final Named named,
+                                                      final String... stateStoreNames) {
+        Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
+        for (final String stateStoreName : stateStoreNames) {
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+        }
+
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
+        final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
+            name,
+            new ProcessorParameters<>(new KStreamFlatTransformValues<>(valueTransformerWithKeySupplier), name),
+            stateStoreNames);
+        transformNode.setValueChangingOperation(true);
+
+        builder.addGraphNode(streamsGraphNode, transformNode);
+
+        // cannot inherit value serde
+        return new KStreamImpl<>(
+            name,
+            keySerde,
+            null,
+            sourceNodes,
+            repartitionRequired,
+            transformNode,
+            builder);
+    }
+
+    @Override
+    public void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
+                        final String... stateStoreNames) {
+        process(processorSupplier, NamedInternal.empty(), stateStoreNames);
+    }
+
+    @Override
+    public void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
+                        final Named named,
+                        final String... stateStoreNames) {
+        Objects.requireNonNull(processorSupplier, "processorSupplier can't be null");
+        Objects.requireNonNull(named, "named can't be null");
+        Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
+        for (final String stateStoreName : stateStoreNames) {
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+        }
+
+        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, PROCESSOR_NAME);
+        final StatefulProcessorNode<? super K, ? super V> processNode = new StatefulProcessorNode<>(
+            name,
+            new ProcessorParameters<>(processorSupplier, name),
+            stateStoreNames);
+
+        builder.addGraphNode(streamsGraphNode, processNode);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1089,7 +1089,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(named, "named can't be null");
         Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
         for (final String stateStoreName : stateStoreNames) {
-            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't contain `null` as store name");
         }
 
         final String name = new NamedInternal(named).name();
@@ -1155,7 +1155,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                   final String... stateStoreNames) {
         Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
         for (final String stateStoreName : stateStoreNames) {
-            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't contain `null` as store name");
         }
 
         final String name = named.orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
@@ -1219,7 +1219,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                       final String... stateStoreNames) {
         Objects.requireNonNull(stateStoreNames, "stateStoreNames can't be a null array");
         for (final String stateStoreName : stateStoreNames) {
-            Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
+            Objects.requireNonNull(stateStoreName, "stateStoreNames can't contain `null` as store name");
         }
 
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1245,7 +1245,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     @Override
     public void process(final ProcessorSupplier<? super K, ? super V> processorSupplier,
                         final String... stateStoreNames) {
-        process(processorSupplier, NamedInternal.empty(), stateStoreNames);
+        process(processorSupplier, Named.as(builder.newProcessorName(PROCESSOR_NAME)), stateStoreNames);
     }
 
     @Override
@@ -1259,7 +1259,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             Objects.requireNonNull(stateStoreName, "stateStoreNames can't be null");
         }
 
-        final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, PROCESSOR_NAME);
+        final String name = new NamedInternal(named).name();
         final StatefulProcessorNode<? super K, ? super V> processNode = new StatefulProcessorNode<>(
             name,
             new ProcessorParameters<>(processorSupplier, name),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -560,7 +560,7 @@ public class EosIntegrationTest {
         gcInjected = new AtomicBoolean(false);
         final StreamsBuilder builder = new StreamsBuilder();
 
-        String[] storeNames = null;
+        String[] storeNames = new String[0];
         if (withState) {
             storeNames = new String[] {storeName};
             final StoreBuilder<KeyValueStore<Long, Long>> storeBuilder = Stores

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -32,6 +33,7 @@ import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.StreamJoined;
@@ -42,13 +44,13 @@ import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.SourceNode;
-import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
@@ -79,11 +81,88 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("unchecked")
 public class KStreamImplTest {
 
     private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
     private final MockProcessorSupplier<String, String> processorSupplier = new MockProcessorSupplier<>();
+    private final TransformerSupplier<String, String, KeyValue<String, String>> transformerSupplier =
+        () -> new Transformer<String, String, KeyValue<String, String>>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public KeyValue<String, String> transform(final String key, final String value) {
+                return new KeyValue<>(key, value);
+            }
+
+            @Override
+            public void close() {}
+        };
+    private final TransformerSupplier<String, String, Iterable<KeyValue<String, String>>> flatTransformerSupplier =
+        () -> new Transformer<String, String, Iterable<KeyValue<String, String>>>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public Iterable<KeyValue<String, String>> transform(final String key, final String value) {
+                return Collections.singleton(new KeyValue<>(key, value));
+            }
+
+            @Override
+            public void close() {}
+        };
+    private final ValueTransformerSupplier<String, String> valueTransformerSupplier =
+        () -> new ValueTransformer<String, String>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public String transform(final String value) {
+                return value;
+            }
+
+            @Override
+            public void close() {}
+        };
+    private final ValueTransformerWithKeySupplier<String, String, String> valueTransformerWithKeySupplier =
+        () -> new ValueTransformerWithKey<String, String, String>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public String transform(final String key, final String value) {
+                return value;
+            }
+
+            @Override
+            public void close() {}
+        };
+    private final ValueTransformerSupplier<String, Iterable<String>> flatValueTransformerSupplier =
+        () -> new ValueTransformer<String, Iterable<String>>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public Iterable<String> transform(final String value) {
+                return Collections.singleton(value);
+            }
+
+            @Override
+            public void close() {}
+        };
+    private final ValueTransformerWithKeySupplier<String, String, Iterable<String>> flatValueTransformerWithKeySupplier =
+        () -> new ValueTransformerWithKey<String, String, Iterable<String>>() {
+            @Override
+            public void init(final ProcessorContext context) {}
+
+            @Override
+            public Iterable<String> transform(final String key, final String value) {
+                return Collections.singleton(value);
+            }
+
+            @Override
+            public void close() {}
+        };
 
     private KStream<String, String> testStream;
     private StreamsBuilder builder;
@@ -91,7 +170,6 @@ public class KStreamImplTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     private final Serde<String> mySerde = new Serdes.StringSerde();
-    private final StreamJoined nullStreamJoinedForTest = null;
 
     @Before
     public void before() {
@@ -99,6 +177,565 @@ public class KStreamImplTest {
         testStream = builder.stream("source");
     }
 
+    @Test
+    public void shouldNotAllowNullPredicateOnFilter() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filter(null));
+        assertThat(exception.getMessage(), equalTo("predicate can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullPredicateOnFilterWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filter(null, Named.as("filter")));
+        assertThat(exception.getMessage(), equalTo("predicate can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFilter() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filter((k, v) -> true, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullPredicateOnFilterNot() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filterNot(null));
+        assertThat(exception.getMessage(), equalTo("predicate can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullPredicateOnFilterNotWithName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filterNot(null, Named.as("filter")));
+        assertThat(exception.getMessage(), equalTo("predicate can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFilterNot() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.filterNot((k, v) -> true, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnSelectKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.selectKey(null));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnSelectKeyWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.selectKey(null, Named.as("keySelector")));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnSelectKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.selectKey((k, v) -> k, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMap() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.map(null));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMapWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.map(null, Named.as("map")));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnMap() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.map(KeyValue::pair, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMapValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues((ValueMapper<Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMapValuesWithKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues((ValueMapperWithKey<Object, Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("valueMapperWithKey can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMapValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues((ValueMapper<Object, Object>) null, Named.as("valueMapper")));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnMapValuesWithKeyWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues((ValueMapperWithKey<Object, Object, Object>) null, Named.as("valueMapperWithKey")));
+        assertThat(exception.getMessage(), equalTo("valueMapperWithKey can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnMapValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues(v -> v, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnMapValuesWithKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.mapValues((k, v) -> v, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMap() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMap(null));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMapWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMap(null, Named.as("flatMapper")));
+        assertThat(exception.getMessage(), equalTo("mapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatMap() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMap((k, v) -> Collections.emptyList(), null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMapValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues((ValueMapper<Object, Iterable<Object>>) null));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMapValuesWithKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues((ValueMapperWithKey<Object, Object, ? extends Iterable<Object>>) null));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMapValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues((ValueMapper<Object, Iterable<Object>>) null, Named.as("flatValueMapper")));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullMapperOnFlatMapValuesWithKeyWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues((ValueMapperWithKey<Object, Object, ? extends Iterable<Object>>) null, Named.as("flatValueMapperWithKey")));
+        assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNameOnFlatMapValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues(v -> Collections.emptyList(), null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNameOnFlatMapValuesWithKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatMapValues((k, v) -> Collections.emptyList(), null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullPrintedOnPrint() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.print(null));
+        assertThat(exception.getMessage(), equalTo("printed can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullActionOnForEach() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.foreach(null));
+        assertThat(exception.getMessage(), equalTo("action can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullActionOnForEachWithName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.foreach(null, Named.as("foreach")));
+        assertThat(exception.getMessage(), equalTo("action can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnForEach() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.foreach((k, v) -> { }, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullActionOnPeek() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.peek(null));
+        assertThat(exception.getMessage(), equalTo("action can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullActionOnPeekWithName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.peek(null, Named.as("peek")));
+        assertThat(exception.getMessage(), equalTo("action can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnPeek() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.peek((k, v) -> { }, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void shouldNotAllowNullPredicatedOnBranch() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.branch((Predicate[]) null));
+        assertThat(exception.getMessage(), equalTo("predicates can't be a null array"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldHaveAtLeastOnPredicateWhenBranching() {
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> testStream.branch());
+        assertThat(exception.getMessage(), equalTo("branch() requires at least one predicate"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldHaveAtLeastOnPredicateWhenBranchingWithNamed() {
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> testStream.branch(Named.as("branch")));
+        assertThat(exception.getMessage(), equalTo("branch() requires at least one predicate"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotAllowNullNamedOnBranch() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.branch((Named) null, (k, v) -> true));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldCantHaveNullPredicate() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.branch((Predicate<Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("predicates can't be null"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldCantHaveNullPredicateWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.branch(Named.as("branch"), (Predicate<Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("predicates can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullKStreamOnMerge() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.merge(null));
+        assertThat(exception.getMessage(), equalTo("stream can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullKStreamOnMergeWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.merge(null, Named.as("merge")));
+        assertThat(exception.getMessage(), equalTo("stream can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnMerge() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.merge(testStream, null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicOnThrough() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.through(null));
+        assertThat(exception.getMessage(), equalTo("topic can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicOnThroughWithProduced() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.through(null, Produced.as("through")));
+        assertThat(exception.getMessage(), equalTo("topic can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProducedOnThrough() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.through("topic", null));
+        assertThat(exception.getMessage(), equalTo("produced can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicOnTo() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to((String) null));
+        assertThat(exception.getMessage(), equalTo("topic can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicChooserOnTo() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to((TopicNameExtractor<String, String>) null));
+        assertThat(exception.getMessage(), equalTo("topicExtractor can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicOnToWithProduced() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to((String) null, Produced.as("to")));
+        assertThat(exception.getMessage(), equalTo("topic can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTopicChooserOnToWithProduced() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to((TopicNameExtractor<String, String>) null, Produced.as("to")));
+        assertThat(exception.getMessage(), equalTo("topicExtractor can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProducedOnToWithTopicName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to("topic", null));
+        assertThat(exception.getMessage(), equalTo("produced can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProducedOnToWithTopicChooser() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.to((k, v, ctx) -> "topic", null));
+        assertThat(exception.getMessage(), equalTo("produced can't be null"));
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullOtherStreamOnJoin() {
+        testStream.join(null, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(ofMillis(10)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullValueJoinerOnJoin() {
+        testStream.join(testStream, null, JoinWindows.of(ofMillis(10)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullJoinWindowsOnJoin() {
+        testStream.join(testStream, MockValueJoiner.TOSTRING_JOINER, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullTableOnTableJoin() {
+        testStream.leftJoin(null, MockValueJoiner.TOSTRING_JOINER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullValueMapperOnTableJoin() {
+        testStream.leftJoin(builder.table("topic", stringConsumed), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullSelectorOnGroupBy() {
+        testStream.groupBy(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullTableOnJoinWithGlobalTable() {
+        testStream.join(null,
+                        MockMapper.selectValueMapper(),
+                        MockValueJoiner.TOSTRING_JOINER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullMapperOnJoinWithGlobalTable() {
+        testStream.join(builder.globalTable("global", stringConsumed),
+                        null,
+                        MockValueJoiner.TOSTRING_JOINER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullJoinerOnJoinWithGlobalTable() {
+        testStream.join(builder.globalTable("global", stringConsumed),
+                        MockMapper.selectValueMapper(),
+                        null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullTableOnJLeftJoinWithGlobalTable() {
+        testStream.leftJoin(null,
+                            MockMapper.selectValueMapper(),
+                            MockValueJoiner.TOSTRING_JOINER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullMapperOnLeftJoinWithGlobalTable() {
+        testStream.leftJoin(builder.globalTable("global", stringConsumed),
+                        null,
+                        MockValueJoiner.TOSTRING_JOINER);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTable() {
+        testStream.leftJoin(builder.globalTable("global", stringConsumed),
+                        MockMapper.selectValueMapper(),
+                        null);
+    }
+
+    @Test
+    public void shouldThrowNullPointerOnLeftJoinWithTableWhenJoinedIsNull() {
+        final KTable<String, String> table = builder.table("blah", stringConsumed);
+        try {
+            testStream.leftJoin(table,
+                                MockValueJoiner.TOSTRING_JOINER,
+                                null);
+            fail("Should have thrown NullPointerException");
+        } catch (final NullPointerException e) {
+            // ok
+        }
+    }
+
+    @Test
+    public void shouldThrowNullPointerOnJoinWithTableWhenJoinedIsNull() {
+        final KTable<String, String> table = builder.table("blah", stringConsumed);
+        try {
+            testStream.join(table,
+                            MockValueJoiner.TOSTRING_JOINER,
+                            null);
+            fail("Should have thrown NullPointerException");
+        } catch (final NullPointerException e) {
+            // ok
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerOnJoinWithStreamWhenStreamJoinedIsNull() {
+        testStream.join(
+            testStream,
+            MockValueJoiner.TOSTRING_JOINER,
+            JoinWindows.of(ofMillis(10)),
+            (StreamJoined<String, String, String>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerOnOuterJoinStreamJoinedIsNull() {
+        testStream.outerJoin(
+            testStream,
+            MockValueJoiner.TOSTRING_JOINER,
+            JoinWindows.of(ofMillis(10)),
+            (StreamJoined<String, String, String>) null);
+    }
+
+    @SuppressWarnings("unchecked")
     @Test
     public void testNumProcesses() {
         final StreamsBuilder builder = new StreamsBuilder();
@@ -108,7 +745,7 @@ public class KStreamImplTest {
         final KStream<String, String> source2 = builder.stream(Arrays.asList("topic-3", "topic-4"), stringConsumed);
 
         final KStream<String, String> stream1 = source1.filter((key, value) -> true)
-                                                       .filterNot((key, value) -> false);
+            .filterNot((key, value) -> false);
 
         final KStream<String, Integer> stream2 = stream1.mapValues(Integer::new);
 
@@ -128,9 +765,9 @@ public class KStreamImplTest {
         final int anyWindowSize = 1;
         final StreamJoined<String, Integer, Integer> joined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
         final KStream<String, Integer> stream4 = streams2[0].join(streams3[0],
-            (value1, value2) -> value1 + value2, JoinWindows.of(ofMillis(anyWindowSize)), joined);
+            Integer::sum, JoinWindows.of(ofMillis(anyWindowSize)), joined);
 
-        streams2[1].join(streams3[1], (value1, value2) -> value1 + value2,
+        streams2[1].join(streams3[1], Integer::sum,
             JoinWindows.of(ofMillis(anyWindowSize)), joined);
 
         stream4.to("topic-5");
@@ -138,18 +775,19 @@ public class KStreamImplTest {
         streams2[1].through("topic-6").process(new MockProcessorSupplier<>());
 
         assertEquals(2 + // sources
-            2 + // stream1
-            1 + // stream2
-            1 + // stream3
-            1 + 2 + // streams2
-            1 + 2 + // streams3
-            5 * 2 + // stream2-stream3 joins
-            1 + // to
-            2 + // through
-            1, // process
+                2 + // stream1
+                1 + // stream2
+                1 + // stream3
+                1 + 2 + // streams2
+                1 + 2 + // streams3
+                5 * 2 + // stream2-stream3 joins
+                1 + // to
+                2 + // through
+                1, // process
             TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build(null).processors().size());
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void shouldPreserveSerdesForOperators() {
         final StreamsBuilder builder = new StreamsBuilder();
@@ -163,30 +801,6 @@ public class KStreamImplTest {
         final ValueMapper<String, String> mapper = value -> value;
         final ValueMapper<String, Iterable<String>> flatMapper = Collections::singleton;
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> value1;
-        final TransformerSupplier<String, String, KeyValue<String, String>> transformerSupplier = () -> new Transformer<String, String, KeyValue<String, String>>() {
-            @Override
-            public void init(final ProcessorContext context) {}
-
-            @Override
-            public KeyValue<String, String> transform(final String key, final String value) {
-                return new KeyValue<>(key, value);
-            }
-
-            @Override
-            public void close() {}
-        };
-        final ValueTransformerSupplier<String, String> valueTransformerSupplier = () -> new ValueTransformer<String, String>() {
-            @Override
-            public void init(final ProcessorContext context) {}
-
-            @Override
-            public String transform(final String value) {
-                return value;
-            }
-
-            @Override
-            public void close() {}
-        };
 
         assertEquals(((AbstractStream) stream1.filter((key, value) -> false)).keySerde(), consumedInternal.keySerde());
         assertEquals(((AbstractStream) stream1.filter((key, value) -> false)).valueSerde(), consumedInternal.valueSerde());
@@ -291,7 +905,7 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
-                    driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "b");
         }
         assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList(new KeyValueTimestamp<>("a", "b", 0))));
@@ -307,7 +921,7 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
-                    driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("e", "f");
         }
         assertThat(processorSupplier.theCapturedProcessor().processed, equalTo(Collections.singletonList(new KeyValueTimestamp<>("e", "f", 0))));
@@ -319,24 +933,24 @@ public class KStreamImplTest {
         final String input = "topic";
         final KStream<String, String> stream = builder.stream(input, stringConsumed);
         stream.to((key, value, context) -> context.topic() + "-" + key + "-" + value.substring(0, 1),
-                  Produced.with(Serdes.String(), Serdes.String()));
+            Produced.with(Serdes.String(), Serdes.String()));
         builder.stream(input + "-a-v", stringConsumed).process(processorSupplier);
         builder.stream(input + "-b-v", stringConsumed).process(processorSupplier);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
-                    driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "v1");
             inputTopic.pipeInput("a", "v2");
             inputTopic.pipeInput("b", "v1");
         }
         final List<MockProcessor<String, String>> mockProcessors = processorSupplier.capturedProcessors(2);
         assertThat(mockProcessors.get(0).processed, equalTo(asList(new KeyValueTimestamp<>("a", "v1", 0),
-                new KeyValueTimestamp<>("a", "v2", 0))));
+            new KeyValueTimestamp<>("a", "v2", 0))));
         assertThat(mockProcessors.get(1).processed, equalTo(Collections.singletonList(new KeyValueTimestamp<>("b", "v1", 0))));
     }
 
-    @SuppressWarnings("deprecation") // specifically testing the deprecated variant
+    @SuppressWarnings({"rawtypes", "deprecation"}) // specifically testing the deprecated variant
     @Test
     public void shouldUseRecordMetadataTimestampExtractorWhenInternalRepartitioningTopicCreatedWithRetention() {
         final StreamsBuilder builder = new StreamsBuilder();
@@ -346,12 +960,12 @@ public class KStreamImplTest {
         final KStream<String, String> stream = kStream
             .map((key, value) -> KeyValue.pair(value, value));
         stream.join(kStream,
-                    valueJoiner,
-                    JoinWindows.of(ofMillis(windowSize)).grace(ofMillis(3 * windowSize)),
-                    Joined.with(Serdes.String(),
-                                Serdes.String(),
-                                Serdes.String()))
-              .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
+            valueJoiner,
+            JoinWindows.of(ofMillis(windowSize)).grace(ofMillis(3 * windowSize)),
+            Joined.with(Serdes.String(),
+                Serdes.String(),
+                Serdes.String()))
+            .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
         final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build();
 
@@ -366,6 +980,7 @@ public class KStreamImplTest {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void shouldUseRecordMetadataTimestampExtractorWhenInternalRepartitioningTopicCreated() {
         final StreamsBuilder builder = new StreamsBuilder();
@@ -380,7 +995,7 @@ public class KStreamImplTest {
             JoinWindows.of(ofMillis(windowSize)).grace(ofMillis(3L * windowSize)),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
         )
-              .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
+            .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
         final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build();
 
@@ -416,258 +1031,6 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void testToWithNullValueSerdeDoesntNPE() {
-        final StreamsBuilder builder = new StreamsBuilder();
-        final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
-        final KStream<String, String> inputStream = builder.stream(Collections.singleton("input"), consumed);
-
-        inputStream.to("output", Produced.with(Serdes.String(), Serdes.String()));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullPredicateOnFilter() {
-        testStream.filter(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullPredicateOnFilterNot() {
-        testStream.filterNot(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnSelectKey() {
-        testStream.selectKey(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnMap() {
-        testStream.map(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnMapValues() {
-        testStream.mapValues((ValueMapper) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnMapValuesWithKey() {
-        testStream.mapValues((ValueMapperWithKey) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnFlatMap() {
-        testStream.flatMap(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnFlatMapValues() {
-        testStream.flatMapValues((ValueMapper<? super String, ? extends Iterable<? extends String>>) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnFlatMapValuesWithKey() {
-        testStream.flatMapValues((ValueMapperWithKey<? super String, ? super String, ? extends Iterable<? extends String>>) null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldHaveAtLeastOnPredicateWhenBranching() {
-        testStream.branch();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldCantHaveNullPredicate() {
-        testStream.branch((Predicate) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTopicOnThrough() {
-        testStream.through(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTopicOnTo() {
-        testStream.to((String) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTopicChooserOnTo() {
-        testStream.to((TopicNameExtractor<String, String>) null);
-    }
-
-    @Test
-    public void shouldNotAllowNullTransformerSupplierOnTransform() {
-        final Exception e = assertThrows(NullPointerException.class, () -> testStream.transform(null));
-        assertEquals("transformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test
-    public void shouldNotAllowNullTransformerSupplierOnFlatTransform() {
-        final Exception e = assertThrows(NullPointerException.class, () -> testStream.flatTransform(null));
-        assertEquals("transformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test
-    public void shouldNotAllowNullValueTransformerWithKeySupplierOnTransformValues() {
-        final Exception e =
-            assertThrows(NullPointerException.class, () -> testStream.transformValues((ValueTransformerWithKeySupplier) null));
-        assertEquals("valueTransformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test
-    public void shouldNotAllowNullValueTransformerSupplierOnTransformValues() {
-        final Exception e =
-            assertThrows(NullPointerException.class, () -> testStream.transformValues((ValueTransformerSupplier) null));
-        assertEquals("valueTransformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test
-    public void shouldNotAllowNullValueTransformerWithKeySupplierOnFlatTransformValues() {
-        final Exception e =
-            assertThrows(NullPointerException.class, () -> testStream.flatTransformValues((ValueTransformerWithKeySupplier) null));
-        assertEquals("valueTransformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test
-    public void shouldNotAllowNullValueTransformerSupplierOnFlatTransformValues() {
-        final Exception e =
-            assertThrows(NullPointerException.class, () -> testStream.flatTransformValues((ValueTransformerSupplier) null));
-        assertEquals("valueTransformerSupplier can't be null", e.getMessage());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullProcessSupplier() {
-        testStream.process(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullOtherStreamOnJoin() {
-        testStream.join(null, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(ofMillis(10)));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullValueJoinerOnJoin() {
-        testStream.join(testStream, null, JoinWindows.of(ofMillis(10)));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullJoinWindowsOnJoin() {
-        testStream.join(testStream, MockValueJoiner.TOSTRING_JOINER, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTableOnTableJoin() {
-        testStream.leftJoin((KTable) null, MockValueJoiner.TOSTRING_JOINER);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullValueMapperOnTableJoin() {
-        testStream.leftJoin(builder.table("topic", stringConsumed), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullSelectorOnGroupBy() {
-        testStream.groupBy(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullActionOnForEach() {
-        testStream.foreach(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTableOnJoinWithGlobalTable() {
-        testStream.join((GlobalKTable) null,
-                        MockMapper.selectValueMapper(),
-                        MockValueJoiner.TOSTRING_JOINER);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnJoinWithGlobalTable() {
-        testStream.join(builder.globalTable("global", stringConsumed),
-                        null,
-                        MockValueJoiner.TOSTRING_JOINER);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullJoinerOnJoinWithGlobalTable() {
-        testStream.join(builder.globalTable("global", stringConsumed),
-                        MockMapper.selectValueMapper(),
-                        null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullTableOnJLeftJoinWithGlobalTable() {
-        testStream.leftJoin((GlobalKTable) null,
-                        MockMapper.selectValueMapper(),
-                        MockValueJoiner.TOSTRING_JOINER);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullMapperOnLeftJoinWithGlobalTable() {
-        testStream.leftJoin(builder.globalTable("global", stringConsumed),
-                        null,
-                        MockValueJoiner.TOSTRING_JOINER);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTable() {
-        testStream.leftJoin(builder.globalTable("global", stringConsumed),
-                        MockMapper.selectValueMapper(),
-                        null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerOnPrintIfPrintedIsNull() {
-        testStream.print(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerOnThroughWhenProducedIsNull() {
-        testStream.through("topic", null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerOnToWhenProducedIsNull() {
-        testStream.to("topic", null);
-    }
-
-    @Test
-    public void shouldThrowNullPointerOnLeftJoinWithTableWhenJoinedIsNull() {
-        final KTable<String, String> table = builder.table("blah", stringConsumed);
-        try {
-            testStream.leftJoin(table,
-                                MockValueJoiner.TOSTRING_JOINER,
-                                null);
-            fail("Should have thrown NullPointerException");
-        } catch (final NullPointerException e) {
-            // ok
-        }
-    }
-
-    @Test
-    public void shouldThrowNullPointerOnJoinWithTableWhenJoinedIsNull() {
-        final KTable<String, String> table = builder.table("blah", stringConsumed);
-        try {
-            testStream.join(table,
-                            MockValueJoiner.TOSTRING_JOINER,
-                            null);
-            fail("Should have thrown NullPointerException");
-        } catch (final NullPointerException e) {
-            // ok
-        }
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerOnJoinWithStreamWhenStreamJoinedIsNull() {
-        testStream.join(testStream, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(ofMillis(10)), nullStreamJoinedForTest);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerOnOuterJoinStreamJoinedIsNull() {
-        testStream.outerJoin(testStream, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(ofMillis(10)), nullStreamJoinedForTest);
-    }
-
-    @Test
     public void shouldMergeTwoStreams() {
         final String topic1 = "topic-1";
         final String topic2 = "topic-2";
@@ -680,9 +1043,9 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
-                    driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
-                    driver.createInputTopic(topic2, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic2, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic1.pipeInput("A", "aa");
             inputTopic2.pipeInput("B", "bb");
             inputTopic2.pipeInput("C", "cc");
@@ -690,9 +1053,9 @@ public class KStreamImplTest {
         }
 
         assertEquals(asList(new KeyValueTimestamp<>("A", "aa", 0),
-                new KeyValueTimestamp<>("B", "bb", 0),
-                new KeyValueTimestamp<>("C", "cc", 0),
-                new KeyValueTimestamp<>("D", "dd", 0)), processorSupplier.theCapturedProcessor().processed);
+            new KeyValueTimestamp<>("B", "bb", 0),
+            new KeyValueTimestamp<>("C", "cc", 0),
+            new KeyValueTimestamp<>("D", "dd", 0)), processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test
@@ -712,13 +1075,13 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
-                    driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
-                    driver.createInputTopic(topic2, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic2, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic3 =
-                    driver.createInputTopic(topic3, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic3, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
-                    driver.createInputTopic(topic4, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic4, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
 
             inputTopic1.pipeInput("A", "aa", 1L);
             inputTopic2.pipeInput("B", "bb", 9L);
@@ -731,14 +1094,14 @@ public class KStreamImplTest {
         }
 
         assertEquals(asList(new KeyValueTimestamp<>("A", "aa", 1),
-                new KeyValueTimestamp<>("B", "bb", 9),
-                new KeyValueTimestamp<>("C", "cc", 2),
-                new KeyValueTimestamp<>("D", "dd", 8),
-                new KeyValueTimestamp<>("E", "ee", 3),
-                new KeyValueTimestamp<>("F", "ff", 7),
-                new KeyValueTimestamp<>("G", "gg", 4),
-                new KeyValueTimestamp<>("H", "hh", 6)),
-                     processorSupplier.theCapturedProcessor().processed);
+            new KeyValueTimestamp<>("B", "bb", 9),
+            new KeyValueTimestamp<>("C", "cc", 2),
+            new KeyValueTimestamp<>("D", "dd", 8),
+            new KeyValueTimestamp<>("E", "ee", 3),
+            new KeyValueTimestamp<>("F", "ff", 7),
+            new KeyValueTimestamp<>("G", "gg", 4),
+            new KeyValueTimestamp<>("H", "hh", 6)),
+            processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test
@@ -749,15 +1112,15 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
-                    driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
-                    driver.createInputTopic("topic-4", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-4", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic5 =
-                    driver.createInputTopic("topic-5", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-5", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic6 =
-                    driver.createInputTopic("topic-6", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-6", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic7 =
-                    driver.createInputTopic("topic-7", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-7", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
 
             inputTopic3.pipeInput("A", "aa", 1L);
             inputTopic4.pipeInput("B", "bb", 5L);
@@ -767,11 +1130,11 @@ public class KStreamImplTest {
         }
 
         assertEquals(asList(new KeyValueTimestamp<>("A", "aa", 1),
-                new KeyValueTimestamp<>("B", "bb", 5),
-                new KeyValueTimestamp<>("C", "cc", 10),
-                new KeyValueTimestamp<>("D", "dd", 8),
-                new KeyValueTimestamp<>("E", "ee", 3)),
-                processorSupplier.theCapturedProcessor().processed);
+            new KeyValueTimestamp<>("B", "bb", 5),
+            new KeyValueTimestamp<>("C", "cc", 10),
+            new KeyValueTimestamp<>("D", "dd", 8),
+            new KeyValueTimestamp<>("E", "ee", 3)),
+            processorSupplier.theCapturedProcessor().processed);
     }
 
     @Test
@@ -787,15 +1150,15 @@ public class KStreamImplTest {
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
-                    driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
-                    driver.createInputTopic("topic-4", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-4", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopicA =
-                    driver.createInputTopic("topic-A", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-A", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopicZ =
-                    driver.createInputTopic("topic-Z", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic("topic-Z", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic =
-                    driver.createInputTopic(topic3, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+                driver.createInputTopic(topic3, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
 
             inputTopic3.pipeInput("A", "aa", 1L);
             inputTopic4.pipeInput("B", "bb", 5L);
@@ -805,10 +1168,659 @@ public class KStreamImplTest {
         }
 
         assertEquals(asList(new KeyValueTimestamp<>("A", "aa", 1),
-                new KeyValueTimestamp<>("B", "bb", 5),
-                new KeyValueTimestamp<>("C", "cc", 10),
-                new KeyValueTimestamp<>("D", "dd", 8),
-                new KeyValueTimestamp<>("E", "ee", 3)),
-                processorSupplier.theCapturedProcessor().processed);
+            new KeyValueTimestamp<>("B", "bb", 5),
+            new KeyValueTimestamp<>("C", "cc", 10),
+            new KeyValueTimestamp<>("D", "dd", 8),
+            new KeyValueTimestamp<>("E", "ee", 3)),
+            processorSupplier.theCapturedProcessor().processed);
     }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(null));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnTransformWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(null, Named.as("transformer")));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnTransformWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(null, Named.as("transformer"), "storeName"));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, Named.as("transform"), (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, Named.as("transform"), (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransformWithStoreName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transform(transformerSupplier, (Named) null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnFlatTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(null));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnFlatTransformWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnFlatTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(null, Named.as("flatTransformer")));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullTransformerSupplierOnFlatTransformWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(null, Named.as("flatTransformer"), "storeName"));
+        assertThat(exception.getMessage(), equalTo("transformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, Named.as("flatTransform"), (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransformWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, Named.as("flatTransform"), (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransform() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransformWithStoreName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransform(flatTransformerSupplier, (Named) null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnTransformValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues((ValueTransformerSupplier<Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnTransformValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues((ValueTransformerWithKeySupplier<Object, Object, Object>) null));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnTransformValuesWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerSupplier<Object, Object>) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnTransformValuesWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Object>) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnTransformValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerSupplier<Object, Object>) null,
+                Named.as("valueTransformer")));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnTransformValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Object>) null,
+                Named.as("valueTransformerWithKey")));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnTransformValuesWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerSupplier<Object, Object>) null,
+                Named.as("valueTransformer"),
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnTransformValuesWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Object>) null,
+                Named.as("valueTransformerWithKey"),
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransformValuesWithValueTransformerSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransformValuesWithValueTransformerWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransformValuesWithValueTransformerSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransformValuesWithValueTransformerWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransformValuesWithValueTransformerSupplierWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                Named.as("valueTransformer"),
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnTransformValuesWithValueTransformerWithKeySupplierWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                Named.as("valueTransformer"),
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransformValuesWithValueTransformerSupplierWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                Named.as("valueTransformer"),
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnTransformValuesWithValueTransformerWithKeySupplierWithName() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                Named.as("valueTransformerWithKey"),
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransformValuesWithValueTransformerSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransformValuesWithValueTransformerWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransformValuesWithValueTransformerSupplierAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerSupplier,
+                (Named) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnTransformValuesWithValueTransformerWithKeySupplierAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.transformValues(
+                valueTransformerWithKeySupplier,
+                (Named) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnFlatTransformValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues((ValueTransformerSupplier<Object, Iterable<Object>>) null));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnFlatTransformValues() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues((ValueTransformerWithKeySupplier<Object, Object, Iterable<Object>>) null));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnFlatTransformValuesWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerSupplier<Object, Iterable<Object>>) null,
+                "stateStore"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnFlatTransformValuesWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Iterable<Object>>) null,
+                "stateStore"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnFlatTransformValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerSupplier<Object, Iterable<Object>>) null,
+                Named.as("flatValueTransformer")));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnFlatTransformValuesWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Iterable<Object>>) null,
+                Named.as("flatValueWithKeyTransformer")));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerSupplierOnFlatTransformValuesWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerSupplier<Object, Iterable<Object>>) null,
+                Named.as("flatValueTransformer"),
+                "stateStore"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueTransformerWithKeySupplierOnFlatTransformValuesWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                (ValueTransformerWithKeySupplier<Object, Object, Iterable<Object>>) null,
+                Named.as("flatValueWitKeyTransformer"),
+                "stateStore"));
+        assertThat(exception.getMessage(), equalTo("valueTransformerSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransformValuesWithFlatValueSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransformValuesWithFlatValueWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransformValuesWithFlatValueSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransformValuesWithFlatValueWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransformValuesWithFlatValueSupplierAndNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                Named.as("flatValueTransformer"),
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnFlatTransformValuesWithFlatValueWithKeySupplierAndNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                Named.as("flatValueWitKeyTransformer"),
+                (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransformValuesWithFlatValueSupplierAndNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                Named.as("flatValueTransformer"),
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnFlatTransformValuesWithFlatValueWithKeySupplierAndNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                Named.as("flatValueWitKeyTransformer"),
+                (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransformValuesWithFlatValueSupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransformValuesWithFlatValueWithKeySupplier() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransformValuesWithFlatValueSupplierAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerSupplier,
+                (Named) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnFlatTransformValuesWithFlatValueWithKeySupplierAndStore() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.flatTransformValues(
+                flatValueTransformerWithKeySupplier,
+                (Named) null,
+                "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProcessSupplierOnProcess() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(null));
+        assertThat(exception.getMessage(), equalTo("processorSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProcessSupplierOnProcessWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("processorSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProcessSupplierOnProcessWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(null, Named.as("processor")));
+        assertThat(exception.getMessage(), equalTo("processorSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullProcessSupplierOnProcessWithNamedAndStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(null, Named.as("processor"), "stateStore"));
+        assertThat(exception.getMessage(), equalTo("processorSupplier can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnProcess() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnProcess() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNamesOnProcessWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, Named.as("processor"), (String[]) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be a null array"));
+    }
+
+    @Test
+    public void shouldNotAllowNullStoreNameOnProcessWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, Named.as("processor"), (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnProcess() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, (Named) null));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullNamedOnProcessWithStores() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.process(processorSupplier, (Named) null, "storeName"));
+        assertThat(exception.getMessage(), equalTo("named can't be null"));
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -301,7 +301,9 @@ public class KStreamImplTest {
     public void shouldNotAllowNullMapperOnMapValuesWithKeyWithNamed() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.mapValues((ValueMapperWithKey<Object, Object, Object>) null, Named.as("valueMapperWithKey")));
+            () -> testStream.mapValues(
+                (ValueMapperWithKey<Object, Object, Object>) null,
+                Named.as("valueMapperWithKey")));
         assertThat(exception.getMessage(), equalTo("valueMapperWithKey can't be null"));
     }
 
@@ -365,7 +367,9 @@ public class KStreamImplTest {
     public void shouldNotAllowNullMapperOnFlatMapValuesWithNamed() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.flatMapValues((ValueMapper<Object, Iterable<Object>>) null, Named.as("flatValueMapper")));
+            () -> testStream.flatMapValues(
+                (ValueMapper<Object, Iterable<Object>>) null,
+                Named.as("flatValueMapper")));
         assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
     }
 
@@ -373,7 +377,9 @@ public class KStreamImplTest {
     public void shouldNotAllowNullMapperOnFlatMapValuesWithKeyWithNamed() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.flatMapValues((ValueMapperWithKey<Object, Object, ? extends Iterable<Object>>) null, Named.as("flatValueMapperWithKey")));
+            () -> testStream.flatMapValues(
+                (ValueMapperWithKey<Object, Object, ? extends Iterable<Object>>) null,
+                Named.as("flatValueMapperWithKey")));
         assertThat(exception.getMessage(), equalTo("valueMapper can't be null"));
     }
 
@@ -598,26 +604,6 @@ public class KStreamImplTest {
             () -> testStream.to((k, v, ctx) -> "topic", null));
         assertThat(exception.getMessage(), equalTo("produced can't be null"));
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullOtherStreamOnJoin() {
@@ -1220,7 +1206,7 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.transform(transformerSupplier, (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1236,7 +1222,7 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.transform(transformerSupplier, Named.as("transform"), (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1300,7 +1286,7 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.flatTransform(flatTransformerSupplier, (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1316,7 +1302,7 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.flatTransform(flatTransformerSupplier, Named.as("flatTransform"), (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1438,9 +1424,8 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.transformValues(
-                valueTransformerSupplier,
-                (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+                valueTransformerSupplier, (String) null));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1450,7 +1435,7 @@ public class KStreamImplTest {
             () -> testStream.transformValues(
                 valueTransformerWithKeySupplier,
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1483,7 +1468,7 @@ public class KStreamImplTest {
                 valueTransformerSupplier,
                 Named.as("valueTransformer"),
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1494,7 +1479,7 @@ public class KStreamImplTest {
                 valueTransformerWithKeySupplier,
                 Named.as("valueTransformerWithKey"),
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1644,7 +1629,7 @@ public class KStreamImplTest {
             () -> testStream.flatTransformValues(
                 flatValueTransformerSupplier,
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1654,7 +1639,7 @@ public class KStreamImplTest {
             () -> testStream.flatTransformValues(
                 flatValueTransformerWithKeySupplier,
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1687,7 +1672,7 @@ public class KStreamImplTest {
                 flatValueTransformerSupplier,
                 Named.as("flatValueTransformer"),
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test
@@ -1698,7 +1683,7 @@ public class KStreamImplTest {
                 flatValueTransformerWithKeySupplier,
                 Named.as("flatValueWitKeyTransformer"),
                 (String) null));
-        assertThat(exception.getMessage(), equalTo("stateStoreNames can't be null"));
+        assertThat(exception.getMessage(), equalTo("stateStoreNames can't contain `null` as store name"));
     }
 
     @Test


### PR DESCRIPTION
During the work on KIP-150, we encountered some inconsistencies with regard to `Named` parameter, ie, not all methods check for `null` (what should not be allowed).

Going over the code, and to make sure we don't forget any case, I reordered couple of methods to keep an overview (ie, same order in interface, implementation, and tests). I'll highlight the actual changes in the code.

Call for review @bbejeck @vvcephei 