### PR TITLE
KAFKA-8532:controller-event-thread deadlock with zk-session-expiry-handler0

### DIFF
--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -363,7 +363,7 @@ class ZooKeeperClient(connectString: String,
     stateChangeHandlers.values.foreach(callBeforeInitializingSession _)
 
     inWriteLock(initializationLock) {
-      if (!connectionState.isAlive) {
+      if (!connectionState.isConnected) {
         zooKeeper.close()
         info(s"Initializing a new session to $connectString.")
         // retry forever until ZooKeeper can be instantiated


### PR DESCRIPTION
We have observed a serious deadlock between controller-event-thead and zk-session-expirey-handle thread. When this issue occurred, it's only one way to recovery the kafka cluster is restart kafka server.

After detailed analysis， I found that that ControllerEvent(RegisterBrokerAndReelect, and Expired) are invoked ZookeeperClient.reinitialize method in same time when zookeeper session expired, this will lead to a controller deadlock. (RegisterBrokerAndReelect need a established zookeeper session to process finish by controller-event-thread, Expired need be process by controller-event-thread to established zookeeper session, but controller-event-thread is busy to handing RegisterBrokerAndReelect ).