### PR TITLE
KAFKA-9352: use 'roundrobin' to assign topic-partition to mirroring tasks

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -44,6 +44,7 @@ import org.apache.kafka.clients.admin.CreateTopicsOptions;
 
 import java.util.Map;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Collection;
@@ -81,6 +82,12 @@ public class MirrorSourceConnector extends SourceConnector {
 
     public MirrorSourceConnector() {
         // nop
+    }
+
+    // visible for testing
+    MirrorSourceConnector(List<TopicPartition> knownTopicPartitions, MirrorConnectorConfig config) {
+        this.knownTopicPartitions = knownTopicPartitions;
+        this.config = config;
     }
 
     // visible for testing
@@ -141,14 +148,32 @@ public class MirrorSourceConnector extends SourceConnector {
     }
 
     // divide topic-partitions among tasks
+    // since each mirrored topic has different traffic and number of partitions, to balance the load
+    // across all mirrormaker instances (workers), 'roundrobin' helps to evenly assign all
+    // topic-partition to the tasks, then the tasks are further distributed to workers.
+    // For example, 3 tasks to mirror 3 topics with 8, 2 and 2 partitions respectively.
+    // 't1' denotes 'task 1', 't0p5' denotes 'topic 0, partition 5'
+    // t1 -> [t0p0, t0p3, t0p6, t1p1]
+    // t2 -> [t0p1, t0p4, t0p7, t2p0]
+    // t3 -> [t0p2, t0p5, t1p0, t2p1]
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
         if (!config.enabled() || knownTopicPartitions.isEmpty()) {
             return Collections.emptyList();
         }
         int numTasks = Math.min(maxTasks, knownTopicPartitions.size());
-        return ConnectorUtils.groupPartitions(knownTopicPartitions, numTasks).stream()
-            .map(config::taskConfigForTopicPartitions)
+        List<List<TopicPartition>> roundRobinByTask = new ArrayList<>(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            roundRobinByTask.add(new ArrayList<>());
+        }
+        int count = 0;
+        for (TopicPartition partition : knownTopicPartitions) {
+            int index = count % numTasks;
+            roundRobinByTask.get(index).add(partition);
+            count++;
+        }
+
+        return roundRobinByTask.stream().map(config::taskConfigForTopicPartitions)
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
originally, when mirrormaker replicates a group of topics, the assignment between topic-partition and tasks are pretty static. E.g. partitions from the same topic tend to be grouped together as much as possible on the same task. For example, 3 tasks to mirror 3 topics with 8, 2 and 2
partitions respectively. 't1' denotes 'task 1', 't0p5' denotes 'topic 0, partition 5'

The original assignment will look like:

t1 -> [t0p0, t0p1, t0p2, t0p3]
t2 -> [t0p4, t0p5, t0p6, t0p7]
t3 -> [t1p0, t1p2, t2p0, t2p1]

The potential issue of above assignment is: if topic 0 has more traffic than other topics (topic 1, topic 2), t1 and t2 will be loaded more traffic than t3. When the tasks are mapped to the mirrormaker instances (workers) and launched, it will create unbalanced load on the workers. Please see the picture below as an unbalanced example of 2 mirrormaker instances:

<img width="783" alt="Screen Shot 2019-12-19 at 12 16 02 PM" src="https://user-images.githubusercontent.com/32080381/71635359-b6eae880-2bd8-11ea-8ada-29f02ac96c4a.png">

Given each mirrored topic has different traffic and number of partitions, to balance the load
across all mirrormaker instances (workers), 'roundrobin' helps to evenly assign all
topic-partition to the tasks, then the tasks are further distributed to workers by calling
'ConnectorUtils.groupPartitions()'. For example, 3 tasks to mirror 3 topics with 8, 2 and 2
partitions respectively. 't1' denotes 'task 1', 't0p5' denotes 'topic 0, partition 5'
t1 -> [t0p0, t0p3, t0p6, t1p1]
t2 -> [t0p1, t0p4, t0p7, t2p0]
t3 -> [t0p2, t0p5, t1p0, t2p1]

The improvement of this new above assignment over the original assignment is: the partitions of topic 0, topic 1 and topic 2 are all spread over all tasks, which creates a relatively even load on all workers, after the tasks are mapped to the workers and launched.
Please see the picture below as a balanced example of 4 mirrormaker instances:

<img width="780" alt="Screen Shot 2019-12-19 at 8 22 17 AM" src="https://user-images.githubusercontent.com/32080381/71635350-a3d81880-2bd8-11ea-80a1-cb6ba494a2aa.png">
