### PR TITLE
KAFKA-8507 kip 499 Unify connection name flag for command line tool

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -133,7 +133,7 @@ object ConsoleProducer {
       .withRequiredArg
       .describedAs("broker-list")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to.")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
       .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("server to connect to")

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -129,13 +129,14 @@ object ConsoleProducer {
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The server(s) to connect to.")
-      .withRequiredArg
-      .describedAs("server to connect to")
-      .ofType(classOf[String])
-    val brokerListOpt = parser.accepts("broker-list", "The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
       .withRequiredArg
       .describedAs("broker-list")
+      .ofType(classOf[String])
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to.")
+      .requiredUnless("broker-list")
+      .withRequiredArg
+      .describedAs("server to connect to")
       .ofType(classOf[String])
     val syncOpt = parser.accepts("sync", "If set message send requests to the brokers are synchronously, one at a time as they arrive.")
     val compressionCodecOpt = parser.accepts("compression-codec", "The compression codec: either 'none', 'gzip', 'snappy', 'lz4', or 'zstd'." +
@@ -229,26 +230,15 @@ object ConsoleProducer {
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps to read data from standard input and publish it to Kafka.")
 
-    if (!options.has(bootstrapServerOpt) && !options.has(brokerListOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
-
-    if (options.has(bootstrapServerOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
-
-    if (options.has(brokerListOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, brokerListOpt)
-
+    CommandLineUtils.checkRequiredArgs(parser, options, topicOpt)
 
     val topic = options.valueOf(topicOpt)
 
     val bootstrapServer = options.valueOf(bootstrapServerOpt)
     val brokerList = options.valueOf(brokerListOpt)
 
-    if (options.has(brokerListOpt))
-      ToolsUtils.validatePortOrDie(parser, brokerList)
-
-    if(options.has(bootstrapServerOpt))
-      ToolsUtils.validatePortOrDie(parser, bootstrapServer)
+    val brokerHostsAndPorts = options.valueOf(if (options.has(bootstrapServerOpt)) bootstrapServerOpt else brokerListOpt)
+    ToolsUtils.validatePortOrDie(parser, brokerHostsAndPorts)
 
     val sync = options.has(syncOpt)
     val compressionCodecOptionValue = options.valueOf(compressionCodecOpt)

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -129,13 +129,13 @@ object ConsoleProducer {
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
-    val brokerListOpt = parser.accepts("broker-list", "The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
-      .withRequiredArg
-      .describedAs("broker-list")
-      .ofType(classOf[String])
     val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The server(s) to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
+      .ofType(classOf[String])
+    val brokerListOpt = parser.accepts("broker-list", "The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+      .withRequiredArg
+      .describedAs("broker-list")
       .ofType(classOf[String])
     val syncOpt = parser.accepts("sync", "If set message send requests to the brokers are synchronously, one at a time as they arrive.")
     val compressionCodecOpt = parser.accepts("compression-codec", "The compression codec: either 'none', 'gzip', 'snappy', 'lz4', or 'zstd'." +
@@ -228,12 +228,22 @@ object ConsoleProducer {
     options = tryParse(parser, args)
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps to read data from standard input and publish it to Kafka.")
+
     if (!options.has(bootstrapServerOpt) && !options.has(brokerListOpt))
       CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
 
+    if (options.has(bootstrapServerOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
+
+    if (options.has(brokerListOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, brokerListOpt)
+
+
     val topic = options.valueOf(topicOpt)
-    val brokerList = options.valueOf(brokerListOpt)
+
     val bootstrapServer = options.valueOf(bootstrapServerOpt)
+    val brokerList = options.valueOf(brokerListOpt)
+
     if (options.has(brokerListOpt))
       ToolsUtils.validatePortOrDie(parser, brokerList)
 

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.{Properties, Random}
 
 import com.typesafe.scalalogging.LazyLogging
+import joptsimple.{OptionException, OptionParser, OptionSet}
 import kafka.utils.{CommandLineUtils, ToolsUtils}
 import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, KafkaConsumer}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
@@ -202,13 +203,14 @@ object ConsumerPerformance extends LazyLogging {
   }
 
   class ConsumerPerfConfig(args: Array[String]) extends PerfConfig(args) {
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The server(s) to connect to.")
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+      .withRequiredArg
+      .describedAs("broker-list")
+      .ofType(classOf[String])
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to.")
+      .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("server to connect to")
-      .ofType(classOf[String])
-    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The server(s) to connect to.")
-      .withRequiredArg()
-      .describedAs("host")
       .ofType(classOf[String])
     val topicOpt = parser.accepts("topic", "REQUIRED: The topic to consume from.")
       .withRequiredArg
@@ -254,18 +256,10 @@ object ConsumerPerformance extends LazyLogging {
       .ofType(classOf[Long])
       .defaultsTo(10000)
 
-    options = parser.parse(args: _*)
-
+    options = tryParse(parser, args)
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 
-    if (!options.has(bootstrapServerOpt) && !options.has(brokerListOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, bootstrapServerOpt)
-
-    if (options.has(brokerListOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, brokerListOpt)
-
-    if (options.has(bootstrapServerOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, bootstrapServerOpt)
+    CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt)
 
     val printMetrics = options.has(printMetricsOpt)
 
@@ -275,10 +269,9 @@ object ConsumerPerformance extends LazyLogging {
       new Properties
 
     import org.apache.kafka.clients.consumer.ConsumerConfig
-    if(options.has(bootstrapServerOpt))
-      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOpt))
-    else
-      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(brokerListOpt))
+
+    val brokerHostsAndPorts = options.valueOf(if (options.has(bootstrapServerOpt)) bootstrapServerOpt else brokerListOpt)
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerHostsAndPorts)
 
     props.put(ConsumerConfig.GROUP_ID_CONFIG, options.valueOf(groupIdOpt))
     props.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, options.valueOf(socketBufferSizeOpt).toString)
@@ -298,5 +291,14 @@ object ConsumerPerformance extends LazyLogging {
     val dateFormat = new SimpleDateFormat(options.valueOf(dateFormatOpt))
     val hideHeader = options.has(hideHeaderOpt)
     val recordFetchTimeoutMs = options.valueOf(recordFetchTimeoutOpt).longValue()
+
+    def tryParse(parser: OptionParser, args: Array[String]): OptionSet = {
+      try
+        parser.parse(args: _*)
+      catch {
+        case e: OptionException =>
+          CommandLineUtils.printUsageAndDie(parser, e.getMessage)
+      }
+    }
   }
 }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -202,6 +202,10 @@ object ConsumerPerformance extends LazyLogging {
   }
 
   class ConsumerPerfConfig(args: Array[String]) extends PerfConfig(args) {
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The server(s) to connect to.")
+      .withRequiredArg
+      .describedAs("server to connect to")
+      .ofType(classOf[String])
     val bootstrapServersOpt = parser.accepts("broker-list", "REQUIRED: The server(s) to connect to.")
       .withRequiredArg()
       .describedAs("host")
@@ -254,7 +258,8 @@ object ConsumerPerformance extends LazyLogging {
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 
-    CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, bootstrapServersOpt)
+    if (!options.has(bootstrapServerOpt) && !options.has(bootstrapServersOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
 
     val printMetrics = options.has(printMetricsOpt)
 
@@ -264,7 +269,10 @@ object ConsumerPerformance extends LazyLogging {
       new Properties
 
     import org.apache.kafka.clients.consumer.ConsumerConfig
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServersOpt))
+    if(options.valueOf(bootstrapServerOpt) != null)
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOpt))
+    else
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServersOpt))
     props.put(ConsumerConfig.GROUP_ID_CONFIG, options.valueOf(groupIdOpt))
     props.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, options.valueOf(socketBufferSizeOpt).toString)
     props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, options.valueOf(fetchSizeOpt).toString)

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -206,7 +206,7 @@ object ConsumerPerformance extends LazyLogging {
       .withRequiredArg
       .describedAs("server to connect to")
       .ofType(classOf[String])
-    val bootstrapServersOpt = parser.accepts("broker-list", "REQUIRED: The server(s) to connect to.")
+    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The server(s) to connect to.")
       .withRequiredArg()
       .describedAs("host")
       .ofType(classOf[String])
@@ -258,8 +258,14 @@ object ConsumerPerformance extends LazyLogging {
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 
-    if (!options.has(bootstrapServerOpt) && !options.has(bootstrapServersOpt))
-      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, bootstrapServerOpt)
+    if (!options.has(bootstrapServerOpt) && !options.has(brokerListOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, bootstrapServerOpt)
+
+    if (options.has(brokerListOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, brokerListOpt)
+
+    if (options.has(bootstrapServerOpt))
+      CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt, bootstrapServerOpt)
 
     val printMetrics = options.has(printMetricsOpt)
 
@@ -269,10 +275,11 @@ object ConsumerPerformance extends LazyLogging {
       new Properties
 
     import org.apache.kafka.clients.consumer.ConsumerConfig
-    if(options.valueOf(bootstrapServerOpt) != null)
+    if(options.has(bootstrapServerOpt))
       props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOpt))
     else
-      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServersOpt))
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(brokerListOpt))
+
     props.put(ConsumerConfig.GROUP_ID_CONFIG, options.valueOf(groupIdOpt))
     props.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, options.valueOf(socketBufferSizeOpt).toString)
     props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, options.valueOf(fetchSizeOpt).toString)

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -51,7 +51,7 @@ class ConsoleProducerTest {
     "--t", // not a valid argument
     "t3"
   )
-  val bootStrapserverOverride: Array[String] = Array(
+  val bootstrapServerOverride: Array[String] = Array(
     "--broker-list",
     "localhost:1001",
     "--bootstrap-server",
@@ -70,7 +70,7 @@ class ConsoleProducerTest {
 
   @Test
   def testValidConfigsBootstrapServer(): Unit = {
-    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
+    val config = new ConsoleProducer.ProducerConfig(bootstrapServerValidArgs)
     val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
     assertEquals(util.Arrays.asList("localhost:1003", "localhost:1004"),
       producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
@@ -96,8 +96,8 @@ class ConsoleProducerTest {
   }
 
   @Test
-  def TestBootStrapServerOverride(): Unit = {
-    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
+  def testBootstrapServerOverride(): Unit = {
+    val config = new ConsoleProducer.ProducerConfig(bootstrapServerOverride)
     val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
     assertEquals(util.Arrays.asList("localhost:1002"),
       producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -37,7 +37,7 @@ class ConsoleProducerTest {
     "--property",
     "key.separator=#"
   )
-  val bootStrapServerValidArgs: Array[String] = Array(
+  val bootstrapServerValidArgs: Array[String] = Array(
     "--bootstrap-server",
     "localhost:1003,localhost:1004",
     "--topic",

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -27,7 +27,7 @@ import kafka.utils.Exit
 
 class ConsoleProducerTest {
 
-  val validArgs: Array[String] = Array(
+  val brokerListValidArgs: Array[String] = Array(
     "--broker-list",
     "localhost:1001,localhost:1002",
     "--topic",
@@ -37,17 +37,42 @@ class ConsoleProducerTest {
     "--property",
     "key.separator=#"
   )
-
+  val bootStrapServerValidArgs: Array[String] = Array(
+    "--bootstrap-server",
+    "localhost:1003,localhost:1004",
+    "--topic",
+    "t3",
+    "--property",
+    "parse.key=true",
+    "--property",
+    "key.separator=#"
+  )
   val invalidArgs: Array[String] = Array(
     "--t", // not a valid argument
     "t3"
   )
+  val bootStrapserverOverride: Array[String] = Array(
+    "--broker-list",
+    "localhost:1001",
+    "--bootstrap-server",
+    "localhost:1002",
+    "--topic",
+    "t3",
+  )
 
   @Test
-  def testValidConfigs(): Unit = {
-    val config = new ConsoleProducer.ProducerConfig(validArgs)
+  def testValidConfigsBrokerList(): Unit = {
+    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
     val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
     assertEquals(util.Arrays.asList("localhost:1001", "localhost:1002"),
+      producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
+  }
+
+  @Test
+  def testValidConfigsBootstrapServer(): Unit = {
+    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
+    val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
+    assertEquals(util.Arrays.asList("localhost:1003", "localhost:1004"),
       producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
   }
 
@@ -63,11 +88,18 @@ class ConsoleProducerTest {
 
   @Test
   def testParseKeyProp(): Unit = {
-    val config = new ConsoleProducer.ProducerConfig(validArgs)
+    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
     val reader = Class.forName(config.readerClass).getDeclaredConstructor().newInstance().asInstanceOf[LineMessageReader]
     reader.init(System.in,ConsoleProducer.getReaderProps(config))
     assert(reader.keySeparator == "#")
     assert(reader.parseKey)
   }
 
+  @Test
+  def TestBootStrapServerOverride(): Unit = {
+    val config = new ConsoleProducer.ProducerConfig(brokerListValidArgs)
+    val producerConfig = new ProducerConfig(ConsoleProducer.producerProps(config))
+    assertEquals(util.Arrays.asList("localhost:1002"),
+      producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
+  }
 }

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -42,7 +42,7 @@ class ConsumerPerformanceTest {
   }
 
   @Test
-  def testConfig(): Unit = {
+  def testConfigBrokerList(): Unit = {
     //Given
     val args: Array[String] = Array(
       "--broker-list", "localhost:9092",
@@ -54,7 +54,44 @@ class ConsumerPerformanceTest {
     val config = new ConsumerPerformance.ConsumerPerfConfig(args)
 
     //Then
-    assertEquals("localhost:9092", config.options.valueOf(config.brokerListOpt))
+    assertEquals("localhost:9092", config.options.valueOf(config.brokerHostsAndPorts))
+    assertEquals("test", config.topic)
+    assertEquals(10, config.numMessages)
+  }
+
+  @Test
+  def testConfigBootStrapServer(): Unit = {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--messages", "10"
+    )
+
+    //When
+    val config = new ConsumerPerformance.ConsumerPerfConfig(args)
+
+    //Then
+    assertEquals("localhost:9092", config.options.valueOf(config.brokerHostsAndPorts))
+    assertEquals("test", config.topic)
+    assertEquals(10, config.numMessages)
+  }
+
+  @Test
+  def testBrokerListOverride(): Unit = {
+    //Given
+    val args: Array[String] = Array(
+      "--broker-list", "localhost:9094",
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--messages", "10"
+    )
+
+    //When
+    val config = new ConsumerPerformance.ConsumerPerfConfig(args)
+
+    //Then
+    assertEquals("localhost:9092", config.brokerHostsAndPorts)
     assertEquals("test", config.topic)
     assertEquals(10, config.numMessages)
   }

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -54,7 +54,7 @@ class ConsumerPerformanceTest {
     val config = new ConsumerPerformance.ConsumerPerfConfig(args)
 
     //Then
-    assertEquals("localhost:9092", config.options.valueOf(config.bootstrapServersOpt))
+    assertEquals("localhost:9092", config.options.valueOf(config.brokerListOpt))
     assertEquals("test", config.topic)
     assertEquals(10, config.numMessages)
   }

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -73,7 +73,7 @@ test
 Run the producer and then type a few messages into the console to send to the server.</p>
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic test
 This is a message
 This is another message
 </pre>
@@ -162,7 +162,7 @@ Topic:test	PartitionCount:1	ReplicationFactor:1	Configs:
 Let's publish a few messages to our new topic:
 </p>
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic my-replicated-topic
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic my-replicated-topic
 ...
 my test message 1
 my test message 2

--- a/docs/security.html
+++ b/docs/security.html
@@ -232,7 +232,7 @@
     <br>
             Examples using console-producer and console-consumer:
             <pre class="brush: bash;">
-            kafka-console-producer.sh --broker-list localhost:9093 --topic test --producer.config client-ssl.properties
+            kafka-console-producer.sh --bootstrap-server localhost:9093 --topic test --producer.config client-ssl.properties
             kafka-console-consumer.sh --bootstrap-server localhost:9093 --topic test --consumer.config client-ssl.properties</pre>
         </li>
     </ol>

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -188,7 +188,7 @@ Hence there won't be any STDOUT output except log entries as the results are wri
 Now we can start the console producer in a separate terminal to write some input data to this topic:
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic streams-plaintext-input
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic streams-plaintext-input
 </pre>
 
 and inspect the output of the WordCount demo application by reading from its output topic with the console consumer in a separate terminal:
@@ -212,7 +212,7 @@ This will send a new message to the input topic, where the message key is null a
 (in practice, input data for applications will typically be streaming continuously into Kafka, rather than being manually entered as we do in this quickstart):
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic streams-plaintext-input
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic streams-plaintext-input
 all streams lead to kafka
 </pre>
 
@@ -246,7 +246,7 @@ Enter the text line "hello kafka streams" and hit &lt;RETURN&gt;.
 Your terminal should look as follows:
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic streams-plaintext-input
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic streams-plaintext-input
 all streams lead to kafka
 hello kafka streams
 </pre>
@@ -279,7 +279,7 @@ representing the most recent word counts as computed by the WordCount applicatio
 Let's enter one final input text line "join kafka summit" and hit &lt;RETURN&gt; in the console producer to the input topic <b>streams-plaintext-input</b> before we wrap up this quickstart:
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic streams-plaintext-input
+&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic streams-plaintext-input
 all streams lead to kafka
 hello kafka streams
 join kafka summit

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -629,9 +629,9 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         }
 
 
-        if(res.get("bootstrapServer") != null ) {
+        if (res.get("bootstrapServer") != null) {
             brokerHostandPort = res.getString("bootstrapServer");
-        } else if(res.getString("brokerList") != null) {
+        } else if (res.getString("brokerList") != null) {
             brokerHostandPort = res.getString("brokerList");
         } else {
             parser.printHelp();

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.apache.kafka.clients.producer.Callback;
@@ -119,8 +120,10 @@ public class VerifiableProducer implements AutoCloseable {
                 .type(String.class)
                 .metavar("TOPIC")
                 .help("Produce messages to this topic.");
-
-        parser.addArgument("--bootstrap-server")
+        MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")
+                .description("Group of arguments for connection to brokers")
+                .required(true);
+        connectionGroup.addArgument("--bootstrap-server")
                 .action(store())
                 .required(false)
                 .type(String.class)
@@ -128,13 +131,13 @@ public class VerifiableProducer implements AutoCloseable {
                 .dest("bootstrapServer")
                 .help("REQUIRED: The server(s) to connect to. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
-        parser.addArgument("--broker-list")
+        connectionGroup.addArgument("--broker-list")
                 .action(store())
                 .required(false)
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
         parser.addArgument("--max-messages")
                 .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -234,9 +234,9 @@ public class VerifiableProducer implements AutoCloseable {
 
         Properties producerProps = new Properties();
 
-        if(res.get("bootstrapServer") != null ) {
+        if (res.get("bootstrapServer") != null) {
             producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("bootstrapServer"));
-        } else if(res.getString("brokerList") != null) {
+        } else if (res.getString("brokerList") != null) {
             producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("brokerList"));
         } else {
             parser.printHelp();

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -120,9 +120,17 @@ public class VerifiableProducer implements AutoCloseable {
                 .metavar("TOPIC")
                 .help("Produce messages to this topic.");
 
+        parser.addArgument("--bootstrap-server")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+                .dest("bootstrapServer")
+                .help("REQUIRED: The server(s) to connect to. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+
         parser.addArgument("--broker-list")
                 .action(store())
-                .required(true)
+                .required(false)
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
@@ -222,7 +230,16 @@ public class VerifiableProducer implements AutoCloseable {
             createTime = null;
 
         Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("brokerList"));
+
+        if(res.get("bootstrapServer") != null ) {
+            producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("bootstrapServer"));
+        } else if(res.getString("brokerList") != null) {
+            producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("brokerList"));
+        } else {
+            parser.printHelp();
+            Exit.exit(0);
+        }
+
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringSerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,


### PR DESCRIPTION
This is a change updates ConsoleProducer, ConsumerPerformance, VerifiableProducer, and VerifiableConsumer classes to add and prefer the --bootstrap-server flag for defining the connection point of the Kafka cluster.


### Committer Checklist (excluded from commit message)
- [x ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
