### PR TITLE
KAFKA-9363 Confirms successful topic creation for JAdminClient

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -188,6 +188,7 @@ object TopicCommand extends Logging {
         newTopic.configs(configsMap)
         val createResult = adminClient.createTopics(Collections.singleton(newTopic))
         createResult.all().get()
+        println(s"Created topic ${topic.name}.")
       } else {
         throw new IllegalArgumentException(s"Topic ${topic.name} already exists")
       }


### PR DESCRIPTION
When admin client script is used with --zookeeper, it's printing a confirmation message. The same doesn't occur when using JAdminClient. Since KIP 500 is going to replace ZK in the future, it would be nice to have this confirmation message retained.

No unit testing is requires as this message is simply a confirmation on the console upon a successful return from the AdminClient API call.