### PR TITLE
KAFKA-9419: Integer Overflow Possible with CircularIterator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
@@ -36,8 +36,7 @@ public class CircularIterator<T> implements Iterator<T> {
 
     private final Iterable<T> iterable;
     private Iterator<T> iterator;
-    private T peek;
-    private boolean hasPeek;
+    private T nextValue;
 
     /**
      * Create a new instance of a CircularIterator. The ordering of this
@@ -51,11 +50,10 @@ public class CircularIterator<T> implements Iterator<T> {
     public CircularIterator(final Collection<T> col) {
         this.iterable = Objects.requireNonNull(col);
         this.iterator = col.iterator();
-        this.peek = null;
-        this.hasPeek = false;
         if (col.isEmpty()) {
             throw new IllegalArgumentException("CircularIterator can only be used on non-empty lists");
         }
+        this.nextValue = advance();
     }
 
     /**
@@ -66,26 +64,27 @@ public class CircularIterator<T> implements Iterator<T> {
      */
     @Override
     public boolean hasNext() {
-        if (this.hasPeek) {
-            return true;
-        }
-        if (!this.iterator.hasNext()) {
-            this.iterator = this.iterable.iterator();
-        }
         return true;
     }
 
     @Override
     public T next() {
-        final T nextValue;
-        if (this.hasPeek) {
-            nextValue = this.peek;
-            this.peek = null;
-            this.hasPeek = false;
-        } else {
-            nextValue = this.iterator.next();
+        final T next = this.nextValue;
+        this.nextValue = advance();
+        return next;
+    }
+
+    /**
+     * Return the next value in the {@code Iterator}, restarting the
+     * {@code Iterator} if necessary.
+     *
+     * @return The next value in the iterator
+     */
+    private T advance() {
+        if (!this.iterator.hasNext()) {
+            this.iterator = this.iterable.iterator();
         }
-        return nextValue;
+        return this.iterator.next();
     }
 
     /**
@@ -97,11 +96,7 @@ public class CircularIterator<T> implements Iterator<T> {
      * @return The next value in this {@code Iterator}
      */
     public T peek() {
-        if (!this.hasPeek) {
-            this.peek = next();
-            this.hasPeek = true;
-        }
-        return this.peek;
+        return this.nextValue;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
@@ -22,14 +22,17 @@ import java.util.Iterator;
 import java.util.Objects;
 
 /**
- * An iterator that cycles through the Iterator of a Collection indefinitely.
- * Useful for tasks such as round-robin load balancing.
+ * An iterator that cycles through the {@code Iterator} of a {@code Collection}
+ * indefinitely. Useful for tasks such as round-robin load balancing. This class
+ * does not provide thread-safe access. This {@code Iterator} supports
+ * {@code null} elements in the underlying {@code Collection}.
  */
 public class CircularIterator<T> implements Iterator<T> {
 
     private final Iterable<T> iterable;
     private Iterator<T> iterator;
     private T peek;
+    private boolean hasPeek;
 
     /**
      * Create a new instance of a CircularIterator. The ordering of this
@@ -44,6 +47,7 @@ public class CircularIterator<T> implements Iterator<T> {
         this.iterable = Objects.requireNonNull(col);
         this.iterator = col.iterator();
         this.peek = null;
+        this.hasPeek = false;
         if (col.isEmpty()) {
             throw new IllegalArgumentException("CircularIterator can only be used on non-empty lists");
         }
@@ -51,7 +55,7 @@ public class CircularIterator<T> implements Iterator<T> {
 
     @Override
     public boolean hasNext() {
-        if (this.peek != null) {
+        if (this.hasPeek) {
             return true;
         }
         if (!this.iterator.hasNext()) {
@@ -63,18 +67,28 @@ public class CircularIterator<T> implements Iterator<T> {
     @Override
     public T next() {
         final T nextValue;
-        if (this.peek != null) {
+        if (this.hasPeek) {
             nextValue = this.peek;
             this.peek = null;
+            this.hasPeek = false;
         } else {
             nextValue = this.iterator.next();
         }
         return nextValue;
     }
 
+    /**
+     * Peek at the next value in the Iterator. Calling this method multiple
+     * times will return the same element without advancing this Iterator. The
+     * value returned by this method will be the next item returned by
+     * {@code next()}.
+     *
+     * @return The next value in this {@code Iterator}
+     */
     public T peek() {
-        if (this.peek == null) {
+        if (!this.hasPeek) {
             this.peek = next();
+            this.hasPeek = true;
         }
         return this.peek;
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.utils;
 
 import java.util.Collection;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -25,7 +26,11 @@ import java.util.Objects;
  * An iterator that cycles through the {@code Iterator} of a {@code Collection}
  * indefinitely. Useful for tasks such as round-robin load balancing. This class
  * does not provide thread-safe access. This {@code Iterator} supports
- * {@code null} elements in the underlying {@code Collection}.
+ * {@code null} elements in the underlying {@code Collection}. This
+ * {@code Iterator} does not support any modification to the underlying
+ * {@code Collection} after it has been wrapped by this class. Changing the
+ * underlying {@code Collection} may cause a
+ * {@link ConcurrentModificationException} or some other undefined behavior.
  */
 public class CircularIterator<T> implements Iterator<T> {
 
@@ -53,6 +58,12 @@ public class CircularIterator<T> implements Iterator<T> {
         }
     }
 
+    /**
+     * Returns true since the iteration will forever cycle through the provided
+     * {@code Collection}.
+     *
+     * @return Always true
+     */
     @Override
     public boolean hasNext() {
         if (this.hasPeek) {
@@ -61,7 +72,7 @@ public class CircularIterator<T> implements Iterator<T> {
         if (!this.iterator.hasNext()) {
             this.iterator = this.iterable.iterator();
         }
-        return this.iterator.hasNext();
+        return true;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
@@ -69,8 +69,8 @@ public class CircularIterator<T> implements Iterator<T> {
 
     @Override
     public T next() {
-        final T next = this.nextValue;
-        this.nextValue = advance();
+        final T next = nextValue;
+        nextValue = advance();
         return next;
     }
 
@@ -81,10 +81,10 @@ public class CircularIterator<T> implements Iterator<T> {
      * @return The next value in the iterator
      */
     private T advance() {
-        if (!this.iterator.hasNext()) {
-            this.iterator = this.iterable.iterator();
+        if (!iterator.hasNext()) {
+            iterator = iterable.iterator();
         }
-        return this.iterator.next();
+        return iterator.next();
     }
 
     /**
@@ -96,7 +96,7 @@ public class CircularIterator<T> implements Iterator<T> {
      * @return The next value in this {@code Iterator}
      */
     public T peek() {
-        return this.nextValue;
+        return nextValue;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CircularIterator.java
@@ -14,36 +14,69 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.kafka.common.utils;
 
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Objects;
 
+/**
+ * An iterator that cycles through the Iterator of a Collection indefinitely.
+ * Useful for tasks such as round-robin load balancing.
+ */
 public class CircularIterator<T> implements Iterator<T> {
-    int i = 0;
-    private List<T> list;
 
-    public CircularIterator(List<T> list) {
-        if (list.isEmpty()) {
+    private final Iterable<T> iterable;
+    private Iterator<T> iterator;
+    private T peek;
+
+    /**
+     * Create a new instance of a CircularIterator. The ordering of this
+     * Iterator will be dictated by the Iterator returned by Collection itself.
+     *
+     * @param col The collection to iterate indefinitely
+     *
+     * @throws NullPointerException if col is {@code null}
+     * @throws IllegalArgumentException if col is empty.
+     */
+    public CircularIterator(final Collection<T> col) {
+        this.iterable = Objects.requireNonNull(col);
+        this.iterator = col.iterator();
+        this.peek = null;
+        if (col.isEmpty()) {
             throw new IllegalArgumentException("CircularIterator can only be used on non-empty lists");
         }
-        this.list = list;
     }
 
     @Override
     public boolean hasNext() {
-        return true;
+        if (this.peek != null) {
+            return true;
+        }
+        if (!this.iterator.hasNext()) {
+            this.iterator = this.iterable.iterator();
+        }
+        return this.iterator.hasNext();
     }
 
     @Override
     public T next() {
-        T next = list.get(i);
-        i = (i + 1) % list.size();
-        return next;
+        final T nextValue;
+        if (this.peek != null) {
+            nextValue = this.peek;
+            this.peek = null;
+        } else {
+            nextValue = this.iterator.next();
+        }
+        return nextValue;
     }
 
     public T peek() {
-        return list.get(i);
+        if (this.peek == null) {
+            this.peek = next();
+        }
+        return this.peek;
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
@@ -39,55 +39,27 @@ public class CircularIteratorTest {
 
     @Test()
     public void testCycleCollection() {
-        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", "B", "C"));
+        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", "B", null, "C"));
 
+        assertEquals("A", it.peek());
         assertTrue(it.hasNext());
         assertEquals("A", it.next());
+        assertEquals("B", it.peek());
         assertTrue(it.hasNext());
         assertEquals("B", it.next());
-        assertTrue(it.hasNext());
-        assertEquals("C", it.next());
-        assertTrue(it.hasNext());
-        assertEquals("A", it.next());
-        assertTrue(it.hasNext());
-    }
-
-    @Test()
-    public void testPeekCollection() {
-        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", "B", "C"));
-
-        assertTrue(it.hasNext());
-        assertEquals("A", it.peek());
-        assertTrue(it.hasNext());
-        assertEquals("A", it.peek());
-        assertTrue(it.hasNext());
-        assertEquals("A", it.next());
-
-        assertEquals("B", it.next());
-        assertTrue(it.hasNext());
-        assertEquals("C", it.next());
-        assertTrue(it.hasNext());
-        assertEquals("A", it.next());
-        assertTrue(it.hasNext());
-    }
-
-    @Test()
-    public void testPeekCollectionNullValue() {
-        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", null, "C"));
-
-        assertTrue(it.hasNext());
-        assertEquals("A", it.peek());
-        assertTrue(it.hasNext());
-        assertEquals("A", it.next());
-
-        assertTrue(it.hasNext());
-        assertEquals(null, it.peek());
-        assertTrue(it.hasNext());
         assertEquals(null, it.peek());
         assertTrue(it.hasNext());
         assertEquals(null, it.next());
-
+        assertEquals("C", it.peek());
         assertTrue(it.hasNext());
         assertEquals("C", it.next());
+        assertEquals("A", it.peek());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+        assertEquals("B", it.peek());
+
+        // Check that peek does not have any side-effects
+        assertEquals("B", it.peek());
     }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
@@ -70,4 +70,24 @@ public class CircularIteratorTest {
         assertEquals("A", it.next());
         assertTrue(it.hasNext());
     }
+
+    @Test()
+    public void testPeekCollectionNullValue() {
+        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", null, "C"));
+
+        assertTrue(it.hasNext());
+        assertEquals("A", it.peek());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+
+        assertTrue(it.hasNext());
+        assertEquals(null, it.peek());
+        assertTrue(it.hasNext());
+        assertEquals(null, it.peek());
+        assertTrue(it.hasNext());
+        assertEquals(null, it.next());
+
+        assertTrue(it.hasNext());
+        assertEquals("C", it.next());
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class CircularIteratorTest {
+
+    @Test(expected = NullPointerException.class)
+    public void testNullCollection() {
+        new CircularIterator<>(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyCollection() {
+        new CircularIterator<>(Collections.emptyList());
+    }
+
+    @Test()
+    public void testCycleCollection() {
+        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", "B", "C"));
+
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("B", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("C", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+        assertTrue(it.hasNext());
+    }
+
+    @Test()
+    public void testPeekCollection() {
+        final CircularIterator<String> it = new CircularIterator<>(Arrays.asList("A", "B", "C"));
+
+        assertTrue(it.hasNext());
+        assertEquals("A", it.peek());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.peek());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+
+        assertEquals("B", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("C", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+        assertTrue(it.hasNext());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -27,14 +28,14 @@ import org.junit.Test;
 
 public class CircularIteratorTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullCollection() {
-        new CircularIterator<>(null);
+        assertThrows(NullPointerException.class, () -> new CircularIterator<>(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEmptyCollection() {
-        new CircularIterator<>(Collections.emptyList());
+        assertThrows(IllegalArgumentException.class, () -> new CircularIterator<>(Collections.emptyList()));
     }
 
     @Test()


### PR DESCRIPTION
The `CircularIterator` class uses a wrapping index-based approach to iterate over a list.  This can be a performance problem O(n^2) for a LinkedList.  Also, the index counter itself is never reset, a modulo is applied to it for every list access.  At some point, it may be possible that the index counter overflows to a negative value and therefore may cause a negative index read and an ArrayIndexOutOfBoundsException.

I propose changing this implementation to avoid these two scenarios.  Use the `Collection` `Iterator` classes to avoid using an index counter and it avoids having to seek to the correct index every time, this avoiding the LinkedList performance issue.

I have added unit tests to validate the new implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
