### PR TITLE
KAFKA-9464: Close the producer in completeShutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -876,7 +876,7 @@ public class StreamThread extends Thread {
 
                 if (originalReset.equals("earliest")) {
                     addToResetList(partition, seekToBeginning, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "earliest", loggedTopics);
-                } else if (originalReset.equals("latest")) {
+                } else {
                     addToResetList(partition, seekToEnd, "No custom setting defined for topic '{}' using original config '{}' for offset reset", "latest", loggedTopics);
                 }
             }
@@ -1125,6 +1125,13 @@ public class StreamThread extends Thread {
         } catch (final Throwable e) {
             log.error("Failed to close restore consumer due to the following error:", e);
         }
+        if (producer != null) {
+            try {
+                producer.close();
+            } catch (final Throwable e) {
+                log.error("Failed to close producer due to the following error:", e);
+            }
+        }
         streamsMetrics.removeAllThreadLevelSensors(getName());
 
         setState(State.DEAD);
@@ -1279,9 +1286,5 @@ public class StreamThread extends Thread {
 
     int currentNumIterations() {
         return numIterations;
-    }
-
-    public StreamThread.StateListener stateListener() {
-        return stateListener;
     }
 }


### PR DESCRIPTION
In StreamThread#completeShutdown, the producer (if not null) should be closed.

Also removed some dead code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
