### PR TITLE
POC: Consolidate testing InternalProcessorContexts

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
@@ -28,31 +28,25 @@ import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.Processor;
-import org.apache.kafka.streams.processor.To;
-import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.ToInternal;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.apache.kafka.test.InternalMockProcessorContext;
-import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.test.MockInternalProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -72,7 +66,6 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private static final String STORE_NAME = "session-store";
 
     private final String threadId = Thread.currentThread().getName();
-    private final ToInternal toInternal = new ToInternal();
     private final Initializer<Long> initializer = () -> 0L;
     private final Aggregator<String, String, Long> aggregator = (aggKey, value, aggregate) -> aggregate + 1;
     private final Merger<String, Long> sessionMerger = (aggKey, aggOne, aggTwo) -> aggOne + aggTwo;
@@ -84,34 +77,22 @@ public class KStreamSessionWindowAggregateProcessorTest {
             aggregator,
             sessionMerger);
 
-    private final List<KeyValueTimestamp> results = new ArrayList<>();
     private final Processor<String, String> processor = sessionAggregator.get();
     private SessionStore<String, Long> sessionStore;
-    private InternalMockProcessorContext context;
-    private Metrics metrics;
+    private MockInternalProcessorContext context;
 
     @Before
     public void initializeStore() {
-        final File stateDir = TestUtils.tempDirectory();
-        metrics = new Metrics();
-        final MockStreamsMetrics metrics = new MockStreamsMetrics(KStreamSessionWindowAggregateProcessorTest.this.metrics);
-
-        context = new InternalMockProcessorContext(
-            stateDir,
-            Serdes.String(),
-            Serdes.String(),
-            metrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
-            MockRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, metrics)
-        ) {
-            @Override
-            public <K, V> void forward(final K key, final V value, final To to) {
-                toInternal.update(to);
-                results.add(new KeyValueTimestamp<>(key, value, toInternal.timestamp()));
-            }
-        };
-
+        context = new MockInternalProcessorContext(
+            StreamsTestUtils.getStreamsConfig(),
+            new TaskId(0, 0),
+            new LogContext("testCache "),
+            100000L
+        );
+        context.setCurrentNode(new ProcessorNode<>("TESTING_NODE"));
+        context.setRecordContext(
+            new ProcessorRecordContext(0L, 0L, 0, "topic", new RecordHeaders())
+        );
         initStore(true);
         processor.init(context);
     }
@@ -139,9 +120,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldCreateSingleSessionWhenWithinGap() {
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("john", "first");
-        context.setTime(500);
+        context.setTimestamp(500);
         processor.process("john", "second");
 
         final KeyValueIterator<Windowed<String>, Long> values =
@@ -152,19 +133,19 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldMergeSessions() {
-        context.setTime(0);
+        context.setTimestamp(0);
         final String sessionId = "mel";
         processor.process(sessionId, "first");
         assertTrue(sessionStore.findSessions(sessionId, 0, 0).hasNext());
 
         // move time beyond gap
-        context.setTime(GAP_MS + 1);
+        context.setTimestamp(GAP_MS + 1);
         processor.process(sessionId, "second");
         assertTrue(sessionStore.findSessions(sessionId, GAP_MS + 1, GAP_MS + 1).hasNext());
         // should still exist as not within gap
         assertTrue(sessionStore.findSessions(sessionId, 0, 0).hasNext());
         // move time back
-        context.setTime(GAP_MS / 2);
+        context.setTimestamp(GAP_MS / 2);
         processor.process(sessionId, "third");
 
         final KeyValueIterator<Windowed<String>, Long> iterator =
@@ -177,7 +158,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldUpdateSessionIfTheSameTime() {
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("mel", "first");
         processor.process("mel", "second");
         final KeyValueIterator<Windowed<String>, Long> iterator =
@@ -190,12 +171,12 @@ public class KStreamSessionWindowAggregateProcessorTest {
     public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap() {
         final String sessionId = "mel";
         long time = 0;
-        context.setTime(time);
+        context.setTimestamp(time);
         processor.process(sessionId, "first");
-        context.setTime(time += GAP_MS + 1);
+        context.setTimestamp(time += GAP_MS + 1);
         processor.process(sessionId, "second");
         processor.process(sessionId, "second");
-        context.setTime(time += GAP_MS + 1);
+        context.setTimestamp(time += GAP_MS + 1);
         processor.process(sessionId, "third");
         processor.process(sessionId, "third");
         processor.process(sessionId, "third");
@@ -216,14 +197,14 @@ public class KStreamSessionWindowAggregateProcessorTest {
                     new Change<>(3L, null),
                     time)
             ),
-            results
+            results()
         );
 
     }
 
     @Test
     public void shouldRemoveMergedSessionsFromStateStore() {
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("a", "1");
 
         // first ensure it is in the store
@@ -231,7 +212,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
             sessionStore.findSessions("a", 0, 0);
         assertEquals(KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 1L), a1.next());
 
-        context.setTime(100);
+        context.setTimestamp(100);
         processor.process("a", "2");
         // a1 from above should have been removed
         // should have merged session in store
@@ -243,17 +224,17 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @Test
     public void shouldHandleMultipleSessionsAndMerging() {
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("a", "1");
         processor.process("b", "1");
         processor.process("c", "1");
         processor.process("d", "1");
-        context.setTime(GAP_MS / 2);
+        context.setTimestamp(GAP_MS / 2);
         processor.process("d", "2");
-        context.setTime(GAP_MS + 1);
+        context.setTimestamp(GAP_MS + 1);
         processor.process("a", "2");
         processor.process("b", "2");
-        context.setTime(GAP_MS + 1 + GAP_MS / 2);
+        context.setTimestamp(GAP_MS + 1 + GAP_MS / 2);
         processor.process("a", "3");
         processor.process("c", "3");
 
@@ -290,7 +271,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
                     new SessionWindow(GAP_MS + 1 + GAP_MS / 2, GAP_MS + 1 + GAP_MS / 2)), new Change<>(1L, null),
                     GAP_MS + 1 + GAP_MS / 2)
             ),
