### PR TITLE
KAFKA-9392; Clarify deleteAcls javadoc and add test for create/delete timing

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -318,6 +318,21 @@ public interface Admin extends AutoCloseable {
      * This operation is not transactional so it may succeed for some ACLs while fail for others.
      * <p>
      * This operation is supported by brokers with version 0.11.0.0 or higher.
+     * <p>
+     * <b>Concurrent updates:</b>
+     * <ul>
+     *     <li>If ACLs are created using {@link #createAcls(Collection)} while a delete is in progress,
+     *     these ACLs may or may not be considered for deletion depending on the order of updates. The
+     *     returned {@link DeleteAclsResult} indicates which ACLs were deleted.</li>
+     *     <li>If the provided filters use resource pattern type
+     *     {@link org.apache.kafka.common.resource.PatternType#MATCH} that needs to filter all resources to determine
+     *     matching ACLs, only ACLs that have already been propagated to the broker processing the ACL update will be
+     *     deleted. This may not include some ACLs that were persisted, but not yet propagated to all brokers. The
+     *     returned {@link DeleteAclsResult} indicates which ACLs were deleted.</li>
+     *     <li>If the provided filters use other resource pattern types that perform a direct match, all matching ACLs
+     *     from previously completed {@link #createAcls(Collection)} are guaranteed to be deleted.</li>
+     * </ul>
+     * </p>
      *
      * @param filters The filters to use.
      * @param options The options to use when deleting the ACLs.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -318,21 +318,6 @@ public interface Admin extends AutoCloseable {
      * This operation is not transactional so it may succeed for some ACLs while fail for others.
      * <p>
      * This operation is supported by brokers with version 0.11.0.0 or higher.
-     * <p>
-     * <b>Concurrent updates:</b>
-     * <ul>
-     *     <li>If ACLs are created using {@link #createAcls(Collection)} while a delete is in progress,
-     *     these ACLs may or may not be considered for deletion depending on the order of updates. The
-     *     returned {@link DeleteAclsResult} indicates which ACLs were deleted.</li>
-     *     <li>If the provided filters use resource pattern type
-     *     {@link org.apache.kafka.common.resource.PatternType#MATCH} that needs to filter all resources to determine
-     *     matching ACLs, only ACLs that have already been propagated to the broker processing the ACL update will be
-     *     deleted. This may not include some ACLs that were persisted, but not yet propagated to all brokers. The
-     *     returned {@link DeleteAclsResult} indicates which ACLs were deleted.</li>
-     *     <li>If the provided filters use other resource pattern types that perform a direct match, all matching ACLs
-     *     from previously completed {@link #createAcls(Collection)} are guaranteed to be deleted.</li>
-     * </ul>
-     * </p>
      *
      * @param filters The filters to use.
      * @param options The options to use when deleting the ACLs.

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
@@ -115,20 +115,7 @@ public interface Authorizer extends Configurable, Closeable {
      * API can return completed futures using {@link java.util.concurrent.CompletableFuture#completedFuture(Object)}
      * to process the update synchronously on the request thread.
      * <p>
-     * <b>Concurrent updates:</b>
-     * <ul>
-     *     <li>If ACLs are created using {@link #createAcls(AuthorizableRequestContext, List)} while a delete is in
-     *     progress, these ACLs may or may not be considered for deletion depending on the order of updates.
-     *     The returned {@link AclDeleteResult} indicates which ACLs were deleted.</li>
-     *     <li>If the provided filters use resource pattern type
-     *     {@link org.apache.kafka.common.resource.PatternType#MATCH} that needs to filter all resources to determine
-     *     matching ACLs, only ACLs that have already been propagated to the broker processing the ACL update will be
-     *     deleted. This may not include some ACLs that were persisted, but not yet propagated to all brokers. The
-     *     returned {@link AclDeleteResult} indicates which ACLs were deleted.</li>
-     *     <li>If the provided filters use other resource pattern types that perform a direct match, all matching ACLs
-     *     from previously completed {@link #createAcls(AuthorizableRequestContext, List)} )} are guaranteed
-     *     to be deleted.</li>
-     * </ul>
+     * Refer to the authorizer implementation docs for details on concurrent update guarantees.
      *
      * @param requestContext Request context if the ACL is being deleted by a broker to handle
      *        a client request to delete ACLs. This may be null if ACLs are deleted directly in ZooKeeper

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/Authorizer.java
@@ -114,6 +114,21 @@ public interface Authorizer extends Configurable, Closeable {
      * This is an asynchronous API that enables the caller to avoid blocking during the update. Implementations of this
      * API can return completed futures using {@link java.util.concurrent.CompletableFuture#completedFuture(Object)}
      * to process the update synchronously on the request thread.
+     * <p>
+     * <b>Concurrent updates:</b>
+     * <ul>
+     *     <li>If ACLs are created using {@link #createAcls(AuthorizableRequestContext, List)} while a delete is in
+     *     progress, these ACLs may or may not be considered for deletion depending on the order of updates.
+     *     The returned {@link AclDeleteResult} indicates which ACLs were deleted.</li>
+     *     <li>If the provided filters use resource pattern type
+     *     {@link org.apache.kafka.common.resource.PatternType#MATCH} that needs to filter all resources to determine
+     *     matching ACLs, only ACLs that have already been propagated to the broker processing the ACL update will be
+     *     deleted. This may not include some ACLs that were persisted, but not yet propagated to all brokers. The
+     *     returned {@link AclDeleteResult} indicates which ACLs were deleted.</li>
+     *     <li>If the provided filters use other resource pattern types that perform a direct match, all matching ACLs
+     *     from previously completed {@link #createAcls(AuthorizableRequestContext, List)} )} are guaranteed
+     *     to be deleted.</li>
+     * </ul>
      *
      * @param requestContext Request context if the ACL is being deleted by a broker to handle
      *        a client request to delete ACLs. This may be null if ACLs are deleted directly in ZooKeeper

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -542,12 +542,16 @@ class AclAuthorizer extends Authorizer with Logging {
     }
   }
 
+  private[authorizer] def processAclChangeNotification(resource: ResourcePattern): Unit = {
+    lock synchronized {
+      val versionedAcls = getAclsFromZk(resource)
+      updateCache(resource, versionedAcls)
+    }
+  }
+
   object AclChangedNotificationHandler extends AclChangeNotificationHandler {
     override def processNotification(resource: ResourcePattern): Unit = {
-      lock synchronized {
-        val versionedAcls = getAclsFromZk(resource)
-        updateCache(resource, versionedAcls)
-      }
+      processAclChangeNotification(resource)
     }
   }
 }

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -216,6 +216,22 @@ class AclAuthorizer extends Authorizer with Logging {
     results.toList.map(CompletableFuture.completedFuture[AclCreateResult]).asJava
   }
 
+  /**
+   *
+   * <b>Concurrent updates:</b>
+   * <ul>
+   *   <li>If ACLs are created using [[kafka.security.authorizer.AclAuthorizer#createAcls]] while a delete is in
+   *   progress, these ACLs may or may not be considered for deletion depending on the order of updates.
+   *   The returned [[org.apache.kafka.server.authorizer.AclDeleteResult]] indicates which ACLs were deleted.</li>
+   *   <li>If the provided filters use resource pattern type
+   *   [[org.apache.kafka.common.resource.PatternType#MATCH]] that needs to filter all resources to determine
+   *   matching ACLs, only ACLs that have already been propagated to the broker processing the ACL update will be
+   *   deleted. This may not include some ACLs that were persisted, but not yet propagated to all brokers. The
+   *   returned [[org.apache.kafka.server.authorizer.AclDeleteResult]] indicates which ACLs were deleted.</li>
+   *   <li>If the provided filters use other resource pattern types that perform a direct match, all matching ACLs
+   *   from previously completed [[kafka.security.authorizer.AclAuthorizer#createAcls]] are guaranteed to be deleted.</li>
+   * </ul>
+   */
   override def deleteAcls(requestContext: AuthorizableRequestContext,
                           aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = {
     val deletedBindings = new mutable.HashMap[AclBinding, Int]()


### PR DESCRIPTION
Follow-on from PR #7911  to clarify the guarantee for deleteAcls and add a deterministic test to ensure we don't regress.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
