### PR TITLE
KAFKA-9436: New Kafka Connect SMT for plainText => Struct(or Map)

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ToStructByRegexTransform.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ToStructByRegexTransform.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.*;
+
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.transforms.util.GroupRegexValidator;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+import java.util.*;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class ToStructByRegexTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+    public static final String OVERVIEW_DOC = "Generate key/value Struct objects supported by ordered Regex Group"
+            + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
+            + "or value (<code>" + Value.class.getName() + "</code>).";
+
+    private static final String TYPE_DELIMITER = ":";
+
+    private interface ConfigName {
+        String REGEX = "regex";
+        String MAPPING_KEY = "mapping";
+        String STURCT_INPUT_KEY_NAME = "struct.field";
+    }
+
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(ConfigName.REGEX, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, new GroupRegexValidator(), ConfigDef.Importance.MEDIUM,
+                    "String Regex Group Pattern.")
+            .define(ConfigName.MAPPING_KEY, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM,
+                    "Ordered Regex Group Mapping Keys ( with :{TYPE} )")
+            .define(ConfigName.STURCT_INPUT_KEY_NAME, ConfigDef.Type.STRING, "message", ConfigDef.Importance.MEDIUM,
+                    "target fieldName In Case struct input");
+
+
+    private static final String PURPOSE = "Transform Struct by regex group mapping";
+
+    private String pattern;
+    private List<KeyData> fieldKeys;
+    private String structField;
+
+    private Cache<Schema, Schema> schemaUpdateCache;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        final AbstractConfig config = new AbstractConfig(CONFIG_DEF, configs, false);
+        pattern = config.getString(ConfigName.REGEX);
+        fieldKeys = toKeyDataList(config.getList(ConfigName.MAPPING_KEY));
+        structField = config.getString(ConfigName.STURCT_INPUT_KEY_NAME);
+
+        schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+    }
+
+    private List<KeyData> toKeyDataList(List<String> mappingKeyList){
+        List<KeyData> resultList = new ArrayList<>();
+        for(String keyWithType : mappingKeyList){
+            String[] keyWithTypeArr = keyWithType.split(TYPE_DELIMITER);
+            resultList.add(new KeyData(keyWithTypeArr[0], keyWithTypeArr.length > 1 ? keyWithTypeArr[1] : null));
+        }
+        return resultList;
+    }
+
+    @Override
+    public R apply(R record) {
+        if (operatingSchema(record) == null) {
+            return applySchemaless(record);
+        } else {
+            return applyWithSchema(record);
+        }
+    }
+
+    private R applySchemaless(R record) {
+        Map<String, Object> resultMap;
+
+        String inputTargetStr;
+        if(operatingValue(record) instanceof String){
+            inputTargetStr = (String)operatingValue(record);
+            resultMap = parseRegexGroupToStringMap(inputTargetStr);
+        }else {
+            Map<String, Object> inputMap = requireMap(operatingValue(record), PURPOSE);
+            resultMap = new HashMap<>(inputMap);
+            inputTargetStr = (String)inputMap.get(structField);
+            resultMap.putAll(parseRegexGroupToStringMap(inputTargetStr));
+
+            //remove orginal field
+            resultMap.remove(structField);
+        }
+
+        return newRecord(record, null, resultMap);
+    }
+
+    private R applyWithSchema(R record) {
+        Schema updatedSchema;
+        Struct updatedStruct;
+
+        String inputTargetStr;
+        if(operatingValue(record) instanceof String){
+            inputTargetStr = (String)operatingValue(record);
+            Map<KeyData, Object> newEntryMap = parseRegexGroup(inputTargetStr);
+            updatedSchema = newSchema( newEntryMap);
+            updatedStruct = newStruct( newEntryMap, updatedSchema );
+        }else {
+            final Struct inputStruct = requireStruct(operatingValue(record), PURPOSE);
+            inputTargetStr = inputStruct.getString(structField);
+            Map<KeyData, Object> newEntryMap = parseRegexGroup(inputTargetStr);
+
+            updatedSchema = mergeSchema(inputStruct, newEntryMap);
+            updatedStruct = mergeStruct(inputStruct, newEntryMap, updatedSchema);
+        }
+
+        return newRecord(record, updatedSchema, updatedStruct);
+    }
+
+
+    private Map<String, Object> parseRegexGroupToStringMap(String inputTargetStr){
+        Map<String, Object> newEntryMap = new HashMap<>();
+        Pattern p = Pattern.compile(pattern);
+        Matcher m = p.matcher(inputTargetStr);
+        if(m.find()){
+            for(int i=0; i < m.groupCount(); i++){
+                String value = m.group(i+1);
+                newEntryMap.put(fieldKeys.get(i).getName(), fieldKeys.get(i).castJavaType(value));
+            }
+        }
+        return newEntryMap;
+    }
+
+    private Map<KeyData, Object> parseRegexGroup(String inputTargetStr){
+        Map<KeyData, Object> newEntryMap = new HashMap<>();
+        Pattern p = Pattern.compile(pattern);
+        Matcher m = p.matcher(inputTargetStr);
+        if(m.find()){
+            for(int i=0; i < m.groupCount(); i++){
+                String value = m.group(i+1);
+                newEntryMap.put(fieldKeys.get(i), fieldKeys.get(i).castJavaType(value));
+            }
+        }
+        return newEntryMap;
+    }
+
+
+
+    private Struct newStruct(Map<KeyData, Object> newEntryMap, Schema updatedSchema){
+        final Struct updatedValue = new Struct(updatedSchema);
+        for (Map.Entry<KeyData, Object> entry : newEntryMap.entrySet()) {
+            updatedValue.put(entry.getKey().getName(), entry.getValue());
+        }
+
+        return updatedValue;
+    }
+
+
+    private Struct mergeStruct(Struct orgStruct, Map<KeyData, Object> newEntryMap, Schema updatedSchema){
+        final Struct updatedValue = new Struct(updatedSchema);
+        for (Field f : orgStruct.schema().fields()) {
+            if(!structField.equals(f.name())) {
+                updatedValue.put(f.name(), orgStruct.get(f.name()));
+            }
+        }
+
+        for (Map.Entry<KeyData, Object> entry : newEntryMap.entrySet()) {
+            updatedValue.put(entry.getKey().getName(), entry.getValue());
+        }
+
+        return updatedValue;
+    }
+
+    private Schema mergeSchema(Struct orgStruct, Map<KeyData, Object> newEntryMap ) {
+        Schema updatedSchema = schemaUpdateCache.get(orgStruct.schema());
+        if (updatedSchema == null) {
+            final SchemaBuilder builder = SchemaUtil.copySchemaBasics(orgStruct.schema(), SchemaBuilder.struct());
+            for (Field orgField : orgStruct.schema().fields()) {
+                builder.field(orgField.name(), orgField.schema());
+            }
+
+            for (Map.Entry<KeyData, Object> entry : newEntryMap.entrySet()) {
+                builder.field(entry.getKey().getName(),entry.getKey().getTypeSchema());
+            }
+            updatedSchema = builder.build();
+            schemaUpdateCache.put(orgStruct.schema(), updatedSchema);
+        }
+
+        return updatedSchema;
+    }
+
+    private Schema newSchema(Map<KeyData, Object> newEntryMap) {
+        final SchemaBuilder builder = SchemaBuilder.struct();
+        for (Map.Entry<KeyData, Object> entry : newEntryMap.entrySet()) {
+            builder.field(entry.getKey().getName(),entry.getKey().getTypeSchema());
+        }
+        Schema schema = builder.build();
+        schemaUpdateCache.put(schema, schema);
+        return schema;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+        schemaUpdateCache = null;
+    }
+
+    protected abstract Schema operatingSchema(R record);
+
+    protected abstract Object operatingValue(R record);
+
+    protected abstract R newRecord(R record, Schema updatedSchema, Object updatedValue);
+
+    public static class Key<R extends ConnectRecord<R>> extends ToStructByRegexTransform<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.keySchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.key();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), updatedSchema, updatedValue, record.valueSchema(), record.value(), record.timestamp());
+        }
+
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends ToStructByRegexTransform<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.valueSchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.value();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), updatedSchema, updatedValue, record.timestamp());
+        }
+
+    }
+
+    public enum TYPE{
+        STRING
+        ,NUMBER
+        ,FLOAT
+        ,BOOLEAN
+        ,TIMEMILLIS
+    }
+
+    private static class KeyData{
+        private String name;
+        private TYPE type;
+
+        private KeyData(String name, String type){
+            this.name = name;
+            this.type = type != null ? TYPE.valueOf(type) : TYPE.STRING;
+        }
+
+        public String getName(){
+            return this.name;
+        }
+
+        public TYPE type(){
+            return this.type;
+        }
+
+        private Object castJavaType(String value){
+            try {
+                switch (this.type) {
+                    case STRING: return value;
+                    case NUMBER: return Long.valueOf(value);
+                    case FLOAT: return Float.valueOf(value);
+                    case BOOLEAN: return Boolean.valueOf(value);
+                    case TIMEMILLIS: return new Date(Long.valueOf(value));
+                    default: return value;
+                }
+            }catch (Exception e){
+                return value;
+            }
+        }
+
+
+        private Schema getTypeSchema(){
+            switch (this.type){
+                case STRING: return Schema.STRING_SCHEMA;
+                case NUMBER: return Schema.INT64_SCHEMA;
+                case FLOAT: return Schema.FLOAT64_SCHEMA;
+                case BOOLEAN: return Schema.BOOLEAN_SCHEMA;
+                case TIMEMILLIS: return Timestamp.SCHEMA;
+                default: return Schema.STRING_SCHEMA;
+            }
+        }
+    }
+
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/GroupRegexValidator.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/GroupRegexValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.transforms.util;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.util.regex.Pattern;
+
+public class GroupRegexValidator implements ConfigDef.Validator{
+
+    @Override
+    public void ensureValid(String name, Object value) {
+        try {
+            Pattern p = Pattern.compile((String) value);
+            if(p.matcher("dummy").groupCount() < 1){
+                throw new ConfigException(name, value, "Regex contain at least one group syntax Required  ex) ^a(.*)c");
+            }
+
+        }catch (Exception e){
+            throw new ConfigException(name, value, "Invalid Regex");
+        }
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
@@ -6,6 +6,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +35,28 @@ public class ToStructByRegexTransformTest {
         assertThat(((Map<String,?>)result.value()).get("path"), is("documentation/#connect"));
 
     }
+
+    @Test
+    public void schemalessStructTimemillisTest() {
+        System.out.println(System.currentTimeMillis());
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("regex", "^(.{3,4})_(.*)_(pc|mw|ios|and)([0-9]{3})_([0-9]{13})");
+        configMap.put("mapping", "env,serviceId,device,sequence,datetime:TIMEMILLIS");
+        configMap.put("struct.field", "code");
+
+        Map<String, String> testData = new HashMap<>();
+        testData.put("code", "dev_kafka_pc001_1580372261372");
+
+        testForm.configure(configMap);
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, testData));
+
+        assertThat(((Map<String, ?>)result.value()).get("env"), is("dev"));
+        assertThat(((Map<String, ?>)result.value()).get("serviceId"), is("kafka"));
+        assertThat(((Map<String, ?>)result.value()).get("device"), is("pc"));
+        assertThat(((Map<String, ?>)result.value()).get("sequence"), is("001"));
+        assertThat(((Map<String, ?>)result.value()).get("datetime"), is(new Date(1580372261372L)));
+    }
+
 
     @Test
     public void schemalessPlainTextTest(){

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
@@ -109,10 +109,6 @@ public class ToStructByRegexTransformTest {
         testForm.configure(configMap);
         SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, testData));
 
