### PR TITLE
KAFKA-9355: Fix bug that removed RocksDB metrics after failure in EOS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -51,4 +51,10 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
             return newSegment;
         }
     }
+
+    @Override
+    public void openExisting(final InternalProcessorContext context, final long streamTime) {
+        metricsRecorder.init(context.metrics(), context.taskId());
+        super.openExisting(context, streamTime);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -203,7 +203,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
             // metrics recorder will clean up statistics object
             final Statistics statistics = new Statistics();
             userSpecifiedOptions.setStatistics(statistics);
-            metricsRecorder.addStatistics(name, statistics, (StreamsMetricsImpl) context.metrics(), context.taskId());
+            metricsRecorder.addStatistics(name, statistics);
         }
     }
 
@@ -225,6 +225,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
                      final StateStore root) {
         // open the DB dir
         internalProcessorContext = context;
+        metricsRecorder.init((StreamsMetricsImpl) context.metrics(), context.taskId());
         openDB(context);
         batchingStateRestoreCallback = new RocksDBBatchingRestoreCallback(this);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -51,4 +51,10 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
             return newSegment;
         }
     }
+
+    @Override
+    public void openExisting(final InternalProcessorContext context, final long streamTime) {
+        metricsRecorder.init(context.metrics(), context.taskId());
+        super.openExisting(context, streamTime);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -70,8 +70,19 @@ public class RocksDBMetricsRecorder {
         return taskId;
     }
 
+    /**
+     * The initialisation of the metrics recorder is idempotent.
+     */
     public void init(final StreamsMetricsImpl streamsMetrics,
                      final TaskId taskId) {
+        if (this.taskId != null && !this.taskId.equals(taskId)) {
+            throw new IllegalStateException("Metrics recorder is re-initialised with different task: previous task is " +
+                this.taskId + " whereas current task is " + taskId + ". This is a bug in Kafka Streams.");
+        }
+        if (this.streamsMetrics != null && this.streamsMetrics != streamsMetrics) {
+            throw new IllegalStateException("Metrics recorder is re-initialised with different Streams metrics. "
+                + "This is a bug in Kafka Streams.");
+        }
         initSensors(streamsMetrics, taskId);
         this.taskId = taskId;
         this.streamsMetrics = streamsMetrics;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -51,7 +51,6 @@ public class RocksDBMetricsRecorder {
     private final String threadId;
     private TaskId taskId;
     private StreamsMetricsImpl streamsMetrics;
-    private boolean isInitialized = false;
 
     public RocksDBMetricsRecorder(final String metricsScope,
                                   final String threadId,
@@ -71,20 +70,15 @@ public class RocksDBMetricsRecorder {
         return taskId;
     }
 
+    public void init(final StreamsMetricsImpl streamsMetrics,
+                     final TaskId taskId) {
+        initSensors(streamsMetrics, taskId);
+        this.taskId = taskId;
+        this.streamsMetrics = streamsMetrics;
+    }
+
     public void addStatistics(final String segmentName,
-                              final Statistics statistics,
-                              final StreamsMetricsImpl streamsMetrics,
-                              final TaskId taskId) {
-        if (!isInitialized) {
-            initSensors(streamsMetrics, taskId);
-            this.taskId = taskId;
-            this.streamsMetrics = streamsMetrics;
-            isInitialized = true;
-        }
-        if (this.taskId != taskId) {
-            throw new IllegalStateException("Statistics of store \"" + segmentName + "\" for task " + taskId
-                + " cannot be added to metrics recorder for task " + this.taskId + ". This is a bug in Kafka Streams.");
-        }
+                              final Statistics statistics) {
         if (statisticsToRecord.isEmpty()) {
             logger.debug(
                 "Adding metrics recorder of task {} to metrics recording trigger",

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -116,11 +116,11 @@ public class RocksDBMetricsIntegrationTest {
 
     @Test
     public void shouldExposeRocksDBMetricsForNonSegmentedStateStoreBeforeAndAfterFailureWithEmptyStateDir() throws Exception {
-        final Properties streamsConfiguration = getStreamsConfig();
+        final Properties streamsConfiguration = streamsConfig();
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
-        final StreamsBuilder builder = getBuilderForNonSegmentedStateStore();
+        final StreamsBuilder builder = builderForNonSegmentedStateStore();
 
-        runAndVerify(
+        cleanUpStateRunAndVerify(
             builder,
             streamsConfiguration,
             IntegerDeserializer.class,
@@ -128,7 +128,7 @@ public class RocksDBMetricsIntegrationTest {
             "rocksdb-state-id"
         );
 
-        runAndVerify(
+        cleanUpStateRunAndVerify(
             builder,
             streamsConfiguration,
             IntegerDeserializer.class,
@@ -139,11 +139,11 @@ public class RocksDBMetricsIntegrationTest {
 
     @Test
     public void shouldExposeRocksDBMetricsForSegmentedStateStoreBeforeAndAfterFailureWithEmptyStateDir() throws Exception {
-        final Properties streamsConfiguration = getStreamsConfig();
+        final Properties streamsConfiguration = streamsConfig();
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
-        final StreamsBuilder builder = getBuilderForSegmentedStateStore();
+        final StreamsBuilder builder = builderForSegmentedStateStore();
 
-        runAndVerify(
+        cleanUpStateRunAndVerify(
             builder,
             streamsConfiguration,
             LongDeserializer.class,
@@ -151,7 +151,7 @@ public class RocksDBMetricsIntegrationTest {
             "rocksdb-window-state-id"
         );
 
-        runAndVerify(
+        cleanUpStateRunAndVerify(
             builder,
             streamsConfiguration,
             LongDeserializer.class,
@@ -160,7 +160,7 @@ public class RocksDBMetricsIntegrationTest {
         );
     }
 
-    private Properties getStreamsConfig() {
+    private Properties streamsConfig() {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-application");
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
@@ -173,7 +173,7 @@ public class RocksDBMetricsIntegrationTest {
         return streamsConfiguration;
     }
 
-    private StreamsBuilder getBuilderForNonSegmentedStateStore() {
+    private StreamsBuilder builderForNonSegmentedStateStore() {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.table(
             STREAM_INPUT,
@@ -182,7 +182,7 @@ public class RocksDBMetricsIntegrationTest {
         return builder;
     }
 
-    private StreamsBuilder getBuilderForSegmentedStateStore() {
+    private StreamsBuilder builderForSegmentedStateStore() {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
             .groupByKey()
@@ -198,11 +198,11 @@ public class RocksDBMetricsIntegrationTest {
         return builder;
     }
 
-    private void runAndVerify(final StreamsBuilder builder,
-                              final Properties streamsConfiguration,
-                              final Class outputKeyDeserializer,
-                              final Class outputValueDeserializer,
-                              final String metricsScope) throws Exception {
+    private void cleanUpStateRunAndVerify(final StreamsBuilder builder,
+                                          final Properties streamsConfiguration,
+                                          final Class outputKeyDeserializer,
+                                          final Class outputValueDeserializer,
+                                          final String metricsScope) throws Exception {
         final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
         kafkaStreams.cleanUp();
         produceRecords();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+@Category({IntegrationTest.class})
+@RunWith(Parameterized.class)
+public class RocksDBMetricsIntegrationTest {
+
+    private static final int NUM_BROKERS = 3;
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    private static final String STREAM_INPUT = "STREAM_INPUT";
+    private static final String STREAM_OUTPUT = "STREAM_OUTPUT";
+    private static final String MY_STORE_PERSISTENT_KEY_VALUE = "myStorePersistentKeyValue";
+    private static final Duration WINDOW_SIZE = Duration.ofMillis(50);
+
+    // RocksDB metrics
+    private static final String BYTES_WRITTEN_RATE = "bytes-written-rate";
+    private static final String BYTES_WRITTEN_TOTAL = "bytes-written-total";
+    private static final String BYTES_READ_RATE = "bytes-read-rate";
+    private static final String BYTES_READ_TOTAL = "bytes-read-total";
+    private static final String MEMTABLE_BYTES_FLUSHED_RATE = "memtable-bytes-flushed-rate";
+    private static final String MEMTABLE_BYTES_FLUSHED_TOTAL = "memtable-bytes-flushed-total";
+    private static final String MEMTABLE_HIT_RATIO = "memtable-hit-ratio";
+    private static final String WRITE_STALL_DURATION_AVG = "write-stall-duration-avg";
+    private static final String WRITE_STALL_DURATION_TOTAL = "write-stall-duration-total";
+    private static final String BLOCK_CACHE_DATA_HIT_RATIO = "block-cache-data-hit-ratio";
+    private static final String BLOCK_CACHE_INDEX_HIT_RATIO = "block-cache-index-hit-ratio";
+    private static final String BLOCK_CACHE_FILTER_HIT_RATIO = "block-cache-filter-hit-ratio";
+    private static final String BYTES_READ_DURING_COMPACTION_RATE = "bytes-read-compaction-rate";
+    private static final String BYTES_WRITTEN_DURING_COMPACTION_RATE = "bytes-written-compaction-rate";
+    private static final String NUMBER_OF_OPEN_FILES = "number-open-files";
+    private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors-total";
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {StreamsConfig.EXACTLY_ONCE},
+            {StreamsConfig.AT_LEAST_ONCE}
+        });
+    }
+
+    @Parameter
+    public String processingGuarantee;
+
+    @Before
+    public void before() throws Exception {
+        CLUSTER.createTopic(STREAM_INPUT, 1, 3);
+    }
+
+    @After
+    public void after() throws Exception {
+        CLUSTER.deleteTopicsAndWait(STREAM_INPUT, STREAM_OUTPUT);
+    }
+
+    @Test
+    public void shouldExposeRocksDBMetricsForNonSegmentedStateStoreBeforeAndAfterFailureWithEmptyStateDir() throws Exception {
+        final Properties streamsConfiguration = getStreamsConfig();
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+        final StreamsBuilder builder = getBuilderForNonSegmentedStateStore();
+
+        runAndVerify(
+            builder,
+            streamsConfiguration,
+            IntegerDeserializer.class,
+            StringDeserializer.class,
+            "rocksdb-state-id"
+        );
+
+        runAndVerify(
+            builder,
+            streamsConfiguration,
+            IntegerDeserializer.class,
+            StringDeserializer.class,
+            "rocksdb-state-id"
+        );
+    }
+
+    @Test
+    public void shouldExposeRocksDBMetricsForSegmentedStateStoreBeforeAndAfterFailureWithEmptyStateDir() throws Exception {
+        final Properties streamsConfiguration = getStreamsConfig();
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+        final StreamsBuilder builder = getBuilderForSegmentedStateStore();
+
+        runAndVerify(
+            builder,
+            streamsConfiguration,
+            LongDeserializer.class,
+            LongDeserializer.class,
+            "rocksdb-window-state-id"
+        );
+
+        runAndVerify(
+            builder,
+            streamsConfiguration,
+            LongDeserializer.class,
+            LongDeserializer.class,
+            "rocksdb-window-state-id"
+        );
+    }
+
+    private Properties getStreamsConfig() {
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-application");
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, Sensor.RecordingLevel.DEBUG.name);
+        streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 10 * 1024 * 1024L);
+        streamsConfiguration.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee);
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        return streamsConfiguration;
+    }
+
+    private StreamsBuilder getBuilderForNonSegmentedStateStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            STREAM_INPUT,
+            Materialized.as(Stores.persistentKeyValueStore(MY_STORE_PERSISTENT_KEY_VALUE)).withCachingEnabled()
+        ).toStream().to(STREAM_OUTPUT);
+        return builder;
+    }
+
+    private StreamsBuilder getBuilderForSegmentedStateStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(TimeWindows.of(WINDOW_SIZE).grace(Duration.ZERO))
+            .aggregate(() -> 0L,
+                (aggKey, newValue, aggValue) -> aggValue,
+                Materialized.<Integer, Long, WindowStore<Bytes, byte[]>>as("time-windowed-aggregated-stream-store")
+                    .withValueSerde(Serdes.Long())
+                    .withRetention(WINDOW_SIZE))
+            .toStream()
+            .map((key, value) -> KeyValue.pair(value, value))
+            .to(STREAM_OUTPUT, Produced.with(Serdes.Long(), Serdes.Long()));
+        return builder;
+    }
+
+    private void runAndVerify(final StreamsBuilder builder,
+                              final Properties streamsConfiguration,
+                              final Class outputKeyDeserializer,
+                              final Class outputValueDeserializer,
+                              final String metricsScope) throws Exception {
+        final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
+        kafkaStreams.cleanUp();
+        produceRecords();
+
+        StreamsTestUtils.startKafkaStreamsAndWaitForRunningState(kafkaStreams, 60000);
+
+        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+            TestUtils.consumerConfig(
+                CLUSTER.bootstrapServers(),
+                "consumerApp",
+                outputKeyDeserializer,
+                outputValueDeserializer,
+                new Properties()
+            ),
+            STREAM_OUTPUT,
+            1
+        );
+        verifyRocksDBMetrics(kafkaStreams, metricsScope);
+        kafkaStreams.close();
+    }
+
+    private void produceRecords() throws Exception {
+        final MockTime mockTime = new MockTime(WINDOW_SIZE.toMillis());
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            STREAM_INPUT,
+            Collections.singletonList(new KeyValue<>(1, "A")),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                IntegerSerializer.class,
+                StringSerializer.class,
+                new Properties()
+            ),
+            mockTime.milliseconds()
+        );
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            STREAM_INPUT,
+            Collections.singletonList(new KeyValue<>(1, "B")),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                IntegerSerializer.class,
+                StringSerializer.class,
+                new Properties()
+            ),
+            mockTime.milliseconds()
+        );
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            STREAM_INPUT,
+            Collections.singletonList(new KeyValue<>(1, "C")),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                IntegerSerializer.class,
+                StringSerializer.class,
+                new Properties()
+            ),
+            mockTime.milliseconds()
+        );
+    }
+
+    private void verifyRocksDBMetrics(final KafkaStreams kafkaStreams, final String metricsScope) {
+        final List<Metric> listMetricStore = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
+            .filter(m -> m.metricName().group().equals("stream-state-metrics") && m.metricName().tags().containsKey(metricsScope))
+            .collect(Collectors.toList());
+        checkMetricByName(listMetricStore, BYTES_WRITTEN_RATE, 1);
+        checkMetricByName(listMetricStore, BYTES_WRITTEN_TOTAL, 1);
+        checkMetricByName(listMetricStore, BYTES_READ_RATE, 1);
+        checkMetricByName(listMetricStore, BYTES_READ_TOTAL, 1);
+        checkMetricByName(listMetricStore, MEMTABLE_BYTES_FLUSHED_RATE, 1);
+        checkMetricByName(listMetricStore, MEMTABLE_BYTES_FLUSHED_TOTAL, 1);
+        checkMetricByName(listMetricStore, MEMTABLE_HIT_RATIO, 1);
+        checkMetricByName(listMetricStore, WRITE_STALL_DURATION_AVG, 1);
+        checkMetricByName(listMetricStore, WRITE_STALL_DURATION_TOTAL, 1);
+        checkMetricByName(listMetricStore, BLOCK_CACHE_DATA_HIT_RATIO, 1);
+        checkMetricByName(listMetricStore, BLOCK_CACHE_INDEX_HIT_RATIO, 1);
+        checkMetricByName(listMetricStore, BLOCK_CACHE_FILTER_HIT_RATIO, 1);
+        checkMetricByName(listMetricStore, BYTES_READ_DURING_COMPACTION_RATE, 1);
+        checkMetricByName(listMetricStore, BYTES_WRITTEN_DURING_COMPACTION_RATE, 1);
+        checkMetricByName(listMetricStore, NUMBER_OF_OPEN_FILES, 1);
+        checkMetricByName(listMetricStore, NUMBER_OF_FILE_ERRORS, 1);
+    }
+
+    private void checkMetricByName(final List<Metric> listMetric, final String metricName, final int numMetric) {
+        final List<Metric> metrics = listMetric.stream()
+            .filter(m -> m.metricName().name().equals(metricName))
+            .collect(Collectors.toList());
+        Assert.assertEquals("Size of metrics of type:'" + metricName + "' must be equal to " + numMetric + " but it's equal to " + metrics.size(), numMetric, metrics.size());
+        for (final Metric m : metrics) {
+            Assert.assertNotNull("Metric:'" + m.metricName() + "' must be not null", m.metricValue());
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
@@ -63,6 +63,7 @@ public class KeyValueSegmentsTest {
             new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
         );
         segments = new KeyValueSegments(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
+        segments.openExisting(context, -1L);
     }
 
     @After
@@ -154,6 +155,7 @@ public class KeyValueSegmentsTest {
     @Test
     public void shouldOpenExistingSegments() {
         segments = new KeyValueSegments("test",  METRICS_SCOPE, 4, 1);
+        segments.openExisting(context, -1L);
         segments.getOrCreateSegmentIfLive(0, context, -1L);
         segments.getOrCreateSegmentIfLive(1, context, -1L);
         segments.getOrCreateSegmentIfLive(2, context, -1L);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -95,12 +95,12 @@ public class RocksDBStoreTest {
     public void setUp() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
-        rocksDBStore = getRocksDBStore();
         dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext(dir,
             Serdes.String(),
             Serdes.String(),
             new StreamsConfig(props));
+        rocksDBStore = getRocksDBStore();
         context.metrics().setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
     }
 
@@ -147,9 +147,7 @@ public class RocksDBStoreTest {
         reset(metricsRecorder);
         metricsRecorder.addStatistics(
             eq(DB_NAME),
-            anyObject(Statistics.class),
-            eq(mockContext.metrics()),
-            eq(mockContext.taskId())
+            anyObject(Statistics.class)
         );
         replay(metricsRecorder);
 
@@ -278,7 +276,7 @@ public class RocksDBStoreTest {
     public void shouldCallRocksDbConfigSetter() {
         MockRocksDbConfigSetter.called = false;
 
-        rocksDBStore.openDB(context);
+        rocksDBStore.init(context, rocksDBStore);
 
         assertTrue(MockRocksDbConfigSetter.called);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -62,8 +62,8 @@ public class SegmentIteratorTest {
                     new LogContext("testCache "),
                     0,
                     new MockStreamsMetrics(new Metrics())));
-        segmentOne.openDB(context);
-        segmentTwo.openDB(context);
+        segmentOne.init(context, segmentOne);
+        segmentTwo.init(context, segmentTwo);
         segmentOne.put(Bytes.wrap("a".getBytes()), "1".getBytes());
         segmentOne.put(Bytes.wrap("b".getBytes()), "2".getBytes());
         segmentTwo.put(Bytes.wrap("c".getBytes()), "3".getBytes());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
@@ -63,6 +63,7 @@ public class TimestampedSegmentsTest {
             new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
         );
         segments = new TimestampedSegments(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
+        segments.openExisting(context, -1L);
     }
 
     @After
@@ -155,6 +156,7 @@ public class TimestampedSegmentsTest {
     @Test
     public void shouldOpenExistingSegments() {
         segments = new TimestampedSegments("test", METRICS_SCOPE, 4, 1);
+        segments.openExisting(context, -1L);
         segments.getOrCreateSegmentIfLive(0, context, -1L);
         segments.getOrCreateSegmentIfLive(1, context, -1L);
         segments.getOrCreateSegmentIfLive(2, context, -1L);


### PR DESCRIPTION
- Added `init()` method to `RocksDBMetricsRecorder`
- Added call to `init()` of `RocksDBMetricsRecorder` to `init()` of RocksDB store
- Added call to `init()` of `RocksDBMetricsRecorder` to `openExisting()` of segmented state stores
- Adapted unit tests
- Added integration test that reproduces the situation in which the bug occurred

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
