### PR TITLE
MINOR: Remove compilation warnings

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -447,6 +447,7 @@ class AdminManager(val config: KafkaConfig,
       alterConfigOp.opType() match {
         case OpType.SET => Log4jController.logLevel(loggerName, logLevel)
         case OpType.DELETE => Log4jController.unsetLogLevel(loggerName)
+        case _ => // ignore
       }
     }
   }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -447,7 +447,6 @@ class AdminManager(val config: KafkaConfig,
       alterConfigOp.opType() match {
         case OpType.SET => Log4jController.logLevel(loggerName, logLevel)
         case OpType.DELETE => Log4jController.unsetLogLevel(loggerName)
-        case _ => // ignore
       }
     }
   }

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -275,7 +275,6 @@ object TopicZNode {
       val assignmentJson = js.asJsonObject
       val partitionsJsonOpt = assignmentJson.get("partitions").map(_.asJsonObject)
       val addingReplicasJsonOpt = assignmentJson.get("addingReplicas").map(_.asJsonObject)
-      val removingReplicasJsonOpt = assignmentJson.get("removingReplicas").map(_.asJsonObject)
       partitionsJsonOpt.map { partitionsJson =>
         partitionsJson.iterator.map { case (partition, replicas) =>
           new TopicPartition(topic, partition.toInt) -> PartitionReplicaAssignment(

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -334,8 +334,8 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
     @volatile var thrownException: Option[Throwable] = None
     @volatile var receivedMessages = 0
 
-    @volatile private var partitionAssignment: mutable.Set[TopicPartition] = new mutable.HashSet[TopicPartition]()
     @volatile private var subscriptionChanged = false
+    private val partitionAssignment: mutable.Set[TopicPartition] = new mutable.HashSet[TopicPartition]()
     private var topicsSubscription = topicsToSubscribe
 
     val rebalanceListener: ConsumerRebalanceListener = new ConsumerRebalanceListener {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -260,7 +260,7 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     val SslKeystorePasswordVal = "${file:ssl.keystore.password:password}"
 
     val configPrefix = listenerPrefix(SecureExternal)
-    var brokerConfigs = describeConfig(adminClients.head, servers).entries.asScala
+    val brokerConfigs = describeConfig(adminClients.head, servers).entries.asScala
     // the following are values before updated
     assertTrue("Initial value of polling interval", brokerConfigs.find(_.name == TestMetricsReporter.PollingIntervalProp) == None)
     assertTrue("Initial value of ssl truststore type", brokerConfigs.find(_.name == configPrefix+KafkaConfig.SslTruststoreTypeProp) == None)


### PR DESCRIPTION
Removed warnings:

1. `kafka/core/src/main/scala/kafka/zk/ZkData.scala:278: local val removingReplicasJsonOpt in value $anonfun is never used`
2. `kafka/core/src/main/scala/kafka/server/AdminManager.scala:447: match may not be exhaustive.`
3. `kafka/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala:337: private var partitionAssignment in class ConsumerAssignmentPoller is never updated: consider using immutable val`
4. `kafka/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala:263: local var brokerConfigs in method testUpdatesUsingConfigProvider is never updated: consider using immutable val`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