-        System.out.println(result.value());
-
-        //{AuthedRemoteUser=-, Ms=101989, IP=10.66.73.112, Request=/api/v1/service_config, Method=OPTIONS, DateTime=08/Aug/2019:18:15:29 +0900, Response=200, RemoteUser=-, Referrer=http://local.test.com/, UserAgent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36, BytesSent=-, Protocol=HTTP/1.1}
-
         assertThat(((Map<String,?>)result.value()).get("IP"), is("111.61.73.113"));
         assertThat(((Map<String,?>)result.value()).get("RemoteUser"), is("-"));
         assertThat(((Map<String,?>)result.value()).get("AuthedRemoteUser"), is("-"));

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ToStructByRegexTransformTest.java
@@ -1,0 +1,132 @@
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ToStructByRegexTransformTest {
+    private ToStructByRegexTransform<SourceRecord> testForm = new ToStructByRegexTransform.Value<>();
+
+    @Test
+    public void schemalessStructFieldTest(){
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("regex", "^(https?):\\/\\/([^/]*)/(.*)");
+        configMap.put("mapping", "protocol,domain,path");
+        configMap.put("struct.field", "url");
+
+        Map<String, String> testData = new HashMap<>();
+        testData.put("url", "https://kafka.apache.org/documentation/#connect");
+
+        testForm.configure(configMap);
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, testData));
+
+        assertThat(((Map<String,?>)result.value()).get("protocol"), is("https"));
+        assertThat(((Map<String,?>)result.value()).get("domain"), is("kafka.apache.org"));
+        assertThat(((Map<String,?>)result.value()).get("path"), is("documentation/#connect"));
+
+    }
+
+    @Test
+    public void schemalessPlainTextTest(){
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("mapping", "protocol,domain,path");
+        configMap.put("regex", "^(https?):\\/\\/([^/]*)/(.*)");
+
+        testForm.configure(configMap);
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, "https://kafka.apache.org/documentation/#connect"));
+
+        assertThat(((Map<String,?>)result.value()).get("protocol"), is("https"));
+        assertThat(((Map<String,?>)result.value()).get("domain"), is("kafka.apache.org"));
+        assertThat(((Map<String,?>)result.value()).get("path"), is("documentation/#connect"));
+
+    }
+
+
+    @Test
+    public void schemalessStructFieldWithTypeTest(){
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("regex", "^(https?):\\/\\/([^/]*)/([0-9]+)");
+        configMap.put("mapping", "protocol,domain,path:NUMBER");
+        configMap.put("struct.field", "url");
+
+        Map<String, String> testData = new HashMap<>();
+        testData.put("url", "https://kafka.apache.org/1234");
+
+        testForm.configure(configMap);
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, testData));
+
+        assertThat(((Map<String,?>)result.value()).get("protocol"), is("https"));
+        assertThat(((Map<String,?>)result.value()).get("domain"), is("kafka.apache.org"));
+        assertThat(((Map<String,?>)result.value()).get("path"), is(1234L));
+
+    }
+
+
+    @Test
+    public void schemaStructFieldTest(){
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("regex", "^(https?):\\/\\/([^/]*)/(.*)");
+        configMap.put("mapping", "protocol,domain,path");
+        configMap.put("struct.field", "url");
+
+        testForm.configure(configMap);
+
+        final Schema inputSampleSchema = SchemaBuilder.struct().name("name").version(1).doc("doc")
+                .field("url", Schema.STRING_SCHEMA).build();
+
+        final Struct testData = new Struct(inputSampleSchema).put("url", "https://kafka.apache.org/documentation/#connect");
+
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, inputSampleSchema, testData));
+
+        assertThat(((Struct)result.value()).get("protocol"), is("https"));
+        assertThat(((Struct)result.value()).get("domain"), is("kafka.apache.org"));
+        assertThat(((Struct)result.value()).get("path"), is("documentation/#connect"));
+
+    }
+
+    @Test
+    public void apacheLogSchemalessTest(){
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("regex", "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(GET|POST|OPTIONS|HEAD|PUT|DELETE|PATCH) (.+?) (.+?)\" (\\d{3}) ([0-9|-]+) ([0-9|-]+) \"([^\"]+)\" \"([^\"]+)\"");
+        configMap.put("mapping", "IP,RemoteUser,AuthedRemoteUser,DateTime,Method,Request,Protocol,Response,BytesSent,Ms:NUMBER,Referrer,UserAgent");
+        configMap.put("struct.field", "apacheLog");
+
+        Map<String, String> testData = new HashMap<>();
+        testData.put("apacheLog", "111.61.73.113 - - [08/Aug/2019:18:15:29 +0900] \"OPTIONS /api/v1/service_config HTTP/1.1\" 200 - 101989 \"http://local.test.com/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36\"");
+
+        testForm.configure(configMap);
+        SourceRecord result = testForm.apply(new SourceRecord(null, null, "", 0, null, testData));
+
+        System.out.println(result.value());
+
+        //{AuthedRemoteUser=-, Ms=101989, IP=10.66.73.112, Request=/api/v1/service_config, Method=OPTIONS, DateTime=08/Aug/2019:18:15:29 +0900, Response=200, RemoteUser=-, Referrer=http://local.test.com/, UserAgent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36, BytesSent=-, Protocol=HTTP/1.1}
+
+        assertThat(((Map<String,?>)result.value()).get("IP"), is("111.61.73.113"));
+        assertThat(((Map<String,?>)result.value()).get("RemoteUser"), is("-"));
+        assertThat(((Map<String,?>)result.value()).get("AuthedRemoteUser"), is("-"));
+        assertThat(((Map<String,?>)result.value()).get("DateTime"), is("08/Aug/2019:18:15:29 +0900"));
+        assertThat(((Map<String,?>)result.value()).get("Method"), is("OPTIONS"));
+        assertThat(((Map<String,?>)result.value()).get("Request"), is("/api/v1/service_config"));
+        assertThat(((Map<String,?>)result.value()).get("Protocol"), is("HTTP/1.1"));
+        assertThat(((Map<String,?>)result.value()).get("Response"), is("200"));
+        assertThat(((Map<String,?>)result.value()).get("BytesSent"), is("-"));
+        assertThat(((Map<String,?>)result.value()).get("Ms"), is(101989L));
+        assertThat(((Map<String,?>)result.value()).get("Referrer"), is("http://local.test.com/"));
+        assertThat(((Map<String,?>)result.value()).get("UserAgent"), is("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"));
+
+
+    }
+
+}


