### PR TITLE
KAFKA-9506: Fix JmxReporter corner cases and optimize

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.metrics;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Sanitizer;
 import org.slf4j.Logger;
@@ -26,36 +25,71 @@ import javax.management.Attribute;
 import javax.management.AttributeList;
 import javax.management.AttributeNotFoundException;
 import javax.management.DynamicMBean;
-import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Register metrics in JMX as dynamic mbeans based on the metric names
+ * Register metrics in JMX as dynamic mbeans based on the metric names.
+ *
+ * There may be multiple JmxReporter objects in the same Java process.  For example,
+ * if you have both a Consumer and a Producer in the same Java process, they will
+ * each have their own distinct JmxReporters.  We expect that each JmxReporter will
+ * manage a distinct, non-overlapping set of Java Mbeans.  To enforce that invariant,
+ * there is a global Registry object which keeps track of which reporters
+ * own which beans and does not allow multiple JmxReporters to claim the same bean.
+ *
+ * The global registry has its own lock.  Since this lock could cause a lot of contention,
+ * we try to minimize the length of time it is held.  In particular, we do not perform JMX
+ * operations while holding the global registry lock.  Instead, each MBean object has its
+ * own lock, which we hold when performing operations on that specific MBean.
+ * The main complexity here is handling deletion via the deleted flag.
  */
 public class JmxReporter implements MetricsReporter {
-
     private static final Logger log = LoggerFactory.getLogger(JmxReporter.class);
-    private static final Object LOCK = new Object();
-    private String prefix;
-    private final Map<String, KafkaMbean> mbeans = new HashMap<>();
+    private final String prefix;
+    private final Registry registry;
+    private final MBeanServer mbeanServer;
 
+    /**
+     * Create a JMX reporter.
+     */
     public JmxReporter() {
         this("");
     }
 
     /**
      * Create a JMX reporter that prefixes all metrics with the given string.
+     *
+     * @param prefix        The string to prefix all metrics with.
      */
     public JmxReporter(String prefix) {
+        this(prefix, Registry.INSTANCE, ManagementFactory.getPlatformMBeanServer());
+    }
+
+    /**
+     * Create a JMX reporter that prefixes all metrics with the given string
+     * and uses the given MBeanServer.
+     *
+     * @param prefix        The string to prefix all metrics with.
+     * @param registry      The registry that stores beans.
+     * @param mbeanServer   The MBean server to use for JMX operations.
+     */
+    public JmxReporter(String prefix, Registry registry, MBeanServer mbeanServer) {
         this.prefix = prefix;
+        this.registry = registry;
+        this.mbeanServer = mbeanServer;
     }
 
     @Override
@@ -63,62 +97,89 @@ public class JmxReporter implements MetricsReporter {
 
     @Override
     public void init(List<KafkaMetric> metrics) {
-        synchronized (LOCK) {
-            for (KafkaMetric metric : metrics)
-                addAttribute(metric);
-            for (KafkaMbean mbean : mbeans.values())
-                reregister(mbean);
-        }
-    }
-
-    public boolean containsMbean(String mbeanName) {
-        return mbeans.containsKey(mbeanName);
+        addMetrics(metrics);
     }
 
     @Override
     public void metricChange(KafkaMetric metric) {
-        synchronized (LOCK) {
-            KafkaMbean mbean = addAttribute(metric);
-            reregister(mbean);
-        }
+        addMetrics(Collections.singleton(metric));
     }
 
     @Override
     public void metricRemoval(KafkaMetric metric) {
-        synchronized (LOCK) {
-            MetricName metricName = metric.metricName();
-            String mBeanName = getMBeanName(prefix, metricName);
-            KafkaMbean mbean = removeAttribute(metric, mBeanName);
-            if (mbean != null) {
-                if (mbean.metrics.isEmpty()) {
-                    unregister(mbean);
-                    mbeans.remove(mBeanName);
-                } else
-                    reregister(mbean);
+        removeMetrics(Collections.singleton(metric));
+    }
+
+    // Visible for testing
+    public boolean containsMbean(String mbeanName) {
+        return registry.findMBeanOwner(mbeanName) == this;
+    }
+
+    void addMetrics(Collection<KafkaMetric> metrics) {
+        Map<String, List<KafkaMetric>> beanNameToMetrics = groupMetrics(metrics);
+        for (Map.Entry<String, List<KafkaMetric>> entry : beanNameToMetrics.entrySet()) {
+            KafkaMbean mbean = registry.getOrCreateLockedMBean(entry.getKey(), this);
+            if (mbean == null) {
+                log.warn("Bean name conflict: {} is already registered to a different " +
+                    "JmxReporter", entry.getKey());
+            } else {
+                try {
+                    mbean.addMetrics(entry.getValue());
+                } finally {
+                    mbean.lock.unlock();
+                }
             }
         }
     }
 
-    private KafkaMbean removeAttribute(KafkaMetric metric, String mBeanName) {
-        MetricName metricName = metric.metricName();
-        KafkaMbean mbean = this.mbeans.get(mBeanName);
-        if (mbean != null)
-            mbean.removeAttribute(metricName.name());
-        return mbean;
+    void removeMetrics(Collection<KafkaMetric> metrics) {
+        Map<String, List<KafkaMetric>> beanNameToMetrics = groupMetrics(metrics);
+        for (Map.Entry<String, List<KafkaMetric>> entry : beanNameToMetrics.entrySet()) {
+            String mbeanName = entry.getKey();
+            KafkaMbean mbean = registry.getOrCreateLockedMBean(mbeanName, this);
+            if (mbean != null) {
+                boolean deleting = false;
+                try {
+                    mbean.removeMetrics(entry.getValue());
+                    if (mbean.beanMetrics.isEmpty()) {
+                        // We can't delete the mbean from the registry here, since we
+                        // don't hold the registry lock here.  However, we want to make sure
+                        // that nobody else tries to use this mbean object, since it's
+                        // about to be removed from the registry.  Therefore, we set the
+                        // deleting flag.
+                        mbean.deleting = true;
+                        deleting = true;
+                    }
+                } finally {
+                    mbean.lock.unlock();
+                }
+                if (deleting) {
+                    // If the mbean was empty, we finish deleting it here.  Registry#removeBean
+                    // will take the registry lock and remove the mbean object.
+                    registry.removeMbean(mbeanName, mbean);
+                }
+            }
+        }
     }
 
-    private KafkaMbean addAttribute(KafkaMetric metric) {
-        try {
-            MetricName metricName = metric.metricName();
-            String mBeanName = getMBeanName(prefix, metricName);
-            if (!this.mbeans.containsKey(mBeanName))
-                mbeans.put(mBeanName, new KafkaMbean(mBeanName));
-            KafkaMbean mbean = this.mbeans.get(mBeanName);
-            mbean.setAttribute(metricName.name(), metric);
-            return mbean;
-        } catch (JMException e) {
-            throw new KafkaException("Error creating mbean attribute for metricName :" + metric.metricName(), e);
+    /**
+     * Group metrics which are on the same mbean together.
+     *
+     * @param metrics   A collection of KafkaMetric objects.
+     * @return          A map from bean names to lists of KafkaMetric objects.
+     */
+    private Map<String, List<KafkaMetric>> groupMetrics(Collection<KafkaMetric> metrics) {
+        Map<String, List<KafkaMetric>> result = new HashMap<>();
+        for (KafkaMetric metric : metrics) {
+            String name = getMBeanName(prefix, metric.metricName());
+            List<KafkaMetric> list = result.get(name);
+            if (list == null) {
+                list = new ArrayList<>();
+                result.put(name, list);
+            }
+            list.add(metric);
         }
+        return result;
     }
 
     /**
@@ -141,38 +202,117 @@ public class JmxReporter implements MetricsReporter {
         return mBeanName.toString();
     }
 
+    @Override
     public void close() {
-        synchronized (LOCK) {
-            for (KafkaMbean mbean : this.mbeans.values())
-                unregister(mbean);
+        List<KafkaMbean> mbeans = registry.removeMBeans(this);
+
+        for (KafkaMbean mbean : mbeans) {
+            mbean.lock.lock();
+            try {
+                mbean.removeAllMetrics();
+            } finally {
+                mbean.lock.unlock();
+            }
         }
     }
 
-    private void unregister(KafkaMbean mbean) {
-        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        try {
-            if (server.isRegistered(mbean.name()))
-                server.unregisterMBean(mbean.name());
-        } catch (JMException e) {
-            throw new KafkaException("Error unregistering mbean", e);
-        }
-    }
+    static class Registry {
+        final static Registry INSTANCE = new Registry();
+        private final Map<String, KafkaMbean> mbeans = new HashMap<>();
 
-    private void reregister(KafkaMbean mbean) {
-        unregister(mbean);
-        try {
-            ManagementFactory.getPlatformMBeanServer().registerMBean(mbean, mbean.name());
-        } catch (JMException e) {
-            throw new KafkaException("Error registering mbean " + mbean.name(), e);
+        synchronized JmxReporter findMBeanOwner(String mbeanName) {
+            KafkaMbean mbean = mbeans.get(mbeanName);
+            return mbean == null ? null : mbean.owner;
+        }
+
+        synchronized void removeMbean(String mbeanName, KafkaMbean mbean) {
+            mbeans.remove(mbeanName, mbean);
+        }
+
+        /**
+         * Remove all the mbeans that belong to a given JmxReporter.
+         *
+         * @param reporter      The JmxReporter.
+         * @return              The mbeans that were removed.
+         */
+        List<KafkaMbean> removeMBeans(JmxReporter reporter) {
+            List<KafkaMbean> results = new ArrayList<>();
+            synchronized (this) {
+                for (KafkaMbean mbean : mbeans.values()) {
+                    if (mbean.owner == reporter) {
+                        results.add(mbean);
+                    }
+                }
+            }
+            // Just like in JmxReporter#removeMetrics, we need to set the
+            // deleting flag before actually removing a bean from the
+            // registry.  Otherwise, we could run into a scenario where
+            // somebody makes modifications to an mbean object that is
+            // already dead (i.e., a distinct newer object exists for the
+            // same mbean name).
+            for (KafkaMbean mbean : results) {
+                mbean.lock.lock();
+                try {
+                    mbean.deleting = true;
+                } finally {
+                    mbean.lock.unlock();
+                }
+            }
+            synchronized (this) {
+                for (KafkaMbean mbean : results) {
+                    mbeans.remove(mbean.mbeanName, mbean);
+                }
+            }
+            return results;
+        }
+
+        /**
+         * Given an mbean name, get the existing KafkaMbean object, or create a new
+         * one if needed.
+         *
+         * @param mbeanName The mbean name.
+         * @param reporter  The JMXReporter trying to get this mbean.
+         * @return          null if the mbean exists and belongs to a different JmxReporter;
+         *                  the bean object otherwise.  The bean object will be locked.
+         */
+        KafkaMbean getOrCreateLockedMBean(String mbeanName, JmxReporter reporter) {
+            while (true) {
+                KafkaMbean mbean;
+                synchronized (this) {
+                    mbean = mbeans.get(mbeanName);
+                    if (mbean != null) {
+                        if (mbean.owner != reporter) {
+                            return null;
+                        }
+                    } else {
+                        try {
+                            mbean = new KafkaMbean(reporter, mbeanName);
+                        } catch (MalformedObjectNameException e) {
+                            throw new RuntimeException(e);
+                        }
+                        mbeans.put(mbeanName, mbean);
+                    }
+                }
+                mbean.lock.lock();
+                if (!mbean.deleting) {
+                    return mbean;
+                }
+                mbean.lock.unlock();
+            }
         }
     }
 
     private static class KafkaMbean implements DynamicMBean {
+        private final JmxReporter owner;
+        private final String mbeanName;
         private final ObjectName objectName;
-        private final Map<String, KafkaMetric> metrics;
+        private final Map<String, KafkaMetric> beanMetrics = new ConcurrentHashMap<>();
+        private final ReentrantLock lock = new ReentrantLock();
+        private boolean deleting = false;
 
-        KafkaMbean(String mbeanName) throws MalformedObjectNameException {
-            this.metrics = new HashMap<>();
+        KafkaMbean(JmxReporter owner, String mbeanName) throws MalformedObjectNameException {
+            this.owner = owner;
+            this.mbeanName = mbeanName;
             this.objectName = new ObjectName(mbeanName);
         }
 
@@ -180,16 +320,13 @@ public class JmxReporter implements MetricsReporter {
             return objectName;
         }
 
-        void setAttribute(String name, KafkaMetric metric) {
-            this.metrics.put(name, metric);
-        }
-
         @Override
         public Object getAttribute(String name) throws AttributeNotFoundException {
-            if (this.metrics.containsKey(name))
-                return this.metrics.get(name).metricValue();
-            else
+            KafkaMetric metric = beanMetrics.get(name);
+            if (metric == null) {
                 throw new AttributeNotFoundException("Could not find attribute " + name);
+            }
+            return metric.metricValue();
         }
 
         @Override
@@ -205,26 +342,24 @@ public class JmxReporter implements MetricsReporter {
             return list;
         }
 
-        KafkaMetric removeAttribute(String name) {
-            return this.metrics.remove(name);
-        }
-
         @Override
         public MBeanInfo getMBeanInfo() {
-            MBeanAttributeInfo[] attrs = new MBeanAttributeInfo[metrics.size()];
-            int i = 0;
-            for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
+            // Note: the size could change in the ConcurrentMap between calling size
+            // here and iterating.  That's OK, though, since the size is just used to
+            // optimize the list capacity allocation anyway.
+            List<MBeanAttributeInfo> attrList = new ArrayList<>(beanMetrics.size());
+            for (Map.Entry<String, KafkaMetric> entry : this.beanMetrics.entrySet()) {
                 String attribute = entry.getKey();
                 KafkaMetric metric = entry.getValue();
-                attrs[i] = new MBeanAttributeInfo(attribute,
-                                                  double.class.getName(),
-                                                  metric.metricName().description(),
-                                                  true,
-                                                  false,
-                                                  false);
-                i += 1;
+                attrList.add(new MBeanAttributeInfo(attribute,
+                                                    double.class.getName(),
+                                                    metric.metricName().description(),
+                                                    true,
+                                                    false,
+                                                    false));
             }
-            return new MBeanInfo(this.getClass().getName(), "", attrs, null, null, null);
+            return new MBeanInfo(this.getClass().getName(), "",
+                attrList.toArray(new MBeanAttributeInfo[0]), null, null, null);
         }
 
         @Override
@@ -242,6 +377,60 @@ public class JmxReporter implements MetricsReporter {
             throw new UnsupportedOperationException("Set not allowed.");
         }
 
-    }
+        /**
+         * Add some new metrics to this mbean, then unregister and re-register the mbean.
+         */
+        void addMetrics(Collection<KafkaMetric> metrics) {
+            checkLocked();
+            if (!beanMetrics.isEmpty()) {
+                unregister();
+            }
+            for (KafkaMetric metric : metrics) {
+                beanMetrics.put(metric.metricName().name(), metric);
+            }
+            register();
+        }
 
+        void removeMetrics(Collection<KafkaMetric> metrics) {
+            checkLocked();
+            if (!beanMetrics.isEmpty()) {
+                unregister();
+            }
+            for (KafkaMetric metric : metrics) {
+                beanMetrics.remove(metric.metricName().name(), metric);
+            }
+            if (!beanMetrics.isEmpty()) {
+                register();
+            }
+        }
+
+        void register() {
+            checkLocked();
+            try {
+                owner.mbeanServer.registerMBean(this, objectName);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to reregister bean " + mbeanName, e);
+            }
+        }
+
+        void unregister() {
+            checkLocked();
+            try {
+                owner.mbeanServer.unregisterMBean(objectName);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to reregister bean " + mbeanName, e);
+            }
+        }
+
+        void removeAllMetrics() {
+            checkLocked();
+            removeMetrics(beanMetrics.values());
+        }
+
+        private void checkLocked() {
+            if (!lock.isLocked()) {
+                throw new RuntimeException("The MBean lock must be held here.");
+            }
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MockMBeanServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MockMBeanServer.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.NotCompliantMBeanException;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.OperationsException;
+import javax.management.QueryExp;
+import javax.management.ReflectionException;
+import javax.management.loading.ClassLoaderRepository;
+import java.io.ObjectInputStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+public class MockMBeanServer implements MBeanServer {
+    private static final Logger log = LoggerFactory.getLogger(MockMBeanServer.class);
+
+    final Map<ObjectName, Object> registered = new ConcurrentHashMap<>();
+    CountDownLatch unregisterMbeanLatch = null;
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name) throws ReflectionException, InstanceAlreadyExistsException, MBeanRegistrationException, MBeanException, NotCompliantMBeanException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, ObjectName loaderName) throws ReflectionException, InstanceAlreadyExistsException, MBeanRegistrationException, MBeanException, NotCompliantMBeanException, InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, Object[] params, String[] signature) throws ReflectionException, InstanceAlreadyExistsException, MBeanRegistrationException, MBeanException, NotCompliantMBeanException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, ObjectName loaderName, Object[] params, String[] signature) throws ReflectionException, InstanceAlreadyExistsException, MBeanRegistrationException, MBeanException, NotCompliantMBeanException, InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ObjectInstance registerMBean(Object object, ObjectName name) throws InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {
+        log.info("registerMBean(object={}, name={})", object, name);
+        registered.putIfAbsent(name, object);
+        return null;
+    }
+
+    @Override
+    public void unregisterMBean(ObjectName name) throws InstanceNotFoundException, MBeanRegistrationException {
+        if (unregisterMbeanLatch != null) {
+            try {
+                unregisterMbeanLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        log.info("unregisterMBean(name={})", name);
+        registered.remove(name);
+    }
+
+    @Override
+    public ObjectInstance getObjectInstance(ObjectName name) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ObjectInstance> queryMBeans(ObjectName name, QueryExp query) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ObjectName> queryNames(ObjectName name, QueryExp query) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRegistered(ObjectName name) {
+        boolean result = registered.containsKey(name);
+        log.info("isRegistered(name={}) = {}", name, result);
+        return result;
+    }
+
+    @Override
+    public Integer getMBeanCount() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(ObjectName name, String attribute) throws MBeanException, AttributeNotFoundException, InstanceNotFoundException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AttributeList getAttributes(ObjectName name, String[] attributes) throws InstanceNotFoundException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(ObjectName name, Attribute attribute) throws InstanceNotFoundException, AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    public AttributeList setAttributes(ObjectName name, AttributeList attributes) throws InstanceNotFoundException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object invoke(ObjectName name, String operationName, Object[] params, String[] signature) throws InstanceNotFoundException, MBeanException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDefaultDomain() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getDomains() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, ObjectName listener) throws InstanceNotFoundException, ListenerNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException, ListenerNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, NotificationListener listener) throws InstanceNotFoundException, ListenerNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException, ListenerNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MBeanInfo getMBeanInfo(ObjectName name) throws InstanceNotFoundException, IntrospectionException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isInstanceOf(ObjectName name, String className) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object instantiate(String className) throws ReflectionException, MBeanException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object instantiate(String className, ObjectName loaderName) throws ReflectionException, MBeanException, InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object instantiate(String className, Object[] params, String[] signature) throws ReflectionException, MBeanException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object instantiate(String className, ObjectName loaderName, Object[] params, String[] signature) throws ReflectionException, MBeanException, InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public ObjectInputStream deserialize(ObjectName name, byte[] data) throws InstanceNotFoundException, OperationsException {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public ObjectInputStream deserialize(String className, byte[] data) throws OperationsException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public ObjectInputStream deserialize(String className, ObjectName loaderName, byte[] data) throws InstanceNotFoundException, OperationsException, ReflectionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClassLoader getClassLoaderFor(ObjectName mbeanName) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClassLoader getClassLoader(ObjectName loaderName) throws InstanceNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClassLoaderRepository getClassLoaderRepository() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -64,6 +64,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -96,6 +97,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*"})
 @PrepareForTest({KafkaStreams.class, StreamThread.class, ClientMetrics.class})
 public class KafkaStreamsTest {
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -140,17 +140,8 @@ public class MeteredSessionStoreTest {
     public void testMetrics() {
         init();
         final JmxReporter reporter = new JmxReporter("kafka.streams");
-        metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean(String.format(
-            "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-            storeLevelGroup,
-            threadIdTagKey,
-            threadId,
-            taskId.toString(),
-            STORE_TYPE,
-            "metered"
-        )));
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
+        try {
+            metrics.addReporter(reporter);
             assertTrue(reporter.containsMbean(String.format(
                 "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
                 storeLevelGroup,
@@ -158,8 +149,21 @@ public class MeteredSessionStoreTest {
                 threadId,
                 taskId.toString(),
                 STORE_TYPE,
-                ROLLUP_VALUE
+                "metered"
             )));
+            if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
+                assertTrue(reporter.containsMbean(String.format(
+                    "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
+                    storeLevelGroup,
+                    threadIdTagKey,
+                    threadId,
+                    taskId.toString(),
+                    STORE_TYPE,
+                    ROLLUP_VALUE
+                )));
+            }
+        } finally {
+            reporter.close();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -128,17 +128,8 @@ public class MeteredWindowStoreTest {
         replay(innerStoreMock);
         store.init(context, store);
         final JmxReporter reporter = new JmxReporter("kafka.streams");
-        metrics.addReporter(reporter);
-        assertTrue(reporter.containsMbean(String.format(
-            "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-            storeLevelGroup,
-            threadIdTagKey,
-            threadId,
-            context.taskId().toString(),
-            STORE_TYPE,
-            STORE_NAME
-        )));
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
+        try {
+            metrics.addReporter(reporter);
             assertTrue(reporter.containsMbean(String.format(
                 "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
                 storeLevelGroup,
@@ -146,8 +137,21 @@ public class MeteredWindowStoreTest {
                 threadId,
                 context.taskId().toString(),
                 STORE_TYPE,
-                ROLLUP_VALUE
+                STORE_NAME
             )));
+            if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
+                assertTrue(reporter.containsMbean(String.format(
+                    "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
+                    storeLevelGroup,
+                    threadIdTagKey,
+                    threadId,
+                    context.taskId().toString(),
+                    STORE_TYPE,
+                    ROLLUP_VALUE
+                )));
+            }
+        } finally {
+            reporter.close();
         }
     }
 


### PR DESCRIPTION
Fix some inconsistencies in the case where multiple JmxReporter objects
attempt to claim a single mbean.  Avoid holding a global lock when
performing JMX operations.

Finally, handle close better. Some calling code continues performing operations after close, so close needs to clean up the internal state