### PR TITLE
KAFKA-8037: Added deserialization check on restoration of global state stores from source topics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.FixedOrderMap;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -52,6 +53,7 @@ import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.converterForStore;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
 
 /**
  * This class is responsible for the initialization, restoration, closing, flushing etc
@@ -74,6 +76,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
     private final Set<String> globalNonPersistentStoresTopics = new HashSet<>();
     private final OffsetCheckpoint checkpointFile;
     private final Map<TopicPartition, Long> checkpointFileCache;
+    private final Map<String, RecordDeserializer> deserializers = new HashMap<>();
+    private final LogContext logContext;
+    private final DeserializationExceptionHandler deserializationExceptionHandler;
 
     public GlobalStateManagerImpl(final LogContext logContext,
                                   final ProcessorTopology topology,
@@ -102,6 +107,8 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         retries = config.getInt(StreamsConfig.RETRIES_CONFIG);
         retryBackoffMs = config.getLong(StreamsConfig.RETRY_BACKOFF_MS_CONFIG);
         pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
+        this.deserializationExceptionHandler = config.defaultDeserializationExceptionHandler();
+        this.logContext = logContext;
     }
 
     @Override
@@ -137,6 +144,26 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
             globalStoreNames.add(stateStore.name());
             final String sourceTopic = storeNameToChangelog.get(stateStore.name());
             changelogTopics.add(sourceTopic);
+
+            final SourceNode source = topology.source(sourceTopic);
+            if (source != null && !ProcessorStateManager
+                .storeChangelogTopic(globalProcessorContext.applicationId(), stateStore.name()).equals(sourceTopic)) {
+                log.info("Found sourceNode {} for topic {}", source.toString(), sourceTopic);
+                deserializers.put(
+                    sourceTopic,
+                    new RecordDeserializer(
+                        source,
+                        deserializationExceptionHandler,
+                        logContext,
+                        droppedRecordsSensorOrSkippedRecordsSensor(
+                            Thread.currentThread().getName(),
+                            globalProcessorContext.taskId().toString(),
+                            globalProcessorContext.metrics()
+                        )
+                    )
+                );
+            }
+
             stateStore.init(globalProcessorContext, stateStore);
         }
 
@@ -314,12 +341,18 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
             stateRestoreListener.onRestoreStart(topicPartition, storeName, offset, highWatermark);
             long restoreCount = 0L;
 
+            final RecordDeserializer recordDeserializer = deserializers.get(topicPartition.topic());
+
             while (offset < highWatermark) {
                 try {
                     final ConsumerRecords<byte[], byte[]> records = globalConsumer.poll(pollTime);
                     final List<ConsumerRecord<byte[], byte[]>> restoreRecords = new ArrayList<>();
                     for (final ConsumerRecord<byte[], byte[]> record : records.records(topicPartition)) {
                         if (record.key() != null) {
+                            if (recordDeserializer != null && recordDeserializer.deserialize(globalProcessorContext, record) == null) {
+                                continue;
+                            }
+
                             restoreRecords.add(recordConverter.convert(record));
                         }
                     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplLogAndContinueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplLogAndContinueTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockSourceNode;
+import org.apache.kafka.test.NoOpReadOnlyStore;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class GlobalStateManagerImplLogAndContinueTest extends GlobalStateManagerImplTest {
+
+    @Before
+    public void before() {
+        final Map<String, String> storeToTopic = new HashMap<>();
+
+        storeToTopic.put(storeName1, t1.topic());
+        storeToTopic.put(storeName2, t2.topic());
+        storeToTopic.put(storeName3, t3.topic());
+        storeToTopic.put(storeName4, t4.topic());
+        storeToTopic.put(storeName5, t5.topic());
+        storeToTopic.put(storeName6, t6.topic());
+
+        store1 = new NoOpReadOnlyStore<>(storeName1, true);
+        store2 = new ConverterStore<>(storeName2, true);
+        store3 = new NoOpReadOnlyStore<>(storeName3);
+        store4 = new NoOpReadOnlyStore<>(storeName4);
+        store5 = new NoOpReadOnlyStore<>(storeName5, true);
+        store6 = new NoOpReadOnlyStore<>(storeName6, true);
+
+        final Deserializer<Long> longDeserializer = Serdes.Long().deserializer();
+        final MockSourceNode<Long, Long> source1 = new MockSourceNode<>(new String[]{t5.topic()}, longDeserializer,
+            longDeserializer);
+        final MockSourceNode<Long, Long> source2 = new MockSourceNode<>(new String[]{t6.topic()}, longDeserializer,
+            longDeserializer);
+
+        topology = withGlobalStores(mkMap(mkEntry(t5.topic(), source1), mkEntry(t6.topic(), source2)),
+            asList(store1, store2, store3, store4, store5, store6),
+            storeToTopic);
+
+        streamsConfig = new StreamsConfig(new Properties() {
+            {
+                put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
+                put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+                put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndContinueExceptionHandler.class);
+            }
+        });
+        stateDirectory = new StateDirectory(streamsConfig, time, true);
+        consumer = new MockConsumer<>(OffsetResetStrategy.NONE);
+        stateManager = new GlobalStateManagerImpl(
+                new LogContext("test"),
+                topology,
+                consumer,
+                stateDirectory,
+                stateRestoreListener,
+                streamsConfig);
+        processorContext = new InternalMockProcessorContext(stateDirectory.globalStateDir(), streamsConfig);
+        stateManager.setGlobalProcessorContext(processorContext);
+        checkpointFile = new File(stateManager.baseDir(), StateManagerUtil.CHECKPOINT_FILE_NAME);
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionWhenRestoringWithLogAndFailExceptionHandler() {
+        return;
+    }
+
+    @Test
+    public void shouldNotThrowStreamsExceptionWhenRestoringWithLogAndContinueExceptionHandler() {
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+        startOffsets.put(t5, 1L);
+        final HashMap<TopicPartition, Long> endOffsets = new HashMap<>();
+        endOffsets.put(t5, 3L);
+        consumer.updatePartitions(t5.topic(), Collections.singletonList(new PartitionInfo(t5.topic(), t5.partition(), null, null, null)));
+        consumer.assign(Collections.singletonList(t5));
+        consumer.updateEndOffsets(endOffsets);
+        consumer.updateBeginningOffsets(startOffsets);
+        final byte[] specialString = "specialKey".getBytes(StandardCharsets.UTF_8);
+        final byte[] longValue = longToBytes(1);
+
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 1, longValue, longValue));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 2, specialString, specialString));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 3, longValue, longValue));
+
+        stateManager.initialize();
+        stateManager.register(store5, stateRestoreCallback);
+
+        assertEquals(2, stateRestoreCallback.restored.size());
+
+    }
+
+    @Test
+    public void shouldProcessTombstoneRecords() {
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+        startOffsets.put(t5, 1L);
+        final HashMap<TopicPartition, Long> endOffsets = new HashMap<>();
+        endOffsets.put(t5, 3L);
+        consumer.updatePartitions(t5.topic(), Collections.singletonList(new PartitionInfo(t5.topic(), t5.partition(), null, null, null)));
+        consumer.assign(Collections.singletonList(t5));
+        consumer.updateEndOffsets(endOffsets);
+        consumer.updateBeginningOffsets(startOffsets);
+        final byte[] specialString = "specialKey".getBytes(StandardCharsets.UTF_8);
+        final byte[] longValue = longToBytes(1);
+
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 1, longValue, longValue));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 2, specialString, specialString));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 3, longValue, null));
+
+        stateManager.initialize();
+        stateManager.register(store5, stateRestoreCallback);
+
+        assertEquals(2, stateRestoreCallback.restored.size());
+        assertNull(store5.get(1L));
+
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
@@ -37,6 +39,7 @@ import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.TestUtils;
@@ -47,6 +50,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,6 +64,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
@@ -73,35 +80,41 @@ import static org.junit.Assert.fail;
 public class GlobalStateManagerImplTest {
 
 
-    private final MockTime time = new MockTime();
-    private final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
-    private final MockStateRestoreListener stateRestoreListener = new MockStateRestoreListener();
-    private final String storeName1 = "t1-store";
-    private final String storeName2 = "t2-store";
-    private final String storeName3 = "t3-store";
-    private final String storeName4 = "t4-store";
-    private final TopicPartition t1 = new TopicPartition("t1", 1);
-    private final TopicPartition t2 = new TopicPartition("t2", 1);
-    private final TopicPartition t3 = new TopicPartition("t3", 1);
-    private final TopicPartition t4 = new TopicPartition("t4", 1);
-    private GlobalStateManagerImpl stateManager;
-    private StateDirectory stateDirectory;
-    private StreamsConfig streamsConfig;
-    private NoOpReadOnlyStore<Object, Object> store1, store2, store3, store4;
-    private MockConsumer<byte[], byte[]> consumer;
-    private File checkpointFile;
-    private ProcessorTopology topology;
-    private InternalMockProcessorContext processorContext;
+    protected final MockTime time = new MockTime();
+    protected final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
+    protected final MockStateRestoreListener stateRestoreListener = new MockStateRestoreListener();
+    protected final String storeName1 = "t1-store";
+    protected final String storeName2 = "t2-store";
+    protected final String storeName3 = "t3-store";
+    protected final String storeName4 = "t4-store";
+    protected final String storeName5 = "t5-store";
+    protected final String storeName6 = "t6-store";
+    protected final TopicPartition t1 = new TopicPartition("t1", 1);
+    protected final TopicPartition t2 = new TopicPartition("t2", 1);
+    protected final TopicPartition t3 = new TopicPartition("t3", 1);
+    protected final TopicPartition t4 = new TopicPartition("t4", 1);
+    protected final TopicPartition t5 = new TopicPartition("t5", 1);
+    protected final TopicPartition t6 = new TopicPartition(ProcessorStateManager.storeChangelogTopic("appId", storeName6), 1);
+    protected GlobalStateManagerImpl stateManager;
+    protected StateDirectory stateDirectory;
+    protected StreamsConfig streamsConfig;
+    protected NoOpReadOnlyStore<Object, Object> store1, store2, store3, store4;
+    protected NoOpReadOnlyStore<Long, Long> store5, store6;
+    protected MockConsumer<byte[], byte[]> consumer;
+    protected File checkpointFile;
+    protected ProcessorTopology topology;
+    protected InternalMockProcessorContext processorContext;
 
-    static ProcessorTopology withGlobalStores(final List<StateStore> stateStores,
+    static ProcessorTopology withGlobalStores(final Map<String, SourceNode> sourcesByTopic,
+                                              final List<StateStore> stateStores,
                                               final Map<String, String> storeToChangelogTopic) {
         return new ProcessorTopology(Collections.emptyList(),
-                                     Collections.emptyMap(),
-                                     Collections.emptyMap(),
-                                     Collections.emptyList(),
-                                     stateStores,
-                                     storeToChangelogTopic,
-                                     Collections.emptySet());
+            sourcesByTopic,
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            stateStores,
+            storeToChangelogTopic,
+            Collections.emptySet());
     }
 
     @Before
@@ -112,13 +125,25 @@ public class GlobalStateManagerImplTest {
         storeToTopic.put(storeName2, t2.topic());
         storeToTopic.put(storeName3, t3.topic());
         storeToTopic.put(storeName4, t4.topic());
+        storeToTopic.put(storeName5, t5.topic());
+        storeToTopic.put(storeName6, t6.topic());
 
         store1 = new NoOpReadOnlyStore<>(storeName1, true);
         store2 = new ConverterStore<>(storeName2, true);
         store3 = new NoOpReadOnlyStore<>(storeName3);
         store4 = new NoOpReadOnlyStore<>(storeName4);
+        store5 = new NoOpReadOnlyStore<>(storeName5, true);
+        store6 = new NoOpReadOnlyStore<>(storeName6, true);
 
-        topology = withGlobalStores(asList(store1, store2, store3, store4), storeToTopic);
+        final Deserializer<Long> longDeserializer = Serdes.Long().deserializer();
+        final MockSourceNode<Long, Long> source1 = new MockSourceNode<>(new String[]{t5.topic()}, longDeserializer,
+            longDeserializer);
+        final MockSourceNode<Long, Long> source2 = new MockSourceNode<>(new String[]{t6.topic()}, longDeserializer,
+            longDeserializer);
+
+        topology = withGlobalStores(mkMap(mkEntry(t5.topic(), source1), mkEntry(t6.topic(), source2)),
+            asList(store1, store2, store3, store4, store5, store6),
+            storeToTopic);
 
         streamsConfig = new StreamsConfig(new Properties() {
             {
@@ -144,6 +169,64 @@ public class GlobalStateManagerImplTest {
     @After
     public void after() throws IOException {
         stateDirectory.unlockGlobalState();
+    }
+
+    public byte[] longToBytes(final long x) {
+        final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(x);
+        return buffer.array();
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionWhenRestoringWithLogAndFailExceptionHandler() {
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+        startOffsets.put(t5, 1L);
+        final HashMap<TopicPartition, Long> endOffsets = new HashMap<>();
+        endOffsets.put(t5, 3L);
+        consumer.updatePartitions(t5.topic(), Collections.singletonList(new PartitionInfo(t5.topic(), t5.partition(), null, null, null)));
+        consumer.assign(Collections.singletonList(t5));
+        consumer.updateEndOffsets(endOffsets);
+        consumer.updateBeginningOffsets(startOffsets);
+        final byte[] specialString = "specialKey".getBytes(StandardCharsets.UTF_8);
+        final byte[] longValue = longToBytes(1);
+
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 1, longValue, longValue));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 2, specialString, specialString));
+        consumer.addRecord(new ConsumerRecord<>(t5.topic(), t5.partition(), 3, longValue, longValue));
+
+        stateManager.initialize();
+
+        try {
+            stateManager.register(store5, stateRestoreCallback);
+            fail("Should not get here as LogAndFailExceptionHandler used");
+        } catch (final StreamsException e) {
+            //expected ok to ignore
+        }
+
+    }
+
+    @Test
+    public void shouldRestoreForChangelogTopics() {
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+        startOffsets.put(t6, 1L);
+        final HashMap<TopicPartition, Long> endOffsets = new HashMap<>();
+        endOffsets.put(t6, 3L);
+        consumer.updatePartitions(t6.topic(),
+            Collections.singletonList(new PartitionInfo(t6.topic(), t6.partition(), null, null, null)));
+        consumer.assign(Collections.singletonList(t6));
+        consumer.updateEndOffsets(endOffsets);
+        consumer.updateBeginningOffsets(startOffsets);
+        final byte[] specialString = "specialKey".getBytes(StandardCharsets.UTF_8);
+        final byte[] longValue = longToBytes(1);
+
+        consumer.addRecord(new ConsumerRecord<>(t6.topic(), t6.partition(), 1, longValue, longValue));
+        consumer.addRecord(new ConsumerRecord<>(t6.topic(), t6.partition(), 2, specialString, specialString));
+        consumer.addRecord(new ConsumerRecord<>(t6.topic(), t6.partition(), 3, longValue, longValue));
+
+        stateManager.initialize();
+        stateManager.register(store6, stateRestoreCallback);
+        assertEquals(3, stateRestoreCallback.restored.size());
+
     }
 
     @Test
@@ -218,7 +301,7 @@ public class GlobalStateManagerImplTest {
     @Test
     public void shouldReturnInitializedStoreNames() {
         final Set<String> storeNames = stateManager.initialize();
-        assertEquals(Utils.mkSet(storeName1, storeName2, storeName3, storeName4), storeNames);
+        assertEquals(Utils.mkSet(storeName1, storeName2, storeName3, storeName4, storeName5, storeName6), storeNames);
     }
 
     @Test
@@ -769,8 +852,8 @@ public class GlobalStateManagerImplTest {
         return expected;
     }
 
-    private static class TheStateRestoreCallback implements StateRestoreCallback {
-        private final List<KeyValue<byte[], byte[]>> restored = new ArrayList<>();
+    static class TheStateRestoreCallback implements StateRestoreCallback {
+        final List<KeyValue<byte[], byte[]>> restored = new ArrayList<>();
 
         @Override
         public void restore(final byte[] key, final byte[] value) {
@@ -778,7 +861,7 @@ public class GlobalStateManagerImplTest {
         }
     }
 
-    private class ConverterStore<K, V> extends NoOpReadOnlyStore<K, V> implements TimestampedBytesStore {
+    protected class ConverterStore<K, V> extends NoOpReadOnlyStore<K, V> implements TimestampedBytesStore {
         ConverterStore(final String name,
                        final boolean rocksdbStore) {
             super(name, rocksdbStore);


### PR DESCRIPTION
@vvcephei @guozhangwang First part for global state stores.
A check for normal changelog topics is included, in this case the check is not performed.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
