### PR TITLE
KAFKA-9353: Add groupInstanceId to DescribeGroup for better visibility

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -124,7 +124,7 @@ object ConsumerGroupCommand extends Logging {
                                                 consumerId: Option[String], host: Option[String],
                                                 clientId: Option[String], logEndOffset: Option[Long])
 
-  private[admin] case class MemberAssignmentState(group: String, consumerId: String, host: String, clientId: String,
+  private[admin] case class MemberAssignmentState(group: String, consumerId: String, host: String, clientId: String, groupInstanceId: String,
                                              numPartitions: Int, assignment: List[TopicPartition])
 
   private[admin] case class GroupState(group: String, coordinator: Node, assignmentStrategy: String, state: String, numMembers: Int)
@@ -249,20 +249,27 @@ object ConsumerGroupCommand extends Logging {
       for ((groupId, (state, assignments)) <- members) {
         if (shouldPrintMemberState(groupId, state, size(assignments))) {
           // find proper columns width
-          var (maxGroupLen, maxConsumerIdLen, maxHostLen, maxClientIdLen) = (15, 15, 15, 15)
+          var (maxGroupLen, maxConsumerIdLen, maxGroupInstanceIdLen, maxHostLen, maxClientIdLen, includeGroupInstanceId) = (15, 15, 17, 15, 15, false)
           assignments match {
             case None => // do nothing
             case Some(memberAssignments) =>
               memberAssignments.foreach { memberAssignment =>
                 maxGroupLen = Math.max(maxGroupLen, memberAssignment.group.length)
                 maxConsumerIdLen = Math.max(maxConsumerIdLen, memberAssignment.consumerId.length)
+                maxGroupInstanceIdLen =  Math.max(maxGroupInstanceIdLen, memberAssignment.groupInstanceId.length)
                 maxHostLen = Math.max(maxHostLen, memberAssignment.host.length)
                 maxClientIdLen = Math.max(maxClientIdLen, memberAssignment.clientId.length)
+                includeGroupInstanceId = includeGroupInstanceId || memberAssignment.groupInstanceId.length > 0
               }
           }
 
-          print(s"\n%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s "
-            .format("GROUP", "CONSUMER-ID", "HOST", "CLIENT-ID", "#PARTITIONS"))
+          if (includeGroupInstanceId) {
+            print(s"\n%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxGroupInstanceIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s "
+                .format("GROUP", "CONSUMER-ID", "GROUP-INSTANCE-ID", "HOST", "CLIENT-ID", "#PARTITIONS"))
+          } else {
+            print(s"\n%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s "
+                .format("GROUP", "CONSUMER-ID", "HOST", "CLIENT-ID", "#PARTITIONS"))
+          }
           if (verbose)
             print(s"%s".format("ASSIGNMENT"))
           println()
@@ -271,8 +278,14 @@ object ConsumerGroupCommand extends Logging {
             case None => // do nothing
             case Some(memberAssignments) =>
               memberAssignments.foreach { memberAssignment =>
-                print(s"%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s ".format(
-                  memberAssignment.group, memberAssignment.consumerId, memberAssignment.host, memberAssignment.clientId, memberAssignment.numPartitions))
+                if (includeGroupInstanceId) {
+                  print(s"%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxGroupInstanceIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s ".format(
+                    memberAssignment.group, memberAssignment.consumerId, memberAssignment.groupInstanceId, memberAssignment.host,
+                    memberAssignment.clientId, memberAssignment.numPartitions))
+                } else {
+                  print(s"%${-maxGroupLen}s %${-maxConsumerIdLen}s %${-maxHostLen}s %${-maxClientIdLen}s %-15s ".format(
+                    memberAssignment.group, memberAssignment.consumerId, memberAssignment.host, memberAssignment.clientId, memberAssignment.numPartitions))
+                }
                 if (verbose) {
                   val partitions = memberAssignment.assignment match {
                     case List() => MISSING_COLUMN_VALUE
@@ -558,6 +571,7 @@ object ConsumerGroupCommand extends Logging {
             consumer.consumerId,
             consumer.host,
             consumer.clientId,
+            consumer.groupInstanceId.orElse(""),
             consumer.assignment.topicPartitions.size(),
             if (verbose) consumer.assignment.topicPartitions.asScala.toList else List()
           )).toList


### PR DESCRIPTION
Kafka-8538(#6957) has already added `group.instance.id` to `MemberDescription` but didn't print it, so we just print it.
before the change, the describe command print as follows:
```
GROUP           CONSUMER-ID                                                  HOST            CLIENT-ID               #PARTITIONS     
DemoConsumer    consumer-DemoConsumer-2-89251f12-f0ae-4dc1-a118-bda49f2a6e86 /127.0.0.1      consumer-DemoConsumer-2 0               
DemoConsumer    consumer-DemoConsumer-1-72221c6b-f3d9-4c68-96db-ffffa12ddf93 /127.0.0.1      consumer-DemoConsumer-1 1               
```

after the change, the describe command print as follows:
```
GROUP           CONSUMER-ID                                    GROUP-INSTANCE-ID HOST            CLIENT-ID                       #PARTITIONS     
DemoConsumer    groupIns2-f050379c-9c0d-433c-bbe0-44de6177b60d groupIns2         /127.0.0.1      consumer-DemoConsumer-groupIns2 0               
DemoConsumer    groupIns1-44805ba9-ae6f-49d3-89af-44a4b95aff8d groupIns1         /127.0.0.1      consumer-DemoConsumer-groupIns1 1                        
```

if all the `GROUP-INSTANCE-ID` is null, just as the previous:
```
GROUP           CONSUMER-ID                                                  HOST            CLIENT-ID               #PARTITIONS     
DemoConsumer    consumer-DemoConsumer-2-89251f12-f0ae-4dc1-a118-bda49f2a6e86 /127.0.0.1      consumer-DemoConsumer-2 0               
DemoConsumer    consumer-DemoConsumer-1-72221c6b-f3d9-4c68-96db-ffffa12ddf93 /127.0.0.1      consumer-DemoConsumer-1 1               
```