### PR TITLE
KAFKA-9449: Adds support for closing the producer's BufferPool.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -802,6 +802,7 @@ public final class RecordAccumulator {
      */
     public void close() {
         this.closed = true;
+        this.free.close();
     }
 
     /*

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -29,7 +29,11 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,6 +41,7 @@ import java.util.concurrent.locks.Condition;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -386,12 +391,7 @@ public class BufferPoolTest {
         // Close the buffer pool. This should prevent any further allocations.
         pool.close();
 
-        try {
-            pool.allocate(1, maxBlockTimeMs);
-            fail("Should have thrown KafkaException");
-        } catch (KafkaException e) {
-            // Expected.
-        }
+        assertThrows(KafkaException.class, () -> pool.allocate(1, maxBlockTimeMs));
 
         // Ensure deallocation still works.
         pool.deallocate(buffer);
@@ -399,37 +399,30 @@ public class BufferPoolTest {
 
     @Test
     public void testCloseNotifyWaiters() throws Exception {
-        BufferPool pool = new BufferPool(10, 1, metrics, Time.SYSTEM, metricGroup);
-        ByteBuffer buffer = pool.allocate(10, Long.MAX_VALUE);
+        BufferPool pool = new BufferPool(1, 1, metrics, Time.SYSTEM, metricGroup);
+        ByteBuffer buffer = pool.allocate(1, Long.MAX_VALUE);
 
-        CountDownLatch waiter1 = asyncAllocateClose(pool, 10);
-        CountDownLatch waiter2 = asyncAllocateClose(pool, 10);
+        CountDownLatch completed = new CountDownLatch(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Callable<Void> work = new Callable<Void>() {
+                public Void call() throws Exception {
+                    assertThrows(KafkaException.class, () -> pool.allocate(1, maxBlockTimeMs));
+                    completed.countDown();
+                    return null;
+                }
+            };
+        Future<Void> waiter1 = executor.submit(work);
+        Future<Void> waiter2 = executor.submit(work);
 
-        assertEquals("Allocation shouldn't have happened yet, waiting on memory", 2L, waiter1.getCount() + waiter2.getCount());
+        assertEquals("Allocation shouldn't have happened yet, waiting on memory", 2L, completed.getCount());
 
         // Close the buffer pool. This should notify all waiters.
         pool.close();
 
-        assertTrue("Allocation should fail soon after close", waiter1.await(1, TimeUnit.SECONDS) && waiter2.await(1, TimeUnit.SECONDS));
+        waiter1.get(200, TimeUnit.MILLISECONDS);
+        waiter2.get(200, TimeUnit.MILLISECONDS);
 
         pool.deallocate(buffer);
     }
 
-    private CountDownLatch asyncAllocateClose(final BufferPool pool, final int size) {
-        final CountDownLatch completed = new CountDownLatch(1);
-        Thread thread = new Thread() {
-            public void run() {
-                try {
-                    pool.allocate(size, maxBlockTimeMs);
-                    fail("Unexpected allocation");
-                } catch (KafkaException e) {
-                    completed.countDown();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-        };
-        thread.start();
-        return completed;
-    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -407,7 +407,7 @@ public class BufferPoolTest {
         ExecutorService executor = Executors.newFixedThreadPool(numWorkers);
         Callable<Void> work = new Callable<Void>() {
                 public Void call() throws Exception {
-                    assertThrows(KafkaException.class, () -> pool.allocate(1, maxBlockTimeMs));
+                    assertThrows(KafkaException.class, () -> pool.allocate(1, Long.MAX_VALUE));
                     completed.countDown();
                     return null;
                 }
@@ -421,7 +421,7 @@ public class BufferPoolTest {
         // Close the buffer pool. This should notify all waiters.
         pool.close();
 
-        completed.await(200, TimeUnit.MILLISECONDS);
+        completed.await(15, TimeUnit.SECONDS);
 
         pool.deallocate(buffer);
     }


### PR DESCRIPTION

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
