### PR TITLE
KAFKA-9358 Explicitly unregister brokers and controller from ZK

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -26,6 +26,7 @@ import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.server._
 import kafka.utils._
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
+import kafka.zk.KafkaZkClient.BrokerEpochAndZkVersion
 import kafka.zk._
 import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler, ZNodeChildChangeHandler}
 import org.apache.kafka.common.ElectionType
@@ -63,7 +64,7 @@ class KafkaController(val config: KafkaConfig,
                       time: Time,
                       metrics: Metrics,
                       initialBrokerInfo: BrokerInfo,
-                      initialBrokerEpoch: Long,
+                      initialBrokerEpochAndVersion: BrokerEpochAndZkVersion,
                       tokenManager: DelegationTokenManager,
                       threadNamePrefix: Option[String] = None)
   extends ControllerEventProcessor with Logging with KafkaMetricsGroup {
@@ -71,7 +72,7 @@ class KafkaController(val config: KafkaConfig,
   this.logIdent = s"[Controller id=${config.brokerId}] "
 
   @volatile private var brokerInfo = initialBrokerInfo
-  @volatile private var _brokerEpoch = initialBrokerEpoch
+  @volatile private var _brokerEpochVersion = initialBrokerEpochAndVersion
 
   private val stateChangeLogger = new StateChangeLogger(config.brokerId, inControllerContext = true, None)
   val controllerContext = new ControllerContext
@@ -135,7 +136,9 @@ class KafkaController(val config: KafkaConfig,
    */
   def isActive: Boolean = activeControllerId == config.brokerId
 
-  def brokerEpoch: Long = _brokerEpoch
+  def brokerEpoch: Long = _brokerEpochVersion.epoch
+
+  def brokerZkVersion: Int = _brokerEpochVersion.zkVersion
 
   def epoch: Int = controllerContext.epoch
 
@@ -169,6 +172,11 @@ class KafkaController(val config: KafkaConfig,
    */
   def shutdown() = {
     eventManager.close()
+    if (isActive)
+      zkClient.unregisterBrokerAndController(brokerInfo, brokerZkVersion, controllerContext.epochZkVersion)
+    else
+      zkClient.unregisterBroker(brokerInfo, brokerZkVersion)
+
     onControllerResignation()
   }
 
@@ -1789,7 +1797,7 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def processRegisterBrokerAndReelect(): Unit = {
-    _brokerEpoch = zkClient.registerBroker(brokerInfo)
+    _brokerEpochVersion = zkClient.registerBroker(brokerInfo)
     processReelect()
   }
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -246,7 +246,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         replicaManager.startup()
 
         val brokerInfo = createBrokerInfo
-        val brokerEpoch = zkClient.registerBroker(brokerInfo)
+        val brokerEpochAndVersion = zkClient.registerBroker(brokerInfo)
 
         // Now that the broker is successfully registered, checkpoint its metadata
         checkpointBrokerMetadata(BrokerMetadata(config.brokerId, Some(clusterId)))
@@ -256,7 +256,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         tokenManager.startup()
 
         /* start kafka controller */
-        kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, threadNamePrefix)
+        kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpochAndVersion, tokenManager, threadNamePrefix)
         kafkaController.startup()
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)

--- a/core/src/test/scala/unit/kafka/controller/ControllerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerShutdownTest.scala
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.controller
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils._
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.log4j.Logger
+import org.junit.After
+import org.junit.Test
+import org.scalatest.Assertions.fail
+
+class ControllerShutdownTest extends KafkaServerTestHarness with Logging {
+  val log = Logger.getLogger(classOf[ControllerShutdownTest])
+  val numNodes = 2
+  val topic = "topic1"
+  val metrics = new Metrics()
+
+  @After
+  override def tearDown(): Unit = {
+    super.tearDown()
+    this.metrics.close()
+  }
+
+  override def generateConfigs = TestUtils.createBrokerConfigs(numNodes, zkConnect)
+    .map(KafkaConfig.fromProps)
+
+  @Test
+  def testCorrectControllerResignation(): Unit = {
+    val initialController = servers.find(_.kafkaController.isActive).map(_.kafkaController).getOrElse {
+      fail("Could not find controller")
+    }
+    // Create topic with one partition
+    createTopic(topic, 1, 1)
+    val topicPartition = new TopicPartition("topic1", 0)
+
+
+    TestUtils.waitUntilTrue(() =>
+      initialController.controllerContext.partitionsInState(OnlinePartition).contains(topicPartition),
+      s"Partition $topicPartition did not transition to online state")
+
+    val activeController = servers.filter(_.kafkaController.isActive).head
+    val controllerEpoch = activeController.kafkaController.epoch
+    // manually force shutdown controller
+    activeController.kafkaController.shutdown()
+
+    TestUtils.waitUntilTrue(() => {
+      servers.filterNot(_ == activeController).exists { server =>
+        server.kafkaController.isActive && server.kafkaController.epoch > controllerEpoch
+      }
+    }, "Failed to find updated controller")
+
+  }
+}


### PR DESCRIPTION
Instead of closing the zkClient immediately after controller shutdown, the controller now resigns on shutdown rather than relying on the zkClient shutdown to implicitly do so.
