### PR TITLE
KAFKA-9458 Fix windows clean log fail caused Runtime.halt

### DIFF
--- a/core/src/main/scala/kafka/log/DeleteFailedException.java
+++ b/core/src/main/scala/kafka/log/DeleteFailedException.java
@@ -1,0 +1,7 @@
+package kafka.log;
+
+public class DeleteFailedException extends RuntimeException {
+    public DeleteFailedException(String message, Exception exp){
+        super(message, exp);
+    }
+}

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2234,7 +2234,14 @@ class Log(@volatile var dir: File,
     def deleteSegments(): Unit = {
       info(s"Deleting segments $segments")
       maybeHandleIOException(s"Error while deleting segments for $topicPartition in dir ${dir.getParent}") {
-        segments.foreach(_.deleteIfExists())
+        segments.foreach( segment =>
+          try {
+            segment.deleteIfExists()
+          }
+          catch {
+            case e: DeleteFailedException => error(s"Segment Delete failed.", e)
+           }
+        )
       }
     }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2566,7 +2566,7 @@ object Log {
   def timeIndexFile(dir: File, offset: Long, suffix: String = ""): File =
     new File(dir, filenamePrefixFromOffset(offset) + TimeIndexFileSuffix + suffix)
 
-  def deleteFileIfExists(file: File, suffix: String = ""): Unit =
+  def deleteFileIfExists(file: File, suffix: String = ""): Boolean =
     Files.deleteIfExists(new File(file.getPath + suffix).toPath)
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -529,7 +529,7 @@ class Log(@volatile var dir: File,
    * in place of existing segment(s). For log splitting, we know that any .swap file whose base offset is higher than
    * the smallest offset .clean file could be part of an incomplete split operation. Such .swap files are also deleted
    * by this method.
-   * @return Set of .swap files that are valid to be swapped in as segment files
+   * @return Set of .swap file offsets that are valid to be swapped in as segment files
    */
   private def removeTempFilesAndCollectSwapFiles(): Set[Long] = {
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -693,8 +693,7 @@ class Log(@volatile var dir: File,
       val swapSegment = LogSegment.open(dir,
         swapFileOffset,
         config,
-        time = time,
-        fileSuffix = SwapFileSuffix)
+        time = time)
       info(s"Found log file with offset $swapFileOffset from interrupted swap operation, repairing.")
       recoverSegment(swapSegment)
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -442,9 +442,9 @@ object LogCleaner {
   }
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
-    LogSegment.deleteIfExists(log.dir, baseOffset, fileSuffix = Log.CleanedFileSuffix)
-    LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      fileSuffix = Log.CleanedFileSuffix, initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+    log.deleteIfExists(baseOffset, fileSuffix = Log.CleanedFileSuffix)
+    LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false
+      , initFileSize = log.initFileSize, preallocate = log.config.preallocate)
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -446,6 +446,7 @@ object LogCleaner {
     val logSegment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false
       , initFileSize = log.initFileSize, preallocate = log.config.preallocate)
     logSegment.changeFileStatus("", Log.CleanedFileSuffix)
+    logSegment
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -443,8 +443,9 @@ object LogCleaner {
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
     log.deleteIfExists(baseOffset, fileSuffix = Log.CleanedFileSuffix)
-    LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false
+    val logSegment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false
       , initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+    logSegment.changeFileStatus("", Log.CleanedFileSuffix)
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -626,9 +626,9 @@ class LogSegment private[log] (val log: FileRecords,
     def delete(delete: () => Boolean, fileType: String, file: File, logIfMissing: Boolean): Unit = {
       try {
         if (delete()) {
-          Files.deleteIfExists(new File(file, Log.CleanedFileSuffix).toPath)
-          Files.deleteIfExists(new File(file, Log.SwapFileSuffix).toPath)
-          Files.deleteIfExists(new File(file, Log.DeletedFileSuffix).toPath)
+          Files.deleteIfExists(new File(file + Log.CleanedFileSuffix).toPath)
+          Files.deleteIfExists(new File(file + Log.SwapFileSuffix).toPath)
+          Files.deleteIfExists(new File(file + Log.DeletedFileSuffix).toPath)
           info(s"Deleted $fileType ${file.getAbsolutePath}.")
         } else if (logIfMissing)
           info(s"Failed to delete $fileType ${file.getAbsolutePath} because it does not exist.")

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -634,7 +634,7 @@ class LogSegment private[log] (val log: FileRecords,
           info(s"Failed to delete $fileType ${file.getAbsolutePath} because it does not exist.")
       }
       catch {
-        case e: IOException => throw new IOException(s"Delete of $fileType ${file.getAbsolutePath} failed.", e)
+        case e: IOException => throw new DeleteFailedException(s"Delete of $fileType ${file.getAbsolutePath} failed.", e)
       }
     }
 

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -625,9 +625,12 @@ class LogSegment private[log] (val log: FileRecords,
   def deleteIfExists(): Unit = {
     def delete(delete: () => Boolean, fileType: String, file: File, logIfMissing: Boolean): Unit = {
       try {
-        if (delete())
+        if (delete()) {
+          Files.deleteIfExists(new File(file, Log.CleanedFileSuffix).toPath)
+          Files.deleteIfExists(new File(file, Log.SwapFileSuffix).toPath)
+          Files.deleteIfExists(new File(file, Log.DeletedFileSuffix).toPath)
           info(s"Deleted $fileType ${file.getAbsolutePath}.")
-        else if (logIfMissing)
+        } else if (logIfMissing)
           info(s"Failed to delete $fileType ${file.getAbsolutePath} because it does not exist.")
       }
       catch {

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -493,24 +493,24 @@ class LogSegment private[log] (val log: FileRecords,
    */
   def changeFileStatus(oldSuffix: String, newSuffix: String): Unit = {
     if(newSuffix.isEmpty) {
-      Files.deleteIfExists(new File(log.file.getPath, oldSuffix).toPath)
-      Files.deleteIfExists(new File(lazyOffsetIndex.file.getPath, oldSuffix).toPath)
-      Files.deleteIfExists(new File(lazyTimeIndex.file.getPath, oldSuffix).toPath)
-      Files.deleteIfExists(new File(txnIndex.file.getPath, oldSuffix).toPath)
+      Files.deleteIfExists(new File(log.file.getPath + oldSuffix).toPath)
+      Files.deleteIfExists(new File(lazyOffsetIndex.file.getPath + oldSuffix).toPath)
+      Files.deleteIfExists(new File(lazyTimeIndex.file.getPath + oldSuffix).toPath)
+      Files.deleteIfExists(new File(txnIndex.file.getPath + oldSuffix).toPath)
     }
     else if(oldSuffix.isEmpty){
-      Files.createFile(new File(log.file.getPath, newSuffix).toPath)
-      Files.createFile(new File(lazyOffsetIndex.file.getPath, newSuffix).toPath)
-      Files.createFile(new File(lazyTimeIndex.file.getPath, newSuffix).toPath)
+      Files.createFile(new File(log.file.getPath + newSuffix).toPath)
+      Files.createFile(new File(lazyOffsetIndex.file.getPath + newSuffix).toPath)
+      Files.createFile(new File(lazyTimeIndex.file.getPath + newSuffix).toPath)
       if(txnIndex.file.exists()){
-        Files.createFile(new File(txnIndex.file.getPath, newSuffix).toPath)
+        Files.createFile(new File(txnIndex.file.getPath + newSuffix).toPath)
       }
     }else{
-      Utils.atomicMoveWithFallback(new File(log.file.getPath, oldSuffix).toPath, new File(log.file.getPath, newSuffix).toPath)
-      Utils.atomicMoveWithFallback(new File(lazyOffsetIndex.file.getPath, oldSuffix).toPath, new File(lazyOffsetIndex.file.getPath, newSuffix).toPath)
-      Utils.atomicMoveWithFallback(new File(lazyTimeIndex.file.getPath, oldSuffix).toPath, new File(lazyTimeIndex.file.getPath, newSuffix).toPath)
+      Utils.atomicMoveWithFallback(new File(log.file.getPath + oldSuffix).toPath, new File(log.file.getPath + newSuffix).toPath)
+      Utils.atomicMoveWithFallback(new File(lazyOffsetIndex.file.getPath + oldSuffix).toPath, new File(lazyOffsetIndex.file.getPath + newSuffix).toPath)
+      Utils.atomicMoveWithFallback(new File(lazyTimeIndex.file.getPath + oldSuffix).toPath, new File(lazyTimeIndex.file.getPath + newSuffix).toPath)
       if(txnIndex.file.exists()){
-        Utils.atomicMoveWithFallback(new File(txnIndex.file.getPath, oldSuffix).toPath, new File(txnIndex.file.getPath, newSuffix).toPath)
+        Utils.atomicMoveWithFallback(new File(txnIndex.file.getPath + oldSuffix).toPath, new File(txnIndex.file.getPath + newSuffix).toPath)
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1353,7 +1353,7 @@ class LogCleanerTest {
 
     // 1) Simulate recovery just after .cleaned file is created, before rename to .swap
     //    On recovery, clean operation is aborted. All messages should be present in the log
-    log.logSegments.head.changeFileSuffixes("", Log.CleanedFileSuffix)
+    log.logSegments.head.changeFileStatus("", Log.CleanedFileSuffix)
     for (file <- dir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix)) {
       Utils.atomicMoveWithFallback(file.toPath, Paths.get(CoreUtils.replaceSuffix(file.getPath, Log.DeletedFileSuffix, "")))
     }
@@ -1369,7 +1369,7 @@ class LogCleanerTest {
 
     // 2) Simulate recovery just after swap file is created, before old segment files are
     //    renamed to .deleted. Clean operation is resumed during recovery.
-    log.logSegments.head.changeFileSuffixes("", Log.SwapFileSuffix)
+    log.logSegments.head.changeFileStatus("", Log.SwapFileSuffix)
     for (file <- dir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix)) {
       Utils.atomicMoveWithFallback(file.toPath, Paths.get(CoreUtils.replaceSuffix(file.getPath, Log.DeletedFileSuffix, "")))
     }
@@ -1390,7 +1390,7 @@ class LogCleanerTest {
 
     // 3) Simulate recovery after swap file is created and old segments files are renamed
     //    to .deleted. Clean operation is resumed during recovery.
-    log.logSegments.head.changeFileSuffixes("", Log.SwapFileSuffix)
+    log.logSegments.head.changeFileStatus("", Log.SwapFileSuffix)
     log = recoverAndCheck(config, cleanedKeys)
 
     // add some more messages and clean the log again

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -262,7 +262,7 @@ class LogSegmentTest {
     val seg = createSegment(40)
     val logFile = seg.log.file
     val indexFile = seg.lazyOffsetIndex.file
-    seg.changeFileSuffixes("", ".deleted")
+    seg.changeFileStatus("", ".deleted")
     assertEquals(logFile.getAbsolutePath + ".deleted", seg.log.file.getAbsolutePath)
     assertEquals(indexFile.getAbsolutePath + ".deleted", seg.lazyOffsetIndex.file.getAbsolutePath)
     assertTrue(seg.log.file.exists)

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2836,7 +2836,7 @@ class LogTest {
     // Simulate recovery just after .cleaned file is created, before rename to .swap. On recovery, existing split
     // operation is aborted but the recovery process itself kicks off split which should complete.
     newSegments.reverse.foreach(segment => {
-      segment.changeFileSuffixes("", Log.CleanedFileSuffix)
+      segment.changeFileStatus("", Log.CleanedFileSuffix)
       segment.truncateTo(0)
     })
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
@@ -2862,9 +2862,9 @@ class LogTest {
     // operation is aborted but the recovery process itself kicks off split which should complete.
     newSegments.reverse.foreach { segment =>
       if (segment != newSegments.last)
-        segment.changeFileSuffixes("", Log.CleanedFileSuffix)
+        segment.changeFileStatus("", Log.CleanedFileSuffix)
       else
-        segment.changeFileSuffixes("", Log.SwapFileSuffix)
+        segment.changeFileStatus("", Log.SwapFileSuffix)
       segment.truncateTo(0)
     }
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
@@ -2889,7 +2889,7 @@ class LogTest {
     // Simulate recovery right after all new segments have been renamed to .swap. On recovery, existing split operation
     // is completed and the old segment must be deleted.
     newSegments.reverse.foreach(segment => {
-        segment.changeFileSuffixes("", Log.SwapFileSuffix)
+        segment.changeFileStatus("", Log.SwapFileSuffix)
     })
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
       Utils.atomicMoveWithFallback(file.toPath, Paths.get(CoreUtils.replaceSuffix(file.getPath, Log.DeletedFileSuffix, "")))
@@ -2915,7 +2915,7 @@ class LogTest {
 
     // Simulate recovery right after all new segments have been renamed to .swap and old segment has been deleted. On
     // recovery, existing split operation is completed.
-    newSegments.reverse.foreach(_.changeFileSuffixes("", Log.SwapFileSuffix))
+    newSegments.reverse.foreach(_.changeFileStatus("", Log.SwapFileSuffix))
 
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
       Utils.delete(file)
@@ -2941,7 +2941,7 @@ class LogTest {
 
     // Simulate recovery right after one of the new segment has been renamed to .swap and the other to .log. On
     // recovery, existing split operation is completed.
-    newSegments.last.changeFileSuffixes("", Log.SwapFileSuffix)
+    newSegments.last.changeFileStatus("", Log.SwapFileSuffix)
 
     // Truncate the old segment
     segmentWithOverflow.truncateTo(0)


### PR DESCRIPTION
Delete or rename a file before close it is illegal in windows, so I changed the rename process to creating a status file and later we can compare the status and delete the segment files. 

I have manually tested it on windows, please review it. though I haven't changed the test cases. If you're okay with this flow I can work on the test cases too. 
