### PR TITLE
KAFKA-9462: Correct exception message in DistributedHerder

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -699,7 +699,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     public Void call() throws Exception {
                         log.trace("Handling connector config request {}", connName);
                         if (!isLeader()) {
-                            callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
+                            callback.onCompletion(new NotLeaderException("Only the leader can delete connector configs.", leaderUrl()), null);
                             return null;
                         }
 


### PR DESCRIPTION
There are a few exception messages in DistributedHerder which were copied from other exception message.

This PR corrects the messages to reflect actual condition

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
