### PR TITLE
KAFKA-7317: Use collections subscription for main consumer to reduce metadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1064,6 +1064,9 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName());
         consumerProps.put(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, getLong(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
 
+        // disable auto topic creation
+        consumerProps.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+
         // add admin retries configs for creating topics
         final AdminClientConfig adminClientDefaultConfig = new AdminClientConfig(getClientPropsWithPrefix(ADMIN_CLIENT_PREFIX, AdminClientConfig.configNames()));
         consumerProps.put(adminClientPrefix(AdminClientConfig.RETRIES_CONFIG), adminClientDefaultConfig.getInt(AdminClientConfig.RETRIES_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -51,7 +51,7 @@ public class StreamSourceNode<K, V> extends StreamsGraphNode {
         this.consumedInternal = consumedInternal;
     }
 
-    public Collection<String> getTopicNames() {
+    public Collection<String> topicNames() {
         return new ArrayList<>(topicNames);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -81,7 +81,7 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
     @Override
     @SuppressWarnings("unchecked")
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-        final String topicName = getTopicNames().iterator().next();
+        final String topicName = topicNames().iterator().next();
 
         // TODO: we assume source KTables can only be timestamped-key-value stores for now.
         // should be expanded for other types of stores as well.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1207,7 +1207,7 @@ public class InternalTopologyBuilder {
         return applicationId + "-" + topic;
     }
 
-    boolean shouldUsePatternSubscription() {
+    boolean usesPatternSubscription() {
         return (!nodeToSourcePatterns.isEmpty());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.StreamsConfig;
@@ -61,10 +60,8 @@ public class InternalTopologyBuilder {
     // node factories in a topological order
     private final Map<String, NodeFactory> nodeFactories = new LinkedHashMap<>();
 
-    // state factories
     private final Map<String, StateStoreFactory> stateFactories = new HashMap<>();
 
-    // built global state stores
     private final Map<String, StoreBuilder> globalStateBuilders = new LinkedHashMap<>();
 
     // built global state stores
@@ -87,10 +84,6 @@ public class InternalTopologyBuilder {
 
     // map from sink processor names to sink topic (without application-id prefix for internal topics)
     private final Map<String, String> nodeToSinkTopic = new HashMap<>();
-
-    // map from topics to their matched regex patterns, this is to ensure one topic is passed through on source node
-    // even if it can be matched by multiple regex patterns
-    private final Map<String, Pattern> topicToPatterns = new HashMap<>();
 
     // map from state store names to all the topics subscribed from source processors that
     // are connected to these state stores
@@ -119,13 +112,12 @@ public class InternalTopologyBuilder {
 
     private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
 
-    private SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
+    // Used to capture subscribed topics via Patterns discovered during the partition assignment process.
+    private final Set<String> subscriptionUpdates = new HashSet<>();
 
     private String applicationId = null;
 
     private Pattern topicPattern = null;
-
-    private Collection<String> topicCollection = null;
 
     private Map<Integer, Set<String>> nodeGroups = null;
 
@@ -220,6 +212,10 @@ public class InternalTopologyBuilder {
             return new Processor(name, new HashSet<>(stateStoreNames));
         }
     }
+
+    // Map from topics to their matched regex patterns, this is to ensure one topic is passed through on source node
+    // even if it can be matched by multiple regex patterns. Only used by SourceNodeFactory
+    private static final Map<String, Pattern> topicToPatterns = new HashMap<>();
 
     private class SourceNodeFactory extends NodeFactory {
         private final List<String> topics;
@@ -918,7 +914,7 @@ public class InternalTopologyBuilder {
                                  final SourceNode node) {
 
         final List<String> topics = (sourceNodeFactory.pattern != null) ?
-                                    sourceNodeFactory.getTopics(subscriptionUpdates.getUpdates()) :
+                                    sourceNodeFactory.getTopics(subscriptionUpdates()) :
                                     sourceNodeFactory.topics;
 
         for (final String topic : topics) {
@@ -1060,24 +1056,23 @@ public class InternalTopologyBuilder {
     }
 
     private void setRegexMatchedTopicsToSourceNodes() {
-        if (subscriptionUpdates.hasUpdates()) {
-            for (final Map.Entry<String, Pattern> stringPatternEntry : nodeToSourcePatterns.entrySet()) {
-                final SourceNodeFactory sourceNode =
-                    (SourceNodeFactory) nodeFactories.get(stringPatternEntry.getKey());
-                //need to update nodeToSourceTopics with topics matched from given regex
-                nodeToSourceTopics.put(
-                    stringPatternEntry.getKey(),
-                    sourceNode.getTopics(subscriptionUpdates.getUpdates()));
-                log.debug("nodeToSourceTopics {}", nodeToSourceTopics);
+        if (hasSubscriptionUpdates()) {
+            for (final String nodeName : nodeToSourcePatterns.keySet()) {
+                //need to update nodeToSourceTopics and sourceTopicNames with topics matched from given regex
+                final List<String> sourceTopics = ((SourceNodeFactory) nodeFactories.get(nodeName))
+                                                      .getTopics(subscriptionUpdates);
+                nodeToSourceTopics.put(nodeName, sourceTopics);
+                sourceTopicNames.addAll(sourceTopics);
             }
+            log.debug("Updated nodeToSourceTopics: {}", nodeToSourceTopics);
         }
     }
 
     private void setRegexMatchedTopicToStateStore() {
-        if (subscriptionUpdates.hasUpdates()) {
+        if (hasSubscriptionUpdates()) {
             for (final Map.Entry<String, Set<Pattern>> storePattern : stateStoreNameToSourceRegex.entrySet()) {
                 final Set<String> updatedTopicsForStateStore = new HashSet<>();
-                for (final String subscriptionUpdateTopic : subscriptionUpdates.getUpdates()) {
+                for (final String subscriptionUpdateTopic : subscriptionUpdates()) {
                     for (final Pattern pattern : storePattern.getValue()) {
                         if (pattern.matcher(subscriptionUpdateTopic).matches()) {
                             updatedTopicsForStateStore.add(subscriptionUpdateTopic);
@@ -1120,11 +1115,11 @@ public class InternalTopologyBuilder {
                                        final Set<Pattern> resetPatterns) {
         final List<String> topics = maybeDecorateInternalSourceTopics(resetTopics);
 
-        return buildPatternForOffsetResetTopics(topics, resetPatterns);
+        return buildPattern(topics, resetPatterns);
     }
 
-    private static Pattern buildPatternForOffsetResetTopics(final Collection<String> sourceTopics,
-                                                            final Collection<Pattern> sourcePatterns) {
+    private static Pattern buildPattern(final Collection<String> sourceTopics,
+                                        final Collection<Pattern> sourcePatterns) {
         final StringBuilder builder = new StringBuilder();
 
         for (final String topic : sourceTopics) {
@@ -1212,69 +1207,26 @@ public class InternalTopologyBuilder {
         return applicationId + "-" + topic;
     }
 
-    SubscriptionUpdates subscriptionUpdates() {
-        return subscriptionUpdates;
-    }
-
-    boolean hasPatternSubscribedTopics() {
+    boolean shouldUsePatternSubscription() {
         return (!nodeToSourcePatterns.isEmpty());
     }
 
     synchronized Collection<String> sourceTopicCollection() {
-        if (hasPatternSubscribedTopics() || topicPattern != null) {
-            log.error("Collection subscription should not be used with hasPatternSubscribedTopics = {}, topicPattern = {}",
-                hasPatternSubscribedTopics(), topicPattern);
-            throw new IllegalStateException("Main consumer tried to use collection subscription when it should have used patterns to subscribe source topics.");
-        } else {
-            log.debug("No source topics using pattern subscription found, using regular subscription for the main consumer.");
-        }
+        log.debug("No source topics using pattern subscription found, using regular subscription for the main consumer.");
 
-        if (topicCollection == null) {
-            topicCollection = new ArrayList<>();
-            if (!nodeToSourceTopics.isEmpty()) {
-                for (final List<String> topics : nodeToSourceTopics.values()) {
-                    topicCollection.addAll(maybeDecorateInternalSourceTopics(topics));
-                }
-                topicCollection.removeAll(globalTopics);
-            }
-        }
-
-        return topicCollection;
+        return sourceTopicNames;
     }
 
     synchronized Pattern sourceTopicPattern() {
-        if (!hasPatternSubscribedTopics() || topicCollection != null) {
-            log.error("Pattern subscription should not be used with hasPatternSubscribedTopics = {}, topicCollection = {}",
-                hasPatternSubscribedTopics(), topicCollection);
-            throw new IllegalStateException("Main consumer tried to use pattern subscription when it should have used collections to subscribe source topics.");
-        } else {
-            log.debug("Found pattern subscribed source topics, falling back to pattern subscription for the main consumer.");
-        }
+        log.debug("Found pattern subscribed source topics, falling back to pattern subscription for the main consumer.");
 
         if (topicPattern == null) {
-            final List<String> allSourceTopics = new ArrayList<>();
-            if (!nodeToSourceTopics.isEmpty()) {
-                for (final List<String> topics : nodeToSourceTopics.values()) {
-                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(topics));
-                }
-                allSourceTopics.removeAll(globalTopics);
-            }
+            final List<String> allSourceTopics = new ArrayList<>(sourceTopicNames);
             Collections.sort(allSourceTopics);
-
-            topicPattern = buildPatternForOffsetResetTopics(allSourceTopics, nodeToSourcePatterns.values());
+            topicPattern = buildPattern(allSourceTopics, nodeToSourcePatterns.values());
         }
 
         return topicPattern;
-    }
-
-    // package-private for testing only
-    synchronized void updateSubscriptions(final SubscriptionUpdates subscriptionUpdates,
-                                          final String logPrefix) {
-        log.debug("{}updating builder with {} topic(s) with possible matching regex subscription(s)",
-                logPrefix, subscriptionUpdates);
-        this.subscriptionUpdates = subscriptionUpdates;
-        setRegexMatchedTopicsToSourceNodes();
-        setRegexMatchedTopicToStateStore();
     }
 
     private boolean isGlobalSource(final String nodeName) {
@@ -1902,42 +1854,25 @@ public class InternalTopologyBuilder {
         return sb.toString();
     }
 
-    /**
-     * Used to capture subscribed topic via Patterns discovered during the
-     * partition assignment process.
-     */
-    public static class SubscriptionUpdates {
-
-        private final Set<String> updatedTopicSubscriptions = new HashSet<>();
-
-        private void updateTopics(final Collection<String> topicNames) {
-            updatedTopicSubscriptions.clear();
-            updatedTopicSubscriptions.addAll(topicNames);
-        }
-
-        public Collection<String> getUpdates() {
-            return Collections.unmodifiableSet(updatedTopicSubscriptions);
-        }
-
-        boolean hasUpdates() {
-            return !updatedTopicSubscriptions.isEmpty();
-        }
-
-        @Override
-        public String toString() {
-            return String.format("SubscriptionUpdates{updatedTopicSubscriptions=%s}", updatedTopicSubscriptions);
-        }
+    Collection<String> subscriptionUpdates() {
+        return Collections.unmodifiableSet(subscriptionUpdates);
     }
 
-    void updateSubscribedTopics(final Set<String> topics,
-                                final String logPrefix) {
-        final SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
-        log.debug("{}found {} topics possibly matching regex", logPrefix, topics);
-        // update the topic groups with the returned subscription set for regex pattern subscriptions
-        subscriptionUpdates.updateTopics(topics);
-        updateSubscriptions(subscriptionUpdates, logPrefix);
+    boolean hasSubscriptionUpdates() {
+        return !subscriptionUpdates.isEmpty();
     }
 
+    synchronized void updateSubscribedTopics(final Set<String> topics,
+                                             final String logPrefix) {
+        log.debug("{}found {} topics possibly matching subscription", logPrefix, topics);
+        subscriptionUpdates.clear();
+        subscriptionUpdates.addAll(topics);
+
+        log.debug("{}updating builder with {} topic(s) with possible matching regex subscription(s)",
+            logPrefix, subscriptionUpdates);
+        setRegexMatchedTopicsToSourceNodes();
+        setRegexMatchedTopicToStateStore();
+    }
 
     // following functions are for test only
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1060,9 +1060,9 @@ public class InternalTopologyBuilder {
     private void setRegexMatchedTopicsToSourceNodes() {
         if (hasSubscriptionUpdates()) {
             for (final String nodeName : nodeToSourcePatterns.keySet()) {
+                final SourceNodeFactory sourceNode = (SourceNodeFactory) nodeFactories.get(nodeName);
+                final List<String> sourceTopics = sourceNode.getTopics(subscriptionUpdates);
                 //need to update nodeToSourceTopics and sourceTopicNames with topics matched from given regex
-                final List<String> sourceTopics = ((SourceNodeFactory) nodeFactories.get(nodeName))
-                                                      .getTopics(subscriptionUpdates);
                 nodeToSourceTopics.put(nodeName, sourceTopics);
                 sourceTopicNames.addAll(sourceTopics);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -717,7 +717,7 @@ public class StreamThread extends Thread {
     }
 
     private void subscribeConsumer() {
-        if (builder.shouldUsePatternSubscription()) {
+        if (builder.usesPatternSubscription()) {
             consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
         } else {
             consumer.subscribe(builder.sourceTopicCollection(), rebalanceListener);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -690,7 +690,7 @@ public class StreamThread extends Thread {
      * @throws StreamsException      if the store's change log does not contain the partition
      */
     private void runLoop() {
-        consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        subscribeConsumer();
 
         while (isRunning()) {
             try {
@@ -713,7 +713,15 @@ public class StreamThread extends Thread {
 
     private void enforceRebalance() {
         consumer.unsubscribe();
-        consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        subscribeConsumer();
+    }
+
+    private void subscribeConsumer() {
+        if (builder.hasPatternSubscribedTopics()) {
+            consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
+        } else {
+            consumer.subscribe(builder.sourceTopicCollection(), rebalanceListener);
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -717,7 +717,7 @@ public class StreamThread extends Thread {
     }
 
     private void subscribeConsumer() {
-        if (builder.hasPatternSubscribedTopics()) {
+        if (builder.shouldUsePatternSubscription()) {
             consumer.subscribe(builder.sourceTopicPattern(), rebalanceListener);
         } else {
             consumer.subscribe(builder.sourceTopicCollection(), rebalanceListener);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -241,9 +241,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     protected static Set<TaskId> prepareForSubscription(final TaskManager taskManager,
-        final Set<String> topics,
-        final Set<TaskId> standbyTasks,
-        final RebalanceProtocol rebalanceProtocol) {
+                                                        final Set<String> topics,
+                                                        final Set<TaskId> standbyTasks,
+                                                        final RebalanceProtocol rebalanceProtocol) {
         // Any tasks that are not yet running are counted as standby tasks for assignment purposes,
         // along with any old tasks for which we still found state on disk
         final Set<TaskId> activeTasks;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -517,7 +517,7 @@ public class TaskManager {
                 assignedTopics.add(topicPartition.topic());
             }
 
-            final Collection<String> existingTopics = builder().subscriptionUpdates().getUpdates();
+            final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.containsAll(assignedTopics)) {
                 assignedTopics.addAll(existingTopics);
                 builder().updateSubscribedTopics(assignedTopics, logPrefix);
@@ -527,7 +527,7 @@ public class TaskManager {
 
     public void updateSubscriptionsFromMetadata(final Set<String> topics) {
         if (builder().sourceTopicPattern() != null) {
-            final Collection<String> existingTopics = builder().subscriptionUpdates().getUpdates();
+            final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.equals(topics)) {
                 builder().updateSubscribedTopics(topics, logPrefix);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -511,7 +511,7 @@ public class TaskManager {
     }
 
     public void updateSubscriptionsFromAssignment(final List<TopicPartition> partitions) {
-        if (builder().sourceTopicPattern() != null) {
+        if (builder().usesPatternSubscription()) {
             final Set<String> assignedTopics = new HashSet<>();
             for (final TopicPartition topicPartition : partitions) {
                 assignedTopics.add(topicPartition.topic());
@@ -526,7 +526,7 @@ public class TaskManager {
     }
 
     public void updateSubscriptionsFromMetadata(final Set<String> topics) {
-        if (builder().sourceTopicPattern() != null) {
+        if (builder().usesPatternSubscription()) {
             final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.equals(topics)) {
                 builder().updateSubscribedTopics(topics, logPrefix);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -511,7 +511,7 @@ public class TaskManager {
     }
 
     public void updateSubscriptionsFromAssignment(final List<TopicPartition> partitions) {
-        if (builder().usesPatternSubscription()) {
+        if (builder().sourceTopicPattern() != null) {
             final Set<String> assignedTopics = new HashSet<>();
             for (final TopicPartition topicPartition : partitions) {
                 assignedTopics.add(topicPartition.topic());
@@ -526,7 +526,7 @@ public class TaskManager {
     }
 
     public void updateSubscriptionsFromMetadata(final Set<String> topics) {
-        if (builder().usesPatternSubscription()) {
+        if (builder().sourceTopicPattern() != null) {
             final Collection<String> existingTopics = builder().subscriptionUpdates();
             if (!existingTopics.equals(topics)) {
                 builder().updateSubscribedTopics(topics, logPrefix);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Arrays;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
@@ -34,7 +36,6 @@ import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -231,7 +232,19 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
-    public void testSourceTopics() {
+    public void testOnlyTopicNameSourceTopics() {
+        builder.setApplicationId("X");
+        builder.addSource(null, "source-1", null, null, null, "topic-1");
+        builder.addSource(null, "source-2", null, null, null, "topic-2");
+        builder.addSource(null, "source-3", null, null, null, "topic-3");
+        builder.addInternalTopic("topic-3");
+
+        assertFalse(builder.usesPatternSubscription());
+        assertEquals(Arrays.asList("X-topic-3", "topic-1", "topic-2"), builder.sourceTopicCollection());
+    }
+
+    @Test
+    public void testPatternSourceTopics() {
         builder.setApplicationId("X");
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSource(null, "source-2", null, null, null, "topic-2");
@@ -667,22 +680,18 @@ public class InternalTopologyBuilderTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldSetCorrectSourceNodesWithRegexUpdatedTopics() throws Exception {
+    public void shouldSetCorrectSourceNodesWithRegexUpdatedTopics() {
         builder.addSource(null, "source-1", null, null, null, "topic-foo");
         builder.addSource(null, "source-2", null, null, null, Pattern.compile("topic-[A-C]"));
         builder.addSource(null, "source-3", null, null, null, Pattern.compile("topic-\\d"));
 
-        final InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates = new InternalTopologyBuilder.SubscriptionUpdates();
-        final Field updatedTopicsField  = subscriptionUpdates.getClass().getDeclaredField("updatedTopicSubscriptions");
-        updatedTopicsField.setAccessible(true);
-
-        final Set<String> updatedTopics = (Set<String>) updatedTopicsField.get(subscriptionUpdates);
+        final Set<String> updatedTopics = new HashSet<>();
 
         updatedTopics.add("topic-B");
         updatedTopics.add("topic-3");
         updatedTopics.add("topic-A");
 
-        builder.updateSubscriptions(subscriptionUpdates, null);
+        builder.updateSubscribedTopics(updatedTopics, null);
         builder.setApplicationId("test-id");
 
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
@@ -690,7 +699,6 @@ public class InternalTopologyBuilderTest {
         assertTrue(topicGroups.get(1).sourceTopics.contains("topic-A"));
         assertTrue(topicGroups.get(1).sourceTopics.contains("topic-B"));
         assertTrue(topicGroups.get(2).sourceTopics.contains("topic-3"));
-
     }
 
     @Test
@@ -754,22 +762,18 @@ public class InternalTopologyBuilderTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldConnectRegexMatchedTopicsToStateStore() throws Exception {
+    public void shouldConnectRegexMatchedTopicsToStateStore() {
         builder.addSource(null, "ingest", null, null, null, Pattern.compile("topic-\\d+"));
         builder.addProcessor("my-processor", new MockProcessorSupplier(), "ingest");
         builder.addStateStore(storeBuilder, "my-processor");
 
-        final InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates = new InternalTopologyBuilder.SubscriptionUpdates();
-        final Field updatedTopicsField  = subscriptionUpdates.getClass().getDeclaredField("updatedTopicSubscriptions");
-        updatedTopicsField.setAccessible(true);
-
-        final Set<String> updatedTopics = (Set<String>) updatedTopicsField.get(subscriptionUpdates);
+        final Set<String> updatedTopics = new HashSet<>();
 
         updatedTopics.add("topic-2");
         updatedTopics.add("topic-3");
         updatedTopics.add("topic-A");
 
-        builder.updateSubscriptions(subscriptionUpdates, "test-thread");
+        builder.updateSubscribedTopics(updatedTopics, "test-thread");
         builder.setApplicationId("test-app");
 
         final Map<String, List<String>> stateStoreAndTopics = builder.stateStoreNameToSourceTopics();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -70,8 +70,7 @@ public class TaskManagerTest {
     private final Map<TaskId, Set<TopicPartition>> taskId0Assignment = Collections.singletonMap(taskId0, taskId0Partitions);
     private final Map<TopicPartition, TaskId> taskId0PartitionToTaskId = Collections.singletonMap(t1p0, taskId0);
 
-    @Mock(type = MockType.STRICT)
-    private InternalTopologyBuilder.SubscriptionUpdates subscriptionUpdates;
+
     @Mock(type = MockType.STRICT)
     private InternalTopologyBuilder topologyBuilder;
     @Mock(type = MockType.STRICT)
@@ -118,6 +117,7 @@ public class TaskManagerTest {
     private final Set<TaskId> revokedTasks = new HashSet<>();
     private final List<TopicPartition> revokedPartitions = new ArrayList<>();
     private final List<TopicPartition> revokedChangelogs = Collections.emptyList();
+    private Set<String> subscriptionUpdates = Collections.emptySet();
 
     @Rule
     public final TemporaryFolder testFolder = new TemporaryFolder();
@@ -152,69 +152,61 @@ public class TaskManagerTest {
     @Test
     public void shouldUpdateSubscriptionFromAssignment() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
         topologyBuilder.updateSubscribedTopics(EasyMock.eq(Utils.mkSet(topic1, topic2)), EasyMock.anyString());
         expectLastCall().once();
 
         EasyMock.replay(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromAssignment(asList(t1p1, t2p1));
 
         EasyMock.verify(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldNotUpdateSubscriptionFromAssignment() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1, topic2));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1, topic2));
 
         EasyMock.replay(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromAssignment(asList(t1p1));
 
         EasyMock.verify(activeTaskCreator,
-                        topologyBuilder,
-                        subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldUpdateSubscriptionFromMetadata() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
         topologyBuilder.updateSubscribedTopics(EasyMock.eq(Utils.mkSet(topic1, topic2)), EasyMock.anyString());
         expectLastCall().once();
 
         EasyMock.replay(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromMetadata(Utils.mkSet(topic1, topic2));
 
         EasyMock.verify(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
     public void shouldNotUpdateSubscriptionFromMetadata() {
         mockTopologyBuilder();
-        expect(subscriptionUpdates.getUpdates()).andReturn(Utils.mkSet(topic1));
+        expect(topologyBuilder.subscriptionUpdates()).andReturn(Utils.mkSet(topic1));
 
         EasyMock.replay(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
 
         taskManager.updateSubscriptionsFromMetadata(Utils.mkSet(topic1));
 
         EasyMock.verify(activeTaskCreator,
-                topologyBuilder,
-                subscriptionUpdates);
+                        topologyBuilder);
     }
 
     @Test
@@ -677,7 +669,7 @@ public class TaskManagerTest {
     }
 
     private void mockSingleActiveTask() {
-        expect(activeTaskCreator.createTasks(EasyMock.<Consumer<byte[], byte[]>>anyObject(),
+        expect(activeTaskCreator.createTasks(EasyMock.anyObject(),
                                                   EasyMock.eq(taskId0Assignment)))
                 .andReturn(Collections.singletonList(streamTask));
 
@@ -685,7 +677,6 @@ public class TaskManagerTest {
 
     private void mockTopologyBuilder() {
         expect(activeTaskCreator.builder()).andReturn(topologyBuilder).anyTimes();
-        expect(topologyBuilder.sourceTopicPattern()).andReturn(Pattern.compile("abc"));
-        expect(topologyBuilder.subscriptionUpdates()).andReturn(subscriptionUpdates);
+        expect(topologyBuilder.sourceTopicPattern()).andReturn(Pattern.compile("abc")).anyTimes();
     }
 }


### PR DESCRIPTION
Also addresses [KAFKA-8821](https://issues.apache.org/jira/browse/KAFKA-8821)

Note that we still have to fall back to using pattern subscription if the user has added any regex-based source nodes to the topology. Includes some minor cleanup on the side

