### PR TITLE
MINOR: change the log level from ERROR to DEBUG when failing to get plugin class loader

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -156,19 +156,16 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     public ClassLoader connectorLoader(String connectorClassOrAlias) {
-        log.debug("Getting plugin class loader for connector: '{}'", connectorClassOrAlias);
         String fullName = aliases.containsKey(connectorClassOrAlias)
                           ? aliases.get(connectorClassOrAlias)
                           : connectorClassOrAlias;
-        PluginClassLoader classLoader = pluginClassLoader(fullName);
-        if (classLoader == null) {
-            log.error(
-                    "Plugin class loader for connector: '{}' was not found. Returning: {}",
-                    connectorClassOrAlias,
-                    this
-            );
-            return this;
-        }
+        ClassLoader classLoader = pluginClassLoader(fullName);
+        if (classLoader == null) classLoader = this;
+        log.debug(
+            "Getting plugin class loader: '{}' for connector: {}",
+            classLoader,
+            connectorClassOrAlias
+        );
         return classLoader;
     }
 


### PR DESCRIPTION
The connectors located at classpath are loaded by AppClassLoader so Worker fails to find the PluginClassLoader for them. It should be normal case but the log level is ERROR.

there is similar case in DelegatingClassLoader#loadClass, and the log level is TRACE.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
