### PR TITLE
KAFKA-6793: Unnecessary warning log message

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -352,7 +352,7 @@ public class AbstractConfig {
      */
     public void logUnused() {
         for (String key : unused())
-            log.warn("The configuration '{}' was supplied but isn't a known config.", key);
+            log.debug("The configuration '{}' was supplied but isn't a known config.", key);
     }
 
     private <T> T getConfiguredInstance(Object klass, Class<T> t, Map<String, Object> configPairs) {


### PR DESCRIPTION
Based on KIP-552 changes log level from WARN to DEBUG for the warning
"The configuration 'x' was supplied but isn't a known config."

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
