### PR TITLE
KAFKA-9431: Expose API in KafkaStreams to fetch all local offset lags

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -450,12 +450,17 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public AlterConsumerGroupOffsetsResult alterConsumerGroupOffsets(String groupId, Map<TopicPartition, OffsetAndMetadata> offsets, AlterConsumerGroupOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implement yet");
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
     public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, ListOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implement yet");
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -450,17 +450,12 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public AlterConsumerGroupOffsetsResult alterConsumerGroupOffsets(String groupId, Map<TopicPartition, OffsetAndMetadata> offsets, AlterConsumerGroupOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        throw new UnsupportedOperationException("Not implement yet");
     }
 
     @Override
     public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, ListOffsetsOptions options) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
-    public ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        throw new UnsupportedOperationException("Not implement yet");
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -16,7 +16,12 @@
  */
 package org.apache.kafka.streams;
 
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -45,12 +50,15 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.StandbyTask;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
 import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidator;
@@ -129,6 +137,7 @@ import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFail
 public class KafkaStreams implements AutoCloseable {
 
     private static final String JMX_PREFIX = "kafka.streams";
+    private static final long UNKNOWN_POSITION = -1;
 
     // processId is expected to be unique across JVMs and to be used
     // in userData of the subscription request to allow assignor be aware
@@ -1205,5 +1214,79 @@ public class KafkaStreams implements AutoCloseable {
             threadMetadata.add(thread.threadMetadata());
         }
         return threadMetadata;
+    }
+
+    /**
+     * Returns {@link LagInfo}, for all store partitions (active or standby) local to this Streams instance. Note that the
+     * values returned are just estimates and meant to be used for making soft decisions on whether the data in the store
+     * partition is fresh enough for querying.
+     *
+     * @return map of store names to another map of partition to {@link LagInfo}s
+     */
+    public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags() {
+        final Map<String, Map<Integer, LagInfo>> localStorePartitionLags = new HashMap<>();
+        final Map<TopicPartition, Long> standbyChangelogPositions = new HashMap<>();
+        final Map<TopicPartition, Long> activeChangelogPositions = new HashMap<>();
+
+        // Obtain the current positions, of all the active-restoring and standby tasks
+        for (final StreamThread streamThread : this.threads) {
+            for (final StandbyTask standbyTask : streamThread.allStandbyTasks()) {
+                final Map<TopicPartition, Long> checkpointedOffsets = standbyTask.checkpointedOffsets();
+                standbyTask.changelogPartitions().forEach(topicPartition ->
+                    standbyChangelogPositions.put(topicPartition, checkpointedOffsets.getOrDefault(topicPartition, UNKNOWN_POSITION)));
+            }
+
+            final Set<TaskId> restoringTaskIds = streamThread.restoringTaskIds();
+            for (final StreamTask activeTask : streamThread.allStreamsTasks()) {
+                final boolean isRestoring = restoringTaskIds.contains(activeTask.id());
+                final Map<TopicPartition, Long> restoredOffsets = activeTask.restoredOffsets();
+                activeTask.changelogPartitions().forEach(topicPartition -> {
+                    if (isRestoring) {
+                        activeChangelogPositions.put(topicPartition, restoredOffsets.getOrDefault(topicPartition, UNKNOWN_POSITION));
+                    } else {
+                        activeChangelogPositions.put(topicPartition, UNKNOWN_POSITION);
+                    }
+                });
+            }
+        }
+
+        log.info("Current changelog positions, for active: " + activeChangelogPositions + " standby:" + standbyChangelogPositions);
+        final Map<TopicPartition, OffsetSpec> offsetSpecMap = Stream.concat(
+            activeChangelogPositions.keySet().stream(), standbyChangelogPositions.keySet().stream())
+            .collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
+        final Map<TopicPartition, ListOffsetsResultInfo> allEndOffsets = new HashMap<>();
+        try {
+            allEndOffsets.putAll(adminClient.listOffsets(offsetSpecMap).all().get());
+        } catch (final Exception e) {
+            throw new StreamsException("Unable to obtain end offsets from kafka", e);
+        }
+        log.info("Current end offsets :" + allEndOffsets);
+        allEndOffsets.forEach((topicPartition, offsetsResultInfo) -> {
+            final String storeName = streamsMetadataState.getStoreForChangelogTopic(topicPartition.topic());
+            final long offsetPosition;
+            if (activeChangelogPositions.containsKey(topicPartition)) {
+                // if unknown, assume it's positioned at the tail of changelog partition
+                offsetPosition = activeChangelogPositions.get(topicPartition) == UNKNOWN_POSITION ?
+                    offsetsResultInfo.offset() : activeChangelogPositions.get(topicPartition);
+            } else if (standbyChangelogPositions.containsKey(topicPartition)) {
+                // if unknown, assume it's positioned at the head of changelog partition
+                offsetPosition = standbyChangelogPositions.get(topicPartition) == UNKNOWN_POSITION ?
+                    0 : standbyChangelogPositions.get(topicPartition);
+            } else {
+                throw new IllegalStateException("Topic Partition " + topicPartition + " should be either active or standby");
+            }
+
+            final LagInfo lagInfo = new LagInfo(offsetPosition, offsetsResultInfo.offset());
+            final Map<Integer, LagInfo> partitionToOffsetLag = localStorePartitionLags.getOrDefault(storeName, new HashMap<>());
+            if (!partitionToOffsetLag.containsKey(topicPartition.partition())) {
+                partitionToOffsetLag.put(topicPartition.partition(), lagInfo);
+            } else {
+                throw new IllegalStateException("Encountered the same store partition" + storeName + ","
+                    + topicPartition.partition() + " more than once");
+            }
+            localStorePartitionLags.put(storeName, partitionToOffsetLag);
+        });
+
+        return Collections.unmodifiableMap(localStorePartitionLags);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates information about lag, at a store partition replica (active or standby). This information is constantly changing as the
+ * tasks process records and thus, they should be treated as simply instantaenous measure of lag.
+ */
+public class LagInfo {
+
+    private final long currentOffsetPosition;
+
+    private final long endOffsetPosition;
+
+    private final long offsetLag;
+
+    LagInfo(final long currentOffsetPosition, final long endOffsetPosition) {
+        this.currentOffsetPosition = currentOffsetPosition;
+        this.endOffsetPosition = endOffsetPosition;
+        this.offsetLag = Math.max(0, endOffsetPosition - currentOffsetPosition);
+    }
+
+    /**
+     * Get the current maximum offset on the store partition's changelog topic, that has been successfully written into
+     * the store partition's state store.
+     *
+     * @return current consume offset for standby/restoring store partitions & simply endoffset for active store partition replicas
+     */
+    public long currentOffsetPosition() {
+        return this.currentOffsetPosition;
+    }
+
+    /**
+     * Get the end offset position for this store partition's changelog topic on the Kafka brokers.
+     *
+     * @return last offset written to the changelog topic partition
+     */
+    public long endOffsetPosition() {
+        return this.endOffsetPosition;
+    }
+
+    /**
+     * Get the measured lag between current and end offset positions, for this store partition replica
+     *
+     * @return lag as measured by message offsets
+     */
+    public long offsetLag() {
+        return this.offsetLag;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof LagInfo)) {
+            return false;
+        }
+        final LagInfo other = (LagInfo) obj;
+        return currentOffsetPosition == other.currentOffsetPosition
+            && endOffsetPosition == other.endOffsetPosition
+            && this.offsetLag == other.offsetLag;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentOffsetPosition, endOffsetPosition, offsetLag);
+    }
+
+    @Override
+    public String toString() {
+        return "LagInfo {" +
+            " currentOffsetPosition=" + currentOffsetPosition +
+            ", endOffsetPosition=" + endOffsetPosition +
+            ", offsetLag=" + offsetLag +
+            '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.Map;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -254,9 +253,5 @@ public abstract class AbstractTask implements Task {
 
     public Collection<TopicPartition> changelogPartitions() {
         return stateMgr.changelogPartitions();
-    }
-
-    public Map<TopicPartition, Long> restoredOffsets() {
-        return stateMgr.changelogReader().restoredOffsets();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Map;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -255,4 +256,7 @@ public abstract class AbstractTask implements Task {
         return stateMgr.changelogPartitions();
     }
 
+    public Map<TopicPartition, Long> restoredOffsets() {
+        return stateMgr.changelogReader().restoredOffsets();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -34,8 +35,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements RestoringTasks {
-    private final Map<TaskId, StreamTask> suspended = new HashMap<>();
-    private final Map<TaskId, StreamTask> restoring = new HashMap<>();
+    private final Map<TaskId, StreamTask> suspended = new ConcurrentHashMap<>();
+    private final Map<TaskId, StreamTask> restoring = new ConcurrentHashMap<>();
     private final Set<TopicPartition> restoredPartitions = new HashSet<>();
     private final Map<TopicPartition, StreamTask> restoringByPartition = new HashMap<>();
     private final Set<TaskId> prevActiveTasks = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 abstract class AssignedTasks<T extends Task> {
     final Logger log;
     final String taskTypeName;
-    final Map<TaskId, T> created = new HashMap<>();
+    final Map<TaskId, T> created = new ConcurrentHashMap<>();
 
     // IQ may access this map.
     final Map<TaskId, T> running = new ConcurrentHashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -102,6 +102,9 @@ public class InternalTopologyBuilder {
     // map from state store names to this state store's corresponding changelog topic if possible
     private final Map<String, String> storeToChangelogTopic = new HashMap<>();
 
+    // map from changelog topic name to its corresponding state store.
+    private final Map<String, String> changelogTopicToStore = new HashMap<>();
+
     // all global topics
     private final Set<String> globalTopics = new HashSet<>();
 
@@ -599,12 +602,21 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
+    public Map<String, String> getStoreToChangelogTopic() {
+        return storeToChangelogTopic;
+    }
+
+    public Map<String, String> getChangelogTopicToStore() {
+        return changelogTopicToStore;
+    }
+
     public void connectSourceStoreAndTopic(final String sourceStoreName,
                                             final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {
             throw new TopologyException("Source store " + sourceStoreName + " is already added.");
         }
         storeToChangelogTopic.put(sourceStoreName, topic);
+        changelogTopicToStore.put(topic, sourceStoreName);
     }
 
     public final void addInternalTopic(final String topicName) {
@@ -940,6 +952,7 @@ public class InternalTopologyBuilder {
                     if (stateStoreFactory.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
                         final String changelogTopic = ProcessorStateManager.storeChangelogTopic(applicationId, stateStoreName);
                         storeToChangelogTopic.put(stateStoreName, changelogTopic);
+                        changelogTopicToStore.put(changelogTopic, stateStoreName);
                     }
                     stateStoreMap.put(stateStoreName, stateStoreFactory.build());
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -602,10 +602,6 @@ public class InternalTopologyBuilder {
         nodeGroups = null;
     }
 
-    public Map<String, String> getStoreToChangelogTopic() {
-        return storeToChangelogTopic;
-    }
-
     public Map<String, String> getChangelogTopicToStore() {
         return changelogTopicToStore;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -456,5 +457,9 @@ public class ProcessorStateManager implements StateManager {
         }
 
         return result;
+    }
+
+    Map<TopicPartition, Long> getStandbyRestoredOffsets() {
+        return Collections.unmodifiableMap(standbyRestoredOffsets);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.FixedOrderMap;
@@ -73,7 +74,7 @@ public class ProcessorStateManager implements StateManager {
     private final boolean eosEnabled;
     private final File baseDir;
     private OffsetCheckpoint checkpointFile;
-    private final Map<TopicPartition, Long> checkpointFileCache = new HashMap<>();
+    private final Map<TopicPartition, Long> checkpointFileCache = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Long> initialLoadedCheckpoints;
 
     /**
@@ -102,7 +103,7 @@ public class ProcessorStateManager implements StateManager {
         offsetLimits = new HashMap<>();
         standbyRestoredOffsets = new HashMap<>();
         this.isStandby = isStandby;
-        restoreCallbacks = isStandby ? new HashMap<>() : null;
+        restoreCallbacks = isStandby ? new ConcurrentHashMap<>() : null;
         recordConverters = isStandby ? new HashMap<>() : null;
         this.storeToChangelogTopic = new HashMap<>(storeToChangelogTopic);
 
@@ -255,6 +256,10 @@ public class ProcessorStateManager implements StateManager {
     private long offsetLimit(final TopicPartition partition) {
         final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;
+    }
+
+    ChangelogReader changelogReader() {
+        return changelogReader;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -75,7 +75,7 @@ public class ProcessorStateManager implements StateManager {
     private final boolean eosEnabled;
     private final File baseDir;
     private OffsetCheckpoint checkpointFile;
-    private final Map<TopicPartition, Long> checkpointFileCache = new ConcurrentHashMap<>();
+    private final Map<TopicPartition, Long> checkpointFileCache = new HashMap<>();
     private final Map<TopicPartition, Long> initialLoadedCheckpoints;
 
     /**
@@ -102,7 +102,7 @@ public class ProcessorStateManager implements StateManager {
             partitionForTopic.put(source.topic(), source);
         }
         offsetLimits = new HashMap<>();
-        standbyRestoredOffsets = new HashMap<>();
+        standbyRestoredOffsets = new ConcurrentHashMap<>();
         this.isStandby = isStandby;
         restoreCallbacks = isStandby ? new ConcurrentHashMap<>() : null;
         recordConverters = isStandby ? new HashMap<>() : null;
@@ -459,7 +459,7 @@ public class ProcessorStateManager implements StateManager {
         return result;
     }
 
-    Map<TopicPartition, Long> getStandbyRestoredOffsets() {
+    Map<TopicPartition, Long> standbyRestoredOffsets() {
         return Collections.unmodifiableMap(standbyRestoredOffsets);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -195,7 +195,7 @@ public class StandbyTask extends AbstractTask {
         return remainingRecords;
     }
 
-    Map<TopicPartition, Long> checkpointedOffsets() {
+    public Map<TopicPartition, Long> checkpointedOffsets() {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -199,8 +199,10 @@ public class StandbyTask extends AbstractTask {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
-    public Map<TopicPartition, Long> getChangelogPositions() {
-        return stateMgr.getStandbyRestoredOffsets();
+    public Map<TopicPartition, Long> changelogPositions() {
+        // this maintains the most upto date value of the latest offset for a record consumed off
+        // the changelog topic, that is also within the offsetLimit tracked.
+        return stateMgr.standbyRestoredOffsets();
     }
 
     private long updateOffsetLimits(final TopicPartition partition) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -195,7 +195,7 @@ public class StandbyTask extends AbstractTask {
         return remainingRecords;
     }
 
-    public Map<TopicPartition, Long> checkpointedOffsets() {
+    Map<TopicPartition, Long> checkpointedOffsets() {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -199,6 +199,10 @@ public class StandbyTask extends AbstractTask {
         return Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
+    public Map<TopicPartition, Long> getChangelogPositions() {
+        return stateMgr.getStandbyRestoredOffsets();
+    }
+
     private long updateOffsetLimits(final TopicPartition partition) {
         if (!offsetLimits.containsKey(partition)) {
             throw new IllegalArgumentException("Topic is not both a source and a changelog: " + partition);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -46,7 +47,7 @@ public class StoreChangelogReader implements ChangelogReader {
     private final StateRestoreListener userStateRestoreListener;
     private final Map<TopicPartition, Long> restoreToOffsets = new HashMap<>();
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
-    private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
+    private final Map<TopicPartition, StateRestorer> stateRestorers = new ConcurrentHashMap<>();
     private final Set<TopicPartition> needsRestoring = new HashSet<>();
     private final Set<TopicPartition> needsInitializing = new HashSet<>();
     private final Set<TopicPartition> completedRestorers = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -962,4 +962,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
         return partitionTimes;
     }
+
+    public Map<TopicPartition, Long> restoredOffsets() {
+        return stateMgr.changelogReader().restoredOffsets();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1191,10 +1191,6 @@ public class StreamThread extends Thread {
         return taskManager.activeTasks();
     }
 
-    public Map<TaskId, StandbyTask> standbyTasks() {
-        return taskManager.standbyTasks();
-    }
-
     public List<StreamTask> allStreamsTasks() {
         return taskManager.allStreamsTasks();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1191,6 +1191,22 @@ public class StreamThread extends Thread {
         return taskManager.activeTasks();
     }
 
+    public Map<TaskId, StandbyTask> standbyTasks() {
+        return taskManager.standbyTasks();
+    }
+
+    public List<StreamTask> allStreamsTasks() {
+        return taskManager.allStreamsTasks();
+    }
+
+    public List<StandbyTask> allStandbyTasks() {
+        return taskManager.allStandbyTasks();
+    }
+
+    public Set<TaskId> restoringTaskIds() {
+        return taskManager.restoringTaskIds();
+    }
+
     public Map<TaskId, Task> allTasks() {
         final Map<TaskId, Task> result = new TreeMap<>();
         result.putAll(taskManager.standbyTasks());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -419,6 +419,10 @@ public class StreamsMetadataState {
         return clusterMetadata != null && !clusterMetadata.topics().isEmpty();
     }
 
+    public String getStoreForChangelogTopic(final String topicName) {
+        return builder.getChangelogTopicToStore().get(topicName);
+    }
+
     private class SourceTopicsInfo {
         private final List<String> sourceTopics;
         private int maxPartitions;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -377,6 +377,18 @@ public class TaskManager {
         consumer.pause(consumer.assignment());
     }
 
+    List<StreamTask> allStreamsTasks() {
+        return active.allTasks();
+    }
+
+    Set<TaskId> restoringTaskIds() {
+        return active.restoringTaskIds();
+    }
+
+    List<StandbyTask> allStandbyTasks() {
+        return standby.allTasks();
+    }
+
     /**
      * @throws IllegalStateException If store gets registered after initialized is already finished
      * @throws StreamsException if the store's change log does not contain the partition

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -17,9 +17,14 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -313,6 +318,10 @@ public class KafkaStreamsTest {
                 Thread.sleep(50L);
                 return null;
             }).anyTimes();
+
+        EasyMock.expect(thread.allStandbyTasks()).andStubReturn(Collections.emptyList());
+        EasyMock.expect(thread.restoringTaskIds()).andStubReturn(Collections.emptySet());
+        EasyMock.expect(thread.allStreamsTasks()).andStubReturn(Collections.emptyList());
     }
 
     @Test
@@ -675,6 +684,27 @@ public class KafkaStreamsTest {
     public void shouldNotGetQueryMetadataWithPartitionerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
         streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+    }
+
+    @Test
+    public void shouldReturnEmptyLocalStorePartitionLags() {
+        // Mock all calls made to compute the offset lags,
+        final ListOffsetsResult result = EasyMock.mock(ListOffsetsResult.class);
+        final KafkaFutureImpl<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = new KafkaFutureImpl<>();
+        allFuture.complete(Collections.emptyMap());
+
+        EasyMock.expect(result.all()).andReturn(allFuture);
+        final MockAdminClient mockAdminClient = EasyMock.partialMockBuilder(MockAdminClient.class)
+            .addMockedMethod("listOffsets", Map.class).createMock();
+        EasyMock.expect(mockAdminClient.listOffsets(anyObject())).andStubReturn(result);
+        final MockClientSupplier mockClientSupplier = EasyMock.partialMockBuilder(MockClientSupplier.class)
+            .addMockedMethod("getAdmin").createMock();
+        EasyMock.expect(mockClientSupplier.getAdmin(anyObject())).andReturn(mockAdminClient);
+        EasyMock.replay(result, mockAdminClient, mockClientSupplier);
+
+        final KafkaStreams streams = new KafkaStreams(new StreamsBuilder().build(), props, mockClientSupplier, time);
+        streams.start();
+        assertEquals(0, streams.allLocalStorePartitionLags().size());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import kafka.utils.MockTime;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreamsWrapper;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+@Category({IntegrationTest.class})
+public class LagFetchIntegrationTest {
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    private static final long CONSUMER_TIMEOUT_MS = 60000;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private final MockTime mockTime = CLUSTER.time;
+    private Properties streamsConfiguration;
+    private Properties consumerConfiguration;
+    private String inputTopicName;
+    private String outputTopicName;
+    private String stateStoreName;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Before
+    public void before() {
+        inputTopicName = "input-topic-" + name.getMethodName();
+        outputTopicName = "output-topic-" + name.getMethodName();
+        stateStoreName = "lagfetch-test-store" + name.getMethodName();
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "lag-fetch-" + name.getMethodName());
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+
+        consumerConfiguration = new Properties();
+        consumerConfiguration.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        consumerConfiguration.setProperty(ConsumerConfig.GROUP_ID_CONFIG, name.getMethodName() + "-consumer");
+        consumerConfiguration.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerConfiguration.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfiguration.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchValidLagsDuringRebalancing() throws Exception {
+        final CountDownLatch latchTillActiveIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyIsRunning = new CountDownLatch(1);
+        final CountDownLatch latchTillStandbyHasPartitionsAssigned = new CountDownLatch(1);
+        final CyclicBarrier lagCheckBarrier = new CyclicBarrier(2);
+        final List<KafkaStreamsWrapper> streamsList = new ArrayList<>();
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        for (int i = 0; i < 2; i++) {
+            final Properties props = (Properties) streamsConfiguration.clone();
+            final File stateDir = folder.newFolder("state-" + i);
+            props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
+            props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
+            props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+            props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+
+            final StreamsBuilder builder = new StreamsBuilder();
+            final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+            t1.toStream().to(outputTopicName);
+            final KafkaStreamsWrapper streams = new KafkaStreamsWrapper(builder.build(), props);
+            streamsList.add(streams);
+        }
+
+        final KafkaStreamsWrapper activeStreams = streamsList.get(0);
+        final KafkaStreamsWrapper standbyStreams = streamsList.get(1);
+        activeStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (newState == StreamThread.State.RUNNING) {
+                latchTillActiveIsRunning.countDown();
+            }
+        });
+        standbyStreams.setStreamThreadStateListener((thread, newState, oldState) -> {
+            if (oldState == StreamThread.State.PARTITIONS_ASSIGNED && newState == StreamThread.State.RUNNING) {
+                latchTillStandbyHasPartitionsAssigned.countDown();
+                try {
+                    lagCheckBarrier.await(60, TimeUnit.SECONDS);
+                } catch (final Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (newState == StreamThread.State.RUNNING) {
+                latchTillStandbyIsRunning.countDown();
+            }
+        });
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+            activeStreams.start();
+            latchTillActiveIsRunning.await(60, TimeUnit.SECONDS);
+
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+            // Check the active reports proper lag values.
+            offsetLagInfoMap = activeStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(0L));
+
+            // start up the standby & make it pause right after it has partition assigned
+            standbyStreams.start();
+            latchTillStandbyHasPartitionsAssigned.await(60, TimeUnit.SECONDS);
+            offsetLagInfoMap = standbyStreams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(lagInfo.offsetLag(), equalTo(5L));
+            // standby thread wont proceed to RUNNING before this barrier is crossed
+            lagCheckBarrier.await(60, TimeUnit.SECONDS);
+
+            // wait till the lag goes down to 0, on the standby
+            TestUtils.waitForCondition(() -> standbyStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+        } finally {
+            for (final KafkaStreams streams : streamsList) {
+                streams.close();
+            }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToFetchValidLagsDuringRestoration() throws Exception {
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputTopicName,
+            mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                LongSerializer.class,
+                new Properties()),
+            mockTime);
+
+        // create stream threads
+        final Properties props = (Properties) streamsConfiguration.clone();
+        final File stateDir = folder.newFolder("state");
+        props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:0");
+        props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-0");
+        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
+        t1.toStream().to(outputTopicName);
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+
+        try {
+            // First start up the active.
+            Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(0));
+
+            // Get the instance to fully catch up and reach RUNNING state
+            startApplicationAndWaitUntilRunning(Collections.singletonList(streams), Duration.ofSeconds(60));
+            IntegrationTestUtils.waitUntilMinValuesRecordsReceived(
+                consumerConfiguration,
+                outputTopicName,
+                5,
+                CONSUMER_TIMEOUT_MS);
+
+            // check for proper lag values.
+            offsetLagInfoMap = streams.allLocalStorePartitionLags();
+            assertThat(offsetLagInfoMap.size(), equalTo(1));
+            assertThat(offsetLagInfoMap.keySet(), equalTo(mkSet(stateStoreName)));
+            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            final LagInfo zeroLagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
+            assertThat(zeroLagInfo.currentOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(zeroLagInfo.offsetLag(), equalTo(0L));
+
+            // Kill instance, delete state to force restoration.
+            assertThat("Streams instance did not close within timeout", streams.close(Duration.ofSeconds(60)));
+            IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+            Files.walk(stateDir.toPath()).sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(f -> assertTrue("Some state " + f + " could not be deleted", f.delete()));
+
+            // wait till the lag goes down to 0
+            final KafkaStreams restartedStreams = new KafkaStreams(builder.build(), props);
+            // set a state restoration listener to track progress of restoration
+            final Map<String, Map<Integer, LagInfo>> restoreStartLagInfo = new HashMap<>();
+            final Map<String, Map<Integer, LagInfo>> restoreEndLagInfo = new HashMap<>();
+            restartedStreams.setGlobalStateRestoreListener(new StateRestoreListener() {
+                @Override
+                public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {
+                    restoreStartLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+
+                @Override
+                public void onBatchRestored(final TopicPartition topicPartition, final String storeName, final long batchEndOffset, final long numRestored) {
+                }
+
+                @Override
+                public void onRestoreEnd(final TopicPartition topicPartition, final String storeName, final long totalRestored) {
+                    restoreEndLagInfo.putAll(restartedStreams.allLocalStorePartitionLags());
+                }
+            });
+
+            restartedStreams.start();
+            TestUtils.waitForCondition(() -> restartedStreams.allLocalStorePartitionLags().get(stateStoreName).get(0).offsetLag() == 0,
+                "Standby should eventually catchup and have zero lag.");
+            final LagInfo fullLagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
+            assertThat(fullLagInfo.currentOffsetPosition(), equalTo(0L));
+            assertThat(fullLagInfo.endOffsetPosition(), equalTo(5L));
+            assertThat(fullLagInfo.offsetLag(), equalTo(5L));
+
+            assertThat(zeroLagInfo, equalTo(restoreEndLagInfo.get(stateStoreName).get(0)));
+        } finally {
+            streams.close();
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -64,7 +64,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 @Category({IntegrationTest.class})
@@ -75,8 +74,6 @@ public class LagFetchIntegrationTest {
 
     private static final long CONSUMER_TIMEOUT_MS = 60000;
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
     private final MockTime mockTime = CLUSTER.time;
     private Properties streamsConfiguration;
     private Properties consumerConfiguration;
@@ -134,12 +131,11 @@ public class LagFetchIntegrationTest {
         // create stream threads
         for (int i = 0; i < 2; i++) {
             final Properties props = (Properties) streamsConfiguration.clone();
-            final File stateDir = folder.newFolder("state-" + i);
             props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
             props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
             props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimization);
             props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
-            props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+            props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(stateStoreName + i).getAbsolutePath());
 
             final StreamsBuilder builder = new StreamsBuilder();
             final KTable<String, Long> t1 = builder.table(inputTopicName, Materialized.as(stateStoreName));
@@ -238,7 +234,7 @@ public class LagFetchIntegrationTest {
 
         // create stream threads
         final Properties props = (Properties) streamsConfiguration.clone();
-        final File stateDir = folder.newFolder("state");
+        final File stateDir = TestUtils.tempDirectory(stateStoreName + "0");
         props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:0");
         props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-0");
         props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());


### PR DESCRIPTION

 - Adds KafkaStreams#allLocalOffsetLags(), which returns lag information of all active/standby tasks local to a streams instance
 - LagInfo class encapsulates the current position in the changelog, endoffset in the changelog and their difference as lag
 - Lag information is a mere estimate; it can over-estimate (source topic optimization), or under-estimate.
 - Each call to allLocalOffsetLags() generates a metadata call to Kafka brokers, so caution advised
 - Unit and Integration tests added.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
