### PR TITLE
MINOR: fix flaky StreamsUpgradeTestIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.integration;
 
+import org.apache.kafka.streams.KafkaStreamsTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStoreTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStoreTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest;
@@ -41,6 +42,8 @@ import org.junit.runners.Suite;
                         GlobalStateStoreProviderTest.class,
                         StreamThreadStateStoreProviderTest.class,
                         WrappingStoreProviderTest.class,
+                        KafkaStreamsTest.class,
+                        LagFetchIntegrationTest.class,
                         QueryableStateIntegrationTest.class,
                     })
 public class StoreQuerySuite {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQuerySuite.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.streams.KafkaStreamsTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStoreTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStoreTest;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStoreTest;
@@ -42,8 +41,6 @@ import org.junit.runners.Suite;
                         GlobalStateStoreProviderTest.class,
                         StreamThreadStateStoreProviderTest.class,
                         WrappingStoreProviderTest.class,
-                        KafkaStreamsTest.class,
-                        LagFetchIntegrationTest.class,
                         QueryableStateIntegrationTest.class,
                     })
 public class StoreQuerySuite {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -36,6 +36,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
+import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -87,9 +88,9 @@ public class StreamsUpgradeTestIntegrationTest {
         final AtomicInteger usedVersion6 = new AtomicInteger();
         final KafkaStreams kafkaStreams6 = buildFutureStreams(usedVersion6);
         startSync(kafkaStreams6);
-        assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1));
-        assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1)));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1)));
+        retryOnExceptionWithTimeout(() -> assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1)));
 
         kafkaStreams4.close(Duration.ZERO);
         kafkaStreams5.close(Duration.ZERO);
@@ -99,14 +100,14 @@ public class StreamsUpgradeTestIntegrationTest {
         kafkaStreams6.close();
     }
 
-    public static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {
+    private static KafkaStreams buildFutureStreams(final AtomicInteger usedVersion4) {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         properties.put("test.future.metadata", usedVersion4);
         return StreamsUpgradeTest.buildStreams(properties);
     }
 
-    public static void startSync(final KafkaStreams... kafkaStreams) throws InterruptedException {
+    private static void startSync(final KafkaStreams... kafkaStreams) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(kafkaStreams.length);
         for (final KafkaStreams streams : kafkaStreams) {
             streams.setStateListener((newState, oldState) -> {


### PR DESCRIPTION
This test failed on trunk recently. It looks like a race condition in which `kafkaStreams4` hadn't completed the rebalance by the time we tested the final version number. Rather than trying to synchronize on state transitions, it's more foolproof (although potentially more opaque) to just wait a while for the versions to converge.

See https://builds.apache.org/blue/organizations/jenkins/kafka-trunk-jdk11/detail/kafka-trunk-jdk11/1085/tests for the failure

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
