### PR TITLE
KAFKA-9460: Enable TLSv1.2 by default and disable all others protocol versions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -49,7 +49,7 @@ public class SslConfigs {
 
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
     public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "
-            + "Default setting is TLS, which is fine for most cases. "
+            + "Default setting is TLSv1.2, which is fine for most cases. "
             + "Allowed values in recent JVMs are TLSv1.2 and TLSv1.3. TLS, TLSv1.1, SSL, SSLv2 and SSLv3 "
             + "may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.";
 

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -50,10 +50,10 @@ public class SslConfigs {
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
     public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "
             + "Default setting is TLS, which is fine for most cases. "
-            + "Allowed values in recent JVMs are TLS, TLSv1.1, TLSv1.2 and TLSv1.3. SSL, SSLv2 and SSLv3 "
+            + "Allowed values in recent JVMs are TLSv1.2 and TLSv1.3. TLS, TLSv1.1, SSL, SSLv2 and SSLv3 "
             + "may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.";
 
-    public static final String DEFAULT_SSL_PROTOCOL = "TLS";
+    public static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
 
     public static final String SSL_PROVIDER_CONFIG = "ssl.provider";
     public static final String SSL_PROVIDER_DOC = "The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.";

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -50,7 +50,7 @@ public class SslConfigs {
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
     public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "
             + "Default setting is TLS, which is fine for most cases. "
-            + "Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 "
+            + "Allowed values in recent JVMs are TLS, TLSv1.1, TLSv1.2 and TLSv1.3. SSL, SSLv2 and SSLv3 "
             + "may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.";
 
     public static final String DEFAULT_SSL_PROTOCOL = "TLS";
@@ -64,7 +64,7 @@ public class SslConfigs {
 
     public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
     public static final String SSL_ENABLED_PROTOCOLS_DOC = "The list of protocols enabled for SSL connections.";
-    public static final String DEFAULT_SSL_ENABLED_PROTOCOLS = "TLSv1.2,TLSv1.1,TLSv1";
+    public static final String DEFAULT_SSL_ENABLED_PROTOCOLS = "TLSv1.2";
 
     public static final String SSL_KEYSTORE_TYPE_CONFIG = "ssl.keystore.type";
     public static final String SSL_KEYSTORE_TYPE_DOC = "The file format of the key store file. "

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -554,7 +554,7 @@ public class SslTransportLayerTest {
     }
 
     /**
-     * Tests that connections cannot be made with default TLS version.
+     * Tests that connection sucess with the default TLS version.
      */
     @Test
     public void testTLSDefaults() throws Exception {
@@ -575,42 +575,6 @@ public class SslTransportLayerTest {
 
         final String node = "0";
 
-        InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
-        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
-
-        NetworkTestUtils.waitForChannelClose(selector, node, ChannelState.State.READY);
-        server.verifyAuthenticationMetrics(1, 0);
-    }
-
-    /**
-     * Tests that connections cannot be made with TLSv1.1 versions
-     */
-    @Test
-    public void testTLS1Version() throws Exception {
-        checkSuccessConnection("TLSv1");
-    }
-
-    /**
-     * Tests that connections cannot be made with TLSv1.1 versions
-     */
-    @Test
-    public void testTLS11Version() throws Exception {
-        checkSuccessConnection("TLSv1.1");
-    }
-
-    /**
-     * Checks connections success with the specific {@code tlsVersion}.
-     * @param tlsVersion
-     * @throws Exception
-     */
-    private void checkSuccessConnection(String tlsVersion) throws Exception {
-        String node = "0";
-
-        sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList(tlsVersion));
-        server = createEchoServer(SecurityProtocol.SSL);
-
-        sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList(tlsVersion));
-        createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -570,6 +570,7 @@ public class SslTransportLayerTest {
 
         NetworkTestUtils.checkClientConnection(selector, "0", 10, 100);
         server.verifyAuthenticationMetrics(1, 0);
+        selector.close();
 
         checkAuthentiationFailed("1", "TLSv1.1");
         server.verifyAuthenticationMetrics(1, 1);
@@ -586,6 +587,8 @@ public class SslTransportLayerTest {
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
         NetworkTestUtils.waitForChannelClose(selector, node, ChannelState.State.AUTHENTICATION_FAILED);
+
+        selector.close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -552,37 +552,29 @@ public class SslTransportLayerTest {
     }
 
     /**
-     * Tests that connection sucess with the default TLS version.
+     * Tests that connection success with the default TLS version.
      */
     @Test
     public void testTLSDefaults() throws Exception {
-        final LogContext logContext = new LogContext();
-
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
         assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslServerConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
         assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslClientConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
 
-        channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
-        channelBuilder.configure(sslServerConfigs);
-        selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, logContext);
-
         server = createEchoServer(SecurityProtocol.SSL);
         createSelector(sslClientConfigs);
 
-        final String node = "0";
-
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
-        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+        selector.connect("0", addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        NetworkTestUtils.checkClientConnection(selector, node, 10, 100);
+        NetworkTestUtils.checkClientConnection(selector, "0", 10, 100);
         server.verifyAuthenticationMetrics(1, 0);
 
-        checkAuthentiationFailed(node, "TLSv1.1");
+        checkAuthentiationFailed("1", "TLSv1.1");
         server.verifyAuthenticationMetrics(1, 1);
 
-        checkAuthentiationFailed(node, "TLSv1");
+        checkAuthentiationFailed("2", "TLSv1");
         server.verifyAuthenticationMetrics(1, 2);
     }
 
@@ -601,11 +593,10 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testUnsupportedTLSVersion() throws Exception {
-        String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
         server = createEchoServer(SecurityProtocol.SSL);
 
-        checkAuthentiationFailed(node, "TLSv1.1");
+        checkAuthentiationFailed("0", "TLSv1.1");
         server.verifyAuthenticationMetrics(0, 1);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -58,8 +58,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.kafka.common.config.SslConfigs.DEFAULT_SSL_PROTOCOL;
-import static org.apache.kafka.common.config.SslConfigs.SSL_PROTOCOL_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -98,7 +96,7 @@ public class SslTransportLayerTest {
         this.tlsProtocol = tlsProtocol;
 
         sslConfigOverrides = new HashMap<>();
-        sslConfigOverrides.put(SSL_PROTOCOL_CONFIG, tlsProtocol);
+        sslConfigOverrides.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
         sslConfigOverrides.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
     }
 
@@ -563,8 +561,8 @@ public class SslTransportLayerTest {
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
-        assertEquals(DEFAULT_SSL_PROTOCOL, sslServerConfigs.get(SSL_PROTOCOL_CONFIG));
-        assertEquals(DEFAULT_SSL_PROTOCOL, sslClientConfigs.get(SSL_PROTOCOL_CONFIG));
+        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslServerConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
+        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslClientConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
 
         channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
         channelBuilder.configure(sslServerConfigs);

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -72,7 +72,7 @@ import java.util.Map;
 public class TestSslUtils {
 
     public static final String TRUST_STORE_PASSWORD = "TrustStorePassword";
-    public static final String DEFAULT_TLS_PROTOCOL_FOR_TESTS = "TLSv1.2";
+    public static final String DEFAULT_TLS_PROTOCOL_FOR_TESTS = SslConfigs.DEFAULT_SSL_PROTOCOL;
 
     /**
      * Create a self-signed X.509 Certificate.


### PR DESCRIPTION
This PR by default disable all SSL protocols except TLSv1.2.
Changes discussed in KIP-553.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
