### PR TITLE
KAFKA-9395: Only acquire write lock in maybeShrinkIsr() if necessary.

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -813,7 +813,8 @@ class Partition(val topicPartition: TopicPartition,
    */
   private def tryCompleteDelayedRequests(): Unit = delayedOperations.checkAndCompleteAll()
 
-  private def shouldShrinkIsr(): Boolean = {
+  // Visible for testing.
+  private[cluster] def shouldShrinkIsr(): Boolean = {
     leaderLogIfLocal match {
       case Some(leaderLog) =>
         inReadLock(leaderIsrUpdateLock) {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -814,14 +814,11 @@ class Partition(val topicPartition: TopicPartition,
   private def tryCompleteDelayedRequests(): Unit = delayedOperations.checkAndCompleteAll()
 
   // Visible for testing.
-  private[cluster] def shouldShrinkIsr(): Boolean = {
-    leaderLogIfLocal match {
-      case Some(leaderLog) =>
-        inReadLock(leaderIsrUpdateLock) {
-          getOutOfSyncReplicas(replicaLagTimeMaxMs).nonEmpty
-        }
-      case None => false
-    }
+  private[cluster] def shouldShrinkIsr: Boolean = {
+    if (isLeader)
+      getOutOfSyncReplicas(replicaLagTimeMaxMs).nonEmpty
+    else
+      false
   }
 
   def maybeShrinkIsr(): Unit = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1244,7 +1244,7 @@ class PartitionTest extends AbstractPartitionTest {
     assertEquals(Log.UnknownOffset, remoteReplica.logStartOffset)
 
     // On initialization, the replica is considered caught up and should not be removed
-    assertFalse(partition.shouldShrinkIsr())
+    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
 
@@ -1257,7 +1257,7 @@ class PartitionTest extends AbstractPartitionTest {
       zkVersion = 1)
     when(stateStore.shrinkIsr(controllerEpoch, updatedLeaderAndIsr)).thenReturn(Some(2))
 
-    assertTrue(partition.shouldShrinkIsr())
+    assertTrue(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId), partition.inSyncReplicaIds)
     assertEquals(10L, partition.localLogOrException.highWatermark)
@@ -1333,7 +1333,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     // The ISR should not be shrunk because the follower has caught up with the leader at the
     // time of the first fetch.
-    assertFalse(partition.shouldShrinkIsr())
+    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
   }
@@ -1393,7 +1393,7 @@ class PartitionTest extends AbstractPartitionTest {
     time.sleep(10001)
 
     // The ISR should not be shrunk because the follower is caught up to the leader's log end
-    assertFalse(partition.shouldShrinkIsr())
+    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
   }
@@ -1445,7 +1445,7 @@ class PartitionTest extends AbstractPartitionTest {
       zkVersion = 1)
     when(stateStore.shrinkIsr(controllerEpoch, updatedLeaderAndIsr)).thenReturn(None)
 
-    assertFalse(partition.shouldShrinkIsr())
+    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
     assertEquals(0L, partition.localLogOrException.highWatermark)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1244,7 +1244,6 @@ class PartitionTest extends AbstractPartitionTest {
     assertEquals(Log.UnknownOffset, remoteReplica.logStartOffset)
 
     // On initialization, the replica is considered caught up and should not be removed
-    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
 
@@ -1257,7 +1256,6 @@ class PartitionTest extends AbstractPartitionTest {
       zkVersion = 1)
     when(stateStore.shrinkIsr(controllerEpoch, updatedLeaderAndIsr)).thenReturn(Some(2))
 
-    assertTrue(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId), partition.inSyncReplicaIds)
     assertEquals(10L, partition.localLogOrException.highWatermark)
@@ -1333,7 +1331,6 @@ class PartitionTest extends AbstractPartitionTest {
 
     // The ISR should not be shrunk because the follower has caught up with the leader at the
     // time of the first fetch.
-    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
   }
@@ -1393,7 +1390,6 @@ class PartitionTest extends AbstractPartitionTest {
     time.sleep(10001)
 
     // The ISR should not be shrunk because the follower is caught up to the leader's log end
-    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
   }
@@ -1445,7 +1441,6 @@ class PartitionTest extends AbstractPartitionTest {
       zkVersion = 1)
     when(stateStore.shrinkIsr(controllerEpoch, updatedLeaderAndIsr)).thenReturn(None)
 
-    assertFalse(partition.shouldShrinkIsr)
     partition.maybeShrinkIsr()
     assertEquals(Set(brokerId, remoteBrokerId), partition.inSyncReplicaIds)
     assertEquals(0L, partition.localLogOrException.highWatermark)


### PR DESCRIPTION

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
