### PR TITLE
KAFKA-9509: Fixing flakiness of MirrorConnectorsIntegrationTest.testReplication

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -201,7 +201,6 @@ public class MirrorConnectorsIntegrationTest {
             "MirrorHeartbeatConnector", MIN_TASKS).isPresent(),
             "Timed out trying to verify connector MirrorHeartbeatConnector was up on"
                 + " primary cluster!");
-
     }
 
     private Optional<Boolean> assertConnectorAndTasksRunning(EmbeddedConnectCluster connectCluster,

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -208,7 +208,7 @@ public class MirrorConnectorsIntegrationTest {
         try {
             ConnectorStateInfo info = connectCluster.connectorStatus(connectorName);
             boolean result = info != null
-                && info.tasks().size() == numTasks
+                && info.tasks().size() >= numTasks
                 && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
                 && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
             log.info("Found connector and tasks running: {}", result);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -65,7 +65,6 @@ public class MirrorConnectorsIntegrationTest {
     private static final int NUM_PARTITIONS = 10;
     private static final int RECORD_TRANSFER_DURATION_MS = 10_000;
     private static final int CHECKPOINT_DURATION_MS = 20_000;
-    private static final int MIN_TASKS = 1;
 
     private MirrorMakerConfig mm2Config; 
     private EmbeddedConnectCluster primary;
@@ -191,21 +190,20 @@ public class MirrorConnectorsIntegrationTest {
         Set<String> connNames) throws InterruptedException {
         for (String connector : connNames) {
             TestUtils.waitForCondition(() -> areConnectorAndTasksRunning(connectCluster,
-                connector, MIN_TASKS), "Timed out trying to verify connector " +
+                connector), "Timed out trying to verify connector " +
                 connector + " was up!" );
         }
-
     }
 
     private boolean areConnectorAndTasksRunning(EmbeddedConnectCluster connectCluster,
-        String connectorName, int numTasks) {
+        String connectorName) {
         try {
             ConnectorStateInfo info = connectCluster.connectorStatus(connectorName);
             boolean result = info != null
-                && info.tasks().size() >= numTasks
+                && !info.tasks().isEmpty()
                 && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
                 && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
-            log.info("Found connector and tasks running: {}", result);
+            log.debug("Found connector and tasks running: {}", result);
             return result;
         } catch (Exception e) {
             log.error("Could not check connector state info.", e);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -191,7 +191,7 @@ public class MirrorConnectorsIntegrationTest {
         for (String connector : connNames) {
             TestUtils.waitForCondition(() -> areConnectorAndTasksRunning(connectCluster,
                 connector), "Timed out trying to verify connector " +
-                connector + " was up!" );
+                connector + " was up!");
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-9509

As the JIRA indicates, `org.apache.kafka.connect.mirror.MirrorConnectorsIntegrationTest.testReplication` has shown to be an increasingly flaky test recently. This PR aims to make this test more deterministic. Specifically, the flakiness was due to a timing issue between the tasks not starting up in time for the test to start running. This PR remediates that by introducing a status check after every connector is started up. These status checks include that the connector is found on the connect cluster as well as there are tasks created and up and running for that connector. These checks are introduced before the test starts running so that there is a confidence that the connectors and tasks are started up correctly before the test runs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
