### PR TITLE
KAFKA-9451: Pass group metadata into producer in Kafka Streams

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -460,7 +461,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         close(KafkaConsumer.DEFAULT_CLOSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
-    @SuppressWarnings("deprecation")
+    @Deprecated
     @Override
     public synchronized void close(long timeout, TimeUnit unit) {
         this.closed = true;
@@ -562,7 +563,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public ConsumerGroupMetadata groupMetadata() {
-        return null;
+        return new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -44,7 +44,9 @@ public abstract class AbstractTask implements Task {
     final Consumer<byte[], byte[]> consumer;
     final String logPrefix;
     final boolean eosEnabled;
+    final boolean eosAlphaEnabled;
     final boolean eosBetaEnabled;
+    final boolean eosUpgradeModeEnabled;
     final Logger log;
     final LogContext logContext;
     final StateDirectory stateDirectory;
@@ -71,8 +73,10 @@ public abstract class AbstractTask implements Task {
         this.partitions = new HashSet<>(partitions);
         this.topology = topology;
         this.consumer = consumer;
-        this.eosBetaEnabled = "exactly_once_beta".equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
-        this.eosEnabled = eosBetaEnabled || StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.eosAlphaEnabled = StreamThread.eosAlphaEnabled(config);
+        this.eosBetaEnabled = StreamThread.eosBetaEnabled(config);
+        this.eosEnabled = StreamThread.eosEnabled(config);
+        this.eosUpgradeModeEnabled = StreamThread.eosUpgradeModeEnabled(config);
         this.stateDirectory = stateDirectory;
 
         final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -44,6 +44,7 @@ public abstract class AbstractTask implements Task {
     final Consumer<byte[], byte[]> consumer;
     final String logPrefix;
     final boolean eosEnabled;
+    final boolean eosBetaEnabled;
     final Logger log;
     final LogContext logContext;
     final StateDirectory stateDirectory;
@@ -70,7 +71,8 @@ public abstract class AbstractTask implements Task {
         this.partitions = new HashSet<>(partitions);
         this.topology = topology;
         this.consumer = consumer;
-        this.eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.eosBetaEnabled = "exactly_once_beta".equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.eosEnabled = eosBetaEnabled || StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
         this.stateDirectory = stateDirectory;
 
         final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -81,7 +81,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                                   final StateDirectory stateDirectory,
                                   final StateRestoreListener stateRestoreListener,
                                   final StreamsConfig config) {
-        eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        eosEnabled = StreamThread.eosEnabled(config);
         baseDir = stateDirectory.globalStateDir();
         checkpointFile = new OffsetCheckpoint(new File(baseDir, CHECKPOINT_FILE_NAME));
         checkpointFileCache = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -29,6 +29,8 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.LogContext;
@@ -443,6 +445,7 @@ public class StreamThread extends Thread {
     private final long commitTimeMs;
     private final int maxPollTimeMs;
     private final String originalReset;
+    private final boolean eosBetaEnabled;
     private final TaskManager taskManager;
     private final AtomicInteger assignmentErrorCode;
 
@@ -498,9 +501,12 @@ public class StreamThread extends Thread {
         Producer<byte[], byte[]> threadProducer = null;
         final boolean eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
         if (!eosEnabled) {
-            final Map<String, Object> producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
             log.info("Creating shared producer client");
+            final Map<String, Object> producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
             threadProducer = clientSupplier.getProducer(producerConfigs);
+            if ("exactly_once_beta".equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
+                threadProducer.initTransactions();
+            }
         }
 
         final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
@@ -618,9 +624,11 @@ public class StreamThread extends Thread {
 
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         final int dummyThreadIdx = 1;
-        this.maxPollTimeMs = new InternalConsumerConfig(config.getMainConsumerConfigs("dummyGroupId", "dummyClientId", dummyThreadIdx))
+        this.maxPollTimeMs =
+            new InternalConsumerConfig(config.getMainConsumerConfigs("dummyGroupId", "dummyClientId", dummyThreadIdx))
                 .getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
         this.commitTimeMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
+        this.eosBetaEnabled = "exactly_once_beta".equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
 
         this.numIterations = 1;
     }
@@ -705,7 +713,10 @@ public class StreamThread extends Thread {
                         "This implies that this thread missed a rebalance and dropped out of the consumer group. " +
                         "Will try to rejoin the consumer group. Below is the detailed description of the task:\n{}",
                     ignoreAndRejoinGroup.migratedTask().id(), ignoreAndRejoinGroup.migratedTask().toString(">"));
-
+                enforceRebalance();
+            } catch (final ProducerFencedException | UnknownProducerIdException ignoreAndRejoinGroup) {
+                log.warn("This thread missed a rebalance and dropped out of the consumer group. " +
+                        "Will try to rejoin the consumer group.", ignoreAndRejoinGroup);
                 enforceRebalance();
             }
         }
@@ -798,6 +809,12 @@ public class StreamThread extends Thread {
                         final int committed = taskManager.maybeCommitActiveTasksPerUserRequested();
 
                         if (committed > 0) {
+                            if (eosBetaEnabled) {
+                                taskManager.commitAllActive();
+                                producer.commitTransaction();
+                                producer.beginTransaction();
+                            }
+
                             final long commitLatency = advanceNowAndComputeLatency();
                             commitSensor.record(commitLatency / (double) committed, now);
                         }
@@ -955,18 +972,26 @@ public class StreamThread extends Thread {
                     taskManager.activeTaskIds(), taskManager.standbyTaskIds(), now - lastCommitMs, commitTimeMs);
             }
 
-            committed = taskManager.commitAll();
+            committed = taskManager.commitAllActive();
             if (committed > 0) {
+                if (eosBetaEnabled) {
+                    producer.commitTransaction();
+                    producer.beginTransaction();
+                }
+            }
+            if (committed > 0 || taskManager.commitAllStandby() > 0) {
                 final long intervalCommitLatency = advanceNowAndComputeLatency();
                 commitSensor.record(intervalCommitLatency / (double) committed, now);
-
-                // try to purge the committed records for repartition topics if possible
-                taskManager.maybePurgeCommitedRecords();
 
                 if (log.isDebugEnabled()) {
                     log.debug("Committed all active tasks {} and standby tasks {} in {}ms",
                         taskManager.activeTaskIds(), taskManager.standbyTaskIds(), intervalCommitLatency);
                 }
+            }
+
+            if (committed > 0) {
+                // try to purge the committed records for repartition topics if possible
+                taskManager.maybePurgeCommittedRecords();
             }
 
             if (committed == -1) {
@@ -979,6 +1004,11 @@ public class StreamThread extends Thread {
         } else {
             committed = taskManager.maybeCommitActiveTasksPerUserRequested();
             if (committed > 0) {
+                if (eosBetaEnabled) {
+                    taskManager.commitAllActive();
+                    producer.commitTransaction();
+                    producer.beginTransaction();
+                }
                 final long requestCommitLatency = advanceNowAndComputeLatency();
                 commitSensor.record(requestCommitLatency / (double) committed, now);
             }
@@ -1162,8 +1192,9 @@ public class StreamThread extends Thread {
         return this;
     }
 
-    private void updateThreadMetadata(final Map<TaskId, StreamTask> activeTasks,
-                                      final Map<TaskId, StandbyTask> standbyTasks) {
+    // visible for testing
+    void updateThreadMetadata(final Map<TaskId, StreamTask> activeTasks,
+                              final Map<TaskId, StandbyTask> standbyTasks) {
         final Set<String> producerClientIds = new HashSet<>();
         final Set<TaskMetadata> activeTasksMetadata = new HashSet<>();
         for (final Map.Entry<TaskId, StreamTask> task : activeTasks.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.ArrayList;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
@@ -32,6 +31,7 @@ import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -539,8 +539,12 @@ public class TaskManager {
      *                               or if the task producer got fenced (EOS)
      * @return number of committed offsets, or -1 if we are in the middle of a rebalance and cannot commit
      */
-    int commitAll() {
-        return rebalanceInProgress ? -1 : active.commit() + standby.commit();
+    int commitAllActive() {
+        return rebalanceInProgress ? -1 : active.commit();
+    }
+
+    int commitAllStandby() {
+        return rebalanceInProgress ? -1 : standby.commit();
     }
 
     /**
@@ -565,7 +569,7 @@ public class TaskManager {
         return rebalanceInProgress ? -1 : active.maybeCommitPerUserRequested();
     }
 
-    void maybePurgeCommitedRecords() {
+    void maybePurgeCommittedRecords() {
         // we do not check any possible exceptions since none of them are fatal
         // that should cause the application to fail, and we will try delete with
         // newer offsets anyways.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -956,6 +956,7 @@ public class StreamThreadTest {
             new MockChangelogReader(),
             PROCESS_ID,
             "log-prefix",
+            null,
             mockStreamThreadConsumer,
             streamsMetadataState,
             null,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -127,6 +127,7 @@ public class TaskManagerTest {
         taskManager = new TaskManager(changeLogReader,
                                       UUID.randomUUID(),
                                       "",
+                                      null,
                                       restoreConsumer,
                                       streamsMetadataState,
                                       activeTaskCreator,


### PR DESCRIPTION
**DO NOT MERGE**

Follow up to #7977 (note that the first commit is the squashed version of 7977; this commits need to be rebased after 7977 is merged).

Second commit (still need to add tests):

Part of KIP-447: when EOS is enabled in Kafka Streams, we need to pass the consumer's group metadata into the producer to use the new GroupCoordinator fencing mechanism.
We also need to first commit all task individually before we commit the transaction or write the local checkpoint file.

During an upgrade, we will still use a producer per task (and rely on transactional fencing), however, we will already pass the metadata to the producer to enable GroupCoordinator fencing (in parallel to transactional fencing), to prepare for a second round of rebalancing that switches to the thread producer model and thus disables transactional fencing.