### PR TITLE
KAFKA-9729: avoid readLock in authorizer ACL lookups

### DIFF
--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -345,7 +345,7 @@ class AclAuthorizer extends Authorizer with Logging {
 
   private def matchingAcls(resourceType: ResourceType, resourceName: String): AclSets = {
     // snapshot immutable aclCache to avoid the need for a readLock that
-    // may get blocked by ACL updates
+    // could be contended during AclChangedNotificationHandler updates
     val aclCacheSnapshot = aclCache
       val wildcard = aclCacheSnapshot.get(new ResourcePattern(resourceType, ResourcePattern.WILDCARD_RESOURCE, PatternType.LITERAL))
         .map(_.acls)


### PR DESCRIPTION
A write lock is currently taken out whenever an ACL update is triggered. This update requires a round trip to ZK to get the ACLs for the resource (https://github.com/apache/kafka/pull/7882/files#diff-852b9cb2ceb2b85ec25b422f72c42620R489). This round trip to ZK can block any ACL lookups, which will block any requests and that require authorization, and their corresponding handler threads. This PR attempts to avoid these read locks by snapshotting the aclCache which is a threadsafe scala immutable.TreeMap.