### PR DESCRIPTION
New SMT
- plain text => struct(map)
- regex group condition with ordered key name
- compatible with single plain text input and struct field input plain text


### sample1

~~~
"111.61.73.113 - - [08/Aug/2019:18:15:29 +0900] \"OPTIONS /api/v1/service_config HTTP/1.1\" 200 - 101989 \"http://local.test.com/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36\""
SMT connect config with regular expression below can easily transform a plain text to struct (or map) data.
~~~
 
~~~
"transforms": "TimestampTopic, RegexTransform",
"transforms.RegexTransform.type": "org.apache.kafka.connect.transforms.ToStructByRegexTransform$Value",

"transforms.RegexTransform.struct.field": "message",
"transforms.RegexTransform.regex": "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(GET|POST|OPTIONS|HEAD|PUT|DELETE|PATCH) (.+?) (.+?)\" (\\d{3}) ([0-9|-]+) ([0-9|-]+) \"([^\"]+)\" \"([^\"]+)\""

"transforms.RegexTransform.mapping": "IP,RemoteUser,AuthedRemoteUser,DateTime,Method,Request,Protocol,Response,BytesSent,Ms:NUMBER,Referrer,UserAgent"
~~~


### sample2

~~~
{
   "code" : "dev_kafka_pc001_1580372261372"
   ,"recode1" : "a"
   ,"recode2" : "b" 
}
~~~

~~~
"transforms": "RegexTransform",
"transforms.RegexTransform.type": "org.apache.kafka.connect.transforms.ToStructByRegexTransform$Value",

"transforms.RegexTransform.struct.field": "message",
"transforms.RegexTransform.regex": "^(.{3,4})_(.*)_(pc|mw|ios|and)([0-9]{3})_([0-9]{13})" "transforms.RegexTransform.mapping": "env,serviceId,device,sequence,datetime:TIMEMILLIS"
 ~~~