### PR TITLE
KAFKA-9418: Add new sendOffsetsToTransaction API to KafkaProducer

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -80,10 +80,10 @@
 
     <!-- clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message)Test.java"/>
+              files="(Sender|Fetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|KafkaAdminClient|Message)Test.java"/>
+              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="MockAdminClient.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -28,7 +28,10 @@ public class ConsumerGroupMetadata {
     final private String memberId;
     final Optional<String> groupInstanceId;
 
-    public ConsumerGroupMetadata(String groupId, int generationId, String memberId, Optional<String> groupInstanceId) {
+    public ConsumerGroupMetadata(String groupId,
+                                 int generationId,
+                                 String memberId,
+                                 Optional<String> groupInstanceId) {
         this.groupId = groupId;
         this.generationId = generationId;
         this.memberId = memberId;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -37,12 +37,8 @@ public class ConsumerGroupMetadata {
                                  Optional<String> groupInstanceId) {
         this.groupId = groupId;
         this.generationId = generationId;
-
-        Objects.requireNonNull(memberId, "member.id can't be null");
-        this.memberId = memberId;
-
-        Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");
-        this.groupInstanceId = groupInstanceId;
+        this.memberId = Objects.requireNonNull(memberId, "member.id can't be null");
+        this.groupInstanceId = Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");
     }
 
     public ConsumerGroupMetadata(String groupId) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.common.requests.JoinGroupRequest;
+
 import java.util.Optional;
 
 /**
@@ -36,6 +38,13 @@ public class ConsumerGroupMetadata {
         this.generationId = generationId;
         this.memberId = memberId;
         this.groupInstanceId = groupInstanceId;
+    }
+
+    public ConsumerGroupMetadata(String groupId) {
+        this(groupId,
+            JoinGroupRequest.UNKNOWN_GENERATION_ID,
+            JoinGroupRequest.UNKNOWN_MEMBER_ID,
+            Optional.empty());
     }
 
     public String groupId() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -26,7 +26,7 @@ public class ConsumerGroupMetadata {
     final private String groupId;
     final private int generationId;
     final private String memberId;
-    final Optional<String> groupInstanceId;
+    final private Optional<String> groupInstanceId;
 
     public ConsumerGroupMetadata(String groupId,
                                  int generationId,
@@ -52,5 +52,14 @@ public class ConsumerGroupMetadata {
 
     public Optional<String> groupInstanceId() {
         return groupInstanceId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("GroupMetadata(groupId = %s, generationId = %d, memberId = %s, groupInstanceId = %s)",
+            groupId,
+            generationId,
+            memberId,
+            groupInstanceId.orElse(""));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -35,7 +35,7 @@ public class ConsumerGroupMetadata {
                                  int generationId,
                                  String memberId,
                                  Optional<String> groupInstanceId) {
-        this.groupId = groupId;
+        this.groupId = Objects.requireNonNull(groupId, "group.id can't be null");
         this.generationId = generationId;
         this.memberId = Objects.requireNonNull(memberId, "member.id can't be null");
         this.groupInstanceId = Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.common.requests.JoinGroupRequest;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -36,7 +37,11 @@ public class ConsumerGroupMetadata {
                                  Optional<String> groupInstanceId) {
         this.groupId = groupId;
         this.generationId = generationId;
+
+        Objects.requireNonNull(memberId, "member.id can't be null");
         this.memberId = memberId;
+
+        Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");
         this.groupInstanceId = groupInstanceId;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -664,8 +664,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *         format used for the offsets topic on the broker does not support transactions
      * @throws org.apache.kafka.common.errors.AuthorizationException fatal error indicating that the configured
      *         transactional.id is not authorized, or the consumer group id is not authorized.
-     * @throws org.apache.kafka.clients.consumer.CommitFailedException  if the commit failed and cannot be retried
+     * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried
      *         (e.g. if the consumer has been kicked out of the group). Users should handle this by aborting the transaction.
+     * @throws org.apache.kafka.common.errors.FencedInstanceIdException if this producer instance gets fenced by broker due to a
+     *                                                                  mis-configured consumer instance id within group metadata.
      * @throws KafkaException if the producer has encountered a previous fatal or abortable error, or for any
      *         other unexpected error
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -693,6 +693,12 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                IllegalGenerationException,
                UnknownMemberIdException,
                FencedInstanceIdException {
+        if (!cachedGroupMetadata.groupId().equals(groupMetadata.groupId())) {
+            // Generally this logic should only be triggered once during first call.
+            log.warn("Cached consumer groupId changed from {} to {}. If the old group id is not empty, this indicates an abuse of this API",
+                cachedGroupMetadata.groupId(), groupMetadata.groupId());
+            cachedGroupMetadata = groupMetadata;
+        }
         sendOffsetsToTransactionInternal(offsets, groupMetadata, true);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -622,9 +622,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * and should also not commit offsets manually (via {@link KafkaConsumer#commitSync(Map) sync} or
      * {@link KafkaConsumer#commitAsync(Map, OffsetCommitCallback) async} commits).
      *
-     * @throws IllegalStateException if no transactional.id has been configured, no transaction has been started,
-     *                               or encounters unexpected group fencing exception which should only be returned from
-     *                               new {@link KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata) sendOffsets}.
+     * @throws IllegalStateException if no transactional.id has been configured, no transaction has been started
      * @throws ProducerFencedException fatal error indicating another producer with the same transactional.id is active
      * @throws org.apache.kafka.common.errors.UnsupportedVersionException fatal error indicating the broker
      *         does not support transactions (i.e. if its version is lower than 0.11.0.0)
@@ -1272,12 +1270,12 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
     private void throwIfInvalidGroupMetadata(ConsumerGroupMetadata groupMetadata) {
         if (groupMetadata == null) {
-            throw new IllegalStateException("Consumer group metadata could not be null");
+            throw new IllegalArgumentException("Consumer group metadata could not be null");
         } else if (groupMetadata.groupId() == null) {
-            throw new IllegalStateException("Passed in group metadata " + groupMetadata + " has empty group.id");
+            throw new IllegalArgumentException("Passed in group metadata " + groupMetadata + " has empty group.id");
         } else if (groupMetadata.generationId() > 0
             && JoinGroupRequest.UNKNOWN_MEMBER_ID.equals(groupMetadata.memberId())) {
-            throw new IllegalStateException("Passed in group metadata " + groupMetadata + " has generationId > 0 but member.id ");
+            throw new IllegalArgumentException("Passed in group metadata " + groupMetadata + " has generationId > 0 but member.id ");
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -683,21 +683,21 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * @throws KafkaException if the producer has encountered a previous fatal or abortable error, or for any
      *         other unexpected error
      */
-     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata)
-         throws ProducerFencedException,
-                IllegalGenerationException,
-                UnknownMemberIdException,
-                FencedInstanceIdException {
-         sendOffsetsToTransactionInternal(offsets, groupMetadata, true);
-     }
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata)
+        throws ProducerFencedException,
+               IllegalGenerationException,
+               UnknownMemberIdException,
+               FencedInstanceIdException {
+        sendOffsetsToTransactionInternal(offsets, groupMetadata, true);
+    }
 
