### PR TITLE
WIP MINOR: move ZK ACL lookup outside of inWriteLock in AclAuthorizer

### DIFF
--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -490,8 +490,8 @@ class AclAuthorizer extends Authorizer with Logging {
 
   object AclChangedNotificationHandler extends AclChangeNotificationHandler {
     override def processNotification(resource: Resource): Unit = {
+      val versionedAcls = getAclsFromZk(resource)
       inWriteLock(lock) {
-        val versionedAcls = getAclsFromZk(resource)
         updateCache(resource, versionedAcls)
       }
     }


### PR DESCRIPTION
WIP:

The inWriteLock taken out in AclChangedNotificationHandler could cause unnecessary contention and block authorize calls/request handler threads when newly updated ACLs are loaded from ZooKeeper. I imagine this call could take >1s on occasion. This change moves the `getAclsFromZk(resource)` call to outside of the write lock where it can't interfere with inReadLock users. I believe this is safe as the update does not depend on locking for the ZK lookup.