### PR TITLE
KAFKA-9445: Allow adding changes to allow serving from a specific partition

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1167,7 +1167,7 @@ public class KafkaStreams implements AutoCloseable {
      *
      * Only permits queries on active replicas of the store (no standbys or restoring replicas).
      * See {@link KafkaStreams#store(StoreQueryParams)}
-     * for the option to set {@code StoreQueryParams.withAllPartitionAndStaleStoresEnabled or StoreQueryParams.withPartitionAndStaleStoresEnabled(final Integer partition)} and trade off consistency in favor of availability.
+     * for the option to set {@code StoreQueryParams.withIncludeStaleStores()} and trade off consistency in favor of availability.
      *
      * @param storeName           name of the store to find
      * @param queryableStoreType  accept only stores that are accepted by {@link QueryableStoreType#accepts(StateStore)}
@@ -1176,8 +1176,9 @@ public class KafkaStreams implements AutoCloseable {
      * @throws InvalidStateStoreException if Kafka Streams is (re-)initializing or a store with {@code storeName} and
      * {@code queryableStoreType} doesn't exist
      */
+    @Deprecated
     public <T> T store(final String storeName, final QueryableStoreType<T> queryableStoreType) {
-        return store(new StoreQueryParams<T>(storeName, queryableStoreType));
+        return store(StoreQueryParams.fromNameAndType(storeName, queryableStoreType));
     }
 
     /**
@@ -1187,10 +1188,10 @@ public class KafkaStreams implements AutoCloseable {
      * The optional parameters to the StoreQueryParams include {@code partition} and {@code includeStaleStores}.
      * The returned object can be used to query the {@link StateStore} instances.
      *
-     * @param storeQueryParams    If storeQueryParams.withPartition(int partition) is used, it allow queries on the specific partition irrespective if it is a standby
+     * @param storeQueryParams    If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withPartition(int partition) is used, it allow queries on the specific partition irrespective if it is a standby
      *                            or a restoring replicas in addition to active ones.
-     *                            If storeQueryParams.withIncludeStaleStores() is used, it allow queries on standbys and restoring replicas in addition to active ones for all the local partitions on the instance.
-     *                            If StoreQueryParams.withIncludeStaleStores().withPartition(int partition), it allow queries on the specific partition irrespective if it is a standby
+     *                            If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores() is used, it allow queries on standbys and restoring replicas in addition to active ones for all the local partitions on the instance.
+     *                            If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores().withPartition(int partition), it allow queries on the specific partition irrespective if it is a standby
      *                            or a restoring replicas in addition to active ones..
      *                            By default, if just storeQueryParams is used, it returns all the local partitions for the store which are in running state.
      * @param <T>                 return type

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1160,21 +1160,9 @@ public class KafkaStreams implements AutoCloseable {
         return streamsMetadataState.getKeyQueryMetadataForKey(storeName, key, partitioner);
     }
 
+
     /**
-     * Get a facade wrapping the local {@link StateStore} instances with the provided {@code storeName} if the Store's
-     * type is accepted by the provided {@link QueryableStoreType#accepts(StateStore) queryableStoreType}.
-     * The returned object can be used to query the {@link StateStore} instances.
-     *
-     * Only permits queries on active replicas of the store (no standbys or restoring replicas).
-     * See {@link KafkaStreams#store(StoreQueryParams)}
-     * for the option to set {@code StoreQueryParams.withIncludeStaleStores()} and trade off consistency in favor of availability.
-     *
-     * @param storeName           name of the store to find
-     * @param queryableStoreType  accept only stores that are accepted by {@link QueryableStoreType#accepts(StateStore)}
-     * @param <T>                 return type
-     * @return A facade wrapping the local {@link StateStore} instances
-     * @throws InvalidStateStoreException if Kafka Streams is (re-)initializing or a store with {@code storeName} and
-     * {@code queryableStoreType} doesn't exist
+     * @deprecated since 2.5 release; use {@link #store(StoreQueryParams)}  instead
      */
     @Deprecated
     public <T> T store(final String storeName, final QueryableStoreType<T> queryableStoreType) {
@@ -1185,16 +1173,9 @@ public class KafkaStreams implements AutoCloseable {
      * Get a facade wrapping the local {@link StateStore} instances with the provided {@link StoreQueryParams}.
      * StoreQueryParams need required parameters to be set, which are {@code storeName} and if
      * type is accepted by the provided {@link QueryableStoreType#accepts(StateStore) queryableStoreType}.
-     * The optional parameters to the StoreQueryParams include {@code partition} and {@code staleStoresEnabled}.
      * The returned object can be used to query the {@link StateStore} instances.
      *
-     * @param storeQueryParams    If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withPartition(int partition) is used, it allow queries on the specific partition irrespective if it is a standby
-     *                            or a restoring replicas in addition to active ones.
-     *                            If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores() is used, it allow queries on standbys and restoring replicas in addition to active ones for all the local partitions on the instance.
-     *                            If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores().withPartition(int partition), it allow queries on the specific partition irrespective if it is a standby
-     *                            or a restoring replicas in addition to active ones..
-     *                            By default, if just storeQueryParams is used, it returns all the local partitions for the store which are in running state.
-     * @param <T>                 return type
+     * @param storeQueryParams   to set the optional parameters to fetch type of stores user wants to fetch when a key is queried
      * @return A facade wrapping the local {@link StateStore} instances
      * @throws InvalidStateStoreException if Kafka Streams is (re-)initializing or a store with {@code storeName} and
      * {@code queryableStoreType} doesn't exist

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1185,7 +1185,7 @@ public class KafkaStreams implements AutoCloseable {
      * Get a facade wrapping the local {@link StateStore} instances with the provided {@link StoreQueryParams}.
      * StoreQueryParams need required parameters to be set, which are {@code storeName} and if
      * type is accepted by the provided {@link QueryableStoreType#accepts(StateStore) queryableStoreType}.
-     * The optional parameters to the StoreQueryParams include {@code partition} and {@code includeStaleStores}.
+     * The optional parameters to the StoreQueryParams include {@code partition} and {@code staleStoresEnabled}.
      * The returned object can be used to query the {@link StateStore} instances.
      *
      * @param storeQueryParams    If StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withPartition(int partition) is used, it allow queries on the specific partition irrespective if it is a standby

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -31,9 +31,33 @@ public class StoreQueryParams<T> {
     private final String storeName;
     private final QueryableStoreType<T> queryableStoreType;
 
-    public StoreQueryParams(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
+    private StoreQueryParams(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
         this.storeName = storeName;
         this.queryableStoreType = queryableStoreType;
+    }
+
+    public static <T> StoreQueryParams<T> fromNameAndType(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
+        return new<T> StoreQueryParams<T>(storeName, queryableStoreType);
+    }
+
+    /**
+     * Get the partition to be used to fetch list of Queryable store from QueryableStoreProvider.
+     * If the function returns null, it would mean that no specific partition has been requested so all the local partitions
+     * for the store will be returned.
+     *
+     * @return Integer partition
+     */
+    public Integer partition() {
+        return partition;
+    }
+
+    /**
+     * Get the flag includeStaleStores. If true, include standbys and recovering stores along with running stores.
+     *
+     * @return boolean includeStaleStores
+     */
+    public boolean includeStaleStores() {
+        return includeStaleStores;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -42,7 +42,7 @@ public class StoreQueryParams<T> {
 
     public static <T> StoreQueryParams<T> fromNameAndType(final String storeName,
                                                           final QueryableStoreType<T>  queryableStoreType) {
-        return new<T> StoreQueryParams<T>(storeName, queryableStoreType);
+        return new StoreQueryParams<T>(storeName, queryableStoreType);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -21,8 +21,12 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 import java.util.Objects;
 
 /**
- * Represents all the query options that a user can provide to state what kind of stores it is expecting. The options would be whether a user would want to enable/disable stale stores* or whether it knows the list of partitions that it specifically wants to fetch. If this information is not provided the default behavior is to fetch the stores for all the partitions available on that instance* for that particular store name.
- * It contains a partition, which for a point queries can be populated from the  KeyQueryMetadata.
+ * Represents all the query options that a user can provide to state what kind of stores it is expecting.
+ * The options would be whether a user would want to enable/disable stale stores
+ * or whether it knows the list of partitions that it specifically wants to fetch.
+ * If this information is not provided the default behavior is to fetch the stores for all the partitions
+ * available on that instance for that particular store name.
+ * It contains a partition, which for a point queries can be populated from the {@link KeyQueryMetadata}.
  */
 public class StoreQueryParams<T> {
 
@@ -36,50 +40,35 @@ public class StoreQueryParams<T> {
         this.queryableStoreType = queryableStoreType;
     }
 
-    public static final <T> StoreQueryParams<T> fromNameAndType(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
+    public static <T> StoreQueryParams<T> fromNameAndType(final String storeName,
+                                                          final QueryableStoreType<T>  queryableStoreType) {
         return new<T> StoreQueryParams<T>(storeName, queryableStoreType);
     }
 
     /**
-     * Get the partition to be used to fetch list of Queryable store from QueryableStoreProvider.
-     * If the function returns null, it would mean that no specific partition has been requested so all the local partitions
-     * for the store will be returned.
-     *
-     * @return Integer partition
-     */
-    public Integer partition() {
-        return partition;
-    }
-
-    /**
-     * Get the flag staleStores. If true, include standbys and recovering stores along with running stores.
-     *
-     * @return boolean staleStores
-     */
-    public boolean staleStoresEnabled() {
-        return staleStores;
-    }
-
-    /**
-     * Get the {@link StoreQueryParams} with stale(standby, restoring) stores added via fetching the stores.
+     * Set a specific partition that should be queried exclusively.
      *
      * @param partition   The specific integer partition to be fetched from the stores list by using {@link StoreQueryParams}.
      *
      * @return String storeName
      */
     public StoreQueryParams<T> withPartition(final Integer partition) {
-        this.partition = partition;
-        return this;
+        final StoreQueryParams<T> storeQueryParams = StoreQueryParams.fromNameAndType(this.storeName(), this.queryableStoreType());
+        storeQueryParams.partition = partition;
+        storeQueryParams.staleStores = this.staleStores;
+        return storeQueryParams;
     }
 
     /**
-     * Get the {@link StoreQueryParams} with stale(standby, restoring) stores added via fetching the stores.
+     * Enable querying of stale state stores, i.e., allow to query active tasks during restore as well as standby tasks.
      *
      * @return String storeName
      */
     public StoreQueryParams<T> enableStaleStores() {
-        this.staleStores = true;
-        return this;
+        final StoreQueryParams<T> storeQueryParams = StoreQueryParams.fromNameAndType(this.storeName(), this.queryableStoreType());
+        storeQueryParams.partition = this.partition;
+        storeQueryParams.staleStores = true;
+        return storeQueryParams;
     }
 
     /**
@@ -87,7 +76,7 @@ public class StoreQueryParams<T> {
      *
      * @return String storeName
      */
-    public String getStoreName() {
+    public String storeName() {
         return storeName;
     }
 
@@ -96,8 +85,28 @@ public class StoreQueryParams<T> {
      *
      * @return QueryableStoreType queryableStoreType
      */
-    public QueryableStoreType<T> getQueryableStoreType() {
+    public QueryableStoreType<T> queryableStoreType() {
         return queryableStoreType;
+    }
+
+    /**
+     * Get the partition to be used to fetch list of stores.
+     * If the method returns {@code null}, it would mean that no specific partition has been requested,
+     * so all the local partitions for the store will be returned.
+     *
+     * @return Integer partition
+     */
+    public Integer partition() {
+        return partition;
+    }
+
+    /**
+     * Get the flag staleStores. If {@code true}, include standbys and recovering stores along with running stores.
+     *
+     * @return boolean staleStores
+     */
+    public boolean staleStoresEnabled() {
+        return staleStores;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class StoreQueryParams<T> {
 
     private Integer partition;
-    private boolean includeStaleStores;
+    private boolean staleStores;
     private final String storeName;
     private final QueryableStoreType<T> queryableStoreType;
 
@@ -36,7 +36,7 @@ public class StoreQueryParams<T> {
         this.queryableStoreType = queryableStoreType;
     }
 
-    public static <T> StoreQueryParams<T> fromNameAndType(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
+    public static final <T> StoreQueryParams<T> fromNameAndType(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
         return new<T> StoreQueryParams<T>(storeName, queryableStoreType);
     }
 
@@ -52,12 +52,12 @@ public class StoreQueryParams<T> {
     }
 
     /**
-     * Get the flag includeStaleStores. If true, include standbys and recovering stores along with running stores.
+     * Get the flag staleStores. If true, include standbys and recovering stores along with running stores.
      *
-     * @return boolean includeStaleStores
+     * @return boolean staleStores
      */
-    public boolean includeStaleStores() {
-        return includeStaleStores;
+    public boolean staleStoresEnabled() {
+        return staleStores;
     }
 
     /**
@@ -77,8 +77,8 @@ public class StoreQueryParams<T> {
      *
      * @return String storeName
      */
-    public StoreQueryParams<T> withIncludeStaleStores() {
-        this.includeStaleStores = true;
+    public StoreQueryParams<T> enableStaleStores() {
+        this.staleStores = true;
         return this;
     }
 
@@ -107,7 +107,7 @@ public class StoreQueryParams<T> {
         }
         final StoreQueryParams storeQueryParams = (StoreQueryParams) obj;
         return Objects.equals(storeQueryParams.partition, partition)
-                && Objects.equals(storeQueryParams.includeStaleStores, includeStaleStores)
+                && Objects.equals(storeQueryParams.staleStores, staleStores)
                 && Objects.equals(storeQueryParams.storeName, storeName)
                 && Objects.equals(storeQueryParams.queryableStoreType, queryableStoreType);
     }
@@ -116,7 +116,7 @@ public class StoreQueryParams<T> {
     public String toString() {
         return "StoreQueryParams {" +
                 "partition=" + partition +
-                ", includeStaleStores=" + includeStaleStores +
+                ", staleStores=" + staleStores +
                 ", storeName=" + storeName +
                 ", queryableStoreType=" + queryableStoreType +
                 '}';
@@ -124,6 +124,6 @@ public class StoreQueryParams<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(partition, includeStaleStores, storeName, queryableStoreType);
+        return Objects.hash(partition, staleStores, storeName, queryableStoreType);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.Objects;
+
+/**
+ * Represents all the query options that a user can provide to state what kind of stores it is expecting. The options would be whether a user would want to enable/disable stale stores* or whether it knows the list of partitions that it specifically wants to fetch. If this information is not provided the default behavior is to fetch the stores for all the partitions available on that instance* for that particular store name.
+ * It contains a list of partitions, which for a point queries can be populated from the  KeyQueryMetadata.
+ */
+public class StoreQueryParams {
+
+    private final Integer partition;
+    private final boolean includeStaleStores;
+
+    public static final StoreQueryParams withPartitionAndStaleStoresDisabled(final Integer partition) {
+        return new StoreQueryParams(partition, false);
+    }
+
+    public static final StoreQueryParams withPartitionAndStaleStoresEnabled(final Integer partition) {
+        return new StoreQueryParams(partition, true);
+    }
+
+    public static final StoreQueryParams withAllPartitionAndStaleStoresDisabled() {
+        return new StoreQueryParams(null, false);
+    }
+
+    public static final StoreQueryParams withAllPartitionAndStaleStoresEnabled() {
+        return new StoreQueryParams(null, true);
+    }
+
+    private StoreQueryParams(final Integer partition, final boolean includeStaleStores) {
+        this.partition = partition;
+        this.includeStaleStores = includeStaleStores;
+    }
+
+
+    /**
+     * Get the partition to be used to fetch list of Queryable store from QueryableStoreProvider.
+     *
+     * @return an Integer partition
+     */
+    public Integer getPartition() {
+        return partition;
+    }
+
+    /**
+     * Get the flag includeStaleStores. If true, include standbys and recovering stores along with running stores
+     *
+     * @return boolean includeStaleStores
+     */
+    public boolean includeStaleStores() {
+        return includeStaleStores;
+    }
+
+    /**
+     * Get whether the store query params are fetching all partitions or a single partition.
+     *
+     * @return boolean. True, if all partitions are requests or false if a specific partition is requested
+     */
+    public boolean getAllLocalPartitions() {
+        return partition == null ? true : false;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof StoreQueryParams)) {
+            return false;
+        }
+        final StoreQueryParams storeQueryParams = (StoreQueryParams) obj;
+        return Objects.equals(storeQueryParams.partition, partition)
+                && Objects.equals(storeQueryParams.includeStaleStores, includeStaleStores);
+    }
+
+
+    @Override
+    public String toString() {
+        return "StoreQueryParams {" +
+                "partition=" + partition +
+                ", includeStaleStores=" + includeStaleStores +
+                '}';
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partition, includeStaleStores);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -16,64 +16,64 @@
  */
 package org.apache.kafka.streams;
 
+import org.apache.kafka.streams.state.QueryableStoreType;
+
 import java.util.Objects;
 
 /**
  * Represents all the query options that a user can provide to state what kind of stores it is expecting. The options would be whether a user would want to enable/disable stale stores* or whether it knows the list of partitions that it specifically wants to fetch. If this information is not provided the default behavior is to fetch the stores for all the partitions available on that instance* for that particular store name.
  * It contains a partition, which for a point queries can be populated from the  KeyQueryMetadata.
  */
-public class StoreQueryParams {
+public class StoreQueryParams<T> {
 
-    private final Integer partition;
-    private final boolean includeStaleStores;
+    private Integer partition;
+    private boolean includeStaleStores;
+    private final String storeName;
+    private final QueryableStoreType<T> queryableStoreType;
 
-    public static final StoreQueryParams withPartitionAndStaleStoresDisabled(final Integer partition) {
-        return new StoreQueryParams(partition, false);
+    public StoreQueryParams(final String storeName, final QueryableStoreType<T>  queryableStoreType) {
+        this.storeName = storeName;
+        this.queryableStoreType = queryableStoreType;
     }
 
-    public static final StoreQueryParams withPartitionAndStaleStoresEnabled(final Integer partition) {
-        return new StoreQueryParams(partition, true);
-    }
-
-    public static final StoreQueryParams withAllPartitionAndStaleStoresDisabled() {
-        return new StoreQueryParams(null, false);
-    }
-
-    public static final StoreQueryParams withAllPartitionAndStaleStoresEnabled() {
-        return new StoreQueryParams(null, true);
-    }
-
-    private StoreQueryParams(final Integer partition, final boolean includeStaleStores) {
+    /**
+     * Get the {@link StoreQueryParams} with stale(standby, restoring) stores added via fetching the stores.
+     *
+     * @param partition   The specific integer partition to be fetched from the stores list by using {@link StoreQueryParams}.
+     *
+     * @return String storeName
+     */
+    public StoreQueryParams<T> withPartition(final Integer partition) {
         this.partition = partition;
-        this.includeStaleStores = includeStaleStores;
-    }
-
-
-    /**
-     * Get the partition to be used to fetch list of Queryable store from QueryableStoreProvider.
-     *
-     * @return an Integer partition
-     */
-    public Integer getPartition() {
-        return partition;
+        return this;
     }
 
     /**
-     * Get the flag includeStaleStores. If true, include standbys and recovering stores along with running stores
+     * Get the {@link StoreQueryParams} with stale(standby, restoring) stores added via fetching the stores.
      *
-     * @return boolean includeStaleStores
+     * @return String storeName
      */
-    public boolean includeStaleStores() {
-        return includeStaleStores;
+    public StoreQueryParams<T> withIncludeStaleStores() {
+        this.includeStaleStores = true;
+        return this;
     }
 
     /**
-     * Get whether the store query params are fetching all partitions or a single partition.
+     * Get the store name for which key is queried by the user.
      *
-     * @return boolean. True, if all partitions are requests or false if a specific partition is requested
+     * @return String storeName
      */
-    public boolean getAllLocalPartitions() {
-        return partition == null ? true : false;
+    public String getStoreName() {
+        return storeName;
+    }
+
+    /**
+     * Get the queryable store type for which key is queried by the user.
+     *
+     * @return QueryableStoreType queryableStoreType
+     */
+    public QueryableStoreType<T> getQueryableStoreType() {
+        return queryableStoreType;
     }
 
     @Override
@@ -83,21 +83,23 @@ public class StoreQueryParams {
         }
         final StoreQueryParams storeQueryParams = (StoreQueryParams) obj;
         return Objects.equals(storeQueryParams.partition, partition)
-                && Objects.equals(storeQueryParams.includeStaleStores, includeStaleStores);
+                && Objects.equals(storeQueryParams.includeStaleStores, includeStaleStores)
+                && Objects.equals(storeQueryParams.storeName, storeName)
+                && Objects.equals(storeQueryParams.queryableStoreType, queryableStoreType);
     }
-
 
     @Override
     public String toString() {
         return "StoreQueryParams {" +
                 "partition=" + partition +
                 ", includeStaleStores=" + includeStaleStores +
+                ", storeName=" + storeName +
+                ", queryableStoreType=" + queryableStoreType +
                 '}';
     }
 
-
     @Override
     public int hashCode() {
-        return Objects.hash(partition, includeStaleStores);
+        return Objects.hash(partition, includeStaleStores, storeName, queryableStoreType);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParams.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 /**
  * Represents all the query options that a user can provide to state what kind of stores it is expecting. The options would be whether a user would want to enable/disable stale stores* or whether it knows the list of partitions that it specifically wants to fetch. If this information is not provided the default behavior is to fetch the stores for all the partitions available on that instance* for that particular store name.
- * It contains a list of partitions, which for a point queries can be populated from the  KeyQueryMetadata.
+ * It contains a partition, which for a point queries can be populated from the  KeyQueryMetadata.
  */
 public class StoreQueryParams {
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1499,7 +1499,7 @@ public class InternalTopologyBuilder {
         @Override
         public String toString() {
             final String topicsString = topics == null ? topicPattern.toString() : topics.toString();
-            
+
             return "Source: " + name + " (topics: " + topicsString + ")\n      --> " + nodeNames(successors);
         }
 
@@ -1701,7 +1701,7 @@ public class InternalTopologyBuilder {
 
     public static class TopicsInfo {
         final Set<String> sinkTopics;
-        final Set<String> sourceTopics;
+        public final Set<String> sourceTopics;
         public final Map<String, InternalTopicConfig> stateChangelogTopics;
         public final Map<String, InternalTopicConfig> repartitionSourceTopics;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -50,8 +50,8 @@ public class QueryableStoreProvider {
      * @return A composite object that wraps the store instances.
      */
     public <T> T getStore(final StoreQueryParams<T> storeQueryParams) {
-        final String storeName = storeQueryParams.getStoreName();
-        final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
+        final String storeName = storeQueryParams.storeName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
         final List<T> globalStore = globalStoreProvider.stores(storeName, queryableStoreType);
         if (!globalStore.isEmpty()) {
             return queryableStoreType.create(globalStoreProvider, storeName);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -42,8 +42,8 @@ public class QueryableStoreProvider {
      * Get a composite object wrapping the instances of the {@link StateStore} with the provided
      * storeName and {@link QueryableStoreType}
      *
-     * @param storeQueryParams       if stateStoresEnabled is used i.e. includeStaleStores is true, include standbys and recovering stores;
-     *                                        if stateStoresDisabled i.e. includeStaleStores is false, only include running actives;
+     * @param storeQueryParams       if stateStoresEnabled is used i.e. staleStoresEnabled is true, include standbys and recovering stores;
+     *                                        if stateStoresDisabled i.e. staleStoresEnabled is false, only include running actives;
      *                                        if partition is null then it fetches all local partitions on the instance;
      *                                        if partition is set then it fetches a specific partition.
      * @param <T>                The expected type of the returned store

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -44,8 +44,10 @@ public class QueryableStoreProvider {
      *
      * @param storeName          name of the store
      * @param queryableStoreType accept stores passing {@link QueryableStoreType#accepts(StateStore)}
-     * @param storeQueryParams       if true, include standbys and recovering stores;
-     *                                        if false, only include running actives.
+     * @param storeQueryParams       if stateStoresEnabled is used i.e. includeStaleStores is true, include standbys and recovering stores;
+     *                                        if stateStoresDisabled i.e. includeStaleStores is false, only include running actives;
+     *                                        if partition is null then it fetches all local partitions on the instance;
+     *                                        if partition is set then it fetches a specific partition.
      * @param <T>                The expected type of the returned store
      * @return A composite object that wraps the store instances.
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -43,27 +44,27 @@ public class QueryableStoreProvider {
      *
      * @param storeName          name of the store
      * @param queryableStoreType accept stores passing {@link QueryableStoreType#accepts(StateStore)}
-     * @param includeStaleStores     if true, include standbys and recovering stores;
+     * @param storeQueryParams       if true, include standbys and recovering stores;
      *                                        if false, only include running actives.
      * @param <T>                The expected type of the returned store
      * @return A composite object that wraps the store instances.
      */
     public <T> T getStore(final String storeName,
                           final QueryableStoreType<T> queryableStoreType,
-                          final boolean includeStaleStores) {
+                          final StoreQueryParams storeQueryParams) {
         final List<T> globalStore = globalStoreProvider.stores(storeName, queryableStoreType);
         if (!globalStore.isEmpty()) {
             return queryableStoreType.create(globalStoreProvider, storeName);
         }
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider storeProvider : storeProviders) {
-            allStores.addAll(storeProvider.stores(storeName, queryableStoreType, includeStaleStores));
+            allStores.addAll(storeProvider.stores(storeName, queryableStoreType, storeQueryParams));
         }
         if (allStores.isEmpty()) {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
         }
         return queryableStoreType.create(
-            new WrappingStoreProvider(storeProviders, includeStaleStores),
+            new WrappingStoreProvider(storeProviders, storeQueryParams),
             storeName
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -49,7 +49,7 @@ public class StreamThreadStateStoreProvider {
     public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
         final String storeName = storeQueryParams.getStoreName();
         final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
-        final TaskId keyTaskId = (storeQueryParams.partition() == null) ? null : createKeyTaskId(storeName, storeQueryParams.partition());
+        final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.partition());
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
@@ -87,6 +87,9 @@ public class StreamThreadStateStoreProvider {
     }
 
     private TaskId createKeyTaskId(final String storeName, final Integer partition) {
+        if (partition == null) {
+            return null;
+        }
         final List<String> sourceTopics = internalTopologyBuilder.stateStoreNameToSourceTopics().get(storeName);
         final Set<String> sourceTopicsSet = sourceTopics.stream().collect(Collectors.toSet());
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = internalTopologyBuilder.topicGroups();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -49,7 +49,7 @@ public class StreamThreadStateStoreProvider {
     public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
         final String storeName = storeQueryParams.getStoreName();
         final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
-        final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.getPartition());
+        final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.partition());
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -40,15 +40,16 @@ public class StreamThreadStateStoreProvider {
     private final StreamThread streamThread;
     private final InternalTopologyBuilder internalTopologyBuilder;
 
-    public StreamThreadStateStoreProvider(final StreamThread streamThread, final InternalTopologyBuilder internalTopologyBuilder) {
+    public StreamThreadStateStoreProvider(final StreamThread streamThread,
+                                          final InternalTopologyBuilder internalTopologyBuilder) {
         this.streamThread = streamThread;
         this.internalTopologyBuilder = internalTopologyBuilder;
     }
 
     @SuppressWarnings("unchecked")
     public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
-        final String storeName = storeQueryParams.getStoreName();
-        final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
+        final String storeName = storeQueryParams.storeName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
         final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.partition());
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -30,27 +32,36 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class StreamThreadStateStoreProvider {
 
     private final StreamThread streamThread;
+    private final InternalTopologyBuilder internalTopologyBuilder;
 
-    public StreamThreadStateStoreProvider(final StreamThread streamThread) {
+    public StreamThreadStateStoreProvider(final StreamThread streamThread, final InternalTopologyBuilder internalTopologyBuilder) {
         this.streamThread = streamThread;
+        this.internalTopologyBuilder = internalTopologyBuilder;
     }
 
     @SuppressWarnings("unchecked")
     public <T> List<T> stores(final String storeName,
                               final QueryableStoreType<T> queryableStoreType,
-                              final boolean includeStaleStores) {
+                              final StoreQueryParams storeQueryParams) {
+
+        final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.getPartition());
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();
         }
         final StreamThread.State state = streamThread.state();
-        if (includeStaleStores ? state.isAlive() : state == StreamThread.State.RUNNING) {
-            final Map<TaskId, ? extends Task> tasks = includeStaleStores ? streamThread.allTasks() : streamThread.activeTasks();
+        if (storeQueryParams.includeStaleStores() ? state.isAlive() : state == StreamThread.State.RUNNING) {
+            final Map<TaskId, ? extends Task> tasks = storeQueryParams.includeStaleStores() ? streamThread.allTasks() : streamThread.activeTasks();
             final List<T> stores = new ArrayList<>();
             for (final Task streamTask : tasks.values()) {
+                if (keyTaskId != null && !keyTaskId.equals(streamTask.id())) {
+                    continue;
+                }
                 final StateStore store = streamTask.getStore(storeName);
                 if (store != null && queryableStoreType.accepts(store)) {
                     if (!store.isOpen()) {
@@ -72,8 +83,23 @@ public class StreamThreadStateStoreProvider {
         } else {
             throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the stream thread is " +
                                                      state + ", not RUNNING" +
-                                                     (includeStaleStores ? " or REBALANCING" : ""));
+                                                     (storeQueryParams.includeStaleStores() ? " or REBALANCING" : ""));
         }
     }
 
+    private TaskId createKeyTaskId(final String storeName, final Integer partition) {
+        if (partition == null) {
+            return null;
+        }
+        final List<String> sourceTopics = internalTopologyBuilder.stateStoreNameToSourceTopics().get(storeName);
+        final Set<String> sourceTopicsSet = sourceTopics.stream().collect(Collectors.toSet());
+        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = internalTopologyBuilder.topicGroups();
+        for (final Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> topicGroup : topicGroups.entrySet()) {
+            if (topicGroup.getValue().sourceTopics.containsAll(sourceTopicsSet)) {
+                return new TaskId(topicGroup.getKey(), partition.intValue());
+            }
+        }
+        throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the requested partition " + partition + "is" +
+                                                "not available on this instance");
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -46,10 +46,9 @@ public class StreamThreadStateStoreProvider {
     }
 
     @SuppressWarnings("unchecked")
-    public <T> List<T> stores(final String storeName,
-                              final QueryableStoreType<T> queryableStoreType,
-                              final StoreQueryParams storeQueryParams) {
-
+    public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
+        final String storeName = storeQueryParams.getStoreName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
         final TaskId keyTaskId = createKeyTaskId(storeName, storeQueryParams.getPartition());
         if (streamThread.state() == StreamThread.State.DEAD) {
             return Collections.emptyList();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -29,11 +29,16 @@ import java.util.List;
 public class WrappingStoreProvider implements StateStoreProvider {
 
     private final List<StreamThreadStateStoreProvider> storeProviders;
-    private final StoreQueryParams storeQueryParams;
+    private StoreQueryParams storeQueryParams;
 
     WrappingStoreProvider(final List<StreamThreadStateStoreProvider> storeProviders,
                           final StoreQueryParams storeQueryParams) {
         this.storeProviders = storeProviders;
+        this.storeQueryParams = storeQueryParams;
+    }
+
+    //visible for testing
+    public void setStoreQueryParams(final StoreQueryParams storeQueryParams) {
         this.storeQueryParams = storeQueryParams;
     }
 
@@ -42,7 +47,7 @@ public class WrappingStoreProvider implements StateStoreProvider {
                               final QueryableStoreType<T> queryableStoreType) {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider provider : storeProviders) {
-            final List<T> stores = provider.stores(storeName, queryableStoreType, storeQueryParams);
+            final List<T> stores = provider.stores(storeQueryParams);
             allStores.addAll(stores);
         }
         if (allStores.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
@@ -28,12 +29,12 @@ import java.util.List;
 public class WrappingStoreProvider implements StateStoreProvider {
 
     private final List<StreamThreadStateStoreProvider> storeProviders;
-    private final boolean includeStaleStores;
+    private final StoreQueryParams storeQueryParams;
 
     WrappingStoreProvider(final List<StreamThreadStateStoreProvider> storeProviders,
-                          final boolean includeStaleStores) {
+                          final StoreQueryParams storeQueryParams) {
         this.storeProviders = storeProviders;
-        this.includeStaleStores = includeStaleStores;
+        this.storeQueryParams = storeQueryParams;
     }
 
     @Override
@@ -41,7 +42,7 @@ public class WrappingStoreProvider implements StateStoreProvider {
                               final QueryableStoreType<T> queryableStoreType) {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider provider : storeProviders) {
-            final List<T> stores = provider.stores(storeName, queryableStoreType, includeStaleStores);
+            final List<T> stores = provider.stores(storeName, queryableStoreType, storeQueryParams);
             allStores.addAll(stores);
         }
         if (allStores.isEmpty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
@@ -750,7 +751,7 @@ public class EosIntegrationTest {
         final long maxWaitingTime = System.currentTimeMillis() + 300000L;
         while (System.currentTimeMillis() < maxWaitingTime) {
             try {
-                store = streams.store(storeName, QueryableStoreTypes.keyValueStore());
+                store = streams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
                 break;
             } catch (final InvalidStateStoreException okJustRetry) {
                 try {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
@@ -138,7 +139,7 @@ public class GlobalKTableEOSIntegrationTest {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> "J".equals(replicatedStore.get(5L)),
@@ -182,7 +183,7 @@ public class GlobalKTableEOSIntegrationTest {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> "J".equals(replicatedStore.get(5L)),
@@ -219,7 +220,7 @@ public class GlobalKTableEOSIntegrationTest {
             () -> {
                 final ReadOnlyKeyValueStore<Long, String> store;
                 try {
-                    store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                    store = kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
                 } catch (final InvalidStateStoreException ex) {
                     return false;
                 }
@@ -253,7 +254,7 @@ public class GlobalKTableEOSIntegrationTest {
             () -> {
                 final ReadOnlyKeyValueStore<Long, String> store;
                 try {
-                    store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                    store = kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
                 } catch (final InvalidStateStoreException ex) {
                     return false;
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -37,8 +38,8 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.TestUtils;
@@ -141,7 +142,7 @@ public class GlobalKTableIntegrationTest {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> "J".equals(replicatedStore.get(5L)),
@@ -149,7 +150,7 @@ public class GlobalKTableIntegrationTest {
             "waiting for data in replicated store");
 
         final ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> replicatedStoreWithTimestamp =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.timestampedKeyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.timestampedKeyValueStore()));
         assertThat(replicatedStoreWithTimestamp.get(5L), equalTo(ValueAndTimestamp.make("J", firstTimestamp + 4L)));
 
         firstTimestamp = mockTime.milliseconds();
@@ -208,7 +209,7 @@ public class GlobalKTableIntegrationTest {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> "J".equals(replicatedStore.get(5L)),
@@ -216,7 +217,7 @@ public class GlobalKTableIntegrationTest {
             "waiting for data in replicated store");
 
         final ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> replicatedStoreWithTimestamp =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.timestampedKeyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.timestampedKeyValueStore()));
         assertThat(replicatedStoreWithTimestamp.get(5L), equalTo(ValueAndTimestamp.make("J", firstTimestamp + 4L)));
 
         firstTimestamp = mockTime.milliseconds();
@@ -253,17 +254,17 @@ public class GlobalKTableIntegrationTest {
         produceInitialGlobalTableValues();
 
         startStreams();
-        ReadOnlyKeyValueStore<Long, String> store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+        ReadOnlyKeyValueStore<Long, String> store = kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertThat(store.approximateNumEntries(), equalTo(4L));
         ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> timestampedStore =
-            kafkaStreams.store(globalStore, QueryableStoreTypes.timestampedKeyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.timestampedKeyValueStore()));
         assertThat(timestampedStore.approximateNumEntries(), equalTo(4L));
         kafkaStreams.close();
 
         startStreams();
-        store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+        store = kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertThat(store.approximateNumEntries(), equalTo(4L));
-        timestampedStore = kafkaStreams.store(globalStore, QueryableStoreTypes.timestampedKeyValueStore());
+        timestampedStore = kafkaStreams.store(StoreQueryParams.fromNameAndType(globalStore, QueryableStoreTypes.timestampedKeyValueStore()));
         assertThat(timestampedStore.approximateNumEntries(), equalTo(4L));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -29,9 +29,10 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.KeyValueTimestamp;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Aggregator;
@@ -673,7 +674,7 @@ public class KStreamAggregationIntegrationTest {
 
         // verify can query data via IQ
         final ReadOnlySessionStore<String, String> sessionStore =
-            kafkaStreams.store(userSessionsStore, QueryableStoreTypes.sessionStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(userSessionsStore, QueryableStoreTypes.sessionStore()));
         final KeyValueIterator<Windowed<String>, String> bob = sessionStore.fetch("bob");
         assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t1, t1)), "start")));
         assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume")));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -45,11 +45,12 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -152,10 +153,10 @@ public class OptimizedKTableIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
 
         final ReadOnlyKeyValueStore<Integer, Integer> store1 = kafkaStreams1
-            .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
+            .store(StoreQueryParams.fromNameAndType(TABLE_NAME, QueryableStoreTypes.keyValueStore()));
 
         final ReadOnlyKeyValueStore<Integer, Integer> store2 = kafkaStreams2
-            .store(TABLE_NAME, QueryableStoreTypes.keyValueStore());
+            .store(StoreQueryParams.fromNameAndType(TABLE_NAME, QueryableStoreTypes.keyValueStore()));
 
         final boolean kafkaStreams1WasFirstActive;
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -307,7 +307,7 @@ public class QueryableStateIntegrationTest {
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final QueryableStoreType<ReadOnlyKeyValueStore<String, Long>> queryableStoreType = QueryableStoreTypes.keyValueStore();
                     final ReadOnlyKeyValueStore<String, Long> store =
-                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores());
+                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableStoreType).enableStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -367,7 +367,7 @@ public class QueryableStateIntegrationTest {
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final QueryableStoreType<ReadOnlyWindowStore<String, Long>> queryableWindowStoreType = QueryableStoreTypes.windowStore();
                     final ReadOnlyWindowStore<String, Long> store =
-                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableWindowStoreType).withIncludeStaleStores());
+                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableWindowStoreType).enableStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -306,9 +306,8 @@ public class QueryableStateIntegrationTest {
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final QueryableStoreType<ReadOnlyKeyValueStore<String, Long>> queryableStoreType = QueryableStoreTypes.keyValueStore();
-                    final StoreQueryParams<ReadOnlyKeyValueStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableStoreType);
                     final ReadOnlyKeyValueStore<String, Long> store =
-                        streamsWithKey.store(storeQueryParams.withIncludeStaleStores());
+                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableStoreType).withIncludeStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -367,9 +366,8 @@ public class QueryableStateIntegrationTest {
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final QueryableStoreType<ReadOnlyWindowStore<String, Long>> queryableWindowStoreType = QueryableStoreTypes.windowStore();
-                    final StoreQueryParams<ReadOnlyWindowStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableWindowStoreType);
                     final ReadOnlyWindowStore<String, Long> store =
-                        streamsWithKey.store(storeQueryParams.withIncludeStaleStores());
+                        streamsWithKey.store(StoreQueryParams.fromNameAndType(storeName, queryableWindowStoreType).withIncludeStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -652,10 +650,10 @@ public class QueryableStateIntegrationTest {
             waitUntilAtLeastNumRecordProcessed(outputTopicConcurrentWindowed, numberOfWordsPerIteration);
 
             final ReadOnlyKeyValueStore<String, Long> keyValueStore =
-                kafkaStreams.store(storeName + "-" + streamConcurrent, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName + "-" + streamConcurrent, QueryableStoreTypes.keyValueStore()));
 
             final ReadOnlyWindowStore<String, Long> windowStore =
-                kafkaStreams.store(windowStoreName + "-" + streamConcurrent, QueryableStoreTypes.windowStore());
+                kafkaStreams.store(StoreQueryParams.fromNameAndType(windowStoreName + "-" + streamConcurrent, QueryableStoreTypes.windowStore()));
 
             final Map<String, Long> expectedWindowState = new HashMap<>();
             final Map<String, Long> expectedCount = new HashMap<>();
@@ -718,9 +716,9 @@ public class QueryableStateIntegrationTest {
         waitUntilAtLeastNumRecordProcessed(outputTopic, 1);
 
         final ReadOnlyKeyValueStore<String, Long>
-            myFilterStore = kafkaStreams.store("queryFilter", QueryableStoreTypes.keyValueStore());
+            myFilterStore = kafkaStreams.store(StoreQueryParams.fromNameAndType("queryFilter", QueryableStoreTypes.keyValueStore()));
         final ReadOnlyKeyValueStore<String, Long>
-            myFilterNotStore = kafkaStreams.store("queryFilterNot", QueryableStoreTypes.keyValueStore());
+            myFilterNotStore = kafkaStreams.store(StoreQueryParams.fromNameAndType("queryFilterNot", QueryableStoreTypes.keyValueStore()));
 
         for (final KeyValue<String, Long> expectedEntry : expectedBatch1) {
             TestUtils.waitForCondition(() -> expectedEntry.value.equals(myFilterStore.get(expectedEntry.key)),
@@ -784,7 +782,7 @@ public class QueryableStateIntegrationTest {
         waitUntilAtLeastNumRecordProcessed(outputTopic, 5);
 
         final ReadOnlyKeyValueStore<String, Long> myMapStore =
-            kafkaStreams.store("queryMapValues", QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType("queryMapValues", QueryableStoreTypes.keyValueStore()));
         for (final KeyValue<String, String> batchEntry : batch1) {
             assertEquals(Long.valueOf(batchEntry.value), myMapStore.get(batchEntry.key));
         }
@@ -832,8 +830,8 @@ public class QueryableStateIntegrationTest {
         waitUntilAtLeastNumRecordProcessed(outputTopic, 1);
 
         final ReadOnlyKeyValueStore<String, Long>
-            myMapStore = kafkaStreams.store("queryMapValues",
-            QueryableStoreTypes.keyValueStore());
+            myMapStore = kafkaStreams.store(StoreQueryParams.fromNameAndType("queryMapValues",
+            QueryableStoreTypes.keyValueStore()));
         for (final KeyValue<String, Long> expectedEntry : expectedBatch1) {
             assertEquals(expectedEntry.value, myMapStore.get(expectedEntry.key));
         }
@@ -893,10 +891,10 @@ public class QueryableStateIntegrationTest {
         waitUntilAtLeastNumRecordProcessed(outputTopic, 1);
 
         final ReadOnlyKeyValueStore<String, Long>
-            myCount = kafkaStreams.store(storeName, QueryableStoreTypes.keyValueStore());
+            myCount = kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
 
         final ReadOnlyWindowStore<String, Long> windowStore =
-            kafkaStreams.store(windowStoreName, QueryableStoreTypes.windowStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(windowStoreName, QueryableStoreTypes.windowStore()));
         verifyCanGetByKey(keys,
             expectedCount,
             expectedCount,
@@ -935,7 +933,7 @@ public class QueryableStateIntegrationTest {
             "waiting for store " + storeName);
 
         final ReadOnlyKeyValueStore<String, Long> store =
-            kafkaStreams.store(storeName, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> Long.valueOf(8).equals(store.get("hello")),
@@ -955,7 +953,7 @@ public class QueryableStateIntegrationTest {
                 try {
                     assertEquals(
                         Long.valueOf(8L),
-                        kafkaStreams.store(storeName, QueryableStoreTypes.<String, Long>keyValueStore()).get("hello"));
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.<String, Long>keyValueStore())).get("hello"));
                     return true;
                 } catch (final InvalidStateStoreException ise) {
                     return false;
@@ -976,7 +974,7 @@ public class QueryableStateIntegrationTest {
         @Override
         public boolean conditionMet() {
             try {
-                kafkaStreams.store(storeName, QueryableStoreTypes.<String, Long>keyValueStore());
+                kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.<String, Long>keyValueStore()));
                 return true;
             } catch (final InvalidStateStoreException ise) {
                 return false;
@@ -1034,7 +1032,7 @@ public class QueryableStateIntegrationTest {
             "waiting for store " + storeName);
 
         final ReadOnlyKeyValueStore<String, String> store =
-            kafkaStreams.store(storeName, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(
             () -> "12".equals(store.get("a")) && "34".equals(store.get("b")),
@@ -1061,7 +1059,7 @@ public class QueryableStateIntegrationTest {
             "waiting for store " + storeName);
 
         final ReadOnlyKeyValueStore<String, String> store2 =
-            kafkaStreams.store(storeName, QueryableStoreTypes.keyValueStore());
+            kafkaStreams.store(StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
 
         try {
             TestUtils.waitForCondition(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -31,11 +31,12 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreamsTest;
-import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
@@ -304,7 +305,7 @@ public class QueryableStateIntegrationTest {
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final ReadOnlyKeyValueStore<String, Long> store =
-                        streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore(), true);
+                        streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresEnabled());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -363,7 +364,7 @@ public class QueryableStateIntegrationTest {
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
                     final ReadOnlyWindowStore<String, Long> store =
-                        streamsWithKey.store(storeName, QueryableStoreTypes.windowStore(), true);
+                        streamsWithKey.store(storeName, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresEnabled());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -49,13 +49,14 @@ import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.StreamsMetadata;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
@@ -304,8 +305,10 @@ public class QueryableStateIntegrationTest {
 
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
+                    final QueryableStoreType<ReadOnlyKeyValueStore<String, Long>> queryableStoreType = QueryableStoreTypes.keyValueStore();
+                    final StoreQueryParams<ReadOnlyKeyValueStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableStoreType);
                     final ReadOnlyKeyValueStore<String, Long> store =
-                        streamsWithKey.store(storeName, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresEnabled());
+                            streamsWithKey.store(storeQueryParams.withIncludeStaleStores(true));
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -363,8 +366,10 @@ public class QueryableStateIntegrationTest {
 
                     final int index = queryMetadata.getActiveHost().port();
                     final KafkaStreams streamsWithKey = pickInstanceByPort ? streamsList.get(index) : streams;
+                    final QueryableStoreType<ReadOnlyWindowStore<String, Long>> queryableWindowStoreType = QueryableStoreTypes.windowStore();
+                    final StoreQueryParams<ReadOnlyWindowStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableWindowStoreType);
                     final ReadOnlyWindowStore<String, Long> store =
-                        streamsWithKey.store(storeName, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresEnabled());
+                            streamsWithKey.store(storeQueryParams.withIncludeStaleStores(true));
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -308,7 +308,7 @@ public class QueryableStateIntegrationTest {
                     final QueryableStoreType<ReadOnlyKeyValueStore<String, Long>> queryableStoreType = QueryableStoreTypes.keyValueStore();
                     final StoreQueryParams<ReadOnlyKeyValueStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableStoreType);
                     final ReadOnlyKeyValueStore<String, Long> store =
-                            streamsWithKey.store(storeQueryParams.withIncludeStaleStores(true));
+                        streamsWithKey.store(storeQueryParams.withIncludeStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;
@@ -369,7 +369,7 @@ public class QueryableStateIntegrationTest {
                     final QueryableStoreType<ReadOnlyWindowStore<String, Long>> queryableWindowStoreType = QueryableStoreTypes.windowStore();
                     final StoreQueryParams<ReadOnlyWindowStore<String, Long>> storeQueryParams = new StoreQueryParams<>(storeName, queryableWindowStoreType);
                     final ReadOnlyWindowStore<String, Long> store =
-                            streamsWithKey.store(storeQueryParams.withIncludeStaleStores(true));
+                        streamsWithKey.store(storeQueryParams.withIncludeStaleStores());
                     if (store == null) {
                         nullStoreKeys.add(key);
                         continue;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -348,30 +348,4 @@ public class StoreQueryIntegrationTest {
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
         return config;
     }
-
-    private StateRestoreListener createTrackingRestoreListener(final AtomicLong restoreStartOffset,
-                                                               final AtomicLong restoreEndOffset) {
-        return new StateRestoreListener() {
-            @Override
-            public void onRestoreStart(final TopicPartition topicPartition,
-                                       final String storeName,
-                                       final long startingOffset,
-                                       final long endingOffset) {
-                restoreStartOffset.set(startingOffset);
-                restoreEndOffset.set(endingOffset);
-            }
-
-            @Override
-            public void onBatchRestored(final TopicPartition topicPartition, final String storeName,
-                                        final long batchEndOffset, final long numRestored) {
-
-            }
-
-            @Override
-            public void onRestoreEnd(final TopicPartition topicPartition, final String storeName,
-                                     final long totalRestored) {
-
-            }
-        };
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -34,7 +33,6 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -55,7 +53,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -100,8 +97,7 @@ public class StoreQueryIntegrationTest {
         final Semaphore semaphore = new Semaphore(0);
 
         final StreamsBuilder builder = new StreamsBuilder();
-        builder
-                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+        builder.table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
                         Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
                                 .withCachingDisabled())
                 .toStream()
@@ -145,8 +141,7 @@ public class StoreQueryIntegrationTest {
         final Semaphore semaphore = new Semaphore(0);
 
         final StreamsBuilder builder = new StreamsBuilder();
-        builder
-                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+        builder.table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
                         Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
                                 .withCachingDisabled())
                 .toStream()
@@ -226,8 +221,7 @@ public class StoreQueryIntegrationTest {
         final Semaphore semaphore = new Semaphore(0);
 
         final StreamsBuilder builder = new StreamsBuilder();
-        builder
-                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+        builder.table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
                         Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
                                 .withCachingDisabled())
                 .toStream()
@@ -263,8 +257,7 @@ public class StoreQueryIntegrationTest {
         final Semaphore semaphore = new Semaphore(0);
 
         final StreamsBuilder builder = new StreamsBuilder();
-        builder
-                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+        builder.table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
                         Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
                                 .withCachingDisabled())
                 .toStream()

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreType;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+
+@Category({IntegrationTest.class})
+public class StoreQueryIntegrationTest {
+
+    private static final int NUM_BROKERS = 1;
+    private static int port = 0;
+    private static final String INPUT_TOPIC_NAME = "input-topic";
+    private static final String TABLE_NAME = "source-table";
+
+    @Rule
+    public final EmbeddedKafkaCluster cluster = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    private final List<KafkaStreams> streamsToCleanup = new ArrayList<>();
+    private final MockTime mockTime = cluster.time;
+
+    @Before
+    public void before() throws InterruptedException {
+        cluster.createTopic(INPUT_TOPIC_NAME, 2, 1);
+    }
+
+    @After
+    public void after() {
+        for (final KafkaStreams kafkaStreams : streamsToCleanup) {
+            kafkaStreams.close();
+        }
+    }
+
+    @Test
+    public void shouldQueryAllActivePartitionStoresByDefault() throws Exception {
+        final int batch1NumMessages = 100;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                        Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                                .withCachingDisabled())
+                .toStream()
+                .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams kafkaStreams1 = createKafkaStreams(builder, streamsConfiguration());
+        final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration());
+        final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
+
+        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+
+        produceValueRange(key, 0, batch1NumMessages);
+
+        // Assert that all messages in the first batch were processed in a timely manner
+        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+
+        final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = QueryableStoreTypes.keyValueStore();
+        final ReadOnlyKeyValueStore<Integer, Integer> store1 = kafkaStreams1
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType));
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store2 = kafkaStreams2
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType));
+
+        final boolean kafkaStreams1IsActive;
+        if ((keyQueryMetadata.getActiveHost().port() % 2) == 1) {
+            kafkaStreams1IsActive = true;
+        } else {
+            kafkaStreams1IsActive = false;
+        }
+
+        // Assert that only active is able to query for a key by default
+        assertThat(kafkaStreams1IsActive ? store1.get(key) : store2.get(key), is(notNullValue()));
+        assertThat(kafkaStreams1IsActive ? store2.get(key) : store1.get(key), is(nullValue()));
+    }
+
+    @Test
+    public void shouldQuerySpecificActivePartitionStores() throws Exception {
+        final int batch1NumMessages = 100;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                        Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                                .withCachingDisabled())
+                .toStream()
+                .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams kafkaStreams1 = createKafkaStreams(builder, streamsConfiguration());
+        final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration());
+        final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
+
+        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+
+        produceValueRange(key, 0, batch1NumMessages);
+
+        // Assert that all messages in the first batch were processed in a timely manner
+        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+
+        //key belongs to this partition
+        final int keyPartition = keyQueryMetadata.getPartition();
+
+        //key doesn't belongs to this partition
+        final int keyDontBelongPartition = (keyPartition == 0) ? 1 : 0;
+        final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = QueryableStoreTypes.keyValueStore();
+        ReadOnlyKeyValueStore<Integer, Integer> store1 = null;
+        ReadOnlyKeyValueStore<Integer, Integer> store2 = null;
+        try {
+            store1 = kafkaStreams1
+                    .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).withPartition(keyPartition));
+        } catch (final InvalidStateStoreException exception) {
+        //Only one among kafkaStreams1 and kafkaStreams2 will contain the specific active store requested. The other will throw exception
+        }
+        try {
+            store2 = kafkaStreams2
+                    .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).withPartition(keyPartition));
+        } catch (final InvalidStateStoreException exception) {
+            //Only one among kafkaStreams1 and kafkaStreams2 will contain the specific active store requested. The other will throw exception
+        }
+        final boolean kafkaStreams1IsActive;
+        if ((keyQueryMetadata.getActiveHost().port() % 2) == 1) {
+            kafkaStreams1IsActive = true;
+            assertThat(store1, is(notNullValue()));
+            assertThat(store2, is(nullValue()));
+        } else {
+            kafkaStreams1IsActive = false;
+            assertThat(store2, is(notNullValue()));
+            assertThat(store1, is(nullValue()));
+        }
+
+        // Assert that only active for a specific requested partition serves key if stale stores and not enabled
+        assertThat(kafkaStreams1IsActive ? store1.get(key) : store2.get(key), is(notNullValue()));
+
+        ReadOnlyKeyValueStore<Integer, Integer> store3 = null;
+        ReadOnlyKeyValueStore<Integer, Integer> store4 = null;
+        try {
+            store3 = kafkaStreams1
+                    .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).withPartition(keyDontBelongPartition));
+        } catch (final InvalidStateStoreException exception) {
+            //Only one among kafkaStreams1 and kafkaStreams2 will contain the specific active store requested. The other will throw exception
+        }
+        try {
+            store4 = kafkaStreams2
+                    .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).withPartition(keyDontBelongPartition));
+        } catch (final InvalidStateStoreException exception) {
+            //Only one among kafkaStreams1 and kafkaStreams2 will contain the specific active store requested. The other will throw exception
+        }
+
+        // Assert that key is not served when wrong specific partition is requested
+        // If kafkaStreams1 is active for keyPartition, kafkaStreams2 would be active for keyDontBelongPartition
+        // So, in that case, store3 would be null and the store4 would not return the value for key as wrong partition was requested
+        assertThat(kafkaStreams1IsActive ? store4.get(key) : store3.get(key), is(nullValue()));
+    }
+
+    @Test
+    public void shouldQueryAllStalePartitionStores() throws Exception {
+        final int batch1NumMessages = 100;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                        Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                                .withCachingDisabled())
+                .toStream()
+                .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams kafkaStreams1 = createKafkaStreams(builder, streamsConfiguration());
+        final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration());
+        final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
+
+        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+
+        produceValueRange(key, 0, batch1NumMessages);
+
+        // Assert that all messages in the first batch were processed in a timely manner
+        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+
+        final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = QueryableStoreTypes.keyValueStore();
+        final ReadOnlyKeyValueStore<Integer, Integer> store1 = kafkaStreams1
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores());
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store2 = kafkaStreams2
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores());
+
+        // Assert that both active and standby are able to query for a key
+        assertThat(store1.get(key), is(notNullValue()));
+        assertThat(store2.get(key), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldQuerySpecificStalePartitionStores() throws Exception {
+        final int batch1NumMessages = 100;
+        final int key = 1;
+        final Semaphore semaphore = new Semaphore(0);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+                .table(INPUT_TOPIC_NAME, Consumed.with(Serdes.Integer(), Serdes.Integer()),
+                        Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as(TABLE_NAME)
+                                .withCachingDisabled())
+                .toStream()
+                .peek((k, v) -> semaphore.release());
+
+        final KafkaStreams kafkaStreams1 = createKafkaStreams(builder, streamsConfiguration());
+        final KafkaStreams kafkaStreams2 = createKafkaStreams(builder, streamsConfiguration());
+        final List<KafkaStreams> kafkaStreamsList = Arrays.asList(kafkaStreams1, kafkaStreams2);
+
+        startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
+
+        produceValueRange(key, 0, batch1NumMessages);
+
+        // Assert that all messages in the first batch were processed in a timely manner
+        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+
+        //key belongs to this partition
+        final int keyPartition = keyQueryMetadata.getPartition();
+
+        //key doesn't belongs to this partition
+        final int keyDontBelongPartition = (keyPartition == 0) ? 1 : 0;
+        final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = QueryableStoreTypes.keyValueStore();
+        final ReadOnlyKeyValueStore<Integer, Integer> store1 = kafkaStreams1
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores().withPartition(keyPartition));
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store2 = kafkaStreams2
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores().withPartition(keyPartition));
+
+        // Assert that both active and standby are able to query for a key
+        assertThat(store1.get(key), is(notNullValue()));
+        assertThat(store2.get(key), is(notNullValue()));
+
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store3 = kafkaStreams1
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores().withPartition(keyDontBelongPartition));
+
+        final ReadOnlyKeyValueStore<Integer, Integer> store4 = kafkaStreams2
+                .store(StoreQueryParams.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores().withPartition(keyDontBelongPartition));
+
+        // Assert that
+        assertThat(store3.get(key), is(nullValue()));
+        assertThat(store4.get(key), is(nullValue()));
+    }
+
+    private KafkaStreams createKafkaStreams(final StreamsBuilder builder, final Properties config) {
+        final KafkaStreams streams = new KafkaStreams(builder.build(config), config);
+        streamsToCleanup.add(streams);
+        return streams;
+    }
+
+    private void produceValueRange(final int key, final int start, final int endExclusive) throws Exception {
+        final Properties producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+                INPUT_TOPIC_NAME,
+                IntStream.range(start, endExclusive)
+                        .mapToObj(i -> KeyValue.pair(key, i))
+                        .collect(Collectors.toList()),
+                producerProps,
+                mockTime);
+    }
+
+    private Properties streamsConfiguration() {
+        final String applicationId = "streamsApp";
+        final Properties config = new Properties();
+        config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        config.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + String.valueOf(++port));
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(applicationId).getPath());
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        config.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
+        config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
+        config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
+        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        return config;
+    }
+
+    private StateRestoreListener createTrackingRestoreListener(final AtomicLong restoreStartOffset,
+                                                               final AtomicLong restoreEndOffset) {
+        return new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(final TopicPartition topicPartition,
+                                       final String storeName,
+                                       final long startingOffset,
+                                       final long endingOffset) {
+                restoreStartOffset.set(startingOffset);
+                restoreEndOffset.set(endingOffset);
+            }
+
+            @Override
+            public void onBatchRestored(final TopicPartition topicPartition, final String storeName,
+                                        final long batchEndOffset, final long numRestored) {
+
+            }
+
+            @Override
+            public void onRestoreEnd(final TopicPartition topicPartition, final String storeName,
+                                     final long totalRestored) {
+
+            }
+        };
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreUpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreUpgradeIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -333,7 +334,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyKeyValueStore<K, V> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.keyValueStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.keyValueStore()));
                     try (final KeyValueIterator<K, V> all = store.all()) {
                         final List<KeyValue<K, V>> storeContent = new LinkedList<>();
                         while (all.hasNext()) {
@@ -358,7 +359,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore()));
                     final ValueAndTimestamp<Long> count = store.get(key);
                     return count.value() == value && count.timestamp() == timestamp;
                 } catch (final Exception swallow) {
@@ -377,7 +378,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyKeyValueStore<K, ValueAndTimestamp<Long>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore()));
                     final ValueAndTimestamp<Long> count = store.get(key);
                     return count.value() == value && count.timestamp() == -1L;
                 } catch (final Exception swallow) {
@@ -407,7 +408,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore()));
                     try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
                         final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
                         while (all.hasNext()) {
@@ -442,7 +443,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedKeyValueStore()));
                     try (final KeyValueIterator<K, ValueAndTimestamp<V>> all = store.all()) {
                         final List<KeyValue<K, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
                         while (all.hasNext()) {
@@ -808,7 +809,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyWindowStore<K, V> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.windowStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.windowStore()));
                     try (final KeyValueIterator<Windowed<K>, V> all = store.all()) {
                         final List<KeyValue<Windowed<K>, V>> storeContent = new LinkedList<>();
                         while (all.hasNext()) {
@@ -832,7 +833,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedWindowStore()));
                     final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
                     return count.value() == value && count.timestamp() == -1L;
                 } catch (final Exception swallow) {
@@ -852,7 +853,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyWindowStore<K, ValueAndTimestamp<Long>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedWindowStore()));
                     final ValueAndTimestamp<Long> count = store.fetch(key.key(), key.window().start());
                     return count.value() == value && count.timestamp() == timestamp;
                 } catch (final Exception swallow) {
@@ -882,7 +883,7 @@ public class StoreUpgradeIntegrationTest {
             () -> {
                 try {
                     final ReadOnlyWindowStore<K, ValueAndTimestamp<V>> store =
-                        kafkaStreams.store(STORE_NAME, QueryableStoreTypes.timestampedWindowStore());
+                        kafkaStreams.store(StoreQueryParams.fromNameAndType(STORE_NAME, QueryableStoreTypes.timestampedWindowStore()));
                     try (final KeyValueIterator<Windowed<K>, ValueAndTimestamp<V>> all = store.all()) {
                         final List<KeyValue<Windowed<K>, ValueAndTimestamp<V>>> storeContent = new LinkedList<>();
                         while (all.hasNext()) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.integration;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -93,7 +94,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
 
             kafkaStreams.start();
             latch.await();
-            assertThrows(InvalidStateStoreException.class, () -> kafkaStreams.store("join-store", QueryableStoreTypes.keyValueStore()));
+            assertThrows(InvalidStateStoreException.class, () -> kafkaStreams.store(StoreQueryParams.fromNameAndType("join-store", QueryableStoreTypes.keyValueStore())));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -66,7 +66,7 @@ public class CompositeReadOnlyKeyValueStoreTest {
         stubProviderOne.addStore("other-store", otherUnderlyingStore);
         final QueryableStoreType<ReadOnlyKeyValueStore<Object, Object>> queryableStoreType = QueryableStoreTypes.keyValueStore();
         theStore = new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>(storeName, QueryableStoreTypes.keyValueStore())),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore())),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );
@@ -299,7 +299,7 @@ public class CompositeReadOnlyKeyValueStoreTest {
     private CompositeReadOnlyKeyValueStore<Object, Object> rebalancing() {
         final QueryableStoreType<ReadOnlyKeyValueStore<Object, Object>> queryableStoreType = QueryableStoreTypes.keyValueStore();
         return new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>(storeName, QueryableStoreTypes.keyValueStore())),
+            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore())),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -21,11 +21,13 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.MockRecordCollector;
@@ -62,9 +64,9 @@ public class CompositeReadOnlyKeyValueStoreTest {
         stubProviderOne.addStore(storeName, stubOneUnderlying);
         otherUnderlyingStore = newStoreInstance();
         stubProviderOne.addStore("other-store", otherUnderlyingStore);
-
+        final QueryableStoreType<ReadOnlyKeyValueStore<Object, Object>> queryableStoreType = QueryableStoreTypes.keyValueStore();
         theStore = new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>(storeName, QueryableStoreTypes.keyValueStore())),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );
@@ -295,8 +297,9 @@ public class CompositeReadOnlyKeyValueStoreTest {
     }
 
     private CompositeReadOnlyKeyValueStore<Object, Object> rebalancing() {
+        final QueryableStoreType<ReadOnlyKeyValueStore<Object, Object>> queryableStoreType = QueryableStoreTypes.keyValueStore();
         return new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>(storeName, QueryableStoreTypes.keyValueStore())),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -63,7 +64,7 @@ public class CompositeReadOnlyKeyValueStoreTest {
         stubProviderOne.addStore("other-store", otherUnderlyingStore);
 
         theStore = new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), false),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );
@@ -295,7 +296,7 @@ public class CompositeReadOnlyKeyValueStoreTest {
 
     private CompositeReadOnlyKeyValueStore<Object, Object> rebalancing() {
         return new CompositeReadOnlyKeyValueStore<>(
-            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), false),
+            new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
             QueryableStoreTypes.keyValueStore(),
             storeName
         );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -58,7 +58,7 @@ public class CompositeReadOnlySessionStoreTest {
         final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
 
         sessionStore = new CompositeReadOnlySessionStore<>(
-            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlySessionStore<Object, Object>>(storeName, queryableStoreType)),
+            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), StoreQueryParams.fromNameAndType(storeName, queryableStoreType)),
             QueryableStoreTypes.sessionStore(), storeName);
     }
 
@@ -113,7 +113,7 @@ public class CompositeReadOnlySessionStoreTest {
         final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
         final CompositeReadOnlySessionStore<String, String> store =
             new CompositeReadOnlySessionStore<>(
-                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), new StoreQueryParams<ReadOnlySessionStore<Object, Object>>("whateva", queryableStoreType)),
+                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.fromNameAndType("whateva", queryableStoreType)),
                 QueryableStoreTypes.sessionStore(),
                 "whateva"
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -21,7 +21,9 @@ import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.test.ReadOnlySessionStoreStub;
 import org.apache.kafka.test.StateStoreProviderStub;
@@ -53,10 +55,10 @@ public class CompositeReadOnlySessionStoreTest {
     public void before() {
         stubProviderOne.addStore(storeName, underlyingSessionStore);
         stubProviderOne.addStore("other-session-store", otherUnderlyingStore);
-
+        final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
 
         sessionStore = new CompositeReadOnlySessionStore<>(
-            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlySessionStore<Object, Object>>(storeName, queryableStoreType)),
             QueryableStoreTypes.sessionStore(), storeName);
     }
 
@@ -108,9 +110,10 @@ public class CompositeReadOnlySessionStoreTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
+        final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
         final CompositeReadOnlySessionStore<String, String> store =
             new CompositeReadOnlySessionStore<>(
-                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), new StoreQueryParams<ReadOnlySessionStore<Object, Object>>("whateva", queryableStoreType)),
                 QueryableStoreTypes.sessionStore(),
                 "whateva"
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
@@ -55,7 +56,7 @@ public class CompositeReadOnlySessionStoreTest {
 
 
         sessionStore = new CompositeReadOnlySessionStore<>(
-            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), false),
+            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
             QueryableStoreTypes.sessionStore(), storeName);
     }
 
@@ -109,7 +110,7 @@ public class CompositeReadOnlySessionStoreTest {
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
         final CompositeReadOnlySessionStore<String, String> store =
             new CompositeReadOnlySessionStore<>(
-                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), false),
+                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
                 QueryableStoreTypes.sessionStore(),
                 "whateva"
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -21,9 +21,7 @@ import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
-import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.StateStoreProviderStub;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -69,9 +67,8 @@ public class CompositeReadOnlyWindowStoreTest {
         otherUnderlyingStore = new ReadOnlyWindowStoreStub<>(WINDOW_SIZE);
         stubProviderOne.addStore("other-window-store", otherUnderlyingStore);
 
-        final QueryableStoreType<ReadOnlyWindowStore<Object, Object>> queryableStoreType = QueryableStoreTypes.windowStore();
         windowStore = new CompositeReadOnlyWindowStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>(storeName, queryableStoreType)),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.fromNameAndType(storeName, QueryableStoreTypes.windowStore())),
                 QueryableStoreTypes.windowStore(),
                 storeName
         );
@@ -141,10 +138,9 @@ public class CompositeReadOnlyWindowStoreTest {
     @Test
     public void shouldThrowInvalidStateStoreExceptionIfFetchThrows() {
         underlyingWindowStore.setOpen(false);
-        final QueryableStoreType<ReadOnlyWindowStore<Object, Object>> queryableStoreType = QueryableStoreTypes.windowStore();
         final CompositeReadOnlyWindowStore<Object, Object> store =
                 new CompositeReadOnlyWindowStore<>(
-                    new WrappingStoreProvider(singletonList(stubProviderOne), new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>("window-store", QueryableStoreTypes.windowStore())),
+                    new WrappingStoreProvider(singletonList(stubProviderOne), StoreQueryParams.fromNameAndType("window-store", QueryableStoreTypes.windowStore())),
                     QueryableStoreTypes.windowStore(),
                     "window-store"
                 );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -21,7 +21,9 @@ import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.StateStoreProviderStub;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -67,9 +69,9 @@ public class CompositeReadOnlyWindowStoreTest {
         otherUnderlyingStore = new ReadOnlyWindowStoreStub<>(WINDOW_SIZE);
         stubProviderOne.addStore("other-window-store", otherUnderlyingStore);
 
-
+        final QueryableStoreType<ReadOnlyWindowStore<Object, Object>> queryableStoreType = QueryableStoreTypes.windowStore();
         windowStore = new CompositeReadOnlyWindowStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>(storeName, queryableStoreType)),
                 QueryableStoreTypes.windowStore(),
                 storeName
         );
@@ -139,9 +141,10 @@ public class CompositeReadOnlyWindowStoreTest {
     @Test
     public void shouldThrowInvalidStateStoreExceptionIfFetchThrows() {
         underlyingWindowStore.setOpen(false);
+        final QueryableStoreType<ReadOnlyWindowStore<Object, Object>> queryableStoreType = QueryableStoreTypes.windowStore();
         final CompositeReadOnlyWindowStore<Object, Object> store =
                 new CompositeReadOnlyWindowStore<>(
-                    new WrappingStoreProvider(singletonList(stubProviderOne), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
+                    new WrappingStoreProvider(singletonList(stubProviderOne), new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>("window-store", QueryableStoreTypes.windowStore())),
                     QueryableStoreTypes.windowStore(),
                     "window-store"
                 );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
@@ -68,7 +69,7 @@ public class CompositeReadOnlyWindowStoreTest {
 
 
         windowStore = new CompositeReadOnlyWindowStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), false),
+            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
                 QueryableStoreTypes.windowStore(),
                 storeName
         );
@@ -140,7 +141,7 @@ public class CompositeReadOnlyWindowStoreTest {
         underlyingWindowStore.setOpen(false);
         final CompositeReadOnlyWindowStore<Object, Object> store =
                 new CompositeReadOnlyWindowStore<>(
-                    new WrappingStoreProvider(singletonList(stubProviderOne), false),
+                    new WrappingStoreProvider(singletonList(stubProviderOne), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()),
                     QueryableStoreTypes.windowStore(),
                     "window-store"
                 );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -54,38 +54,38 @@ public class QueryableStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfKVStoreDoesntExist() {
-        storeProvider.getStore(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.keyValueStore()));
+        storeProvider.getStore(StoreQueryParams.fromNameAndType("not-a-store", QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfWindowStoreDoesntExist() {
-        storeProvider.getStore(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.windowStore()));
+        storeProvider.getStore(StoreQueryParams.fromNameAndType("not-a-store", QueryableStoreTypes.windowStore()));
     }
 
     @Test
     public void shouldReturnKVStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(new StoreQueryParams<>(keyValueStore, QueryableStoreTypes.keyValueStore())));
+        assertNotNull(storeProvider.getStore(StoreQueryParams.fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore())));
     }
 
     @Test
     public void shouldReturnWindowStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(new StoreQueryParams<>(windowStore, QueryableStoreTypes.windowStore())));
+        assertNotNull(storeProvider.getStore(StoreQueryParams.fromNameAndType(windowStore, QueryableStoreTypes.windowStore())));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() {
-        storeProvider.getStore(new StoreQueryParams<>(windowStore, QueryableStoreTypes.keyValueStore()));
+        storeProvider.getStore(StoreQueryParams.fromNameAndType(windowStore, QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() {
-        storeProvider.getStore(new StoreQueryParams<>(keyValueStore, QueryableStoreTypes.windowStore()));
+        storeProvider.getStore(StoreQueryParams.fromNameAndType(keyValueStore, QueryableStoreTypes.windowStore()));
     }
 
     @Test
     public void shouldFindGlobalStores() {
         globalStateStores.put("global", new NoOpReadOnlyStore<>());
-        assertNotNull(storeProvider.getStore(new StoreQueryParams<>("global", QueryableStoreTypes.keyValueStore())));
+        assertNotNull(storeProvider.getStore(StoreQueryParams.fromNameAndType("global", QueryableStoreTypes.keyValueStore())));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -54,38 +54,38 @@ public class QueryableStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfKVStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        storeProvider.getStore(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfWindowStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        storeProvider.getStore(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.windowStore()));
     }
 
     @Test
     public void shouldReturnKVStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
+        assertNotNull(storeProvider.getStore(new StoreQueryParams<>(keyValueStore, QueryableStoreTypes.keyValueStore())));
     }
 
     @Test
     public void shouldReturnWindowStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
+        assertNotNull(storeProvider.getStore(new StoreQueryParams<>(windowStore, QueryableStoreTypes.windowStore())));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() {
-        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        storeProvider.getStore(new StoreQueryParams<>(windowStore, QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() {
-        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        storeProvider.getStore(new StoreQueryParams<>(keyValueStore, QueryableStoreTypes.windowStore()));
     }
 
     @Test
     public void shouldFindGlobalStores() {
         globalStateStores.put("global", new NoOpReadOnlyStore<>());
-        assertNotNull(storeProvider.getStore("global", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
+        assertNotNull(storeProvider.getStore(new StoreQueryParams<>("global", QueryableStoreTypes.keyValueStore())));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.NoOpWindowStore;
@@ -53,38 +54,38 @@ public class QueryableStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfKVStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore(), false);
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionIfWindowStoreDoesntExist() {
-        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore(), false);
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test
     public void shouldReturnKVStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.keyValueStore(), false));
+        assertNotNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
     }
 
     @Test
     public void shouldReturnWindowStoreWhenItExists() {
-        assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore(), false));
+        assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() {
-        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore(), false);
+        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() {
-        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore(), false);
+        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test
     public void shouldFindGlobalStores() {
         globalStateStores.put("global", new NoOpReadOnlyStore<>());
-        assertNotNull(storeProvider.getStore("global", QueryableStoreTypes.keyValueStore(), false));
+        assertNotNull(storeProvider.getStore("global", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -163,7 +163,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, String>> kvStores =
-            provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, kvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -175,7 +175,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -187,7 +187,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindKeyValueStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-                provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
+                provider.stores(StoreQueryParams.fromNameAndType("kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(0, tkvStores.size());
     }
 
@@ -195,7 +195,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStoresAsKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-                provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.keyValueStore()));
+                provider.stores(StoreQueryParams.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -207,7 +207,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, String>> windowStores =
-            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.windowStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -219,7 +219,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -231,7 +231,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindWindowStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.timestampedWindowStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("window-store", QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(0, windowStores.size());
     }
 
@@ -239,7 +239,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStoresAsWindowStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.windowStore()));
+            provider.stores(StoreQueryParams.fromNameAndType("timestamped-window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -251,28 +251,28 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
-        provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
+        provider.stores(StoreQueryParams.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
-        provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
+        provider.stores(StoreQueryParams.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
-        provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.windowStore()));
+        provider.stores(StoreQueryParams.fromNameAndType("window-store", QueryableStoreTypes.windowStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
-        provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
+        provider.stores(StoreQueryParams.fromNameAndType("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
     }
 
     @Test
@@ -280,7 +280,7 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.keyValueStore())));
+            provider.stores(StoreQueryParams.fromNameAndType("not-a-store", QueryableStoreTypes.keyValueStore())));
     }
 
     @Test
@@ -288,14 +288,14 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.keyValueStore()))
+            provider.stores(StoreQueryParams.fromNameAndType("window-store", QueryableStoreTypes.keyValueStore()))
         );
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
-        provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
+        provider.stores(StoreQueryParams.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -24,14 +24,16 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
-import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.StoreChangelogReader;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -125,7 +127,8 @@ public class StreamThreadStateStoreProviderTest {
         configureRestoreConsumer(clientSupplier, "applicationId-kv-store-changelog");
         configureRestoreConsumer(clientSupplier, "applicationId-window-store-changelog");
 
-        final ProcessorTopology processorTopology = topology.getInternalBuilder(applicationId).build();
+        final InternalTopologyBuilder internalTopologyBuilder = topology.getInternalBuilder(applicationId);
+        final ProcessorTopology processorTopology = internalTopologyBuilder.build();
 
         tasks = new HashMap<>();
         stateDirectory = new StateDirectory(streamsConfig, new MockTime(), true);
@@ -147,7 +150,7 @@ public class StreamThreadStateStoreProviderTest {
         tasks.put(new TaskId(0, 1), taskTwo);
 
         threadMock = EasyMock.createNiceMock(StreamThread.class);
-        provider = new StreamThreadStateStoreProvider(threadMock);
+        provider = new StreamThreadStateStoreProvider(threadMock, internalTopologyBuilder);
 
     }
 
@@ -160,7 +163,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, String>> kvStores =
-            provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
+            provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, kvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -172,7 +175,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
+            provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -184,7 +187,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindKeyValueStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
+                provider.stores("kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(0, tkvStores.size());
     }
 
@@ -192,7 +195,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStoresAsKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("timestamped-kv-store", QueryableStoreTypes.keyValueStore(), false);
+                provider.stores("timestamped-kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -204,7 +207,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, String>> windowStores =
-            provider.stores("window-store", QueryableStoreTypes.windowStore(), false);
+            provider.stores("window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -216,7 +219,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), false);
+            provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -228,7 +231,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindWindowStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("window-store", QueryableStoreTypes.timestampedWindowStore(), false);
+            provider.stores("window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(0, windowStores.size());
     }
 
@@ -236,7 +239,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStoresAsWindowStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", QueryableStoreTypes.windowStore(), false);
+            provider.stores("timestamped-window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -248,28 +251,28 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
+        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
-        provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), false);
+        provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
-        provider.stores("window-store", QueryableStoreTypes.windowStore(), false);
+        provider.stores("window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
-        provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), false);
+        provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     @Test
@@ -277,7 +280,7 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("not-a-store", QueryableStoreTypes.keyValueStore(), false));
+            provider.stores("not-a-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
     }
 
     @Test
@@ -285,14 +288,14 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("window-store", QueryableStoreTypes.keyValueStore(), false)
+            provider.stores("window-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled())
         );
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), false);
+        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -163,7 +163,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, String>> kvStores =
-            provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, kvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -175,7 +175,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-            provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -187,7 +187,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindKeyValueStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-                provider.stores("kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+                provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(0, tkvStores.size());
     }
 
@@ -195,7 +195,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedKeyValueStoresAsKeyValueStores() {
         mockThread(true);
         final List<ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>>> tkvStores =
-                provider.stores("timestamped-kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+                provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
             assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
@@ -207,7 +207,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, String>> windowStores =
-            provider.stores("window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -219,7 +219,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStores() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -231,7 +231,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldNotFindWindowStoresAsTimestampedStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(0, windowStores.size());
     }
 
@@ -239,7 +239,7 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindTimestampedWindowStoresAsWindowStore() {
         mockThread(true);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> windowStores =
-            provider.stores("timestamped-window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+            provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
@@ -251,28 +251,28 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
-        provider.stores("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        provider.stores(new StoreQueryParams<>("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
-        provider.stores("window-store", QueryableStoreTypes.windowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.windowStore()));
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
-        provider.stores("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        provider.stores(new StoreQueryParams<>("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
     }
 
     @Test
@@ -280,7 +280,7 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("not-a-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled()));
+            provider.stores(new StoreQueryParams<>("not-a-store", QueryableStoreTypes.keyValueStore())));
     }
 
     @Test
@@ -288,14 +288,14 @@ public class StreamThreadStateStoreProviderTest {
         mockThread(true);
         assertEquals(
             Collections.emptyList(),
-            provider.stores("window-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled())
+            provider.stores(new StoreQueryParams<>("window-store", QueryableStoreTypes.keyValueStore()))
         );
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
-        provider.stores("kv-store", QueryableStoreTypes.keyValueStore(), StoreQueryParams.withAllPartitionAndStaleStoresDisabled());
+        provider.stores(new StoreQueryParams<>("kv-store", QueryableStoreTypes.keyValueStore()));
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -57,7 +57,7 @@ public class WrappingStoreProviderTest {
         stubProviderTwo.addStore("window", new NoOpWindowStore());
         wrappingStoreProvider = new WrappingStoreProvider(
             Arrays.asList(stubProviderOne, stubProviderTwo),
-            new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>("kv", QueryableStoreTypes.keyValueStore())
+            StoreQueryParams.fromNameAndType("kv", QueryableStoreTypes.keyValueStore())
         );
     }
 
@@ -70,7 +70,7 @@ public class WrappingStoreProviderTest {
 
     @Test
     public void shouldFindWindowStores() {
-        wrappingStoreProvider.setStoreQueryParams(new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>("window", windowStore()));
+        wrappingStoreProvider.setStoreQueryParams(StoreQueryParams.fromNameAndType("window", windowStore()));
         final List<ReadOnlyWindowStore<Object, Object>>
                 windowStores =
                 wrappingStoreProvider.stores("window", windowStore());
@@ -79,7 +79,7 @@ public class WrappingStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNoStoreOfTypeFound() {
-        wrappingStoreProvider.setStoreQueryParams(new StoreQueryParams<ReadOnlyKeyValueStore<String, String>>("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore()));
+        wrappingStoreProvider.setStoreQueryParams(StoreQueryParams.fromNameAndType("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore()));
         wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.test.StateStoreProviderStub;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,10 +55,9 @@ public class WrappingStoreProviderTest {
                 Serdes.serdeFrom(String.class))
                 .build());
         stubProviderTwo.addStore("window", new NoOpWindowStore());
-
         wrappingStoreProvider = new WrappingStoreProvider(
             Arrays.asList(stubProviderOne, stubProviderTwo),
-            StoreQueryParams.withAllPartitionAndStaleStoresDisabled()
+            new StoreQueryParams<ReadOnlyKeyValueStore<Object, Object>>("kv", QueryableStoreTypes.keyValueStore())
         );
     }
 
@@ -71,6 +70,7 @@ public class WrappingStoreProviderTest {
 
     @Test
     public void shouldFindWindowStores() {
+        wrappingStoreProvider.setStoreQueryParams(new StoreQueryParams<ReadOnlyWindowStore<Object, Object>>("window", windowStore()));
         final List<ReadOnlyWindowStore<Object, Object>>
                 windowStores =
                 wrappingStoreProvider.stores("window", windowStore());
@@ -79,6 +79,7 @@ public class WrappingStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNoStoreOfTypeFound() {
-        wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.keyValueStore());
+        wrappingStoreProvider.setStoreQueryParams(new StoreQueryParams<ReadOnlyKeyValueStore<String, String>>("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore()));
+        wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -57,7 +58,7 @@ public class WrappingStoreProviderTest {
 
         wrappingStoreProvider = new WrappingStoreProvider(
             Arrays.asList(stubProviderOne, stubProviderTwo),
-            false
+            StoreQueryParams.withAllPartitionAndStaleStoresDisabled()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -40,8 +40,8 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     @SuppressWarnings("unchecked")
     @Override
     public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
-        final String storeName = storeQueryParams.getStoreName();
-        final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
+        final String storeName = storeQueryParams.storeName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.queryableStoreType();
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
         }

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -39,9 +39,9 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<T> stores(final String storeName,
-                              final QueryableStoreType<T> queryableStoreType,
-                              final StoreQueryParams storeQueryParams) {
+    public <T> List<T> stores(final StoreQueryParams storeQueryParams) {
+        final String storeName = storeQueryParams.getStoreName();
+        final QueryableStoreType<T> queryableStoreType = storeQueryParams.getQueryableStoreType();
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
         }

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.streams.StoreQueryParams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -32,7 +33,7 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     private final boolean throwException;
 
     public StateStoreProviderStub(final boolean throwException) {
-        super(null);
+        super(null, null);
         this.throwException = throwException;
     }
 
@@ -40,7 +41,7 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     @Override
     public <T> List<T> stores(final String storeName,
                               final QueryableStoreType<T> queryableStoreType,
-                              final boolean includeStaleStores) {
+                              final StoreQueryParams storeQueryParams) {
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
         }


### PR DESCRIPTION
This is the implementation of KIP-562: https://cwiki.apache.org/confluence/display/KAFKA/KIP-562%3A+Allow+fetching+a+key+from+a+single+partition+rather+than+iterating+over+all+the+stores+on+an+instance



 ### Committer Checklist (excluded from commit message)
 * [ ]  Verify design and implementation
 * [ ]  Verify test coverage and CI build status
 * [ ]  Verify documentation (including upgrade notes)