-            results
+            results()
         );
     }
 
@@ -298,9 +279,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     public void shouldGetAggregatedValuesFromValueGetter() {
         final KTableValueGetter<Windowed<String>, Long> getter = sessionAggregator.view().get();
         getter.init(context);
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("a", "1");
-        context.setTime(GAP_MS + 1);
+        context.setTimestamp(GAP_MS + 1);
         processor.process("a", "1");
         processor.process("a", "2");
         final long t0 = getter.get(new Windowed<>("a", new SessionWindow(0, 0))).value();
@@ -314,7 +295,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
         initStore(false);
         processor.init(context);
 
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("a", "1");
         processor.process("b", "1");
         processor.process("c", "1");
@@ -334,7 +315,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
                     new Change<>(1L, null),
                     0L)
             ),
-            results
+            results()
         );
     }
 
@@ -343,9 +324,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
         initStore(false);
         processor.init(context);
 
-        context.setTime(0);
+        context.setTimestamp(0);
         processor.process("a", "1");
-        context.setTime(5);
+        context.setTimestamp(5);
         processor.process("a", "1");
         assertEquals(
             Arrays.asList(
@@ -362,7 +343,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
                     new Change<>(2L, null),
                     5L)
             ),
-            results
+            results()
         );
 
     }
@@ -378,7 +359,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     private void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final String builtInMetricsVersion) {
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
+        final MockInternalProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
         processor.init(context);
         context.setRecordContext(
             new ProcessorRecordContext(-1, -2, -3, "topic", null)
@@ -416,7 +397,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     private void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final String builtInMetricsVersion) {
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
+        final MockInternalProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
         final Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.with(ofMillis(10L)).grace(ofMillis(0L)),
             STORE_NAME,
@@ -487,9 +468,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
                 )
             );
         }
-        assertThat(metrics.metrics().get(dropTotal).metricValue(), is(1.0));
+        assertThat(context.metrics().metrics().get(dropTotal).metricValue(), is(1.0));
         assertThat(
-            (Double) metrics.metrics().get(dropRate).metricValue(),
+            (Double) context.metrics().metrics().get(dropRate).metricValue(),
             greaterThan(0.0)
         );
         assertThat(
@@ -509,7 +490,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     private void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final String builtInMetricsVersion) {
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
+        final MockInternalProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
         final Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.with(ofMillis(10L)).grace(ofMillis(1L)),
             STORE_NAME,
@@ -590,33 +571,29 @@ public class KStreamSessionWindowAggregateProcessorTest {
             );
         }
 
-        assertThat(metrics.metrics().get(dropTotal).metricValue(), is(1.0));
+        assertThat(context.metrics().metrics().get(dropTotal).metricValue(), is(1.0));
         assertThat(
-            (Double) metrics.metrics().get(dropRate).metricValue(),
+            (Double) context.metrics().metrics().get(dropRate).metricValue(),
             greaterThan(0.0));
         assertThat(
             appender.getMessages(),
             hasItem("Skipping record for expired window. key=[Late1] topic=[topic] partition=[-3] offset=[-2] timestamp=[0] window=[0,0] expiration=[1] streamTime=[2]"));
     }
 
-    private InternalMockProcessorContext createInternalMockProcessorContext(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "test", builtInMetricsVersion);
-        final InternalMockProcessorContext context = new InternalMockProcessorContext(
-            TestUtils.tempDirectory(),
-            Serdes.String(),
-            Serdes.String(),
-            streamsMetrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
-            MockRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics)
-        ) {
-            @Override
-            public <K, V> void forward(final K key, final V value, final To to) {
-                toInternal.update(to);
-                results.add(new KeyValueTimestamp<>(key, value, toInternal.timestamp()));
-            }
-        };
-        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, context.taskId().toString(), streamsMetrics);
+    private static MockInternalProcessorContext createInternalMockProcessorContext(final String builtInMetricsVersion) {
+        final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
+        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
+        final MockInternalProcessorContext context = new MockInternalProcessorContext(
+            streamsConfig,
+            new TaskId(0, 0),
+            new LogContext("testCache "),
+            100000L
+        );
+        context.setCurrentNode(new ProcessorNode<>("TESTING_NODE"));
+        context.setRecordContext(
+            new ProcessorRecordContext(0L, 0L, 0, "topic", new RecordHeaders())
+        );
+
         final StoreBuilder<SessionStore<String, Long>> storeBuilder =
             Stores.sessionStoreBuilder(
                 Stores.persistentSessionStore(STORE_NAME, ofMillis(GAP_MS * 3)),
@@ -627,4 +604,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
         sessionStore.init(context, sessionStore);
         return context;
     }
+
+    private List<KeyValueTimestamp<Object, Object>> results() {
+        return context.forwarded().stream().map(cf -> new KeyValueTimestamp<>(cf.keyValue().key, cf.keyValue().value, cf.timestamp())).collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
Demonstrate the consolidation approach via: migrating
KStreamSessionWindowAggregateProcessorTest to use
MockInternalProcessorContext instead of InternalMockProcessorContext

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
