### PR TITLE
MINOR: Introduce 2.5-IV0 IBP

### DIFF
--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -94,7 +94,9 @@ object ApiVersion {
     // Add adding_replicas and removing_replicas fields to LeaderAndIsrRequest
     KAFKA_2_4_IV0,
     // Flexible version support in inter-broker APIs
-    KAFKA_2_4_IV1
+    KAFKA_2_4_IV1,
+    // No new APIs, equivalent to 2.4-IV1
+    KAFKA_2_5_IV0
   )
 
   // Map keys are the union of the short and full versions
@@ -332,6 +334,13 @@ case object KAFKA_2_4_IV1 extends DefaultApiVersion {
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
   val id: Int = 25
+}
+
+case object KAFKA_2_5_IV0 extends DefaultApiVersion {
+  val shortVersion: String = "2.5"
+  val subVersion = "IV0"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 26
 }
 
 object ApiVersionValidator extends Validator {


### PR DESCRIPTION
As the feature freeze approaches, we should
support `2.5` as the inter.broker.protocol.version
value. There are no new APIs so far, so
`2.5` is effectively equivalent to `2.4`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