-     private void sendOffsetsToTransactionInternal(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata consumerGroupMetadata, boolean enableGroupFencing) {
-         throwIfNoTransactionManager();
-         throwIfProducerClosed();
-         TransactionalRequestResult result = transactionManager.sendOffsetsToTransaction(offsets, consumerGroupMetadata, enableGroupFencing);
-         sender.wakeup();
-         result.await();
-     }
+    private void sendOffsetsToTransactionInternal(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata consumerGroupMetadata, boolean enableGroupFencing) {
+        throwIfNoTransactionManager();
+        throwIfProducerClosed();
+        TransactionalRequestResult result = transactionManager.sendOffsetsToTransaction(offsets, consumerGroupMetadata, enableGroupFencing);
+        sender.wakeup();
+        result.await();
+    }
 
     /**
      * Commits the ongoing transaction. This method will flush any unsent records before actually committing the transaction.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1271,8 +1271,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     private void throwIfInvalidGroupMetadata(ConsumerGroupMetadata groupMetadata) {
         if (groupMetadata == null) {
             throw new IllegalArgumentException("Consumer group metadata could not be null");
-        } else if (groupMetadata.groupId() == null) {
-            throw new IllegalArgumentException("Passed in group metadata " + groupMetadata + " has empty group.id");
         } else if (groupMetadata.generationId() > 0
             && JoinGroupRequest.UNKNOWN_MEMBER_ID.equals(groupMetadata.memberId())) {
             throw new IllegalArgumentException("Passed in group metadata " + groupMetadata + " has generationId > 0 but member.id ");

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -63,7 +63,6 @@ import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.KafkaThread;
@@ -79,7 +78,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -638,9 +636,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      */
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          String consumerGroupId) throws ProducerFencedException {
-        sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(
-            consumerGroupId, JoinGroupRequest.UNKNOWN_GENERATION_ID,
-            JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty()));
+        sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(consumerGroupId));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -646,7 +646,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                                          String consumerGroupId) throws ProducerFencedException {
         if (!cachedGroupMetadata.groupId().equals(consumerGroupId)) {
             // Generally this logic should only be triggered once during first call.
-            log.warn("Cached consumer groupId changed from {} to {}. If the old group id is set, this indicates a problem",
+            log.warn("Cached consumer groupId changed from {} to {}. If the old group id is not empty, this indicates an abuse of this API",
                 cachedGroupMetadata.groupId(), consumerGroupId);
             cachedGroupMetadata = new ConsumerGroupMetadata(consumerGroupId,
                 JoinGroupRequest.UNKNOWN_GENERATION_ID, JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty());
@@ -670,7 +670,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *
      * This API won't deprecate the existing {@link KafkaProducer#sendOffsetsToTransaction(Map, String) sendOffsets} API as standalone
      * mode EOS applications are still relying on it. If the broker version is lower than 2.5.0 which doesn't support the new underlying protocol,
-     * the application will crash with UnsupportedVersionException.
+     * this API call will throw UnsupportedVersionException.
      *
      * @throws IllegalStateException if no transactional.id has been configured or no transaction has been started.
      * @throws ProducerFencedException fatal error indicating another producer with the same transactional.id is active

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -27,7 +27,10 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
+import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Time;
@@ -175,7 +178,10 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     @Override
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException,
+                                                                                     IllegalGenerationException,
+                                                                                     UnknownMemberIdException,
+                                                                                     FencedInstanceIdException {
         sendOffsetsToTransaction(offsets, groupMetadata.groupId());
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -157,10 +157,10 @@ public class MockProducer<K, V> implements Producer<K, V> {
     @Override
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          String consumerGroupId) throws ProducerFencedException {
+        Objects.requireNonNull(consumerGroupId);
         verifyProducerState();
         verifyTransactionsInitialized();
         verifyNoTransactionInFlight();
-        Objects.requireNonNull(consumerGroupId);
         if (offsets.size() == 0) {
             return;
         }
@@ -176,8 +176,8 @@ public class MockProducer<K, V> implements Producer<K, V> {
     @Override
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
-        String groupId = groupMetadata != null ? groupMetadata.groupId() : null;
-        sendOffsetsToTransaction(offsets, groupId);
+        Objects.requireNonNull(groupMetadata);
+        sendOffsetsToTransaction(offsets, groupMetadata.groupId());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.producer;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.clients.producer.internals.FutureRecordMetadata;
@@ -170,6 +171,12 @@ public class MockProducer<K, V> implements Producer<K, V> {
         }
         uncommittedOffsets.putAll(offsets);
         this.sentOffsets = true;
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+        sendOffsetsToTransaction(offsets, groupMetadata.groupId());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -27,10 +27,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.FencedInstanceIdException;
-import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
-import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Time;
@@ -178,11 +175,9 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     @Override
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException,
-                                                                                     IllegalGenerationException,
-                                                                                     UnknownMemberIdException,
-                                                                                     FencedInstanceIdException {
-        sendOffsetsToTransaction(offsets, groupMetadata.groupId());
+                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+        String groupId = groupMetadata != null ? groupMetadata.groupId() : null;
+        sendOffsetsToTransaction(offsets, groupId);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.producer;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -52,6 +53,12 @@ public interface Producer<K, V> extends Closeable {
      */
     void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                   String consumerGroupId) throws ProducerFencedException;
+
+    /**
+     * See {@link KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)}
+     */
+    void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+                                  ConsumerGroupMetadata groupMetadata) throws ProducerFencedException;
 
     /**
      * See {@link KafkaProducer#commitTransaction()}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -22,10 +22,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.FencedInstanceIdException;
-import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
-import org.apache.kafka.common.errors.UnknownMemberIdException;
 
 import java.io.Closeable;
 import java.time.Duration;
@@ -61,10 +58,7 @@ public interface Producer<K, V> extends Closeable {
      * See {@link KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)}
      */
     void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                  ConsumerGroupMetadata groupMetadata) throws ProducerFencedException,
-                                                                              IllegalGenerationException,
-                                                                              UnknownMemberIdException,
-                                                                              FencedInstanceIdException;
+                                  ConsumerGroupMetadata groupMetadata) throws ProducerFencedException;
 
     /**
      * See {@link KafkaProducer#commitTransaction()}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -22,7 +22,10 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
+import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
 
 import java.io.Closeable;
 import java.time.Duration;
@@ -58,7 +61,10 @@ public interface Producer<K, V> extends Closeable {
      * See {@link KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)}
      */
     void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                  ConsumerGroupMetadata groupMetadata) throws ProducerFencedException;
+                                  ConsumerGroupMetadata groupMetadata) throws ProducerFencedException,
+                                                                              IllegalGenerationException,
+                                                                              UnknownMemberIdException,
+                                                                              FencedInstanceIdException;
 
     /**
      * See {@link KafkaProducer#commitTransaction()}

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1525,15 +1525,15 @@ public class TransactionManager {
         }
     }
 
-    private boolean isFatalException(Errors error) {
-        return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
-                || error == Errors.INVALID_PRODUCER_EPOCH
-                || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
-    }
-
     private boolean isGroupFencingException(Errors error) {
         return error == Errors.FENCED_INSTANCE_ID
                    || error == Errors.UNKNOWN_MEMBER_ID
                    || error == Errors.ILLEGAL_GENERATION;
+    }
+
+    private boolean isFatalException(Errors error) {
+        return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
+                   || error == Errors.INVALID_PRODUCER_EPOCH
+                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1482,7 +1482,8 @@ public class TransactionManager {
                 } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
-                } else if (isGroupMetadataMisMatch(error)) {
+                } else if (error == Errors.UNKNOWN_MEMBER_ID
+                        || error == Errors.ILLEGAL_GENERATION) {
                     abortableError(new CommitFailedException("Transaction offset Commit failed " +
                         "due to consumer group metadata mismatch: " + error.exception().getMessage()));
                     break;
@@ -1506,15 +1507,10 @@ public class TransactionManager {
         }
     }
 
-    private boolean isGroupMetadataMisMatch(Errors error) {
-        return error == Errors.FENCED_INSTANCE_ID
-                   || error == Errors.UNKNOWN_MEMBER_ID
-                   || error == Errors.ILLEGAL_GENERATION;
-    }
-
     private boolean isFatalException(Errors error) {
         return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
                    || error == Errors.INVALID_PRODUCER_EPOCH
-                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
+                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT
+                   || error == Errors.FENCED_INSTANCE_ID;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1482,6 +1482,9 @@ public class TransactionManager {
                 } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
+                } else if (error == Errors.FENCED_INSTANCE_ID) {
+                    abortableError(error.exception());
+                    break;
                 } else if (error == Errors.UNKNOWN_MEMBER_ID
                         || error == Errors.ILLEGAL_GENERATION) {
                     abortableError(new CommitFailedException("Transaction offset Commit failed " +
@@ -1510,7 +1513,6 @@ public class TransactionManager {
     private boolean isFatalException(Errors error) {
         return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
                    || error == Errors.INVALID_PRODUCER_EPOCH
-                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT
-                   || error == Errors.FENCED_INSTANCE_ID;
+                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1497,8 +1497,7 @@ public class TransactionManager {
                     fatalError(new KafkaException("Unexpected group fencing" +
                         " exception encountered when the group fencing mechanism is not enabled: " + error.message()));
                     break;
-                }
-                else if (isFatalException(error)) {
+                } else if (isFatalException(error)) {
                     fatalError(error.exception());
                     break;
                 } else if (isGroupFencingException(error)) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1482,9 +1482,9 @@ public class TransactionManager {
                 } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
-                } else if (error == Errors.UNKNOWN_MEMBER_ID
-                        || error == Errors.ILLEGAL_GENERATION) {
-                    abortableError(new CommitFailedException("Txn offset Commit failed due to consumer group metadata mismatch" + error.exception().getMessage()));
+                } else if (isGroupMetadataMisMatch(error)) {
+                    abortableError(new CommitFailedException("Transaction offset Commit failed " +
+                        "due to consumer group metadata mismatch: " + error.exception().getMessage()));
                     break;
                 } else if (isFatalException(error)) {
                     fatalError(error.exception());
@@ -1506,10 +1506,15 @@ public class TransactionManager {
         }
     }
 
+    private boolean isGroupMetadataMisMatch(Errors error) {
+        return error == Errors.FENCED_INSTANCE_ID
+                   || error == Errors.UNKNOWN_MEMBER_ID
+                   || error == Errors.ILLEGAL_GENERATION;
+    }
+
     private boolean isFatalException(Errors error) {
         return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
                    || error == Errors.INVALID_PRODUCER_EPOCH
-                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT
-                   || error == Errors.FENCED_INSTANCE_ID;
+                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
@@ -50,13 +50,14 @@ public class TxnOffsetCommitRequest extends AbstractRequest {
                        final long producerId,
                        final short producerEpoch,
                        final Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits) {
-            super(ApiKeys.TXN_OFFSET_COMMIT);
-            this.data = new TxnOffsetCommitRequestData()
-                            .setTransactionalId(transactionalId)
-                            .setGroupId(consumerGroupId)
-                            .setProducerId(producerId)
-                            .setProducerEpoch(producerEpoch)
-                            .setTopics(getTopics(pendingTxnOffsetCommits));
+            this(transactionalId,
+                consumerGroupId,
+                producerId,
+                producerEpoch,
+                pendingTxnOffsetCommits,
+                JoinGroupRequest.UNKNOWN_MEMBER_ID,
+                JoinGroupRequest.UNKNOWN_GENERATION_ID,
+                Optional.empty());
         }
 
         public Builder(final String transactionalId,

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
@@ -45,9 +45,38 @@ public class TxnOffsetCommitRequest extends AbstractRequest {
 
         public final TxnOffsetCommitRequestData data;
 
-        public Builder(TxnOffsetCommitRequestData data) {
+        public Builder(final String transactionalId,
+                       final String consumerGroupId,
+                       final long producerId,
+                       final short producerEpoch,
+                       final Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits) {
             super(ApiKeys.TXN_OFFSET_COMMIT);
-            this.data = data;
+            this.data = new TxnOffsetCommitRequestData()
+                            .setTransactionalId(transactionalId)
+                            .setGroupId(consumerGroupId)
+                            .setProducerId(producerId)
+                            .setProducerEpoch(producerEpoch)
+                            .setTopics(getTopics(pendingTxnOffsetCommits));
+        }
+
+        public Builder(final String transactionalId,
+                       final String consumerGroupId,
+                       final long producerId,
+                       final short producerEpoch,
+                       final Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits,
+                       final String memberId,
+                       final int generationId,
+                       final Optional<String> groupInstanceId) {
+            super(ApiKeys.TXN_OFFSET_COMMIT);
+            this.data = new TxnOffsetCommitRequestData()
+                            .setTransactionalId(transactionalId)
+                            .setGroupId(consumerGroupId)
+                            .setProducerId(producerId)
+                            .setProducerEpoch(producerEpoch)
+                            .setTopics(getTopics(pendingTxnOffsetCommits))
+                            .setMemberId(memberId)
+                            .setGenerationId(generationId)
+                            .setGroupInstanceId(groupInstanceId.orElse(null));
         }
 
         @Override
@@ -86,7 +115,7 @@ public class TxnOffsetCommitRequest extends AbstractRequest {
         return offsetMap;
     }
 
-    public static List<TxnOffsetCommitRequestTopic> getTopics(Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits) {
+    static List<TxnOffsetCommitRequestTopic> getTopics(Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits) {
         Map<String, List<TxnOffsetCommitRequestPartition>> topicPartitionMap = new HashMap<>();
         for (Map.Entry<TopicPartition, CommittedOffset> entry : pendingTxnOffsetCommits.entrySet()) {
             TopicPartition topicPartition = entry.getKey();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -16,18 +16,22 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.junit.Test;
 
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ConsumerGroupMetadataTest {
 
+    private String groupId = "group";
+
     @Test
     public void testAssignmentConstructor() {
-        String groupId = "group";
         String memberId = "member";
         int generationId = 2;
         String groupInstanceId = "instance";
@@ -40,5 +44,34 @@ public class ConsumerGroupMetadataTest {
         assertEquals(memberId, groupMetadata.memberId());
         assertTrue(groupMetadata.groupInstanceId().isPresent());
         assertEquals(groupInstanceId, groupMetadata.groupInstanceId().get());
+    }
+
+    @Test
+    public void testGroupIdConstructor() {
+        ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId);
+
+        assertEquals(groupId, groupMetadata.groupId());
+        assertEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, groupMetadata.generationId());
+        assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, groupMetadata.memberId());
+        assertFalse(groupMetadata.groupInstanceId().isPresent());
+    }
+
+    @Test
+    public void testInvalidMemberId() {
+        int generationId = 2;
+
+        assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
+            groupId, generationId, null, Optional.empty())
+        );
+    }
+
+    @Test
+    public void testInvalidInstanceId() {
+        String memberId = "member";
+        int generationId = 2;
+
+        assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
+            groupId, generationId, memberId, null)
+        );
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -57,6 +57,16 @@ public class ConsumerGroupMetadataTest {
     }
 
     @Test
+    public void testInvalidGroupId() {
+        String memberId = "member";
+        int generationId = 2;
+
+        assertThrows(NullPointerException.class, () -> new ConsumerGroupMetadata(
+            null, generationId, memberId, Optional.empty())
+        );
+    }
+
+    @Test
     public void testInvalidMemberId() {
         int generationId = 2;
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -111,7 +110,7 @@ public class PartitionAssignorAdapterTest {
         TopicPartition tp2 = new TopicPartition("tp2", 2);
         List<TopicPartition> partitions = Arrays.asList(tp1, tp2);
 
-        adaptedAssignor.onAssignment(new Assignment(partitions), new ConsumerGroupMetadata("", 1, "", Optional.empty()));
+        adaptedAssignor.onAssignment(new Assignment(partitions), new ConsumerGroupMetadata(""));
 
         assertEquals(oldAssignor.partitions, partitions);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -720,10 +720,10 @@ public class KafkaProducerTest {
         client.prepareResponse(addOffsetsToTxnResponse(Errors.NONE));
         client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
         String groupId = "group";
-        client.prepareResponse((request) ->
+        client.prepareResponse(request ->
             ((TxnOffsetCommitRequest) request).data.groupId().equals(groupId),
             txnOffsetsCommitResponse(Collections.singletonMap(
-                new TopicPartition("topic", 0), Errors.NONE)), true);
+                new TopicPartition("topic", 0), Errors.NONE)));
         client.prepareResponse(endTxnResponse(Errors.NONE));
 
         try (Producer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
@@ -760,13 +760,13 @@ public class KafkaProducerTest {
         String memberId = "member";
         int generationId = 5;
         String groupInstanceId = "instance";
-        client.prepareResponse((request) -> {
-                TxnOffsetCommitRequestData data = ((TxnOffsetCommitRequest) request).data;
-                return data.groupId().equals(groupId) &&
-                    data.memberId().equals(memberId) &&
-                    data.generationId() == generationId &&
-                    data.groupInstanceId().equals(groupInstanceId);
-            },
+        client.prepareResponse(request -> {
+            TxnOffsetCommitRequestData data = ((TxnOffsetCommitRequest) request).data;
+            return data.groupId().equals(groupId) &&
+                       data.memberId().equals(memberId) &&
+                       data.generationId() == generationId &&
+                       data.groupInstanceId().equals(groupInstanceId);
+        },
             txnOffsetsCommitResponse(Collections.singletonMap(
                 new TopicPartition("topic", 0), Errors.NONE)));
         client.prepareResponse(endTxnResponse(Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -821,7 +821,7 @@ public class KafkaProducerTest {
             new StringSerializer(), metadata, client, null, time)) {
             producer.initTransactions();
             producer.beginTransaction();
-            assertThrows(IllegalStateException.class,
+            assertThrows(IllegalArgumentException.class,
                 () -> producer.sendOffsetsToTransaction(Collections.emptyMap(), groupMetadata));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.producer.internals.ProducerInterceptors;
 import org.apache.kafka.clients.producer.internals.ProducerMetadata;
 import org.apache.kafka.clients.producer.internals.Sender;
@@ -26,19 +27,26 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
+import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.Selectable;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
+import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
+import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -61,6 +69,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -689,6 +698,90 @@ public class KafkaProducerTest {
         }
     }
 
+    @Test
+    public void testSendTxnOffsetsWithGroupId() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10000);
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+
+        Time time = new MockTime(1);
+        MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+
+        MockClient client = new MockClient(time, metadata);
+        client.updateMetadata(initialUpdateResponse);
+
+        Node node = metadata.fetch().nodes().get(0);
+        client.throttle(node, 5000);
+
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+        client.prepareResponse(addOffsetsToTxnResponse(Errors.NONE));
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+        String groupId = "group";
+        client.prepareResponse((request) ->
+            ((TxnOffsetCommitRequest) request).data.groupId().equals(groupId),
+            txnOffsetsCommitResponse(Collections.singletonMap(
+                new TopicPartition("topic", 0), Errors.NONE)), true);
+        client.prepareResponse(endTxnResponse(Errors.NONE));
+
+        try (Producer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
+            new StringSerializer(), metadata, client, null, time)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.sendOffsetsToTransaction(Collections.emptyMap(), groupId);
+            producer.commitTransaction();
+        }
+    }
+
+    @Test
+    public void testSendTxnOffsetsWithGroupMetadata() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10000);
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+
+        Time time = new MockTime(1);
+        MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
+        ProducerMetadata metadata = newMetadata(0, Long.MAX_VALUE);
+
+        MockClient client = new MockClient(time, metadata);
+        client.updateMetadata(initialUpdateResponse);
+
+        Node node = metadata.fetch().nodes().get(0);
+        client.throttle(node, 5000);
+
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+        client.prepareResponse(addOffsetsToTxnResponse(Errors.NONE));
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+        String groupId = "group";
+        String memberId = "member";
+        int generationId = 5;
+        String groupInstanceId = "instance";
+        client.prepareResponse((request) -> {
+                TxnOffsetCommitRequestData data = ((TxnOffsetCommitRequest) request).data;
+                return data.groupId().equals(groupId) &&
+                    data.memberId().equals(memberId) &&
+                    data.generationId() == generationId &&
+                    data.groupInstanceId().equals(groupInstanceId);
+            },
+            txnOffsetsCommitResponse(Collections.singletonMap(
+                new TopicPartition("topic", 0), Errors.NONE)));
+        client.prepareResponse(endTxnResponse(Errors.NONE));
+
+        try (Producer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
+            new StringSerializer(), metadata, client, null, time)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata(groupId,
+                generationId, memberId, Optional.of(groupInstanceId));
+            producer.sendOffsetsToTransaction(Collections.emptyMap(), groupMetadata);
+            producer.commitTransaction();
+        }
+    }
+
     private InitProducerIdResponse initProducerIdResponse(long producerId, short producerEpoch, Errors error) {
         InitProducerIdResponseData responseData = new InitProducerIdResponseData()
                 .setErrorCode(error.code())
@@ -698,6 +791,19 @@ public class KafkaProducerTest {
         return new InitProducerIdResponse(responseData);
     }
 
+    private AddOffsetsToTxnResponse addOffsetsToTxnResponse(Errors error) {
+        return new AddOffsetsToTxnResponse(10, error);
+    }
+
+    private TxnOffsetCommitResponse txnOffsetsCommitResponse(Map<TopicPartition, Errors> errorMap) {
+        return new TxnOffsetCommitResponse(10, errorMap);
+    }
+
+    private EndTxnResponse endTxnResponse(Errors error) {
+        return new EndTxnResponse(new EndTxnResponseData()
+                                      .setErrorCode(error.code())
+                                      .setThrottleTimeMs(0));
+    }
 
     @Test
     public void testOnlyCanExecuteCloseAfterInitTransactionsTimeout() {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -789,11 +789,6 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testNullGroupIdInSendOffsets() {
-        verifyInvalidGroupMetadata(new ConsumerGroupMetadata(null));
-    }
-
-    @Test
     public void testInvalidGenerationIdAndMemberIdCombinedInSendOffsets() {
         verifyInvalidGroupMetadata(new ConsumerGroupMetadata("group", 2, JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty()));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -80,8 +79,8 @@ public class MockProducerTest {
     public void testPartitioner() throws Exception {
         PartitionInfo partitionInfo0 = new PartitionInfo(topic, 0, null, null, null);
         PartitionInfo partitionInfo1 = new PartitionInfo(topic, 1, null, null, null);
-        Cluster cluster = new Cluster(null, new ArrayList<Node>(0), asList(partitionInfo0, partitionInfo1),
-                Collections.<String>emptySet(), Collections.<String>emptySet());
+        Cluster cluster = new Cluster(null, new ArrayList<>(0), asList(partitionInfo0, partitionInfo1),
+                Collections.emptySet(), Collections.emptySet());
         MockProducer<String, String> producer = new MockProducer<>(cluster, true, new DefaultPartitioner(), new StringSerializer(), new StringSerializer());
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, "key", "value");
         Future<RecordMetadata> metadata = producer.send(record);
@@ -152,7 +151,7 @@ public class MockProducerTest {
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOnSendOffsetsToTransactionIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.sendOffsetsToTransaction(null, null);
+        producer.sendOffsetsToTransaction(null, "");
     }
 
     @Test
@@ -160,7 +159,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         try {
-            producer.sendOffsetsToTransaction(null, null);
+            producer.sendOffsetsToTransaction(null, "");
             fail("Should have thrown as producer has no open transaction");
         } catch (IllegalStateException e) { }
     }
@@ -279,7 +278,7 @@ public class MockProducerTest {
         producer.initTransactions();
         producer.fenceProducer();
         try {
-            producer.sendOffsetsToTransaction(null, null);
+            producer.sendOffsetsToTransaction(null, "");
             fail("Should have thrown as producer is fenced off");
         } catch (ProducerFencedException e) { }
     }
@@ -433,7 +432,8 @@ public class MockProducerTest {
         producer.beginTransaction();
 
         try {
-            producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), null);
+            String consumerGroupId = null;
+            producer.sendOffsetsToTransaction(Collections.emptyMap(), consumerGroupId);
             fail("Should have thrown NullPointerException");
         } catch (NullPointerException e) { }
     }
@@ -603,7 +603,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.close();
         try {
-            producer.sendOffsetsToTransaction(null, null);
+            producer.sendOffsetsToTransaction(null, "");
             fail("Should have thrown as producer is already closed");
         } catch (IllegalStateException e) { }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -18,10 +18,12 @@ package org.apache.kafka.clients.producer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Cluster;
@@ -82,6 +84,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -823,8 +826,10 @@ public class TransactionManagerTest {
 
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(tp1, new OffsetAndMetadata(1));
+
         final String consumerGroupId = "myconsumergroup";
-        TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(offsets, consumerGroupId);
+        TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(
+            offsets, groupMetadata(consumerGroupId), true);
 
         assertFalse(transactionManager.hasPendingOffsetCommits());
 
@@ -923,7 +928,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-                singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+                singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -954,7 +959,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-            singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+            singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -985,7 +990,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-            singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+            singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -1016,7 +1021,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-            singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+            singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -1186,7 +1191,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-                singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(39L)), consumerGroupId);
+                singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -1218,7 +1223,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-                singletonMap(tp1, new OffsetAndMetadata(39L)), consumerGroupId);
+                singletonMap(tp1, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -1254,7 +1259,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-                singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+                singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled
@@ -1279,7 +1284,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
-                singletonMap(tp, new OffsetAndMetadata(39L)), consumerGroupId);
+                singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), false);
 
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
         sender.runOnce();  // AddOffsetsToTxn Handled, TxnOffsetCommit Enqueued
@@ -1735,7 +1740,8 @@ public class TransactionManagerTest {
         assertThrows(ProducerFencedException.class, () -> transactionManager.beginTransaction());
         assertThrows(ProducerFencedException.class, () -> transactionManager.beginCommit());
         assertThrows(ProducerFencedException.class, () -> transactionManager.beginAbort());
-        assertThrows(ProducerFencedException.class, () -> transactionManager.sendOffsetsToTransaction(Collections.emptyMap(), "dummyId"));
+        assertThrows(ProducerFencedException.class, () -> transactionManager.sendOffsetsToTransaction(
+            Collections.emptyMap(), groupMetadata("dummyId"), false));
     }
 
     @Test
@@ -2141,7 +2147,8 @@ public class TransactionManagerTest {
         offsets.put(tp1, new OffsetAndMetadata(1));
         final String consumerGroupId = "myconsumergroup";
 
-        TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(offsets, consumerGroupId);
+        TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(
+            offsets, groupMetadata(consumerGroupId), false);
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
 
         sender.runOnce();  // send AddOffsetsToTxnResult
@@ -2213,7 +2220,7 @@ public class TransactionManagerTest {
         offsets.put(tp1, new OffsetAndMetadata(1));
         final String consumerGroupId = "myconsumergroup";
 
-        transactionManager.sendOffsetsToTransaction(offsets, consumerGroupId);
+        transactionManager.sendOffsetsToTransaction(offsets, groupMetadata(consumerGroupId), false);
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
@@ -2239,7 +2246,7 @@ public class TransactionManagerTest {
         offsets.put(tp1, new OffsetAndMetadata(1));
         final String consumerGroupId = "myconsumergroup";
 
-        transactionManager.sendOffsetsToTransaction(offsets, consumerGroupId);
+        transactionManager.sendOffsetsToTransaction(offsets, groupMetadata(consumerGroupId), false);
 
         TransactionalRequestResult abortResult = transactionManager.beginAbort();
 
@@ -2251,6 +2258,56 @@ public class TransactionManagerTest {
         assertTrue(abortResult.isCompleted());
         assertFalse(abortResult.isSuccessful());
         assertTrue(transactionManager.hasFatalError());
+    }
+
+    @Test
+    public void testSendOffsetsWithGroupMetadata() {
+        final long pid = 13131L;
+        final short epoch = 1;
+
+        doInitTransactions(pid, epoch);
+
+        transactionManager.beginTransaction();
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(tp0, new OffsetAndMetadata(1));
+        offsets.put(tp1, new OffsetAndMetadata(1));
+        final String consumerGroupId = "myconsumergroup";
+        final String groupInstanceId = "instance";
+        final String memberId = "member";
+        final int generationId = 5;
+
+        TransactionalRequestResult addOffsetsResult = transactionManager.sendOffsetsToTransaction(
+            offsets, new ConsumerGroupMetadata(consumerGroupId, generationId, memberId, Optional.of(groupInstanceId)), true);
+        prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, pid, epoch);
+
+        sender.runOnce();  // send AddOffsetsToTxnResult
+
+        assertFalse(addOffsetsResult.isCompleted());  // The request should complete only after the TxnOffsetCommit completes.
+
+        Map<TopicPartition, Errors> txnOffsetCommitResponse = new HashMap<>();
+        txnOffsetCommitResponse.put(tp0, Errors.NONE);
+        txnOffsetCommitResponse.put(tp1, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+
+        prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
+        prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, groupInstanceId, memberId, generationId, txnOffsetCommitResponse);
+
+        assertNull(transactionManager.coordinator(CoordinatorType.GROUP));
+        sender.runOnce();  // try to send TxnOffsetCommitRequest, but find we don't have a group coordinator.
+        sender.runOnce();  // send find coordinator for group request
+        assertNotNull(transactionManager.coordinator(CoordinatorType.GROUP));
+        assertTrue(transactionManager.hasPendingOffsetCommits());
+
+        sender.runOnce();  // send TxnOffsetCommitRequest request.
+
+        assertTrue(transactionManager.hasPendingOffsetCommits());  // The TxnOffsetCommit failed.
+        assertFalse(addOffsetsResult.isCompleted());  // We should only be done after both RPCs complete successfully.
+
+        txnOffsetCommitResponse.put(tp1, Errors.NONE);
+        prepareTxnOffsetCommitResponse(consumerGroupId, pid, epoch, txnOffsetCommitResponse);
+        sender.runOnce();  // Send TxnOffsetCommitRequest again.
+
+        assertTrue(addOffsetsResult.isCompleted());
+        assertTrue(addOffsetsResult.isSuccessful());
     }
 
     @Test
@@ -2863,6 +2920,7 @@ public class TransactionManagerTest {
     private void prepareProduceResponse(Errors error, final long producerId, final short producerEpoch) {
         client.prepareResponse(produceRequestMatcher(producerId, producerEpoch), produceResponse(tp0, 0, error, 0));
     }
+
     private MockClient.RequestMatcher produceRequestMatcher(final long pid, final short epoch) {
         return body -> {
             ProduceRequest produceRequest = (ProduceRequest) body;
@@ -2963,6 +3021,29 @@ public class TransactionManagerTest {
             assertEquals(producerEpoch, txnOffsetCommitRequest.data.producerEpoch());
             return true;
         }, new TxnOffsetCommitResponse(0, txnOffsetCommitResponse));
+    }
+
+    private void prepareTxnOffsetCommitResponse(final String consumerGroupId,
+                                                final long producerId,
+                                                final short producerEpoch,
+                                                final String groupInstanceId,
+                                                final String memberId,
+                                                final int generationId,
+                                                Map<TopicPartition, Errors> txnOffsetCommitResponse) {
+        client.prepareResponse(request -> {
+            TxnOffsetCommitRequest txnOffsetCommitRequest = (TxnOffsetCommitRequest) request;
+            assertEquals(consumerGroupId, txnOffsetCommitRequest.data.groupId());
+            assertEquals(producerId, txnOffsetCommitRequest.data.producerId());
+            assertEquals(producerEpoch, txnOffsetCommitRequest.data.producerEpoch());
+            assertEquals(groupInstanceId, txnOffsetCommitRequest.data.groupInstanceId());
+            assertEquals(memberId, txnOffsetCommitRequest.data.memberId());
+            assertEquals(generationId, txnOffsetCommitRequest.data.generationId());
+            return true;
+        }, new TxnOffsetCommitResponse(0, txnOffsetCommitResponse));
+    }
+
+    private ConsumerGroupMetadata groupMetadata(String consumerGroupId) {
+        return new ConsumerGroupMetadata(consumerGroupId, JoinGroupRequest.UNKNOWN_GENERATION_ID, JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty());
     }
 
     private ProduceResponse produceResponse(TopicPartition tp, long offset, Errors error, int throttleTimeMs) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -987,7 +987,7 @@ public class TransactionManagerTest {
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
         assertTrue(sendOffsetsResult.error() instanceof FencedInstanceIdException);
-        assertFatalError(FencedInstanceIdException.class);
+        assertAbortableError(FencedInstanceIdException.class);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1025,7 +1025,7 @@ public class TransactionManagerTest {
 
         transactionManager.beginTransaction();
 
-        final boolean enableGroupFencing = false;
+        final boolean enableGroupFencing = true;
         TransactionalRequestResult sendOffsetsResult = transactionManager.sendOffsetsToTransaction(
             singletonMap(tp, new OffsetAndMetadata(39L)), groupMetadata(consumerGroupId), enableGroupFencing);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -984,11 +983,11 @@ public class TransactionManagerTest {
         sender.runOnce();  // TxnOffsetCommit Handled
 
         assertTrue(transactionManager.hasError());
-        assertTrue(transactionManager.lastError() instanceof FencedInstanceIdException);
+        assertTrue(transactionManager.lastError() instanceof CommitFailedException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
-        assertTrue(sendOffsetsResult.error() instanceof FencedInstanceIdException);
-        assertFatalError(FencedInstanceIdException.class);
+        assertTrue(sendOffsetsResult.error() instanceof CommitFailedException);
+        assertAbortableError(CommitFailedException.class);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -982,11 +983,11 @@ public class TransactionManagerTest {
         sender.runOnce();  // TxnOffsetCommit Handled
 
         assertTrue(transactionManager.hasError());
-        assertTrue(transactionManager.lastError() instanceof CommitFailedException);
+        assertTrue(transactionManager.lastError() instanceof FencedInstanceIdException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
-        assertTrue(sendOffsetsResult.error() instanceof CommitFailedException);
-        assertAbortableError(CommitFailedException.class);
+        assertTrue(sendOffsetsResult.error() instanceof FencedInstanceIdException);
+        assertFatalError(FencedInstanceIdException.class);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -431,11 +431,11 @@ public final class MessageTest {
 
             if (version < 3) {
                 final short finalVersion = version;
-                assertThrows(UnsupportedVersionException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, requestData));
+                assertThrows(UnsupportedVersionException.class, () -> testEquivalentMessageRoundTrip(finalVersion, requestData));
                 requestData.setGroupInstanceId(null);
-                assertThrows(UnsupportedVersionException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, requestData));
+                assertThrows(UnsupportedVersionException.class, () -> testEquivalentMessageRoundTrip(finalVersion, requestData));
                 requestData.setMemberId("");
-                assertThrows(UnsupportedVersionException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, requestData));
+                assertThrows(UnsupportedVersionException.class, () -> testEquivalentMessageRoundTrip(finalVersion, requestData));
                 requestData.setGenerationId(-1);
             }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
@@ -41,6 +41,8 @@ import static org.junit.Assert.assertThrows;
 public class OffsetCommitRequestTest {
 
     protected static String groupId = "groupId";
+    protected static String memberId = "consumerId";
+    protected static String groupInstanceId = "groupInstanceId";
     protected static String topicOne = "topicOne";
     protected static String topicTwo = "topicTwo";
     protected static int partitionOne = 1;
@@ -123,9 +125,9 @@ public class OffsetCommitRequestTest {
     public void testVersionSupportForGroupInstanceId() {
         OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
             new OffsetCommitRequestData()
-                .setGroupId("groupId")
-                .setMemberId("consumerId")
-                .setGroupInstanceId("groupInstanceId")
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setGroupInstanceId(groupInstanceId)
         );
 
         for (short version = 0; version <= ApiKeys.OFFSET_COMMIT.latestVersion(); version++) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData.TxnOffsetCommitRequestPartition;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData.TxnOffsetCommitRequestTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -29,6 +28,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,63 +40,62 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
     private static int producerId = 10;
     private static short producerEpoch = 1;
 
-    private static TxnOffsetCommitRequestData data;
-
     @Before
     @Override
     public void setUp() {
         super.setUp();
-        data = new TxnOffsetCommitRequestData()
-                   .setGroupId(groupId)
-                   .setTransactionalId(transactionalId)
-                   .setProducerId(producerId)
-                   .setProducerEpoch(producerEpoch)
-                   .setTopics(Arrays.asList(
-                       new TxnOffsetCommitRequestTopic()
-                           .setName(topicOne)
-                           .setPartitions(Collections.singletonList(
-                               new TxnOffsetCommitRequestPartition()
-                                   .setPartitionIndex(partitionOne)
-                                   .setCommittedOffset(offset)
-                                   .setCommittedLeaderEpoch(leaderEpoch)
-                                   .setCommittedMetadata(metadata)
-                           )),
-                       new TxnOffsetCommitRequestTopic()
-                           .setName(topicTwo)
-                           .setPartitions(Collections.singletonList(
-                               new TxnOffsetCommitRequestPartition()
-                                   .setPartitionIndex(partitionTwo)
-                                   .setCommittedOffset(offset)
-                                   .setCommittedLeaderEpoch(leaderEpoch)
-                                   .setCommittedMetadata(metadata)
-                           ))
-                   ));
     }
 
     @Test
     @Override
     public void testConstructor() {
-        Map<TopicPartition, CommittedOffset> expectedOffsets = new HashMap<>();
-        expectedOffsets.put(new TopicPartition(topicOne, partitionOne),
+        Map<TopicPartition, CommittedOffset> offsets = new HashMap<>();
+        offsets.put(new TopicPartition(topicOne, partitionOne),
                             new CommittedOffset(
                                 offset,
                                 metadata,
                                 Optional.of((int) leaderEpoch)));
-        expectedOffsets.put(new TopicPartition(topicTwo, partitionTwo),
+        offsets.put(new TopicPartition(topicTwo, partitionTwo),
                             new CommittedOffset(
                                 offset,
                                 metadata,
                                 Optional.of((int) leaderEpoch)));
 
-        TxnOffsetCommitRequest.Builder builder = new TxnOffsetCommitRequest.Builder(data);
+        TxnOffsetCommitRequest.Builder builder = new TxnOffsetCommitRequest.Builder(
+            transactionalId,
+            groupId,
+            producerId,
+            producerEpoch,
+            offsets);
         Map<TopicPartition, Errors> errorsMap = new HashMap<>();
         errorsMap.put(new TopicPartition(topicOne, partitionOne), Errors.NOT_COORDINATOR);
         errorsMap.put(new TopicPartition(topicTwo, partitionTwo), Errors.NOT_COORDINATOR);
 
+        List<TxnOffsetCommitRequestTopic> expectedTopics = Arrays.asList(
+            new TxnOffsetCommitRequestTopic()
+                .setName(topicOne)
+                .setPartitions(Collections.singletonList(
+                    new TxnOffsetCommitRequestPartition()
+                        .setPartitionIndex(partitionOne)
+                        .setCommittedOffset(offset)
+                        .setCommittedLeaderEpoch(leaderEpoch)
+                        .setCommittedMetadata(metadata)
+                )),
+            new TxnOffsetCommitRequestTopic()
+                .setName(topicTwo)
+                .setPartitions(Collections.singletonList(
+                    new TxnOffsetCommitRequestPartition()
+                        .setPartitionIndex(partitionTwo)
+                        .setCommittedOffset(offset)
+                        .setCommittedLeaderEpoch(leaderEpoch)
+                        .setCommittedMetadata(metadata)
+                ))
+        );
+
         for (short version = 0; version <= ApiKeys.TXN_OFFSET_COMMIT.latestVersion(); version++) {
             TxnOffsetCommitRequest request = builder.build(version);
-            assertEquals(expectedOffsets, request.offsets());
-            assertEquals(data.topics(), TxnOffsetCommitRequest.getTopics(request.offsets()));
+            assertEquals(offsets, request.offsets());
+            assertEquals(expectedTopics, TxnOffsetCommitRequest.getTopics(request.offsets()));
 
             TxnOffsetCommitResponse response =
                 request.getErrorResponse(throttleTimeMs, Errors.NOT_COORDINATOR.exception());

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -26,7 +26,7 @@ import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils.consumeRecords
-import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerGroupMetadata, KafkaConsumer, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.{ProducerFencedException, TimeoutException}
@@ -227,7 +227,20 @@ class TransactionsTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testSendOffsets() = {
+  def testSendOffsetsWithGroupId() = {
+    sendOffset((producer, groupId, consumer) =>
+      producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, groupId))
+  }
+
+  @Test
+  def testSendOffsetsWithGroupMetadata() = {
+    sendOffset((producer, groupId, consumer) =>
+      producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, consumer.groupMetadata()))
+  }
+
+  private def sendOffset(commit: (KafkaProducer[Array[Byte], Array[Byte]],
+    String, KafkaConsumer[Array[Byte], Array[Byte]]) => Unit) = {
+
     // The basic plan for the test is as follows:
     //  1. Seed topic1 with 1000 unique, numbered, messages.
     //  2. Run a consume/process/produce loop to transactionally copy messages from topic1 to topic2 and commit
@@ -242,7 +255,7 @@ class TransactionsTest extends KafkaServerTestHarness {
 
     TestUtils.seedTopicWithNumberedRecords(topic1, numSeedMessages, servers)
 
-    val producer = transactionalProducers(0)
+    val producer = transactionalProducers.head
 
     val consumer = createReadCommittedConsumer(consumerGroupId, maxPollRecords = numSeedMessages / 4)
     consumer.subscribe(List(topic1).asJava)
@@ -263,7 +276,7 @@ class TransactionsTest extends KafkaServerTestHarness {
           producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic2, key, value, willBeCommitted = shouldCommit))
         }
 
-        producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, consumerGroupId)
+        commit(producer, consumerGroupId, consumer)
         if (shouldCommit) {
           producer.commitTransaction()
           recordsProcessed += records.size

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -287,7 +287,7 @@ class TransactionsTest extends KafkaServerTestHarness {
           debug(s"aborted transaction Last committed record: ${new String(records.last.value(), "UTF-8")}. Num " +
             s"records written to $topic2: $recordsProcessed")
           TestUtils.resetToCommittedPositions(consumer)
-       }
+        }
       }
     } finally {
       consumer.close()

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -234,7 +234,7 @@ class TransactionsTest extends KafkaServerTestHarness {
 
   @Test
   def testSendOffsetsWithGroupMetadata() = {
-    sendOffset((producer, groupId, consumer) =>
+    sendOffset((producer, _, consumer) =>
       producer.sendOffsetsToTransaction(TestUtils.consumerPositions(consumer).asJava, consumer.groupMetadata()))
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{MemoryRecords, RecordBatch}
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
-import org.apache.kafka.common.requests.{JoinGroupRequest, JoinGroupResponse, OffsetCommitRequest, OffsetFetchResponse, TransactionResult}
+import org.apache.kafka.common.requests.{JoinGroupRequest, OffsetCommitRequest, OffsetFetchResponse, TransactionResult}
 import org.easymock.{Capture, EasyMock, IAnswer}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
@@ -2489,8 +2489,12 @@ class GroupCoordinatorTest {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val leaderNoMemberIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), groupInstanceId = leaderInstanceId)
+      Map(tp -> offset), memberId = JoinGroupRequest.UNKNOWN_MEMBER_ID, groupInstanceId = leaderInstanceId)
     assertEquals(Errors.FENCED_INSTANCE_ID, leaderNoMemberIdCommitOffsetResult (tp))
+
+    val leaderInvalidMemberIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
+      Map(tp -> offset), memberId = "invalid-member", groupInstanceId = leaderInstanceId)
+    assertEquals(Errors.FENCED_INSTANCE_ID, leaderInvalidMemberIdCommitOffsetResult (tp))
 
     val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
       Map(tp -> offset), rebalanceResult.leaderId, leaderInstanceId)
@@ -2498,7 +2502,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def testTxnCommitOffsetWithUnknownMemberId(): Unit = {
+  def testTxnCommitOffsetWithInvalidMemberId(): Unit = {
     val tp = new TopicPartition("topic", 0)
     val offset = offsetAndMetadata(0)
     val producerId = 1000L
@@ -2510,16 +2514,25 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     val invalidIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), "invalid-member", Option.empty)
+      Map(tp -> offset), "invalid-member")
     assertEquals(Errors.UNKNOWN_MEMBER_ID, invalidIdCommitOffsetResult (tp))
+  }
 
-    val unknownMemberIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), JoinGroupRequest.UNKNOWN_MEMBER_ID, Option.empty)
-    assertEquals(Errors.NONE, unknownMemberIdCommitOffsetResult (tp))
+  @Test
+  def testTxnCommitOffsetWithKnownMemberId(): Unit = {
+    val tp = new TopicPartition("topic", 0)
+    val offset = offsetAndMetadata(0)
+    val producerId = 1000L
+    val producerEpoch : Short = 2
 
+    val joinGroupResult = dynamicJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols)
+    val joinGroupError = joinGroupResult.error
+    assertEquals(Errors.NONE, joinGroupError)
+
+    EasyMock.reset(replicaManager)
     val assignedConsumerId = joinGroupResult.memberId
     val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), assignedConsumerId, Option.empty)
+      Map(tp -> offset), assignedConsumerId)
     assertEquals(Errors.NONE, leaderCommitOffsetResult (tp))
   }
 
@@ -2538,13 +2551,29 @@ class GroupCoordinatorTest {
 
     val assignedConsumerId = joinGroupResult.memberId
     val initialGenerationId = joinGroupResult.generationId
-    val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), assignedConsumerId, Option.empty, initialGenerationId)
-    assertEquals(Errors.NONE, leaderCommitOffsetResult (tp))
-
     val illegalGenerationCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), assignedConsumerId, Option.empty, initialGenerationId + 5)
+      Map(tp -> offset), memberId = assignedConsumerId, generationId = initialGenerationId + 5)
     assertEquals(Errors.ILLEGAL_GENERATION, illegalGenerationCommitOffsetResult (tp))
+  }
+
+  @Test
+  def testTxnCommitOffsetWithLegalGeneration(): Unit = {
+    val tp = new TopicPartition("topic", 0)
+    val offset = offsetAndMetadata(0)
+    val producerId = 1000L
+    val producerEpoch : Short = 2
+
+    val joinGroupResult = dynamicJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols)
+    val joinGroupError = joinGroupResult.error
+    assertEquals(Errors.NONE, joinGroupError)
+
+    EasyMock.reset(replicaManager)
+
+    val assignedConsumerId = joinGroupResult.memberId
+    val initialGenerationId = joinGroupResult.generationId
+    val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
+      Map(tp -> offset), memberId = assignedConsumerId, generationId = initialGenerationId)
+    assertEquals(Errors.NONE, leaderCommitOffsetResult (tp))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2288,7 +2288,7 @@ class GroupCoordinatorTest {
       case _ =>
     }
 
-     groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(partitions)) match {
+    groupCoordinator.handleFetchOffsets(groupIds(1), requireStable, Some(partitions)) match {
       case (error, partData) =>
         errors.append(error)
         partitionData.append(partData)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -170,14 +170,11 @@ class KafkaApisTest {
       val invalidTopicPartition = new TopicPartition(topic, invalidPartitionId)
       val partitionOffsetCommitData = new TxnOffsetCommitRequest.CommittedOffset(15L, "", Optional.empty())
       val (offsetCommitRequest, request) = buildRequest(new TxnOffsetCommitRequest.Builder(
-        new TxnOffsetCommitRequestData()
-          .setTransactionalId("txnlId")
-          .setGroupId("groupId")
-          .setProducerId(15L)
-          .setProducerEpoch(0.toShort)
-          .setTopics(TxnOffsetCommitRequest.getTopics(
-            Map(invalidTopicPartition -> partitionOffsetCommitData).asJava))
-      ))
+        "txnId",
+        "groupId",
+        15L,
+        0.toShort,
+        Map(invalidTopicPartition -> partitionOffsetCommitData).asJava))
 
       val capturedResponse = expectNoThrottling()
       EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -404,15 +404,11 @@ class RequestQuotaTest extends BaseRequestTest {
 
         case ApiKeys.TXN_OFFSET_COMMIT =>
           new TxnOffsetCommitRequest.Builder(
-            new TxnOffsetCommitRequestData()
-              .setTransactionalId("test-transactional-id")
-              .setGroupId("test-txn-group")
-              .setProducerId(2)
-              .setProducerEpoch(0)
-              .setTopics(TxnOffsetCommitRequest.getTopics(
-                Map.empty[TopicPartition, TxnOffsetCommitRequest.CommittedOffset].asJava
-              ))
-          )
+            "test-transactional-id",
+            "test-txn-group",
+            2,
+            0,
+            Map.empty[TopicPartition, TxnOffsetCommitRequest.CommittedOffset].asJava)
 
         case ApiKeys.DESCRIBE_ACLS =>
           new DescribeAclsRequest.Builder(AclBindingFilter.ANY)


### PR DESCRIPTION
As title suggests, the change is bringing in the consumer group metadata as part of the transaction API for correct fencing after 447.
This PR mainly changes on the Producer end for compatible paths to old `sendOffsetsToTxn(offsets, groupId)` vs new `sendOffsetsToTxn(offsets, groupMetadata)`.

Some integration test extensions are also added to test out the validity of the new sendOffsets API.

This PR also contains some fixes towards the closed protocol PR.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
