### PR TITLE
KAFKA-9360: Fix heartbeat and checkpoint emission can not turn off

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -106,7 +106,7 @@ public class MirrorCheckpointTask extends SourceTask {
 
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
-        try { 
+        try {
             long deadline = System.currentTimeMillis() + interval.toMillis();
             while (!stopping && System.currentTimeMillis() < deadline) {
                 offsetSyncStore.update(pollTimeout);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatConnector.java
@@ -30,6 +30,15 @@ import java.util.Collections;
 public class MirrorHeartbeatConnector extends SourceConnector {
     private MirrorConnectorConfig config;
     private Scheduler scheduler;
+    
+    public MirrorHeartbeatConnector() {
+        // nop
+    }
+
+    // visible for testing
+    MirrorHeartbeatConnector(MirrorConnectorConfig config) {
+        this.config = config;
+    }
 
     @Override
     public void start(Map<String, String> props) {
@@ -50,6 +59,11 @@ public class MirrorHeartbeatConnector extends SourceConnector {
 
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
+        // if the heartbeats emission is disabled by setting `emit.heartbeats.enabled` to `false`,
+        // the interval heartbeat emission will be negative and no `MirrorHeartbeatTask` will be created
+        if (config.emitHeartbeatsInterval().isNegative()) {
+            return Collections.emptyList();
+        }
         // just need a single task
         return Collections.singletonList(config.originalsStrings());
     }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnectorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class MirrorCheckpointConnectorTest {
+
+    @Test
+    public void testMirrorCheckpointConnectorDisabled() {
+        // disable the checkpoint emission
+        MirrorConnectorConfig config = new MirrorConnectorConfig(
+            makeProps("emit.checkpoints.enabled", "false"));
+
+        List<String> knownConsumerGroups = new ArrayList<>();
+        knownConsumerGroups.add("consumer-group-1");
+        // MirrorCheckpointConnector as minimum to run taskConfig()
+        MirrorCheckpointConnector connector = new MirrorCheckpointConnector(knownConsumerGroups,
+                                                                            config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect no task will be created
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void testNoConsumerGroup() {
+        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
+        MirrorCheckpointConnector connector = new MirrorCheckpointConnector(new ArrayList<>(), config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect no task will be created
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void testReplicationDisabled() {
+        // disable the replication
+        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("enabled", "false"));
+
+        List<String> knownConsumerGroups = new ArrayList<>();
+        knownConsumerGroups.add("consumer-group-1");
+        // MirrorCheckpointConnector as minimum to run taskConfig()
+        MirrorCheckpointConnector connector = new MirrorCheckpointConnector(knownConsumerGroups, config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect no task will be created
+        assertEquals(0, output.size());
+    }
+
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -22,26 +22,14 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.HashSet;
 
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
 public class MirrorConnectorConfigTest {
-
-    private Map<String, String> makeProps(String... keyValues) {
-        Map<String, String> props = new HashMap<>();
-        props.put("name", "ConnectorName");
-        props.put("connector.class", "ConnectorClass");
-        props.put("source.cluster.alias", "source1");
-        props.put("target.cluster.alias", "target2");
-        for (int i = 0; i < keyValues.length; i += 2) {
-            props.put(keyValues[i], keyValues[i + 1]);
-        }
-        return props;
-    }
 
     @Test
     public void testTaskConfigTopicPartitions() {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorHeartBeatConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorHeartBeatConnectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
+import static org.junit.Assert.assertEquals;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class MirrorHeartBeatConnectorTest {
+
+    @Test
+    public void testMirrorHeartbeatConnectorDisabled() {
+        // disable the heartbeat emission
+        MirrorConnectorConfig config = new MirrorConnectorConfig(
+            makeProps("emit.heartbeats.enabled", "false"));
+
+        // MirrorHeartbeatConnector as minimum to run taskConfig()
+        MirrorHeartbeatConnector connector = new MirrorHeartbeatConnector(config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect no task will be created
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void testReplicationDisabled() {
+        // disable the replication
+        MirrorConnectorConfig config = new MirrorConnectorConfig(
+            makeProps("enabled", "false"));
+
+        // MirrorHeartbeatConnector as minimum to run taskConfig()
+        MirrorHeartbeatConnector connector = new MirrorHeartbeatConnector(config);
+        List<Map<String, String>> output = connector.taskConfigs(1);
+        // expect one task will be created, even the replication is disabled
+        assertEquals(1, output.size());
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.Test;
 
 import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.TASK_TOPIC_PARTITIONS;
+import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -155,12 +156,7 @@ public class MirrorSourceConnectorTest {
         knownSourceTopicPartitions.add(new TopicPartition("t2", 1));
 
         // MirrorConnectorConfig example for test
-        Map<String, String> props = new HashMap<>();
-        props.put("name", "ConnectorName");
-        props.put("connector.class", "ConnectorClass");
-        props.put("source.cluster.alias", "source1");
-        props.put("target.cluster.alias", "target2");
-        MirrorConnectorConfig config = new MirrorConnectorConfig(props);
+        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
 
         // MirrorSourceConnector as minimum to run taskConfig()
         MirrorSourceConnector connector = new MirrorSourceConnector(knownSourceTopicPartitions, config);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/TestUtils.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/TestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestUtils {
+
+    static Map<String, String> makeProps(String... keyValues) {
+        Map<String, String> props = new HashMap<>();
+        props.put("name", "ConnectorName");
+        props.put("connector.class", "ConnectorClass");
+        props.put("source.cluster.alias", "source1");
+        props.put("target.cluster.alias", "target2");
+        for (int i = 0; i < keyValues.length; i += 2) {
+            props.put(keyValues[i], keyValues[i + 1]);
+        }
+        return props;
+    }
+}


### PR DESCRIPTION
`emit.heartbeats.enabled` and `emit.checkpoints.enabled` are supposed to
be the knobs to control if the heartbeat message or checkpoint message
will be sent or not to the topics respectively. In our experiments,
setting them to false will not suspend the activity in their SourceTasks,
e.g. MirrorHeartbeatTask, MirrorCheckpointTask.

The observations are, when setting those knobs to false, huge volume of
`SourceRecord` are being sent without interval, causing significantly high
CPU usage of MirrorMaker 2 instance, GC time and congesting the single partition of
the heartbeat topic and checkpoint topic.

<img width="522" alt="Screen Shot 2020-01-02 at 2 55 38 PM" src="https://user-images.githubusercontent.com/32080381/71699003-7a52f480-2d72-11ea-9cb8-dc339ed9561a.png">

<img width="793" alt="Screen Shot 2020-01-02 at 3 18 23 PM" src="https://user-images.githubusercontent.com/32080381/71699215-59d76a00-2d73-11ea-8cf1-328babe5cb12.png">


The proposed fix in the following PR is to (1) explicitly check if `interval`
is set to negative (e.g. -1), when the `emit.heartbeats.enabled` or
`emit.checkpoints.enabled` is off. (2) if `interval` is indeed set to negative,
put the thread in sleep mode for a while (e.g. 5 seconds) and return null, in order
to prevent it from (1) hogging the cpu, (2) sending heartbeat or checkpoint messages
to Kafka topics

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
