### PR TITLE
KAFKA-9327: GroupMetadata metrics are not documented

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -964,6 +964,21 @@
         <td>See above</td>
       </tr>
       <tr>
+        <td>Consumer Group Offset Count</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumOffsets</td>
+        <td>Total number of committed offsets for Consumer Groups</td>
+      </tr>
+      <tr>
+        <td>Consumer Group Count</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumGroups</td>
+        <td>Total number of Consumer Groups</td>
+      </tr>
+      <tr>
+        <td>Consumer Group Count, per State</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumGroups[PreparingRebalance,CompletingRebalance,Empty,Stable,Dead]</td>
+        <td>The number of Consumer Groups in each state: PreparingRebalance, CompletingRebalance, Empty, Stable, Dead</td>
+      </tr>
+      <tr>
         <td>Max lag in messages btw follower and leader replicas</td>
         <td>kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica</td>
         <td>lag should be proportional to the maximum batch size of a produce request.</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -964,21 +964,6 @@
         <td>See above</td>
       </tr>
       <tr>
-        <td>Consumer Group Offset Count</td>
-        <td>kafka.server:type=GroupMetadataManager,name=NumOffsets</td>
-        <td>Total number of committed offsets for Consumer Groups</td>
-      </tr>
-      <tr>
-        <td>Consumer Group Count</td>
-        <td>kafka.server:type=GroupMetadataManager,name=NumGroups</td>
-        <td>Total number of Consumer Groups</td>
-      </tr>
-      <tr>
-        <td>Consumer Group Count, per State</td>
-        <td>kafka.server:type=GroupMetadataManager,name=NumGroups[PreparingRebalance,CompletingRebalance,Empty,Stable,Dead]</td>
-        <td>The number of Consumer Groups in each state: PreparingRebalance, CompletingRebalance, Empty, Stable, Dead</td>
-      </tr>
-      <tr>
         <td>Max lag in messages btw follower and leader replicas</td>
         <td>kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica</td>
         <td>lag should be proportional to the maximum batch size of a produce request.</td>
@@ -1103,6 +1088,21 @@
         <td>Avg time to load transaction metadata</td>
         <td>kafka.server:type=transaction-coordinator-metrics,name=partition-load-time-avg</td>
         <td>average time, in milliseconds, it took to load transaction metadata from the consumer offset partitions loaded in the last 30 seconds</td>
+      </tr>
+      <tr>
+        <td>Consumer Group Offset Count</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumOffsets</td>
+        <td>Total number of committed offsets for Consumer Groups</td>
+      </tr>
+      <tr>
+        <td>Consumer Group Count</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumGroups</td>
+        <td>Total number of Consumer Groups</td>
+      </tr>
+      <tr>
+        <td>Consumer Group Count, per State</td>
+        <td>kafka.server:type=GroupMetadataManager,name=NumGroups[PreparingRebalance,CompletingRebalance,Empty,Stable,Dead]</td>
+        <td>The number of Consumer Groups in each state: PreparingRebalance, CompletingRebalance, Empty, Stable, Dead</td>
       </tr>
   </tbody></table>
 


### PR DESCRIPTION
This commit adds documentation on following `GroupMetadata` gauges:

- `NumOffsets`
- `NumGroups`
- `NumGroupsPreparingRebalance`
- `NumGroupsCompletingRebalance`
- `NumGroupsEmpty`
- `NumGroupsStable`
- `NumGroupsDead`

cc/ @gwenshap

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
