### PR TITLE
KAFKA-7737; Use single path in producer for initializing the producerId

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -312,7 +312,10 @@ public class Sender implements Runnable {
                     return;
                 }
 
-                transactionManager.resetProducerIdIfNeeded();
+                // Check whether we need a new producerId. If so, we will enqueue an InitProducerId
+                // request which will be sent below
+                transactionManager.resetIdempotentProducerIdIfNeeded();
+
                 if (maybeSendAndPollTransactionalRequest()) {
                     return;
                 }
@@ -374,7 +377,7 @@ public class Sender implements Runnable {
         expiredBatches.addAll(expiredInflightBatches);
 
         // Reset the producer id if an expired batch has previously been sent to the broker. Also update the metrics
-        // for expired batches. see the documentation of @TransactionState.resetProducerId to understand why
+        // for expired batches. see the documentation of @TransactionState.resetIdempotentProducerId to understand why
         // we need to reset the producer id here.
         if (!expiredBatches.isEmpty())
             log.trace("Expired {} batches in accumulator", expiredBatches.size());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
-import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
@@ -37,8 +36,6 @@ import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
@@ -48,8 +45,6 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
-import org.apache.kafka.common.requests.InitProducerIdRequest;
-import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.ProduceRequest;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -300,26 +295,25 @@ public class Sender implements Runnable {
     void runOnce() {
         if (transactionManager != null) {
             try {
-                transactionManager.resetProducerIdIfNeeded();
-
-                if (!transactionManager.isTransactional()) {
-                    // this is an idempotent producer, so make sure we have a producer id
-                    maybeWaitForProducerId();
-                } else if (transactionManager.hasUnresolvedSequences() && !transactionManager.hasFatalError()) {
+                if (transactionManager.isTransactional()
+                        && transactionManager.hasUnresolvedSequences()
+                        && !transactionManager.hasFatalError()) {
                     transactionManager.transitionToFatalError(
-                        new KafkaException("The client hasn't received acknowledgment for " +
-                            "some previously sent messages and can no longer retry them. It isn't safe to continue."));
-                } else if (maybeSendAndPollTransactionalRequest()) {
-                    return;
+                            new KafkaException("The client hasn't received acknowledgment for " +
+                                    "some previously sent messages and can no longer retry them. It isn't safe to continue."));
                 }
 
-                // do not continue sending if the transaction manager is in a failed state or if there
-                // is no producer id (for the idempotent case).
-                if (transactionManager.hasFatalError() || !transactionManager.hasProducerId()) {
+                // do not continue sending if the transaction manager is in a failed state
+                if (transactionManager.hasFatalError()) {
                     RuntimeException lastError = transactionManager.lastError();
                     if (lastError != null)
                         maybeAbortBatches(lastError);
                     client.poll(retryBackoffMs, time.milliseconds());
+                    return;
+                }
+
+                transactionManager.resetProducerIdIfNeeded();
+                if (maybeSendAndPollTransactionalRequest()) {
                     return;
                 }
             } catch (AuthenticationException e) {
@@ -419,7 +413,7 @@ public class Sender implements Runnable {
      * Returns true if a transactional request is sent or polled, or if a FindCoordinator request is enqueued
      */
     private boolean maybeSendAndPollTransactionalRequest() {
-        if (transactionManager.hasInFlightTransactionalRequest()) {
+        if (transactionManager.hasInFlightRequest()) {
             // as long as there are outstanding transactional requests, we simply wait for them to return
             client.poll(retryBackoffMs, time.milliseconds());
             return true;
@@ -443,7 +437,7 @@ public class Sender implements Runnable {
             accumulator.beginFlush();
         }
 
-        TransactionManager.TxnRequestHandler nextRequestHandler = transactionManager.nextRequestHandler(accumulator.hasIncomplete());
+        TransactionManager.TxnRequestHandler nextRequestHandler = transactionManager.nextRequest(accumulator.hasIncomplete());
         if (nextRequestHandler == null)
             return false;
 
@@ -452,12 +446,13 @@ public class Sender implements Runnable {
         try {
             targetNode = awaitNodeReady(nextRequestHandler.coordinatorType());
             if (targetNode == null) {
-                lookupCoordinatorAndRetry(nextRequestHandler);
+                maybeFindCoordinatorAndRetry(nextRequestHandler);
                 return true;
             }
 
             if (nextRequestHandler.isRetry())
                 time.sleep(nextRequestHandler.retryBackoffMs());
+
             long currentTimeMs = time.milliseconds();
             ClientRequest clientRequest = client.newClientRequest(
                 targetNode.idString(), requestBuilder, currentTimeMs, true, requestTimeoutMs, nextRequestHandler);
@@ -470,12 +465,12 @@ public class Sender implements Runnable {
             log.debug("Disconnect from {} while trying to send request {}. Going " +
                     "to back off and retry.", targetNode, requestBuilder, e);
             // We break here so that we pick up the FindCoordinator request immediately.
-            lookupCoordinatorAndRetry(nextRequestHandler);
+            maybeFindCoordinatorAndRetry(nextRequestHandler);
             return true;
         }
     }
 
-    private void lookupCoordinatorAndRetry(TransactionManager.TxnRequestHandler nextRequestHandler) {
+    private void maybeFindCoordinatorAndRetry(TransactionManager.TxnRequestHandler nextRequestHandler) {
         if (nextRequestHandler.needsCoordinator()) {
             transactionManager.lookupCoordinator(nextRequestHandler);
         } else {
@@ -517,16 +512,6 @@ public class Sender implements Runnable {
         return running;
     }
 
-    private ClientResponse sendAndAwaitInitProducerIdRequest(Node node) throws IOException {
-        String nodeId = node.idString();
-        InitProducerIdRequestData requestData = new InitProducerIdRequestData()
-                .setTransactionalId(null)
-                .setTransactionTimeoutMs(Integer.MAX_VALUE);
-        InitProducerIdRequest.Builder builder = new InitProducerIdRequest.Builder(requestData);
-        ClientRequest request = client.newClientRequest(nodeId, builder, time.milliseconds(), true, requestTimeoutMs, null);
-        return NetworkClientUtils.sendAndReceive(client, request, time);
-    }
-
     private Node awaitNodeReady(FindCoordinatorRequest.CoordinatorType coordinatorType) throws IOException {
         Node node = coordinatorType != null ?
                 transactionManager.coordinator(coordinatorType) :
@@ -536,41 +521,6 @@ public class Sender implements Runnable {
             return node;
         }
         return null;
-    }
-
-    private void maybeWaitForProducerId() {
-        while (!forceClose && !transactionManager.hasProducerId() && !transactionManager.hasError()) {
-            Node node = null;
-            try {
-                node = awaitNodeReady(null);
-                if (node != null) {
-                    ClientResponse response = sendAndAwaitInitProducerIdRequest(node);
-                    InitProducerIdResponse initProducerIdResponse = (InitProducerIdResponse) response.responseBody();
-                    Errors error = initProducerIdResponse.error();
-                    if (error == Errors.NONE) {
-                        ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(
-                                initProducerIdResponse.data.producerId(), initProducerIdResponse.data.producerEpoch());
-                        transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
-                        return;
-                    } else if (error.exception() instanceof RetriableException) {
-                        log.debug("Retriable error from InitProducerId response", error.message());
-                    } else {
-                        transactionManager.transitionToFatalError(error.exception());
-                        break;
-                    }
-                } else {
-                    log.debug("Could not find an available broker to send InitProducerIdRequest to. Will back off and retry.");
-                }
-            } catch (UnsupportedVersionException e) {
-                transactionManager.transitionToFatalError(e);
-                break;
-            } catch (IOException e) {
-                log.debug("Broker {} disconnected while awaiting InitProducerId response", node, e);
-            }
-            log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);
-            time.sleep(retryBackoffMs);
-            metadata.requestUpdate();
-        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -278,6 +278,10 @@ public class TransactionManager {
 
     public synchronized TransactionalRequestResult initializeTransactions() {
         return handleCachedTransactionRequestResult(() -> {
+            if (currentState != State.UNINITIALIZED)
+                throw new KafkaException("The `initializeTransactions` API should only be called once " +
+                        "after the producer is instantiated");
+
             transitionTo(State.INITIALIZING);
             setProducerIdAndEpoch(ProducerIdAndEpoch.NONE);
             InitProducerIdRequestData requestData = new InitProducerIdRequestData()

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
@@ -39,8 +39,9 @@ public final class TransactionalRequestResult {
         this.operation = operation;
     }
 
-    public void setError(RuntimeException error) {
+    public void fail(RuntimeException error) {
         this.error = error;
+        this.latch.countDown();
     }
 
     public void done() {

--- a/clients/src/main/java/org/apache/kafka/common/utils/ProducerIdAndEpoch.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ProducerIdAndEpoch.java
@@ -37,4 +37,23 @@ public class ProducerIdAndEpoch {
     public String toString() {
         return "(producerId=" + producerId + ", epoch=" + epoch + ")";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProducerIdAndEpoch that = (ProducerIdAndEpoch) o;
+
+        if (producerId != that.producerId) return false;
+        return epoch == that.epoch;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (producerId ^ (producerId >>> 32));
+        result = 31 * result + (int) epoch;
+        return result;
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1166,8 +1166,9 @@ public class SenderTest {
     public void testResetOfProducerStateShouldAllowQueuedBatchesToDrain() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1209,8 +1210,9 @@ public class SenderTest {
     public void testCloseWithProducerIdReset() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         Metrics m = new Metrics();
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
@@ -1246,8 +1248,9 @@ public class SenderTest {
     @Test
     public void testForceCloseWithProducerIdReset() throws Exception {
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(1L, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(1L, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         Metrics m = new Metrics();
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
@@ -1279,8 +1282,9 @@ public class SenderTest {
     public void testBatchesDrainedWithOldProducerIdShouldFailWithOutOfOrderSequenceOnSubsequentRetry() throws Exception {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1761,8 +1765,9 @@ public class SenderTest {
     public void testSequenceNumberIncrement() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1804,8 +1809,9 @@ public class SenderTest {
     public void testAbortRetryWhenProducerIdChanges() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1824,8 +1830,8 @@ public class SenderTest {
         assertEquals(0, client.inFlightRequestCount());
         assertFalse("Client ready status should be false", client.isReady(node, time.milliseconds()));
 
-        transactionManager.resetProducerId();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId + 1, (short) 0));
+        transactionManager.resetIdempotentProducerId();
+        prepareAndReceiveInitProducerId(producerId + 1, Errors.NONE);
         sender.runOnce(); // receive error
         sender.runOnce(); // reconnect
         sender.runOnce(); // nothing to do, since the pid has changed. We should check the metrics for errors.
@@ -1842,8 +1848,9 @@ public class SenderTest {
     public void testResetWhenOutOfOrderSequenceReceived() throws InterruptedException {
         final long producerId = 343434L;
         TransactionManager transactionManager = new TransactionManager();
-        transactionManager.setProducerIdAndEpoch(new ProducerIdAndEpoch(producerId, (short) 0));
         setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
 
         int maxRetries = 10;
         Metrics m = new Metrics();
@@ -1872,7 +1879,9 @@ public class SenderTest {
         TopicPartition tp = new TopicPartition("testSplitBatchAndSend", 1);
         TransactionManager txnManager = new TransactionManager();
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
-        txnManager.setProducerIdAndEpoch(producerIdAndEpoch);
+        setupWithTransactionState(txnManager);
+        prepareAndReceiveInitProducerId(123456L, Errors.NONE);
+        assertTrue(txnManager.hasProducerId());
         testSplitBatchAndSend(txnManager, producerIdAndEpoch, tp);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -861,6 +861,15 @@ public class TransactionManagerTest {
     }
 
     @Test
+    public void testInitializeTransactionsTwiceRaisesError() {
+        final long producerId = 13131L;
+        final short epoch = 1;
+        doInitTransactions(producerId, epoch);
+        assertTrue(transactionManager.hasProducerId());
+        assertThrows(KafkaException.class, () -> transactionManager.initializeTransactions());
+    }
+
+    @Test
     public void testUnsupportedFindCoordinator() {
         transactionManager.initializeTransactions();
         client.prepareUnsupportedVersionResponse(body -> {


### PR DESCRIPTION
Previously the idempotent producer and transactional producer use separate logic when initializing the producerId. This patch consolidates the two paths. We also do some cleanup in `TransactionManagerTest` to eliminate brittle expectations on `Sender`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
