### PR TITLE
MINOR. Use `transform` instead of `mapValues`

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2804,7 +2804,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                                logIfDenied: Boolean = true): Set[String] = {
     authorizer match {
       case Some(authZ) =>
-        val resources = resourceNames.groupBy(identity).mapValues(_.size).toList
+        val resources = resourceNames.groupBy(identity).transform((_, resourceNameList) => resourceNameList.size).toList
         val actions = resources.map { case (resourceName, count) =>
           val resource = new ResourcePattern(resourceType, resourceName, PatternType.LITERAL)
           new Action(operation, resource, count, logIfAllowed, logIfDenied)


### PR DESCRIPTION
mapValues is a view and doesn't create a new collection (so is lazy). So
its good to use it if not all values in the Map is going to be
processed. However if we are going to process all the values multiple
times, its wasteful as it runs transformation function each time. If the
transformation function is random, then the resulting collection each
time we map isn't same either. On the other hand `transform` is strict
and creates a new collection with updated values.

In `KafkaApis::filterAuthorized` we are using mapValues and then using
'map' to go over the resulting collection couple of times. This change
updates the code to use `transform` instead of `mapValues`.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
