### PR TITLE
fixed an incoherence about existing Kafka APIs

### DIFF
--- a/docs/introduction.html
+++ b/docs/introduction.html
@@ -37,13 +37,14 @@
       <li>The Kafka cluster stores streams of <i>records</i> in categories called <i>topics</i>.
     <li>Each record consists of a key, a value, and a timestamp.
   </ul>
-  <p>Kafka has four core APIs:</p>
+  <p>Kafka has five core APIs:</p>
   <div style="overflow: hidden;">
       <ul style="float: left; width: 40%;">
       <li>The <a href="/documentation.html#producerapi">Producer API</a> allows an application to publish a stream of records to one or more Kafka topics.
       <li>The <a href="/documentation.html#consumerapi">Consumer API</a> allows an application to subscribe to one or more topics and process the stream of records produced to them.
     <li>The <a href="/documentation/streams">Streams API</a> allows an application to act as a <i>stream processor</i>, consuming an input stream from one or more topics and producing an output stream to one or more output topics, effectively transforming the input streams to output streams.
     <li>The <a href="/documentation.html#connect">Connector API</a> allows building and running reusable producers or consumers that connect Kafka topics to existing applications or data systems. For example, a connector to a relational database might capture every change to a table.
+    <li>The <a href="/documentation.html#adminapi">Admin API</a> allows managing and inspecting topics, brokers and other Kafka objects.
   </ul>
       <img src="/{{version}}/images/kafka-apis.png" style="float: right; width: 50%;">
       </div>


### PR DESCRIPTION
Although APIs section in Kafka documentation lists 5 core APIs (https://kafka.apache.org/documentation/#api), introduction page in Kafka documentation lists 4 of them. I've added the missing list element to fix this incoherence.