### PR TITLE
KAFKA-9362: Missing GC logs when running Kafka with Java 11 with OpenJ9 VM

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -292,8 +292,8 @@ if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   # 10.0.1 -> java version "10.0.1" 2018-04-17
   # We need to match to the end of the line to prevent sed from printing the characters that do not match
   JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-  JAVA_VM_ISJ9=$($JAVA -version 2>&1|grep J9)
-  if [[ "$JAVA_MAJOR_VERSION" -ge "9" && -z "$JAVA_VM_ISJ9" ]] ; then
+  JAVA_VM_IS_OPENJ9=$($JAVA -version 2>&1|grep OpenJ9)
+  if [[ "$JAVA_MAJOR_VERSION" -ge "9" && -z "$JAVA_VM_IS_OPENJ9" ]] ; then
     KAFKA_GC_LOG_OPTS="-Xlog:gc*:file=$LOG_DIR/$GC_LOG_FILE_NAME:time,tags:filecount=10,filesize=102400"
   else
     KAFKA_GC_LOG_OPTS="-Xloggc:$LOG_DIR/$GC_LOG_FILE_NAME -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -292,7 +292,8 @@ if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   # 10.0.1 -> java version "10.0.1" 2018-04-17
   # We need to match to the end of the line to prevent sed from printing the characters that do not match
   JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-  if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
+  JAVA_VM_ISJ9=$($JAVA -version 2>&1|grep J9)
+  if [[ "$JAVA_MAJOR_VERSION" -ge "9" && -z "$JAVA_VM_ISJ9" ]] ; then
     KAFKA_GC_LOG_OPTS="-Xlog:gc*:file=$LOG_DIR/$GC_LOG_FILE_NAME:time,tags:filecount=10,filesize=102400"
   else
     KAFKA_GC_LOG_OPTS="-Xloggc:$LOG_DIR/$GC_LOG_FILE_NAME -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"


### PR DESCRIPTION
Modified `bin/kafka-run-class.sh` to use Java 8-like way of enabling GC logs when using a Java version based on OpenJ9 JVM, because this JVM does not support JEP 158 new options for GC logging.

To test the change, I ran the Quickstart with various types of Java:
* ORACLE Java 8
* AdoptOpenJDK8 with HotSpot
* AdoptOpenJDK11 with HotSpot
* AdoptOpenJDK8 with OpenJ9
* AdoptOpenJDK11 with OpenJ9

Without this PR, running Quickstart with AdoptOpenJDK11 with OpenJ9 led to `JVMJ9VM085W`  errors in Zookeeper and in Kafka server output, and no GC logs were generated. With this PR, there are no more OpenJ9 errors and GC logs are produced as expected.

Also ran the graddle tests just for non-reg.
