### PR TITLE
MINOR: MiniKdc JVM shutdown hook fix

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
@@ -74,10 +74,6 @@ public class Exit {
         haltProcedure.execute(statusCode, message);
     }
 
-    public static void addShutdownHook(Runnable runnable) {
-        addShutdownHook(null, runnable);
-    }
-
     public static void addShutdownHook(String name, Runnable runnable) {
         shutdownHookAdder.addShutdownHook(name, runnable);
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
@@ -27,7 +27,7 @@ public class Exit {
     }
 
     public interface ShutdownHookAdder {
-        void addShutdownHook(Runnable runnable, String name);
+        void addShutdownHook(String name, Runnable runnable);
     }
 
     private static final Procedure DEFAULT_HALT_PROCEDURE = new Procedure() {
@@ -46,7 +46,7 @@ public class Exit {
 
     private static final ShutdownHookAdder DEFAULT_SHUTDOWN_HOOK_ADDER = new ShutdownHookAdder() {
         @Override
-        public void addShutdownHook(Runnable runnable, String name) {
+        public void addShutdownHook(String name, Runnable runnable) {
             if (name != null)
                 Runtime.getRuntime().addShutdownHook(KafkaThread.nonDaemon(name, runnable));
             else
@@ -75,11 +75,11 @@ public class Exit {
     }
 
     public static void addShutdownHook(Runnable runnable) {
-        addShutdownHook(runnable, null);
+        addShutdownHook(null, runnable);
     }
 
-    public static void addShutdownHook(Runnable runnable, String name) {
-        shutdownHookAdder.addShutdownHook(runnable, name);
+    public static void addShutdownHook(String name, Runnable runnable) {
+        shutdownHookAdder.addShutdownHook(name, runnable);
     }
 
     public static void setExitProcedure(Procedure procedure) {

--- a/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Exit.java
@@ -26,6 +26,10 @@ public class Exit {
         void execute(int statusCode, String message);
     }
 
+    public interface ShutdownHookAdder {
+        void addShutdownHook(Runnable runnable, String name);
+    }
+
     private static final Procedure DEFAULT_HALT_PROCEDURE = new Procedure() {
         @Override
         public void execute(int statusCode, String message) {
@@ -40,8 +44,19 @@ public class Exit {
         }
     };
 
+    private static final ShutdownHookAdder DEFAULT_SHUTDOWN_HOOK_ADDER = new ShutdownHookAdder() {
+        @Override
+        public void addShutdownHook(Runnable runnable, String name) {
+            if (name != null)
+                Runtime.getRuntime().addShutdownHook(KafkaThread.nonDaemon(name, runnable));
+            else
+                Runtime.getRuntime().addShutdownHook(new Thread(runnable));
+        }
+    };
+
     private volatile static Procedure exitProcedure = DEFAULT_EXIT_PROCEDURE;
     private volatile static Procedure haltProcedure = DEFAULT_HALT_PROCEDURE;
+    private volatile static ShutdownHookAdder shutdownHookAdder = DEFAULT_SHUTDOWN_HOOK_ADDER;
 
     public static void exit(int statusCode) {
         exit(statusCode, null);
@@ -59,12 +74,24 @@ public class Exit {
         haltProcedure.execute(statusCode, message);
     }
 
+    public static void addShutdownHook(Runnable runnable) {
+        addShutdownHook(runnable, null);
+    }
+
+    public static void addShutdownHook(Runnable runnable, String name) {
+        shutdownHookAdder.addShutdownHook(runnable, name);
+    }
+
     public static void setExitProcedure(Procedure procedure) {
         exitProcedure = procedure;
     }
 
     public static void setHaltProcedure(Procedure procedure) {
         haltProcedure = procedure;
+    }
+
+    public static void setShutdownHookAdder(ShutdownHookAdder shutdownHookAdder) {
+        Exit.shutdownHookAdder = shutdownHookAdder;
     }
 
     public static void resetExitProcedure() {
@@ -75,4 +102,7 @@ public class Exit {
         haltProcedure = DEFAULT_HALT_PROCEDURE;
     }
 
+    public static void resetShutdownHookAdder() {
+        shutdownHookAdder = DEFAULT_SHUTDOWN_HOOK_ADDER;
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
@@ -71,9 +71,8 @@ public class ExitTest {
         try {
             Runnable runnable = () -> { };
             String name = "name";
-            Exit.addShutdownHook(runnable);
             Exit.addShutdownHook(name, runnable);
-            assertEquals(Arrays.asList(null, runnable, name, runnable), list);
+            assertEquals(Arrays.asList(name, runnable), list);
         } finally {
             Exit.resetShutdownHookAdder();
         }
@@ -83,8 +82,6 @@ public class ExitTest {
     public void shouldNotInvokeShutdownHookImmediately() {
         List<Object> list = new ArrayList<>();
         Runnable runnable = () -> list.add(this);
-        Exit.addShutdownHook(runnable);
-        assertEquals(0, list.size());
         Exit.addShutdownHook("message", runnable);
         assertEquals(0, list.size());
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
@@ -64,16 +64,16 @@ public class ExitTest {
     @Test
     public void shouldAddShutdownHookImmediately() {
         List<Object> list = new ArrayList<>();
-        Exit.setShutdownHookAdder((runnable, name) -> {
-            list.add(runnable);
+        Exit.setShutdownHookAdder((name, runnable) -> {
             list.add(name);
+            list.add(runnable);
         });
         try {
             Runnable runnable = () -> { };
             String name = "name";
             Exit.addShutdownHook(runnable);
-            Exit.addShutdownHook(runnable, name);
-            assertEquals(Arrays.asList(runnable, null, runnable, name), list);
+            Exit.addShutdownHook(name, runnable);
+            assertEquals(Arrays.asList(null, runnable, name, runnable), list);
         } finally {
             Exit.resetShutdownHookAdder();
         }
@@ -85,7 +85,7 @@ public class ExitTest {
         Runnable runnable = () -> list.add(this);
         Exit.addShutdownHook(runnable);
         assertEquals(0, list.size());
-        Exit.addShutdownHook(runnable, "messge");
+        Exit.addShutdownHook("message", runnable);
         assertEquals(0, list.size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExitTest {
+    @Test
+    public void shouldHaltImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setHaltProcedure((statusCode, message) -> {
+            list.add(statusCode);
+            list.add(message);
+        });
+        try {
+            int statusCode = 0;
+            String message = "mesaage";
+            Exit.halt(statusCode);
+            Exit.halt(statusCode, message);
+            assertEquals(Arrays.asList(statusCode, null, statusCode, message), list);
+        } finally {
+            Exit.resetHaltProcedure();
+        }
+    }
+
+    @Test
+    public void shouldExitImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setExitProcedure((statusCode, message) -> {
+            list.add(statusCode);
+            list.add(message);
+        });
+        try {
+            int statusCode = 0;
+            String message = "mesaage";
+            Exit.exit(statusCode);
+            Exit.exit(statusCode, message);
+            assertEquals(Arrays.asList(statusCode, null, statusCode, message), list);
+        } finally {
+            Exit.resetExitProcedure();
+        }
+    }
+
+    @Test
+    public void shouldAddShutdownHookImmediately() {
+        List<Object> list = new ArrayList<>();
+        Exit.setShutdownHookAdder((runnable, name) -> {
+            list.add(runnable);
+            list.add(name);
+        });
+        try {
+            Runnable runnable = () -> { };
+            String name = "name";
+            Exit.addShutdownHook(runnable);
+            Exit.addShutdownHook(runnable, name);
+            assertEquals(Arrays.asList(runnable, null, runnable, name), list);
+        } finally {
+            Exit.resetShutdownHookAdder();
+        }
+    }
+
+    @Test
+    public void shouldNotInvokeShutdownHookImmediately() {
+        List<Object> list = new ArrayList<>();
+        Runnable runnable = () -> list.add(this);
+        Exit.addShutdownHook(runnable);
+        assertEquals(0, list.size());
+        Exit.addShutdownHook(runnable, "messge");
+        assertEquals(0, list.size());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -263,7 +263,7 @@ public class TestUtils {
         }
         file.deleteOnExit();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("delete-temp-file-shutdown-hook", () -> {
             try {
                 Utils.delete(file);
             } catch (IOException e) {

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -262,14 +263,11 @@ public class TestUtils {
         }
         file.deleteOnExit();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Utils.delete(file);
-                } catch (IOException e) {
-                    log.error("Error deleting {}", file.getAbsolutePath(), e);
-                }
+        Exit.addShutdownHook(() -> {
+            try {
+                Utils.delete(file);
+            } catch (IOException e) {
+                log.error("Error deleting {}", file.getAbsolutePath(), e);
             }
         });
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -164,7 +164,7 @@ public class MirrorMaker {
         }
         startLatch = new CountDownLatch(herders.size());
         stopLatch = new CountDownLatch(herders.size());
-        Exit.addShutdownHook(shutdownHook);
+        Exit.addShutdownHook("mirror-maker-shutdown-hook", shutdownHook);
         for (Herder herder : herders.values()) {
             try {
                 herder.start();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -164,7 +164,7 @@ public class MirrorMaker {
         }
         startLatch = new CountDownLatch(herders.size());
         stopLatch = new CountDownLatch(herders.size());
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        Exit.addShutdownHook(shutdownHook);
         for (Herder herder : herders.values()) {
             try {
                 herder.start();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -49,7 +49,7 @@ public class Connect {
     public void start() {
         try {
             log.info("Kafka Connect starting");
-            Exit.addShutdownHook(shutdownHook);
+            Exit.addShutdownHook("connect-shutdown-hook", shutdownHook);
 
             herder.start();
             rest.initializeResources(herder);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ public class Connect {
     public void start() {
         try {
             log.info("Kafka Connect starting");
-            Runtime.getRuntime().addShutdownHook(shutdownHook);
+            Exit.addShutdownHook(shutdownHook);
 
             herder.start();
             rest.initializeResources(herder);

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -77,9 +77,7 @@ object Kafka extends Logging {
       }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
-      Runtime.getRuntime().addShutdownHook(new Thread("kafka-shutdown-hook") {
-        override def run(): Unit = kafkaServerStartable.shutdown()
-      })
+      Exit.addShutdownHook(() => kafkaServerStartable.shutdown, Some("kafka-shutdown-hook"))
 
       kafkaServerStartable.startup()
       kafkaServerStartable.awaitShutdown()

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -77,7 +77,7 @@ object Kafka extends Logging {
       }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
-      Exit.addShutdownHook(() => kafkaServerStartable.shutdown, Some("kafka-shutdown-hook"))
+      Exit.addShutdownHook(kafkaServerStartable.shutdown, Some("kafka-shutdown-hook"))
 
       kafkaServerStartable.startup()
       kafkaServerStartable.awaitShutdown()

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -77,7 +77,7 @@ object Kafka extends Logging {
       }
 
       // attach shutdown handler to catch terminating signals as well as normal termination
-      Exit.addShutdownHook(kafkaServerStartable.shutdown, Some("kafka-shutdown-hook"))
+      Exit.addShutdownHook("kafka-shutdown-hook", kafkaServerStartable.shutdown)
 
       kafkaServerStartable.startup()
       kafkaServerStartable.awaitShutdown()

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -28,7 +28,7 @@ import com.typesafe.scalalogging.LazyLogging
 import joptsimple._
 import kafka.common.MessageFormatter
 import kafka.utils.Implicits._
-import kafka.utils._
+import kafka.utils.{Exit, _}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{AuthenticationException, TimeoutException, WakeupException}
@@ -85,8 +85,7 @@ object ConsoleConsumer extends Logging {
   }
 
   def addShutdownHook(consumer: ConsumerWrapper, conf: ConsumerConfig): Unit = {
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = {
+    Exit.addShutdownHook(() => {
         consumer.wakeup()
 
         shutdownLatch.await()
@@ -94,7 +93,6 @@ object ConsoleConsumer extends Logging {
         if (conf.enableSystestEventsLogging) {
           System.out.println("shutdown_complete")
         }
-      }
     })
   }
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -85,7 +85,7 @@ object ConsoleConsumer extends Logging {
   }
 
   def addShutdownHook(consumer: ConsumerWrapper, conf: ConsumerConfig): Unit = {
-    Exit.addShutdownHook(() => {
+    Exit.addShutdownHook({
         consumer.wakeup()
 
         shutdownLatch.await()

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -85,7 +85,7 @@ object ConsoleConsumer extends Logging {
   }
 
   def addShutdownHook(consumer: ConsumerWrapper, conf: ConsumerConfig): Unit = {
-    Exit.addShutdownHook({
+    Exit.addShutdownHook("consumer-shutdown-hook", {
         consumer.wakeup()
 
         shutdownLatch.await()

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -44,7 +44,7 @@ object ConsoleProducer {
 
         val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
 
-    Exit.addShutdownHook(producer.close)
+    Exit.addShutdownHook("producer-shutdown-hook", producer.close)
 
         var record: ProducerRecord[Array[Byte], Array[Byte]] = null
         do {

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -44,11 +44,7 @@ object ConsoleProducer {
 
         val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
 
-        Runtime.getRuntime.addShutdownHook(new Thread() {
-          override def run(): Unit = {
-            producer.close()
-          }
-        })
+    Exit.addShutdownHook(() => producer.close)
 
         var record: ProducerRecord[Array[Byte], Array[Byte]] = null
         do {

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -44,7 +44,7 @@ object ConsoleProducer {
 
         val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
 
-    Exit.addShutdownHook(() => producer.close)
+    Exit.addShutdownHook(producer.close)
 
         var record: ProducerRecord[Array[Byte], Array[Byte]] = null
         do {

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -532,7 +532,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       producer = new MirrorMakerProducer(sync, producerProps)
 
       // Create consumers
-      val customRebalanceListener = {
+      val customRebalanceListener: Option[ConsumerRebalanceListener] = {
         val customRebalanceListenerClass = options.valueOf(consumerRebalanceListenerOpt)
         if (customRebalanceListenerClass != null) {
           val rebalanceListenerArgs = options.valueOf(rebalanceListenerArgsOpt)
@@ -540,7 +540,9 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
             Some(CoreUtils.createObject[ConsumerRebalanceListener](customRebalanceListenerClass, rebalanceListenerArgs))
           else
             Some(CoreUtils.createObject[ConsumerRebalanceListener](customRebalanceListenerClass))
-        } else None
+        } else {
+          None
+        }
       }
       val mirrorMakerConsumers = createConsumers(
         numStreams,
@@ -556,10 +558,14 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       val customMessageHandlerClass = options.valueOf(messageHandlerOpt)
       val messageHandlerArgs = options.valueOf(messageHandlerArgsOpt)
       messageHandler = {
-        if (customMessageHandlerClass != null) if (messageHandlerArgs != null)
-          CoreUtils.createObject[MirrorMakerMessageHandler](customMessageHandlerClass, messageHandlerArgs)
-        else
-          CoreUtils.createObject[MirrorMakerMessageHandler](customMessageHandlerClass) else defaultMirrorMakerMessageHandler
+        if (customMessageHandlerClass != null) {
+          if (messageHandlerArgs != null)
+            CoreUtils.createObject[MirrorMakerMessageHandler](customMessageHandlerClass, messageHandlerArgs)
+          else
+            CoreUtils.createObject[MirrorMakerMessageHandler](customMessageHandlerClass)
+        } else {
+          defaultMirrorMakerMessageHandler
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -515,7 +515,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       offsetCommitIntervalMs = options.valueOf(offsetCommitIntervalMsOpt).intValue()
       val numStreams = options.valueOf(numStreamsOpt).intValue()
 
-      Exit.addShutdownHook(cleanShutdown(), Some("MirrorMakerShutdownHook"))
+      Exit.addShutdownHook("MirrorMakerShutdownHook", cleanShutdown())
 
       // create producer
       val producerProps = Utils.loadProps(options.valueOf(producerConfigOpt))

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -515,7 +515,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       offsetCommitIntervalMs = options.valueOf(offsetCommitIntervalMsOpt).intValue()
       val numStreams = options.valueOf(numStreamsOpt).intValue()
 
-      Exit.addShutdownHook(() => cleanShutdown(), Some("MirrorMakerShutdownHook"))
+      Exit.addShutdownHook(cleanShutdown(), Some("MirrorMakerShutdownHook"))
 
       // create producer
       val producerProps = Utils.loadProps(options.valueOf(producerConfigOpt))

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -200,7 +200,7 @@ object ReplicaVerificationTool extends Logging {
         fetcherId = counter.incrementAndGet())
     }
 
-    Exit.addShutdownHook({
+    Exit.addShutdownHook("ReplicaVerificationToolShutdownHook", {
         info("Stopping all fetchers")
         fetcherThreads.foreach(_.shutdown())
     })

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -200,7 +200,7 @@ object ReplicaVerificationTool extends Logging {
         fetcherId = counter.incrementAndGet())
     }
 
-    Exit.addShutdownHook(() => {
+    Exit.addShutdownHook({
         info("Stopping all fetchers")
         fetcherThreads.foreach(_.shutdown())
     })

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -200,11 +200,9 @@ object ReplicaVerificationTool extends Logging {
         fetcherId = counter.incrementAndGet())
     }
 
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = {
+    Exit.addShutdownHook(() => {
         info("Stopping all fetchers")
         fetcherThreads.foreach(_.shutdown())
-      }
     })
     fetcherThreads.foreach(_.start())
     println(s"${ReplicaVerificationTool.getCurrentTimeString()}: verification process is started.")

--- a/core/src/main/scala/kafka/utils/Exit.scala
+++ b/core/src/main/scala/kafka/utils/Exit.scala
@@ -45,7 +45,7 @@ object Exit {
     JExit.setHaltProcedure(functionToProcedure(haltProcedure))
 
   def setShutdownHookAdder(shutdownHookAdder: (String, => Unit) => Unit): Unit = {
-    JExit.setShutdownHookAdder(functionToShutdownHookAdder(shutdownHookAdder))
+    JExit.setShutdownHookAdder((name, runnable) => shutdownHookAdder(name, runnable.run))
   }
 
   def resetExitProcedure(): Unit =
@@ -59,9 +59,5 @@ object Exit {
 
   private def functionToProcedure(procedure: (Int, Option[String]) => Nothing) = new JExit.Procedure {
     def execute(statusCode: Int, message: String): Unit = procedure(statusCode, Option(message))
-  }
-
-  private def functionToShutdownHookAdder(procedure: (String, => Unit) => Unit) = new JExit.ShutdownHookAdder {
-    def addShutdownHook(name: String, runnable: Runnable): Unit = procedure(name, runnable.run)
   }
 }

--- a/core/src/main/scala/kafka/utils/Exit.scala
+++ b/core/src/main/scala/kafka/utils/Exit.scala
@@ -34,8 +34,8 @@ object Exit {
     throw new AssertionError("halt should not return, but it did.")
   }
 
-  def addShutdownHook(code: => Unit, name: Option[String] = None): Unit = {
-    JExit.addShutdownHook(() => code, name.orNull)
+  def addShutdownHook(statementByName: => Unit, name: Option[String] = None): Unit = {
+    JExit.addShutdownHook(() => statementByName, name.orNull)
   }
 
   def setExitProcedure(exitProcedure: (Int, Option[String]) => Nothing): Unit =

--- a/core/src/main/scala/kafka/utils/Exit.scala
+++ b/core/src/main/scala/kafka/utils/Exit.scala
@@ -34,8 +34,8 @@ object Exit {
     throw new AssertionError("halt should not return, but it did.")
   }
 
-  def addShutdownHook(statementByName: => Unit, name: Option[String] = None): Unit = {
-    JExit.addShutdownHook(() => statementByName, name.orNull)
+  def addShutdownHook(name: String, shutdownHook: => Unit): Unit = {
+    JExit.addShutdownHook(name, () => shutdownHook)
   }
 
   def setExitProcedure(exitProcedure: (Int, Option[String]) => Nothing): Unit =
@@ -44,7 +44,7 @@ object Exit {
   def setHaltProcedure(haltProcedure: (Int, Option[String]) => Nothing): Unit =
     JExit.setHaltProcedure(functionToProcedure(haltProcedure))
 
-  def setShutdownHookAdder(shutdownHookAdder: (=> Unit, Option[String]) => Unit): Unit = {
+  def setShutdownHookAdder(shutdownHookAdder: (String, => Unit) => Unit): Unit = {
     JExit.setShutdownHookAdder(functionToShutdownHookAdder(shutdownHookAdder))
   }
 
@@ -61,7 +61,7 @@ object Exit {
     def execute(statusCode: Int, message: String): Unit = procedure(statusCode, Option(message))
   }
 
-  private def functionToShutdownHookAdder(procedure: (=> Unit, Option[String]) => Unit) = new JExit.ShutdownHookAdder {
-    def addShutdownHook(runnable: Runnable, name: String): Unit = procedure(runnable.run, Option(name))
+  private def functionToShutdownHookAdder(procedure: (String, => Unit) => Unit) = new JExit.ShutdownHookAdder {
+    def addShutdownHook(name: String, runnable: Runnable): Unit = procedure(name, runnable.run)
   }
 }

--- a/core/src/main/scala/kafka/utils/Exit.scala
+++ b/core/src/main/scala/kafka/utils/Exit.scala
@@ -34,11 +34,19 @@ object Exit {
     throw new AssertionError("halt should not return, but it did.")
   }
 
+  def addShutdownHook(runnable: Runnable, name: Option[String] = None): Unit = {
+    JExit.addShutdownHook(runnable, name.orNull)
+  }
+
   def setExitProcedure(exitProcedure: (Int, Option[String]) => Nothing): Unit =
     JExit.setExitProcedure(functionToProcedure(exitProcedure))
 
   def setHaltProcedure(haltProcedure: (Int, Option[String]) => Nothing): Unit =
     JExit.setHaltProcedure(functionToProcedure(haltProcedure))
+
+  def setShutdownHookAdder(shutdownHookAdder: (Runnable, Option[String]) => Unit): Unit = {
+    JExit.setShutdownHookAdder(functionToShutdownHookAdder(shutdownHookAdder))
+  }
 
   def resetExitProcedure(): Unit =
     JExit.resetExitProcedure()
@@ -46,8 +54,14 @@ object Exit {
   def resetHaltProcedure(): Unit =
     JExit.resetHaltProcedure()
 
+  def resetShutdownHookAdder(): Unit =
+    JExit.resetShutdownHookAdder()
+
   private def functionToProcedure(procedure: (Int, Option[String]) => Nothing) = new JExit.Procedure {
     def execute(statusCode: Int, message: String): Unit = procedure(statusCode, Option(message))
   }
 
+  private def functionToShutdownHookAdder(procedure: (Runnable, Option[String]) => Unit) = new JExit.ShutdownHookAdder {
+    def addShutdownHook(runnable: Runnable, name: String): Unit = procedure(runnable, Option(name))
+  }
 }

--- a/core/src/main/scala/kafka/utils/Exit.scala
+++ b/core/src/main/scala/kafka/utils/Exit.scala
@@ -34,8 +34,8 @@ object Exit {
     throw new AssertionError("halt should not return, but it did.")
   }
 
-  def addShutdownHook(runnable: Runnable, name: Option[String] = None): Unit = {
-    JExit.addShutdownHook(runnable, name.orNull)
+  def addShutdownHook(code: => Unit, name: Option[String] = None): Unit = {
+    JExit.addShutdownHook(() => code, name.orNull)
   }
 
   def setExitProcedure(exitProcedure: (Int, Option[String]) => Nothing): Unit =
@@ -44,7 +44,7 @@ object Exit {
   def setHaltProcedure(haltProcedure: (Int, Option[String]) => Nothing): Unit =
     JExit.setHaltProcedure(functionToProcedure(haltProcedure))
 
-  def setShutdownHookAdder(shutdownHookAdder: (Runnable, Option[String]) => Unit): Unit = {
+  def setShutdownHookAdder(shutdownHookAdder: (=> Unit, Option[String]) => Unit): Unit = {
     JExit.setShutdownHookAdder(functionToShutdownHookAdder(shutdownHookAdder))
   }
 
@@ -61,7 +61,7 @@ object Exit {
     def execute(statusCode: Int, message: String): Unit = procedure(statusCode, Option(message))
   }
 
-  private def functionToShutdownHookAdder(procedure: (Runnable, Option[String]) => Unit) = new JExit.ShutdownHookAdder {
-    def addShutdownHook(runnable: Runnable, name: String): Unit = procedure(runnable, Option(name))
+  private def functionToShutdownHookAdder(procedure: (=> Unit, Option[String]) => Unit) = new JExit.ShutdownHookAdder {
+    def addShutdownHook(runnable: Runnable, name: String): Unit = procedure(runnable.run, Option(name))
   }
 }

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -390,7 +390,7 @@ object MiniKdc {
       |
     """.stripMargin
     println(infoMessage)
-    Exit.addShutdownHook(miniKdc.stop, Some("minikdc-shutdown-hook"))
+    Exit.addShutdownHook("minikdc-shutdown-hook", miniKdc.stop)
     miniKdc
   }
 

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -390,7 +390,7 @@ object MiniKdc {
       |
     """.stripMargin
     println(infoMessage)
-    Exit.addShutdownHook(() => miniKdc.stop, Some("minikdc-shutdown-hook"))
+    Exit.addShutdownHook(miniKdc.stop, Some("minikdc-shutdown-hook"))
     miniKdc
   }
 

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -390,9 +390,7 @@ object MiniKdc {
       |
     """.stripMargin
     println(infoMessage)
-    Runtime.getRuntime.addShutdownHook(new KafkaThread("minikdc-shutdown-hook", false) {
-      miniKdc.stop()
-    })
+    Runtime.getRuntime.addShutdownHook(new KafkaThread("minikdc-shutdown-hook", () => miniKdc.stop(), false))
   }
 
   val OrgName = "org.name"

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -49,7 +49,7 @@ import org.apache.directory.server.kerberos.shared.keytab.{Keytab, KeytabEntry}
 import org.apache.directory.server.protocol.shared.transport.{TcpTransport, UdpTransport}
 import org.apache.directory.server.xdbm.Index
 import org.apache.directory.shared.kerberos.KerberosTime
-import org.apache.kafka.common.utils.{Java, KafkaThread, Utils}
+import org.apache.kafka.common.utils.{Java, Utils}
 
 /**
   * Mini KDC based on Apache Directory Server that can be embedded in tests or used from command line as a standalone
@@ -370,7 +370,7 @@ object MiniKdc {
     }
   }
 
-  private def start(workDir: File, config: Properties, keytabFile: File, principals: Seq[String]): Unit = {
+  private[minikdc] def start(workDir: File, config: Properties, keytabFile: File, principals: Seq[String]): MiniKdc = {
     val miniKdc = new MiniKdc(config, workDir)
     miniKdc.start()
     miniKdc.createPrincipal(keytabFile, principals: _*)
@@ -390,7 +390,8 @@ object MiniKdc {
       |
     """.stripMargin
     println(infoMessage)
-    Runtime.getRuntime.addShutdownHook(new KafkaThread("minikdc-shutdown-hook", () => miniKdc.stop(), false))
+    Exit.addShutdownHook(() => miniKdc.stop, Some("minikdc-shutdown-hook"))
+    miniKdc
   }
 
   val OrgName = "org.name"

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdcTest.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdcTest.scala
@@ -23,7 +23,7 @@ import kafka.utils.TestUtils
 import org.junit.Test
 import org.junit.Assert._
 
-class MinikdcTest {
+class MiniKdcTest {
   @Test
   def shouldNotStopImmediatelyWhenStarted(): Unit = {
     val config = new Properties()

--- a/core/src/test/scala/kafka/security/minikdc/MinikdcTest.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MinikdcTest.scala
@@ -17,9 +17,6 @@
 
 package kafka.security.minikdc
 
-import java.io.{File, FileWriter}
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.util.Properties
 
 import kafka.utils.TestUtils

--- a/core/src/test/scala/kafka/security/minikdc/MinikdcTest.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MinikdcTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.security.minikdc
+
+import java.io.{File, FileWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Properties
+
+import kafka.utils.TestUtils
+import org.junit.Test
+import org.junit.Assert._
+
+class MinikdcTest {
+  @Test
+  def shouldNotStopImmediatelyWhenStarted(): Unit = {
+    val config = new Properties()
+    config.setProperty("kdc.bind.address", "0.0.0.0")
+    config.setProperty("transport", "TCP");
+    config.setProperty("max.ticket.lifetime", "86400000")
+    config.setProperty("org.name", "Example")
+    config.setProperty("kdc.port", "0")
+    config.setProperty("org.domain", "COM")
+    config.setProperty("max.renewable.lifetime", "604800000")
+    config.setProperty("instance", "DefaultKrbServer")
+    val minikdc = MiniKdc.start(TestUtils.tempDir(), config, TestUtils.tempFile(), List("foo"))
+    val running = System.getProperty(MiniKdc.JavaSecurityKrb5Conf) != null
+    try {
+      assertTrue("MiniKdc stopped immediately; it should not have", running)
+    } finally {
+      if (running) minikdc.stop()
+    }
+  }
+}

--- a/core/src/test/scala/kafka/utils/ExitTest.scala
+++ b/core/src/test/scala/kafka/utils/ExitTest.scala
@@ -17,8 +17,11 @@
 
 package kafka.utils
 
+import java.io.IOException
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.scalatest.Assertions.intercept
 
 class ExitTest {
   @Test
@@ -27,28 +30,19 @@ class ExitTest {
     def haltProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
       array(0) = exitStatus
       array(1) = message
-      throw new Exception()
+      throw new IOException()
     }
     Exit.setHaltProcedure(haltProcedure)
     val statusCode = 0
     val message = Some("message")
     try {
-      try {
-        Exit.halt(statusCode)
-      } catch {
-        case e: Exception => {
-          assertEquals(statusCode, array(0))
-          assertEquals(None, array(1))
-        }
-      }
-      try {
-        Exit.halt(statusCode, message)
-      } catch {
-        case e: Exception => {
-          assertEquals(statusCode, array(0))
-          assertEquals(message, array(1))
-        }
-      }
+      intercept[IOException] {Exit.halt(statusCode)}
+      assertEquals(statusCode, array(0))
+      assertEquals(None, array(1))
+
+      intercept[IOException] {Exit.halt(statusCode, message)}
+      assertEquals(statusCode, array(0))
+      assertEquals(message, array(1))
     } finally {
       Exit.resetHaltProcedure()
     }
@@ -60,28 +54,19 @@ class ExitTest {
     def exitProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
       array(0) = exitStatus
       array(1) = message
-      throw new Exception()
+      throw new IOException()
     }
     Exit.setExitProcedure(exitProcedure)
     val statusCode = 0
     val message = Some("message")
     try {
-      try {
-        Exit.exit(statusCode)
-      } catch {
-        case e: Exception => {
-          assertEquals(statusCode, array(0))
-          assertEquals(None, array(1))
-        }
-      }
-      try {
-        Exit.exit(statusCode, message)
-      } catch {
-        case e: Exception => {
-          assertEquals(statusCode, array(0))
-          assertEquals(message, array(1))
-        }
-      }
+      intercept[IOException] {Exit.exit(statusCode)}
+      assertEquals(statusCode, array(0))
+      assertEquals(None, array(1))
+
+      intercept[IOException] {Exit.exit(statusCode, message)}
+      assertEquals(statusCode, array(0))
+      assertEquals(message, array(1))
     } finally {
       Exit.resetExitProcedure()
     }

--- a/core/src/test/scala/kafka/utils/ExitTest.scala
+++ b/core/src/test/scala/kafka/utils/ExitTest.scala
@@ -90,10 +90,10 @@ class ExitTest {
   @Test
   def shouldAddShutdownHookImmediately(): Unit = {
     val array:Array[Any] = Array(0, Some("other thing"))
-    // immediately invoke the code to mutate the data when a hook is added
-    def shutdownHookAdder(code: => Unit, name: Option[String]) : Unit = {
-      // invoke the code (see below, it mutates the first element)
-      code
+    // immediately invoke the statement to mutate the data when a hook is added
+    def shutdownHookAdder(statementByName: => Unit, name: Option[String]) : Unit = {
+      // invoke the statement (see below, it mutates the first element)
+      statementByName
       // mutate the second element
       array(1) = name
     }
@@ -138,6 +138,7 @@ class ExitTest {
     assertEquals(value, array(0))
     Exit.addShutdownHook(sideEffect()) // by-name parameter, not invoked
     // again make sure the first element wasn't mutated
+    assertEquals(value, array(0))
     Exit.addShutdownHook(array(0) = array(0).toString + array(0).toString) // by-name parameter, not invoked
     // again make sure the first element wasn't mutated
     assertEquals(value, array(0))

--- a/core/src/test/scala/kafka/utils/ExitTest.scala
+++ b/core/src/test/scala/kafka/utils/ExitTest.scala
@@ -1,0 +1,127 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+class ExitTest {
+  @Test
+  def shouldHaltImmediately(): Unit = {
+    val array:Array[Any] = Array("a", "b")
+    def haltProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
+      array(0) = exitStatus
+      array(1) = message
+      throw new Exception()
+    }
+    Exit.setHaltProcedure(haltProcedure)
+    val statusCode = 0
+    val message = Some("mesaage")
+    try {
+      try {
+        Exit.halt(statusCode)
+      } catch {
+        case e: Exception => {
+          assertEquals(statusCode, array(0))
+          assertEquals(None, array(1))
+        }
+      }
+      try {
+        Exit.halt(statusCode, message)
+      } catch {
+        case e: Exception => {
+          assertEquals(statusCode, array(0))
+          assertEquals(message, array(1))
+        }
+      }
+    } finally {
+      Exit.resetHaltProcedure()
+    }
+  }
+
+  @Test
+  def shouldExitImmediately(): Unit = {
+    val array:Array[Any] = Array("a", "b")
+    def exitProcedure(exitStatus: Int, message: Option[String]) : Nothing = {
+      array(0) = exitStatus
+      array(1) = message
+      throw new Exception()
+    }
+    Exit.setExitProcedure(exitProcedure)
+    val statusCode = 0
+    val message = Some("mesaage")
+    try {
+      try {
+        Exit.exit(statusCode)
+      } catch {
+        case e: Exception => {
+          assertEquals(statusCode, array(0))
+          assertEquals(None, array(1))
+        }
+      }
+      try {
+        Exit.exit(statusCode, message)
+      } catch {
+        case e: Exception => {
+          assertEquals(statusCode, array(0))
+          assertEquals(message, array(1))
+        }
+      }
+    } finally {
+      Exit.resetExitProcedure()
+    }
+  }
+
+  @Test
+  def shouldAddShutdownHookImmediately(): Unit = {
+    val array:Array[Any] = Array("a", "b")
+    def shutdownHookAdder(runnable: Runnable, name: Option[String]) : Unit = {
+      array(0) = runnable
+      array(1) = name
+    }
+    Exit.setShutdownHookAdder(shutdownHookAdder)
+    val runnable: Runnable = () => {}
+    val message = Some("mesaage")
+    try {
+      Exit.addShutdownHook(runnable)
+      assertEquals(runnable, array(0))
+      assertEquals(None, array(1))
+      Exit.addShutdownHook(runnable, message)
+      assertEquals(runnable, array(0))
+      assertEquals(message, array(1))
+    } finally {
+      Exit.resetShutdownHookAdder()
+    }
+  }
+
+  @Test
+  def shouldNotInvokeShutdownHookImmediately(): Unit = {
+    val value = "a"
+    val array:Array[Any] = Array(value)
+    val runnable: Runnable = () => {}
+    try {
+        Exit.addShutdownHook(runnable)
+        assertEquals(value, array(0))
+        Exit.addShutdownHook(runnable, Some("mesaage"))
+        assertEquals(value, array(0))
+    } finally {
+      Exit.resetShutdownHookAdder()
+    }
+  }
+}

--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -57,7 +57,7 @@ object StressTestLog {
     val reader = new ReaderThread(log)
     reader.start()
 
-    Exit.addShutdownHook({
+    Exit.addShutdownHook("stress-test-shutdown-hook", {
         running.set(false)
         writer.join()
         reader.join()

--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -57,7 +57,7 @@ object StressTestLog {
     val reader = new ReaderThread(log)
     reader.start()
 
-    Exit.addShutdownHook(() => {
+    Exit.addShutdownHook({
         running.set(false)
         writer.join()
         reader.join()

--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -57,13 +57,11 @@ object StressTestLog {
     val reader = new ReaderThread(log)
     reader.start()
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      override def run() = {
+    Exit.addShutdownHook(() => {
         running.set(false)
         writer.join()
         reader.join()
         Utils.delete(dir)
-      }
     })
 
     while(running.get) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestClient.java
@@ -54,7 +54,7 @@ public class EosTestClient extends SmokeTestUtil {
     private volatile boolean isRunning = true;
 
     public void start() {
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             isRunning = false;
             streams.close(Duration.ofSeconds(300));
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestClient.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 import java.time.Duration;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -53,25 +54,21 @@ public class EosTestClient extends SmokeTestUtil {
     private volatile boolean isRunning = true;
 
     public void start() {
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                isRunning = false;
-                streams.close(Duration.ofSeconds(300));
+        Exit.addShutdownHook(() -> {
+            isRunning = false;
+            streams.close(Duration.ofSeconds(300));
 
-                // need to wait for callback to avoid race condition
-                // -> make sure the callback printout to stdout is there as it is expected test output
-                waitForStateTransitionCallback();
+            // need to wait for callback to avoid race condition
+            // -> make sure the callback printout to stdout is there as it is expected test output
+            waitForStateTransitionCallback();
 
-                // do not remove these printouts since they are needed for health scripts
-                if (!uncaughtException) {
-                    System.out.println(System.currentTimeMillis());
-                    System.out.println("EOS-TEST-CLIENT-CLOSED");
-                    System.out.flush();
-                }
-
+            // do not remove these printouts since they are needed for health scripts
+            if (!uncaughtException) {
+                System.out.println(System.currentTimeMillis());
+                System.out.println("EOS-TEST-CLIENT-CLOSED");
+                System.out.flush();
             }
-        }));
+        });
 
         while (isRunning) {
             if (streams == null) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -69,7 +69,7 @@ public class EosTestDriver extends SmokeTestUtil {
 
     static void generate(final String kafka) {
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-eos-test-driver-shutdown-hook", () -> {
             System.out.println("Terminating");
             System.out.flush();
             isRunning = false;

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -69,11 +69,11 @@ public class EosTestDriver extends SmokeTestUtil {
 
     static void generate(final String kafka) {
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             System.out.println("Terminating");
             System.out.flush();
             isRunning = false;
-        }));
+        });
 
         final Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "EosTest");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
@@ -62,7 +62,7 @@ public class ShutdownDeadlockTest {
             }
         });
 
-        Exit.addShutdownHook(() -> streams.close(Duration.ofSeconds(5)));
+        Exit.addShutdownHook("streams-shutdown-hook", () -> streams.close(Duration.ofSeconds(5)));
 
         final Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "SmokeTest");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/ShutdownDeadlockTest.java
@@ -62,12 +62,7 @@ public class ShutdownDeadlockTest {
             }
         });
 
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                streams.close(Duration.ofSeconds(5));
-            }
-        }));
+        Exit.addShutdownHook(() -> streams.close(Duration.ofSeconds(5)));
 
         final Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, "SmokeTest");

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -77,7 +77,7 @@ public class SmokeTestClient extends SmokeTestUtil {
             e.printStackTrace();
         });
 
-        Exit.addShutdownHook(() -> close());
+        Exit.addShutdownHook("streams-shutdown-hook", () -> close());
 
         thread = new Thread(() -> streams.start());
         thread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -76,7 +77,7 @@ public class SmokeTestClient extends SmokeTestUtil {
             e.printStackTrace();
         });
 
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        Exit.addShutdownHook(() -> close());
 
         thread = new Thread(() -> streams.start());
         thread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
@@ -71,7 +71,7 @@ public class StaticMemberTestClient {
 
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StaticMemberTestClient.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -70,15 +71,12 @@ public class StaticMemberTestClient {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                System.out.println("closing Kafka Streams instance");
-                System.out.flush();
-                streams.close();
-                System.out.println("Static membership test closed");
-                System.out.flush();
-            }
+        Exit.addShutdownHook(() -> {
+            System.out.println("closing Kafka Streams instance");
+            System.out.flush();
+            streams.close();
+            System.out.println("Static membership test closed");
+            System.out.flush();
         });
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -115,7 +115,7 @@ public class StreamsBrokerDownResilienceTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             streams.close(Duration.ofSeconds(30));
             System.out.println("Complete shutdown of streams resilience test app now");
             System.out.flush();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
@@ -114,12 +115,11 @@ public class StreamsBrokerDownResilienceTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             streams.close(Duration.ofSeconds(30));
             System.out.println("Complete shutdown of streams resilience test app now");
             System.out.flush();
-        }
-        ));
+        });
     }
 
     private static boolean confirmCorrectConfigs(final Properties properties) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
@@ -111,7 +111,7 @@ public class StreamsNamedRepartitionTest {
 
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close(Duration.ofMillis(5000));

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsNamedRepartitionTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -110,12 +111,12 @@ public class StreamsNamedRepartitionTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close(Duration.ofMillis(5000));
             System.out.println("NAMED_REPARTITION_TEST Streams Stopped");
             System.out.flush();
-        }));
+        });
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -132,7 +132,7 @@ public class StreamsOptimizedTest {
 
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close(Duration.ofMillis(5000));

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -131,15 +132,12 @@ public class StreamsOptimizedTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                System.out.println("closing Kafka Streams instance");
-                System.out.flush();
-                streams.close(Duration.ofMillis(5000));
-                System.out.println("OPTIMIZE_TEST Streams Stopped");
-                System.out.flush();
-            }
+        Exit.addShutdownHook(() -> {
+            System.out.println("closing Kafka Streams instance");
+            System.out.flush();
+            streams.close(Duration.ofMillis(5000));
+            System.out.println("OPTIMIZE_TEST Streams Stopped");
+            System.out.flush();
         });
 
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
@@ -148,7 +148,7 @@ public class StreamsStandByReplicaTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             shutdown(streams);
             System.out.println("Shut down streams now");
         });

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -147,10 +148,10 @@ public class StreamsStandByReplicaTest {
         System.out.println("Start Kafka Streams");
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             shutdown(streams);
             System.out.println("Shut down streams now");
-        }));
+        });
     }
 
     private static void shutdown(final KafkaStreams streams) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -82,7 +82,7 @@ public class StreamsUpgradeTest {
         final KafkaStreams streams = buildStreams(streamsProperties);
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
@@ -81,13 +82,13 @@ public class StreamsUpgradeTest {
         final KafkaStreams streams = buildStreams(streamsProperties);
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             System.out.println("closing Kafka Streams instance");
             System.out.flush();
             streams.close();
             System.out.println("UPGRADE-TEST-CLIENT-CLOSED");
             System.out.flush();
-        }));
+        });
     }
 
     public static KafkaStreams buildStreams(final Properties streamsProperties) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
@@ -109,7 +109,7 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
 
         streams.start();
 
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("streams-shutdown-hook", () -> {
             streams.close();
             System.out.println(String.format("%sCOOPERATIVE-REBALANCE-TEST-CLIENT-CLOSED", upgradePhase));
             System.out.flush();

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.tests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -108,11 +109,11 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
 
         streams.start();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             streams.close();
             System.out.println(String.format("%sCOOPERATIVE-REBALANCE-TEST-CLIENT-CLOSED", upgradePhase));
             System.out.flush();
-        }));
+        });
     }
 
     private static void addTasksToBuilder(final List<String> tasks, final StringBuilder builder) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -265,7 +265,7 @@ public class TransactionalMessageCopier {
         final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
         final AtomicLong remainingMessages = new AtomicLong(maxMessages);
         final AtomicLong numMessagesProcessed = new AtomicLong(0);
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("transactional-message-copier-shutdown-hook", () -> {
             isShuttingDown.set(true);
             // Flush any remaining messages
             producer.close();

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.utils.Exit;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -264,7 +265,7 @@ public class TransactionalMessageCopier {
         final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
         final AtomicLong remainingMessages = new AtomicLong(maxMessages);
         final AtomicLong numMessagesProcessed = new AtomicLong(0);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             isShuttingDown.set(true);
             // Flush any remaining messages
             producer.close();
@@ -272,7 +273,7 @@ public class TransactionalMessageCopier {
                 consumer.close();
             }
             System.out.println(shutDownString(numMessagesProcessed.get(), remainingMessages.get(), transactionalId));
-        }));
+        });
 
         try {
             Random random = new Random();

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -644,7 +644,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         try {
             final VerifiableConsumer consumer = createFromArgs(parser, args);
-            Exit.addShutdownHook(() -> consumer.close());
+            Exit.addShutdownHook("verifiable-consumer-shutdown-hook", () -> consumer.close());
 
             consumer.run();
         } catch (ArgumentParserException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -644,7 +644,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         try {
             final VerifiableConsumer consumer = createFromArgs(parser, args);
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> consumer.close()));
+            Exit.addShutdownHook(() -> consumer.close());
 
             consumer.run();
         } catch (ArgumentParserException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -242,7 +242,7 @@ public class VerifiableLog4jAppender {
         boolean infinite = appender.maxMessages < 0;
 
         // Trigger main thread to stop producing messages when shutting down
-        Exit.addShutdownHook(() -> appender.stopLogging = true);
+        Exit.addShutdownHook("verifiable-log4j-appender-shutdown-hook", () -> appender.stopLogging = true);
 
         long maxMessages = infinite ? Long.MAX_VALUE : appender.maxMessages;
         for (long i = 0; i < maxMessages; i++) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -241,10 +241,8 @@ public class VerifiableLog4jAppender {
         final VerifiableLog4jAppender appender = createFromArgs(args);
         boolean infinite = appender.maxMessages < 0;
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Trigger main thread to stop producing messages
-            appender.stopLogging = true;
-        }));
+        // Trigger main thread to stop producing messages when shutting down
+        Exit.addShutdownHook(() -> appender.stopLogging = true);
 
         long maxMessages = infinite ? Long.MAX_VALUE : appender.maxMessages;
         for (long i = 0; i < maxMessages; i++) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -517,7 +517,7 @@ public class VerifiableProducer implements AutoCloseable {
             final long startMs = System.currentTimeMillis();
             ThroughputThrottler throttler = new ThroughputThrottler(producer.throughput, startMs);
 
-            Exit.addShutdownHook(() -> {
+            Exit.addShutdownHook("verifiable-producer-shutdown-hook", () -> {
                 // Trigger main thread to stop producing messages
                 producer.stopProducing = true;
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -517,7 +517,7 @@ public class VerifiableProducer implements AutoCloseable {
             final long startMs = System.currentTimeMillis();
             ThroughputThrottler throttler = new ThroughputThrottler(producer.throughput, startMs);
 
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Exit.addShutdownHook(() -> {
                 // Trigger main thread to stop producing messages
                 producer.stopProducing = true;
 
@@ -529,7 +529,7 @@ public class VerifiableProducer implements AutoCloseable {
                 double avgThroughput = 1000 * ((producer.numAcked) / (double) (stopMs - startMs));
 
                 producer.printJson(new ToolData(producer.numSent, producer.numAcked, producer.throughput, avgThroughput));
-            }));
+            });
 
             producer.run(throttler);
         } catch (ArgumentParserException e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -249,7 +249,7 @@ public final class Agent {
         log.info("Starting agent process.");
         final Agent agent = new Agent(platform, Scheduler.SYSTEM, restServer, resource);
         restServer.start(resource);
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("agent-shutdown-hook", () -> {
             log.warn("Running agent shutdown hook.");
             try {
                 agent.beginShutdown();

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -249,7 +249,7 @@ public final class Agent {
         log.info("Starting agent process.");
         final Agent agent = new Agent(platform, Scheduler.SYSTEM, restServer, resource);
         restServer.start(resource);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             log.warn("Running agent shutdown hook.");
             try {
                 agent.beginShutdown();
@@ -257,7 +257,7 @@ public final class Agent {
             } catch (Exception e) {
                 log.error("Got exception while running agent shutdown hook.", e);
             }
-        }));
+        });
         if (taskSpec != null) {
             TaskSpec spec = null;
             try {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -171,7 +171,7 @@ public final class Coordinator {
         final Coordinator coordinator = new Coordinator(platform, Scheduler.SYSTEM,
             restServer, resource, ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE / 2));
         restServer.start(resource);
-        Exit.addShutdownHook(() -> {
+        Exit.addShutdownHook("coordinator-shutdown-hook", () -> {
             log.warn("Running coordinator shutdown hook.");
             try {
                 coordinator.beginShutdown(false);

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -171,7 +171,7 @@ public final class Coordinator {
         final Coordinator coordinator = new Coordinator(platform, Scheduler.SYSTEM,
             restServer, resource, ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE / 2));
         restServer.start(resource);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Exit.addShutdownHook(() -> {
             log.warn("Running coordinator shutdown hook.");
             try {
                 coordinator.beginShutdown(false);
@@ -179,7 +179,7 @@ public final class Coordinator {
             } catch (Exception e) {
                 log.error("Got exception while running coordinator shutdown hook.", e);
             }
-        }));
+        });
         coordinator.waitForShutdown();
     }
 };


### PR DESCRIPTION
When started as a separate process (which happens only in system tests), the shutdown hook for `MiniKdc` was running immediately, which causes tests that depend on it for Kerberos to fail.  The system tests in `zookeeper_security_upgrade_test.py`, for example, fail because ZooKeeper is unable to contact the KDC.

I ran the above system test locally and confirmed it failed prior to the fix and succeeded after the fix:

WITHOUT FIX:
```
$ ducktape tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
[INFO  - 2020-01-13 09:19:04,249 - runner_client - log - lineno:240]: RunnerClient: kafkatest.tests.core.zookeeper_security_upgrade_test.ZooKeeperSecurityUpgradeTest.test_zk_security_upgrade.security_protocol=PLAINTEXT: Summary: Zookeeper node failed to start
Traceback (most recent call last):
...
test_id:    kafkatest.tests.core.zookeeper_security_upgrade_test.ZooKeeperSecurityUpgradeTest.test_zk_security_upgrade.security_protocol=PLAINTEXT
status:     FAIL
```

WITH FIX:
```
$ ducktape tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
[INFO:2020-01-13 09:24:08,072]: RunnerClient: kafkatest.tests.core.zookeeper_security_upgrade_test.ZooKeeperSecurityUpgradeTest.test_zk_security_upgrade.security_protocol=PLAINTEXT: PASS
...
test_id:    kafkatest.tests.core.zookeeper_security_upgrade_test.ZooKeeperSecurityUpgradeTest.test_zk_security_upgrade.security_protocol=PLAINTEXT
status:     PASS
```
