### PR TITLE
MINOR Update config validate help message to point to the correct config validation endpoint

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -556,7 +556,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             callback.onCompletion(
                 new BadRequestException(
                     messages.append(
-                        "\nYou can also find the above list of errors at the endpoint `/{connectorType}/config/validate`"
+                        "\nYou can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
                     ).toString()
                 ), null
             );

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -617,7 +617,7 @@ public class StandaloneHerderTest {
             capture.getValue().getMessage(),
             "Connector configuration is invalid and contains the following 1 error(s):\n" +
                 error + "\n" +
-                "You can also find the above list of errors at the endpoint `/{connectorType}/config/validate`"
+                "You can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
         );
 
         PowerMock.verifyAll();


### PR DESCRIPTION
Hi,

When we submit a bad connector configuration we are asked to check it against `/connector-plugins/{connectorType}/config/validate` while it's `/connector-plugins/{connectorType}/config/validate` 

This PR is to be consistent with the doc : https://kafka.apache.org/documentation/#connect_rest 

StandaloneHerderTest OK on my local installation 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
