### PR TITLE
KAFKA-9379; Fix flaky test TopicCommandWithAdminClientTest.testCreateAlterTopicWithRackAware

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -91,11 +91,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
   }
 
   def waitForTopicCreated(topicName: String, timeout: Int = 10000): Unit = {
-    // Wait until metadata is propagated to all brokers so that adminClient.listTopics returns the topic from any broker
-    TestUtils.waitUntilTrue(() => servers.forall { server => server.metadataCache.contains(topicName) },
-      s"Topic not created and propagated within $timeout ms", timeout)
-    val topics = adminClient.listTopics(new ListTopicsOptions().listInternal(true)).names().get()
-    assertTrue(s"Topic $topicName not returned by adminClient", topics.contains(topicName))
+    TestUtils.waitUntilMetadataIsPropagated(servers, topicName, partition = 0, timeout)
   }
 
   @Before


### PR DESCRIPTION
Test creates a topic, waits for `adminClient.listTopics` to return the topic and then performs `alterTopic()`, which also uses `adminClient.listTopics` to verify that the topic exists. This may fail if the topic hadn't yet been propagated to the broker to which the second `listTopics` is sent. This PR updates the test to wait for topic to be in the metadata cache of all brokers before calling `alterTopic()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
