### PR TITLE
KAFKA-9403: Remove BaseConsumer from Mirrormake

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -17,8 +17,9 @@
 
 package kafka.tools
 
-import kafka.consumer.BaseConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.record.{RecordBatch, TimestampType}
+
 import scala.collection.JavaConverters._
 import org.junit.Assert._
 import org.junit.Test
@@ -28,7 +29,8 @@ class MirrorMakerTest {
   @Test
   def testDefaultMirrorMakerMessageHandler(): Unit = {
     val now = 12345L
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes, "value".getBytes)
+    val consumerRecord = new ConsumerRecord[Array[Byte], Array[Byte]]("topic", 0, 1L, now, TimestampType.CREATE_TIME,
+      0, 0, 0, "key".getBytes, "value".getBytes)
 
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)
@@ -43,8 +45,8 @@ class MirrorMakerTest {
 
   @Test
   def testDefaultMirrorMakerMessageHandlerWithNoTimestampInSourceMessage(): Unit = {
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, RecordBatch.NO_TIMESTAMP, TimestampType.CREATE_TIME,
-      "key".getBytes, "value".getBytes)
+    val consumerRecord = new ConsumerRecord[Array[Byte], Array[Byte]]("topic", 0, 1L, RecordBatch.NO_TIMESTAMP, TimestampType.CREATE_TIME,
+      0, 0, 0, "key".getBytes, "value".getBytes)
 
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)
@@ -60,8 +62,9 @@ class MirrorMakerTest {
   @Test
   def testDefaultMirrorMakerMessageHandlerWithHeaders(): Unit = {
     val now = 12345L
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes,
-      "value".getBytes)
+    val consumerRecord = new ConsumerRecord[Array[Byte], Array[Byte]]("topic", 0, 1L, now, TimestampType.CREATE_TIME,
+      0, 0, 0, "key".getBytes, "value".getBytes)
+
     consumerRecord.headers.add("headerKey", "headerValue".getBytes)
     val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
     assertEquals(1, result.size)


### PR DESCRIPTION
BaseConsumerRecord is deprecated
but MirrorMaker using BaseConsumerRecord

Remove BaseConsumer from Mirrormaker

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
