### PR TITLE
KAFKA-9312: Wait for splitted batches to be processed after a KafkaProducer#flush()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /*
  * A thread-safe helper class to hold batches that haven't been acknowledged yet (including those
@@ -50,15 +49,6 @@ class IncompleteBatches {
     public List<ProducerBatch> copyAll() {
         synchronized (incomplete) {
             return new ArrayList<>(this.incomplete);
-        }
-    }
-
-    public List<ProducerBatch> copyAllSplitted() {
-        synchronized (incomplete) {
-            return this.incomplete
-                    .stream()
-                    .filter(ProducerBatch::isSplitBatch)
-                    .collect(Collectors.toList());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
@@ -18,7 +18,9 @@ package org.apache.kafka.clients.producer.internals;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /*
  * A thread-safe helper class to hold batches that haven't been acknowledged yet (including those
@@ -45,9 +47,18 @@ class IncompleteBatches {
         }
     }
 
-    public Iterable<ProducerBatch> copyAll() {
+    public List<ProducerBatch> copyAll() {
         synchronized (incomplete) {
             return new ArrayList<>(this.incomplete);
+        }
+    }
+
+    public List<ProducerBatch> copyAllSplitted() {
+        synchronized (incomplete) {
+            return this.incomplete
+                    .stream()
+                    .filter(ProducerBatch::isSplitBatch)
+                    .collect(Collectors.toList());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -250,7 +250,7 @@ public final class ProducerBatch {
         return childrenProducerBatch;
     }
 
-    public void clearChildrenProducerBatch() {
+    public synchronized void clearChildrenProducerBatch() {
         childrenProducerBatch.clear();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -82,12 +82,17 @@ public final class ProducerBatch {
     }
 
     public ProducerBatch(TopicPartition tp, MemoryRecordsBuilder recordsBuilder, long createdMs, boolean isSplitBatch) {
+        this(tp, recordsBuilder, createdMs, isSplitBatch, new ProduceRequestResult(tp));
+    }
+
+    ProducerBatch(TopicPartition tp, MemoryRecordsBuilder recordsBuilder, long createdMs, boolean isSplitBatch,
+                  ProduceRequestResult produceFuture) {
         this.createdMs = createdMs;
         this.lastAttemptMs = createdMs;
         this.recordsBuilder = recordsBuilder;
         this.topicPartition = tp;
         this.lastAppendTime = createdMs;
-        this.produceFuture = new ProduceRequestResult(topicPartition);
+        this.produceFuture = produceFuture;
         this.retry = false;
         this.isSplitBatch = isSplitBatch;
         float compressionRatioEstimation = CompressionRatioEstimator.estimation(topicPartition.topic(),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -303,7 +303,7 @@ public final class ProducerBatch {
         return batches;
     }
 
-    public boolean completed() {
+    boolean completed() {
         return produceFuture.completed();
     }
 
@@ -321,7 +321,7 @@ public final class ProducerBatch {
         }
     }
 
-    private void addChildrenProducerBatch(final ProducerBatch batch) {
+    private synchronized void addChildrenProducerBatch(final ProducerBatch batch) {
         if (childrenProducerBatch == null) {
             childrenProducerBatch = new ArrayList<>();
         }
@@ -329,7 +329,7 @@ public final class ProducerBatch {
         childrenProducerBatch.add(batch);
     }
 
-    private List<ProducerBatch> getChildrenProducerBatch() {
+    private synchronized List<ProducerBatch> getChildrenProducerBatch() {
         if (childrenProducerBatch == null) {
             return Collections.emptyList();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -61,14 +62,14 @@ public final class ProducerBatch {
 
     final long createdMs;
     final TopicPartition topicPartition;
-    final ProduceRequestResult produceFuture;
 
+    private final ProduceRequestResult produceFuture;
     private final List<Thunk> thunks = new ArrayList<>();
     private final MemoryRecordsBuilder recordsBuilder;
     private final AtomicInteger attempts = new AtomicInteger(0);
     private final boolean isSplitBatch;
     private final AtomicReference<FinalState> finalState = new AtomicReference<>(null);
-    private final List<ProducerBatch> childrenProducerBatch;
+    private List<ProducerBatch> childrenProducerBatch;
 
     int recordCount;
     int maxRecordSize;
@@ -84,7 +85,7 @@ public final class ProducerBatch {
 
     public ProducerBatch(final TopicPartition tp, final MemoryRecordsBuilder recordsBuilder,
                          final long createdMs, final boolean isSplitBatch) {
-        this(tp, recordsBuilder, createdMs, isSplitBatch, new ProduceRequestResult(tp), new ArrayList<>());
+        this(tp, recordsBuilder, createdMs, isSplitBatch, new ProduceRequestResult(tp), null);
     }
 
     ProducerBatch(final TopicPartition tp, final MemoryRecordsBuilder recordsBuilder, final long createdMs,
@@ -246,14 +247,6 @@ public final class ProducerBatch {
         produceFuture.done();
     }
 
-    public List<ProducerBatch> getChildrenProducerBatch() {
-        return childrenProducerBatch;
-    }
-
-    public synchronized void clearChildrenProducerBatch() {
-        childrenProducerBatch.clear();
-    }
-
     public Deque<ProducerBatch> split(int splitBatchSize) {
         Deque<ProducerBatch> batches = new ArrayDeque<>();
         MemoryRecords memoryRecords = recordsBuilder.build();
@@ -284,7 +277,7 @@ public final class ProducerBatch {
             // A newly created batch can always host the first message.
             if (!batch.tryAppendForSplit(record.timestamp(), record.key(), record.value(), record.headers(), thunk)) {
                 batches.add(batch);
-                childrenProducerBatch.add(batch);
+                addChildrenProducerBatch(batch);
                 batch = createBatchOffAccumulatorForRecord(record, splitBatchSize);
                 batch.tryAppendForSplit(record.timestamp(), record.key(), record.value(), record.headers(), thunk);
             }
@@ -293,7 +286,7 @@ public final class ProducerBatch {
         // Close the last batch and add it to the batch list after split.
         if (batch != null) {
             batches.add(batch);
-            childrenProducerBatch.add(batch);
+            addChildrenProducerBatch(batch);
         }
 
         produceFuture.set(ProduceResponse.INVALID_OFFSET, NO_TIMESTAMP, new RecordBatchTooLargeException());
@@ -308,6 +301,45 @@ public final class ProducerBatch {
             }
         }
         return batches;
+    }
+
+    public boolean completed() {
+        return produceFuture.completed();
+    }
+
+    public void await() throws InterruptedException {
+        produceFuture.await();
+        waitForPossibleSplittedBatches();
+        clearChildrenProducerBatch();
+    }
+
+    private void waitForPossibleSplittedBatches() throws InterruptedException {
+        for (ProducerBatch child : getChildrenProducerBatch()) {
+            child.produceFuture.await();
+            child.waitForPossibleSplittedBatches();
+            child.clearChildrenProducerBatch();
+        }
+    }
+
+    private void addChildrenProducerBatch(final ProducerBatch batch) {
+        if (childrenProducerBatch == null) {
+            childrenProducerBatch = new ArrayList<>();
+        }
+
+        childrenProducerBatch.add(batch);
+    }
+
+    private List<ProducerBatch> getChildrenProducerBatch() {
+        if (childrenProducerBatch == null) {
+            return Collections.emptyList();
+        }
+        return childrenProducerBatch;
+    }
+
+    private synchronized void clearChildrenProducerBatch() {
+        if (childrenProducerBatch != null) {
+            childrenProducerBatch.clear();
+        }
     }
 
     private ProducerBatch createBatchOffAccumulatorForRecord(Record record, int batchSize) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -313,7 +313,7 @@ public final class ProducerBatch {
         clearChildrenProducerBatch();
     }
 
-    private void waitForPossibleSplittedBatches() throws InterruptedException {
+    private synchronized void waitForPossibleSplittedBatches() throws InterruptedException {
         for (ProducerBatch child : getChildrenProducerBatch()) {
             child.produceFuture.await();
             child.waitForPossibleSplittedBatches();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -749,20 +749,10 @@ public final class RecordAccumulator {
     public void awaitFlushCompletion() throws InterruptedException {
         try {
             for (ProducerBatch batch : this.incomplete.copyAll()) {
-                batch.produceFuture.await();
-                waitForPossibleSplittedBatches(batch);
-                batch.clearChildrenProducerBatch();
+                batch.await();
             }
         } finally {
             this.flushesInProgress.decrementAndGet();
-        }
-    }
-
-    private void waitForPossibleSplittedBatches(final ProducerBatch batch) throws InterruptedException {
-        for (ProducerBatch child : batch.getChildrenProducerBatch()) {
-            child.produceFuture.await();
-            waitForPossibleSplittedBatches(child);
-            child.clearChildrenProducerBatch();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -116,6 +116,41 @@ public final class RecordAccumulator {
                              ApiVersions apiVersions,
                              TransactionManager transactionManager,
                              BufferPool bufferPool) {
+        this(logContext, batchSize, compression, lingerMs, retryBackoffMs, deliveryTimeoutMs, metrics, metricGrpName,
+                time, apiVersions, transactionManager, bufferPool, new IncompleteBatches());
+    }
+
+    /**
+     * Create a new record accumulator (package private for testing purpose)
+     *
+     * @param logContext The log context used for logging
+     * @param batchSize The size to use when allocating {@link MemoryRecords} instances
+     * @param compression The compression codec for the records
+     * @param lingerMs An artificial delay time to add before declaring a records instance that isn't full ready for
+     *        sending. This allows time for more records to arrive. Setting a non-zero lingerMs will trade off some
+     *        latency for potentially better throughput due to more batching (and hence fewer, larger requests).
+     * @param retryBackoffMs An artificial delay time to retry the produce request upon receiving an error. This avoids
+     *        exhausting all retries in a short period of time.
+     * @param metrics The metrics
+     * @param time The time instance to use.
+     * @param apiVersions Request API versions for current connected brokers
+     * @param transactionManager The shared transaction state object which tracks producer IDs, epochs, and sequence
+     *                           numbers per partition.
+     * @param incomplete the IncompleteBatches object to track the batches to be sent.
+     */
+    RecordAccumulator(final LogContext logContext,
+                      final int batchSize,
+                      final CompressionType compression,
+                      final int lingerMs,
+                      long retryBackoffMs,
+                      int deliveryTimeoutMs,
+                      Metrics metrics,
+                      String metricGrpName,
+                      Time time,
+                      ApiVersions apiVersions,
+                      TransactionManager transactionManager,
+                      BufferPool bufferPool,
+                      IncompleteBatches incomplete) {
         this.log = logContext.logger(RecordAccumulator.class);
         this.drainIndex = 0;
         this.closed = false;
@@ -128,7 +163,7 @@ public final class RecordAccumulator {
         this.deliveryTimeoutMs = deliveryTimeoutMs;
         this.batches = new CopyOnWriteMap<>();
         this.free = bufferPool;
-        this.incomplete = new IncompleteBatches();
+        this.incomplete = incomplete;
         this.muted = new HashMap<>();
         this.time = time;
         this.apiVersions = apiVersions;
@@ -713,8 +748,13 @@ public final class RecordAccumulator {
      */
     public void awaitFlushCompletion() throws InterruptedException {
         try {
-            for (ProducerBatch batch : this.incomplete.copyAll())
+            for (ProducerBatch batch : this.incomplete.copyAll()) {
                 batch.produceFuture.await();
+            }
+
+            for (ProducerBatch batch : this.incomplete.copyAllSplitted()) {
+                batch.produceFuture.await();
+            }
         } finally {
             this.flushesInProgress.decrementAndGet();
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/IncompleteBatchesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/IncompleteBatchesTest.java
@@ -27,7 +27,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,19 +53,6 @@ public class IncompleteBatchesTest {
         final boolean isNotSplitBatch = false;
         splittedBatch = new ProducerBatch(topicPartition, recordsBuilder, createdMs, isSplitBatch);
         nonSplittedBatch = new ProducerBatch(topicPartition, recordsBuilder, createdMs, isNotSplitBatch);
-    }
-
-    @Test
-    public void testCopyAllSplitted() {
-        final int expectedSplittedBatches = 1;
-        final IncompleteBatches incompleteBatches = new IncompleteBatches();
-        incompleteBatches.add(splittedBatch);
-        incompleteBatches.add(nonSplittedBatch);
-
-        final List<ProducerBatch> batches = incompleteBatches.copyAllSplitted();
-
-        assertThat(batches, hasItem(splittedBatch));
-        assertThat(expectedSplittedBatches, is(batches.size()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/IncompleteBatchesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/IncompleteBatchesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.producer.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IncompleteBatchesTest {
+
+    @Mock
+    private MemoryRecordsBuilder recordsBuilder;
+    @Mock
+    private CompressionType compressionType;
+
+    private TopicPartition topicPartition;
+    private ProducerBatch splittedBatch;
+    private ProducerBatch nonSplittedBatch;
+    private final long createdMs = 0;
+
+    @Before
+    public void setUp() {
+        when(recordsBuilder.compressionType()).thenReturn(compressionType);
+        topicPartition = new TopicPartition("test", 0);
+        final boolean isSplitBatch = true;
+        final boolean isNotSplitBatch = false;
+        splittedBatch = new ProducerBatch(topicPartition, recordsBuilder, createdMs, isSplitBatch);
+        nonSplittedBatch = new ProducerBatch(topicPartition, recordsBuilder, createdMs, isNotSplitBatch);
+    }
+
+    @Test
+    public void testCopyAllSplitted() {
+        final int expectedSplittedBatches = 1;
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(splittedBatch);
+        incompleteBatches.add(nonSplittedBatch);
+
+        final List<ProducerBatch> batches = incompleteBatches.copyAllSplitted();
+
+        assertThat(batches, hasItem(splittedBatch));
+        assertThat(expectedSplittedBatches, is(batches.size()));
+    }
+
+    @Test
+    public void testCopyAll() {
+        final int expectedBatches = 2;
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(splittedBatch);
+        incompleteBatches.add(nonSplittedBatch);
+
+        final List<ProducerBatch> batches = incompleteBatches.copyAll();
+
+        assertThat(batches, hasItems(splittedBatch, nonSplittedBatch));
+        assertThat(expectedBatches, is(batches.size()));
+    }
+
+    @Test
+    public void testAdd() {
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+
+        incompleteBatches.add(nonSplittedBatch);
+
+        assertThat(incompleteBatches.isEmpty(), is(false));
+    }
+
+    @Test
+    public void testRemove() {
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(nonSplittedBatch);
+
+        assertThat(incompleteBatches.isEmpty(), is(false));
+
+        incompleteBatches.remove(nonSplittedBatch);
+
+        assertThat(incompleteBatches.isEmpty(), is(true));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemoveShouldThrowAIllegalStateException() {
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(nonSplittedBatch);
+
+        incompleteBatches.remove(splittedBatch);
+    }
+
+    @Test
+    public void testIsEmptyShouldBeTrue() {
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+
+        assertThat(incompleteBatches.isEmpty(), is(true));
+    }
+
+    @Test
+    public void testIsEmptyShouldBeFalse() {
+        final IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(nonSplittedBatch);
+
+        assertThat(incompleteBatches.isEmpty(), is(false));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -44,6 +44,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -415,7 +418,7 @@ public class RecordAccumulatorTest {
     }
 
     @Test
-    public void testAwaitFlushComplete() throws Exception {
+    public void testAwaitFlushCompleteShouldThrowInterruptException() throws Exception {
         RecordAccumulator accum = createTestRecordAccumulator(
             4 * 1024 + DefaultRecordBatch.RECORD_BATCH_OVERHEAD, 64 * 1024, CompressionType.NONE, Integer.MAX_VALUE);
         accum.append(new TopicPartition(topic, 0), 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
@@ -429,6 +432,31 @@ public class RecordAccumulatorTest {
         } catch (InterruptedException e) {
             assertFalse("flushInProgress count should be decremented even if thread is interrupted", accum.flushInProgress());
         }
+    }
+
+    @Test
+    public void testAwaitFlushCompleteShouldWaitForSplittedBatch() throws Exception {
+        int expectedSplittedBatches = 2;
+        int batchSize = 1025;
+        boolean isSplittedBatch = true;
+        boolean isNonSplittedBatch = false;
+        TopicPartition topicPartition = new TopicPartition("test", 0);
+        MemoryRecordsBuilder memoryRecordsBuilder = MemoryRecords.builder(ByteBuffer.allocate(128),
+                CompressionType.NONE, TimestampType.CREATE_TIME, 128);
+        ProduceRequestResult splittedBatchResult = mock(ProduceRequestResult.class);
+        ProduceRequestResult batchResult = mock(ProduceRequestResult.class);
+        ProducerBatch splittedBatch = new ProducerBatch(topicPartition, memoryRecordsBuilder, 0, isSplittedBatch, splittedBatchResult);
+        ProducerBatch batch = new ProducerBatch(topicPartition, memoryRecordsBuilder, 0, isNonSplittedBatch, batchResult);
+        IncompleteBatches incompleteBatches = new IncompleteBatches();
+        incompleteBatches.add(splittedBatch);
+        incompleteBatches.add(batch);
+        RecordAccumulator accumulator = createTestRecordAccumulator(3200, batchSize + DefaultRecordBatch.RECORD_BATCH_OVERHEAD,
+                10L * batchSize, CompressionType.NONE, 10, incompleteBatches);
+
+        accumulator.awaitFlushCompletion();
+
+        verify(batchResult).await();
+        verify(splittedBatchResult, VerificationModeFactory.times(expectedSplittedBatches)).await();
     }
 
     @Test
@@ -1079,15 +1107,22 @@ public class RecordAccumulatorTest {
     }
 
 
-    private RecordAccumulator createTestRecordAccumulator(int batchSize, long totalSize, CompressionType type, int lingerMs) {
+    private RecordAccumulator createTestRecordAccumulator(int batchSize, long totalSize, CompressionType type, int lingerMs)
+            throws InterruptedException {
         int deliveryTimeoutMs = 3200;
-        return createTestRecordAccumulator(deliveryTimeoutMs, batchSize, totalSize, type, lingerMs);
+        return createTestRecordAccumulator(deliveryTimeoutMs, batchSize, totalSize, type, lingerMs, new IncompleteBatches());
+    }
+
+    private RecordAccumulator createTestRecordAccumulator(int deliveryTimeoutMs, int batchSize, long totalSize, CompressionType type, int lingerMs) {
+        return createTestRecordAccumulator(deliveryTimeoutMs, batchSize, totalSize, type, lingerMs, new IncompleteBatches());
     }
 
     /**
      * Return a test RecordAccumulator instance
      */
-    private RecordAccumulator createTestRecordAccumulator(int deliveryTimeoutMs, int batchSize, long totalSize, CompressionType type, int lingerMs) {
+    private RecordAccumulator createTestRecordAccumulator(int deliveryTimeoutMs, int batchSize, long totalSize, CompressionType type,
+                                                          int lingerMs, IncompleteBatches incompleteBatches) {
+
         long retryBackoffMs = 100L;
         String metricGrpName = "producer-metrics";
 
@@ -1103,6 +1138,7 @@ public class RecordAccumulatorTest {
             time,
             new ApiVersions(),
             null,
-            new BufferPool(totalSize, batchSize, metrics, time, metricGrpName));
+            new BufferPool(totalSize, batchSize, metrics, time, metricGrpName),
+            incompleteBatches);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -491,7 +491,7 @@ public class RecordAccumulatorTest {
         for (Map.Entry<Integer, List<ProducerBatch>> drainedEntry : drained.entrySet()) {
             for (ProducerBatch batch : drainedEntry.getValue()) {
                 assertTrue(batch.isClosed());
-                assertFalse(batch.produceFuture.completed());
+                assertFalse(batch.completed());
                 numDrainedRecords += batch.recordCount;
             }
         }
@@ -534,7 +534,7 @@ public class RecordAccumulatorTest {
         for (Map.Entry<Integer, List<ProducerBatch>> drainedEntry : drained.entrySet()) {
             for (ProducerBatch batch : drainedEntry.getValue()) {
                 assertTrue(batch.isClosed());
-                assertFalse(batch.produceFuture.completed());
+                assertFalse(batch.completed());
                 numDrainedRecords += batch.recordCount;
             }
         }


### PR DESCRIPTION
This commit adds the logic to wait for `splitted` batches to be processed after a Message Too Large Exception has been received.
Also, add a new test class to cover `IncompleteBatches` class.

This code adds a new constructor to the classes `ProducerBatch` and `RecordAccumulator` visible to the package, this decouples the dependency between `ProduceRequestResult` and `IncompleteBatches` respectively and allow to test the method `RecordAccumulator#awaitFlushCompletion()`

The [Jira ticket](https://issues.apache.org/jira/browse/KAFKA-9312) provides a [test here](https://github.com/lbradstreet/kafka/commit/733a683273c31823df354d0a785cb2c24365735a#diff-0b8da0c7ceecaa1f00486dadb53208b1R2339) that prove the error without these changes.
This PR does not include that specific test since it involves sleeping the thread and could lead to indeterminate behavior.
