### PR TITLE
KAFKA-9383: Expose consumer group metadata

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -244,6 +244,11 @@ public interface Consumer<K, V> extends Closeable {
     Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout);
 
     /**
+     * @see KafkaConsumer#groupMetadata()
+     */
+    ConsumerGroupMetadata groupMetadata();
+
+    /**
      * @see KafkaConsumer#close()
      */
     void close();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -23,24 +23,16 @@ import java.util.Optional;
  * Note: Any change to this class is considered public and requires a KIP.
  */
 public class ConsumerGroupMetadata {
-    private String groupId;
-    private int generationId;
-    private String memberId;
-    Optional<String> groupInstanceId;
+    final private String groupId;
+    final private int generationId;
+    final private String memberId;
+    final Optional<String> groupInstanceId;
 
     public ConsumerGroupMetadata(String groupId, int generationId, String memberId, Optional<String> groupInstanceId) {
         this.groupId = groupId;
         this.generationId = generationId;
         this.memberId = memberId;
         this.groupInstanceId = groupInstanceId;
-    }
-
-    public ConsumerGroupMetadata(ConsumerGroupMetadata other) {
-        String otherGroupInstanceId = other.groupInstanceId.orElse(null);
-        this.groupId = other.groupId;
-        this.generationId = other.generationId;
-        this.memberId = other.memberId;
-        this.groupInstanceId =  Optional.ofNullable(otherGroupInstanceId);
     }
 
     public String groupId() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -18,6 +18,10 @@ package org.apache.kafka.clients.consumer;
 
 import java.util.Optional;
 
+/**
+ * A metadata struct containing the consumer group information.
+ * Note: Any change to this class is considered public and requires a KIP.
+ */
 public class ConsumerGroupMetadata {
     private String groupId;
     private int generationId;
@@ -29,6 +33,14 @@ public class ConsumerGroupMetadata {
         this.generationId = generationId;
         this.memberId = memberId;
         this.groupInstanceId = groupInstanceId;
+    }
+
+    public ConsumerGroupMetadata(ConsumerGroupMetadata other) {
+        String otherGroupInstanceId = other.groupInstanceId.orElse(null);
+        this.groupId = other.groupId;
+        this.generationId = other.generationId;
+        this.memberId = other.memberId;
+        this.groupInstanceId =  Optional.ofNullable(otherGroupInstanceId);
     }
 
     public String groupId() {
@@ -46,5 +58,4 @@ public class ConsumerGroupMetadata {
     public Optional<String> groupInstanceId() {
         return groupInstanceId;
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2200,6 +2200,16 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
+     * Return the current group metadata associated with this consumer.
+     *
+     * @return consumer group metadata
+     */
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return coordinator.groupMetadata();
+    }
+
+    /**
      * Close the consumer, waiting for up to the default timeout of 30 seconds for any needed cleanup.
      * If auto-commit is enabled, this will commit the current offsets if possible within the default
      * timeout. See {@link #close(Duration)} for details. Note that {@link #wakeup()}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -558,6 +558,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return null;
+    }
+
+    @Override
     public void close(Duration timeout) {
         close();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -52,6 +52,8 @@ import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.JoinGroupResponse;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.OffsetCommitResponse;
 import org.apache.kafka.common.requests.OffsetFetchRequest;
@@ -104,6 +106,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     private MetadataSnapshot assignmentSnapshot;
     private Timer nextAutoCommitTimer;
     private AtomicBoolean asyncCommitFenced;
+    private ConsumerGroupMetadata groupMetadata;
 
     // hold onto request&future for committed offset requests to enable async calls.
     private PendingCommittedOffsetRequest pendingCommittedOffsetRequest = null;
@@ -163,6 +166,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         this.interceptors = interceptors;
         this.pendingAsyncCommits = new AtomicInteger();
         this.asyncCommitFenced = new AtomicBoolean(false);
+        this.groupMetadata = new ConsumerGroupMetadata(rebalanceConfig.groupId,
+            JoinGroupResponse.UNKNOWN_GENERATION_ID, JoinGroupRequest.UNKNOWN_MEMBER_ID, rebalanceConfig.groupInstanceId);
 
         if (autoCommitEnabled)
             this.nextAutoCommitTimer = time.timer(autoCommitIntervalMs);
@@ -387,8 +392,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         maybeUpdateJoinedSubscription(assignedPartitions);
 
         // give the assignor a chance to update internal state based on the received assignment
-        ConsumerGroupMetadata metadata = new ConsumerGroupMetadata(rebalanceConfig.groupId, generation, memberId, rebalanceConfig.groupInstanceId);
-        assignor.onAssignment(assignment, metadata);
+        groupMetadata = new ConsumerGroupMetadata(rebalanceConfig.groupId, generation, memberId, rebalanceConfig.groupInstanceId);
+        assignor.onAssignment(assignment, groupMetadata);
 
         // reschedule the auto commit starting from now
         if (autoCommitEnabled)
@@ -813,6 +818,15 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             }
         } while (timer.notExpired());
         return null;
+    }
+
+    /**
+     * Return the consumer group metadata.
+     *
+     * @return the current consumer group metadata
+     */
+    public ConsumerGroupMetadata groupMetadata() {
+        return new ConsumerGroupMetadata(groupMetadata);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -826,7 +826,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
      * @return the current consumer group metadata
      */
     public ConsumerGroupMetadata groupMetadata() {
-        return new ConsumerGroupMetadata(groupMetadata);
+        return groupMetadata;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -41,25 +41,4 @@ public class ConsumerGroupMetadataTest {
         assertTrue(groupMetadata.groupInstanceId().isPresent());
         assertEquals(groupInstanceId, groupMetadata.groupInstanceId().get());
     }
-
-    @Test
-    public void testCopyConstructor() {
-        String groupId = "group";
-        String memberId = "member";
-        int generationId = 2;
-        String groupInstanceId = "instance";
-
-        ConsumerGroupMetadata originalGroupMetadata = new ConsumerGroupMetadata(groupId,
-            generationId, memberId, Optional.of(groupInstanceId));
-
-        ConsumerGroupMetadata otherGroupMetadata = new ConsumerGroupMetadata(originalGroupMetadata);
-
-        assertTrue(otherGroupMetadata.groupInstanceId().isPresent());
-        assertEquals(groupInstanceId, otherGroupMetadata.groupInstanceId().get());
-
-        originalGroupMetadata.groupInstanceId = Optional.empty();
-
-        assertTrue(otherGroupMetadata.groupInstanceId().isPresent());
-        assertEquals(groupInstanceId, otherGroupMetadata.groupInstanceId().get());
-    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -52,7 +52,6 @@ public class ConsumerGroupMetadataTest {
         ConsumerGroupMetadata originalGroupMetadata = new ConsumerGroupMetadata(groupId,
             generationId, memberId, Optional.of(groupInstanceId));
 
-
         ConsumerGroupMetadata otherGroupMetadata = new ConsumerGroupMetadata(originalGroupMetadata);
 
         assertTrue(otherGroupMetadata.groupInstanceId().isPresent());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConsumerGroupMetadataTest {
+
+    @Test
+    public void testAssignmentConstructor() {
+        String groupId = "group";
+        String memberId = "member";
+        int generationId = 2;
+        String groupInstanceId = "instance";
+
+        ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId,
+            generationId, memberId, Optional.of(groupInstanceId));
+
+        assertEquals(groupId, groupMetadata.groupId());
+        assertEquals(generationId, groupMetadata.generationId());
+        assertEquals(memberId, groupMetadata.memberId());
+        assertTrue(groupMetadata.groupInstanceId().isPresent());
+        assertEquals(groupInstanceId, groupMetadata.groupInstanceId().get());
+    }
+
+    @Test
+    public void testCopyConstructor() {
+        String groupId = "group";
+        String memberId = "member";
+        int generationId = 2;
+        String groupInstanceId = "instance";
+
+        ConsumerGroupMetadata originalGroupMetadata = new ConsumerGroupMetadata(groupId,
+            generationId, memberId, Optional.of(groupInstanceId));
+
+
+        ConsumerGroupMetadata otherGroupMetadata = new ConsumerGroupMetadata(originalGroupMetadata);
+
+        assertTrue(otherGroupMetadata.groupInstanceId().isPresent());
+        assertEquals(groupInstanceId, otherGroupMetadata.groupInstanceId().get());
+
+        originalGroupMetadata.groupInstanceId = Optional.empty();
+
+        assertTrue(otherGroupMetadata.groupInstanceId().isPresent());
+        assertEquals(groupInstanceId, otherGroupMetadata.groupInstanceId().get());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class MockConsumerTest {
     
@@ -86,13 +87,14 @@ public class MockConsumerTest {
         assertEquals(2L, consumer.position(tp));
         consumer.commitSync();
         assertEquals(2L, consumer.committed(Collections.singleton(tp)).get(tp).offset());
+        assertNull(consumer.groupMetadata());
     }
 
     @Test
     public void testConsumerRecordsIsEmptyWhenReturningNoRecords() {
         TopicPartition partition = new TopicPartition("test", 0);
         consumer.assign(Collections.singleton(partition));
-        consumer.addRecord(new ConsumerRecord<String, String>("test", 0, 0, null, null));
+        consumer.addRecord(new ConsumerRecord<>("test", 0, 0, null, null));
         consumer.updateEndOffsets(Collections.singletonMap(partition, 1L));
         consumer.seekToEnd(Collections.singleton(partition));
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1));


### PR DESCRIPTION
Expose consumer group metadata to empower transactional producer do offset commit with more credentials, such as generation.id, member.id and group.instance.id. The change happens essentially in ConsumerCoordinator where we maintain an internal reference of the group metadata and update it every time we are in a rejoin callback. The exposed struct is a deep-copy instead of the actual object living inside the ConsumerCoordinator to avoid impact from caller.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
