### PR TITLE
KAFKA-9390: Make serde pseudo-topics unique

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchema.java
@@ -28,14 +28,19 @@ import java.nio.ByteBuffer;
  * Factory for creating CombinedKey serializers / deserializers.
  */
 public class CombinedKeySchema<KO, K> {
-    private final String serdeTopic;
+    private final String primaryKeySerdeTopic;
+    private final String foreignKeySerdeTopic;
     private Serializer<K> primaryKeySerializer;
     private Deserializer<K> primaryKeyDeserializer;
     private Serializer<KO> foreignKeySerializer;
     private Deserializer<KO> foreignKeyDeserializer;
 
-    public CombinedKeySchema(final String serdeTopic, final Serde<KO> foreignKeySerde, final Serde<K> primaryKeySerde) {
-        this.serdeTopic = serdeTopic;
+    public CombinedKeySchema(final String foreignKeySerdeTopic,
+                             final Serde<KO> foreignKeySerde,
+                             final String primaryKeySerdeTopic,
+                             final Serde<K> primaryKeySerde) {
+        this.primaryKeySerdeTopic = primaryKeySerdeTopic;
+        this.foreignKeySerdeTopic = foreignKeySerdeTopic;
         primaryKeySerializer = primaryKeySerde == null ? null : primaryKeySerde.serializer();
         primaryKeyDeserializer = primaryKeySerde == null ? null : primaryKeySerde.deserializer();
         foreignKeyDeserializer = foreignKeySerde == null ? null : foreignKeySerde.deserializer();
@@ -54,10 +59,12 @@ public class CombinedKeySchema<KO, K> {
         //The serialization format - note that primaryKeySerialized may be null, such as when a prefixScan
         //key is being created.
         //{Integer.BYTES foreignKeyLength}{foreignKeySerialized}{Optional-primaryKeySerialized}
-        final byte[] foreignKeySerializedData = foreignKeySerializer.serialize(serdeTopic, foreignKey);
+        final byte[] foreignKeySerializedData = foreignKeySerializer.serialize(foreignKeySerdeTopic,
+                                                                               foreignKey);
 
         //? bytes
-        final byte[] primaryKeySerializedData = primaryKeySerializer.serialize(serdeTopic, primaryKey);
+        final byte[] primaryKeySerializedData = primaryKeySerializer.serialize(primaryKeySerdeTopic,
+                                                                               primaryKey);
 
         final ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES + foreignKeySerializedData.length + primaryKeySerializedData.length);
         buf.putInt(foreignKeySerializedData.length);
@@ -74,11 +81,11 @@ public class CombinedKeySchema<KO, K> {
         final int foreignKeyLength = dataBuffer.getInt();
         final byte[] foreignKeyRaw = new byte[foreignKeyLength];
         dataBuffer.get(foreignKeyRaw, 0, foreignKeyLength);
-        final KO foreignKey = foreignKeyDeserializer.deserialize(serdeTopic, foreignKeyRaw);
+        final KO foreignKey = foreignKeyDeserializer.deserialize(foreignKeySerdeTopic, foreignKeyRaw);
 
         final byte[] primaryKeyRaw = new byte[dataArray.length - foreignKeyLength - Integer.BYTES];
         dataBuffer.get(primaryKeyRaw, 0, primaryKeyRaw.length);
-        final K primaryKey = primaryKeyDeserializer.deserialize(serdeTopic, primaryKeyRaw);
+        final K primaryKey = primaryKeyDeserializer.deserialize(primaryKeySerdeTopic, primaryKeyRaw);
         return new CombinedKey<>(foreignKey, primaryKey);
     }
 
@@ -86,7 +93,7 @@ public class CombinedKeySchema<KO, K> {
         //The serialization format. Note that primaryKeySerialized is not required/used in this function.
         //{Integer.BYTES foreignKeyLength}{foreignKeySerialized}{Optional-primaryKeySerialized}
 
-        final byte[] foreignKeySerializedData = foreignKeySerializer.serialize(serdeTopic, key);
+        final byte[] foreignKeySerializedData = foreignKeySerializer.serialize(foreignKeySerdeTopic, key);
 
         final ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES + foreignKeySerializedData.length);
         buf.putInt(foreignKeySerializedData.length);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
@@ -43,20 +43,23 @@ public class ForeignJoinSubscriptionSendProcessorSupplier<K, KO, V> implements P
     private static final Logger LOG = LoggerFactory.getLogger(ForeignJoinSubscriptionSendProcessorSupplier.class);
 
     private final Function<V, KO> foreignKeyExtractor;
-    private final String repartitionTopicName;
+    private final String foreignKeySerdeTopic;
+    private final String valueSerdeTopic;
     private final boolean leftJoin;
     private Serializer<KO> foreignKeySerializer;
     private Serializer<V> valueSerializer;
 
     public ForeignJoinSubscriptionSendProcessorSupplier(final Function<V, KO> foreignKeyExtractor,
+                                                        final String foreignKeySerdeTopic,
+                                                        final String valueSerdeTopic,
                                                         final Serde<KO> foreignKeySerde,
-                                                        final String repartitionTopicName,
                                                         final Serializer<V> valueSerializer,
                                                         final boolean leftJoin) {
         this.foreignKeyExtractor = foreignKeyExtractor;
+        this.foreignKeySerdeTopic = foreignKeySerdeTopic;
+        this.valueSerdeTopic = valueSerdeTopic;
         this.valueSerializer = valueSerializer;
         this.leftJoin = leftJoin;
-        this.repartitionTopicName = repartitionTopicName;
         foreignKeySerializer = foreignKeySerde == null ? null : foreignKeySerde.serializer();
     }
 
@@ -91,7 +94,7 @@ public class ForeignJoinSubscriptionSendProcessorSupplier<K, KO, V> implements P
         public void process(final K key, final Change<V> change) {
             final long[] currentHash = change.newValue == null ?
                 null :
-                Murmur3.hash128(valueSerializer.serialize(repartitionTopicName, change.newValue));
+                Murmur3.hash128(valueSerializer.serialize(valueSerdeTopic, change.newValue));
 
             if (change.oldValue != null) {
                 final KO oldForeignKey = foreignKeyExtractor.apply(change.oldValue);
@@ -114,8 +117,10 @@ public class ForeignJoinSubscriptionSendProcessorSupplier<K, KO, V> implements P
                         return;
                     }
 
-                    final byte[] serialOldForeignKey = foreignKeySerializer.serialize(repartitionTopicName, oldForeignKey);
-                    final byte[] serialNewForeignKey = foreignKeySerializer.serialize(repartitionTopicName, newForeignKey);
+                    final byte[] serialOldForeignKey =
+                        foreignKeySerializer.serialize(foreignKeySerdeTopic, oldForeignKey);
+                    final byte[] serialNewForeignKey =
+                        foreignKeySerializer.serialize(foreignKeySerdeTopic, newForeignKey);
                     if (!Arrays.equals(serialNewForeignKey, serialOldForeignKey)) {
                         //Different Foreign Key - delete the old key value and propagate the new one.
                         //Delete it from the oldKey's state store

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
@@ -30,9 +30,12 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
     private final SubscriptionWrapperSerializer<K> serializer;
     private final SubscriptionWrapperDeserializer<K> deserializer;
 
-    public SubscriptionWrapperSerde(final Serde<K> primaryKeySerde) {
-        serializer = new SubscriptionWrapperSerializer<>(primaryKeySerde == null ? null : primaryKeySerde.serializer());
-        deserializer = new SubscriptionWrapperDeserializer<>(primaryKeySerde == null ? null : primaryKeySerde.deserializer());
+    public SubscriptionWrapperSerde(final String primaryKeySerializationPseudoTopic,
+                                    final Serde<K> primaryKeySerde) {
+        serializer = new SubscriptionWrapperSerializer<>(primaryKeySerializationPseudoTopic,
+                                                         primaryKeySerde == null ? null : primaryKeySerde.serializer());
+        deserializer = new SubscriptionWrapperDeserializer<>(primaryKeySerializationPseudoTopic,
+                                                             primaryKeySerde == null ? null : primaryKeySerde.deserializer());
     }
 
     @Override
@@ -45,12 +48,15 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
         return deserializer;
     }
 
-    public static class SubscriptionWrapperSerializer<K>
+    private static class SubscriptionWrapperSerializer<K>
         implements Serializer<SubscriptionWrapper<K>>, WrappingNullableSerializer<SubscriptionWrapper<K>, K> {
 
+        private final String primaryKeySerializationPseudoTopic;
         private Serializer<K> primaryKeySerializer;
 
-        SubscriptionWrapperSerializer(final Serializer<K> primaryKeySerializer) {
+        SubscriptionWrapperSerializer(final String primaryKeySerializationPseudoTopic,
+                                      final Serializer<K> primaryKeySerializer) {
+            this.primaryKeySerializationPseudoTopic = primaryKeySerializationPseudoTopic;
             this.primaryKeySerializer = primaryKeySerializer;
         }
 
@@ -62,7 +68,7 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
         }
 
         @Override
-        public byte[] serialize(final String topic, final SubscriptionWrapper<K> data) {
+        public byte[] serialize(final String ignored, final SubscriptionWrapper<K> data) {
             //{1-bit-isHashNull}{7-bits-version}{1-byte-instruction}{Optional-16-byte-Hash}{PK-serialized}
 
             //7-bit (0x7F) maximum for data version.
@@ -70,7 +76,10 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
                 throw new UnsupportedVersionException("SubscriptionWrapper version is larger than maximum supported 0x7F");
             }
 
-            final byte[] primaryKeySerializedData = primaryKeySerializer.serialize(topic, data.getPrimaryKey());
+            final byte[] primaryKeySerializedData = primaryKeySerializer.serialize(
+                primaryKeySerializationPseudoTopic,
+                data.getPrimaryKey()
+            );
 
             final ByteBuffer buf;
             if (data.getHash() != null) {
@@ -94,12 +103,15 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
 
     }
 
-    public static class SubscriptionWrapperDeserializer<K>
+    private static class SubscriptionWrapperDeserializer<K>
         implements Deserializer<SubscriptionWrapper<K>>, WrappingNullableDeserializer<SubscriptionWrapper<K>, K> {
 
+        private final String primaryKeySerializationPseudoTopic;
         private Deserializer<K> primaryKeyDeserializer;
 
-        SubscriptionWrapperDeserializer(final Deserializer<K> primaryKeyDeserializer) {
+        SubscriptionWrapperDeserializer(final String primaryKeySerializationPseudoTopic,
+                                        final Deserializer<K> primaryKeyDeserializer) {
+            this.primaryKeySerializationPseudoTopic = primaryKeySerializationPseudoTopic;
             this.primaryKeyDeserializer = primaryKeyDeserializer;
         }
 
@@ -111,7 +123,7 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
         }
 
         @Override
-        public SubscriptionWrapper<K> deserialize(final String topic, final byte[] data) {
+        public SubscriptionWrapper<K> deserialize(final String ignored, final byte[] data) {
             //{7-bits-version}{1-bit-isHashNull}{1-byte-instruction}{Optional-16-byte-Hash}{PK-serialized}
             final ByteBuffer buf = ByteBuffer.wrap(data);
             final byte versionAndIsHashNull = buf.get();
@@ -132,7 +144,8 @@ public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>
 
             final byte[] primaryKeyRaw = new byte[data.length - lengthSum]; //The remaining data is the serialized pk
             buf.get(primaryKeyRaw, 0, primaryKeyRaw.length);
-            final K primaryKey = primaryKeyDeserializer.deserialize(topic, primaryKeyRaw);
+            final K primaryKey = primaryKeyDeserializer.deserialize(primaryKeySerializationPseudoTopic,
+                                                                    primaryKeyRaw);
 
             return new SubscriptionWrapper<>(hash, inst, primaryKey, version);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDefaultSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDefaultSerdeTest.java
@@ -30,11 +30,13 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -161,10 +163,11 @@ public class KTableKTableForeignKeyJoinDefaultSerdeTest {
 
     private static void validateTopologyCanProcessData(final StreamsBuilder builder) {
         final Properties config = new Properties();
-        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "dummy");
+        config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "dummy-" + UUID.randomUUID());
         config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy");
         config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        config.setProperty(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         try (final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), config)) {
             final TestInputTopic<String, String> aTopic = topologyTestDriver.createInputTopic("A", new StringSerializer(), new StringSerializer());
             final TestInputTopic<String, String> bTopic = topologyTestDriver.createInputTopic("B", new StringSerializer(), new StringSerializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
@@ -28,7 +28,8 @@ public class CombinedKeySchemaTest {
 
     @Test
     public void nonNullPrimaryKeySerdeTest() {
-        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("someTopic", Serdes.String(), Serdes.Integer());
+        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("fkTopic", Serdes.String(),
+                                                                               "pkTopic", Serdes.Integer());
         final Integer primary = -999;
         final Bytes result = cks.toBytes("foreignKey", primary);
 
@@ -39,21 +40,25 @@ public class CombinedKeySchemaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullPrimaryKeySerdeTest() {
-        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("someTopic", Serdes.String(), Serdes.Integer());
+        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("fkTopic", Serdes.String(),
+                                                                               "pkTopic", Serdes.Integer());
         cks.toBytes("foreignKey", null);
     }
 
     @Test(expected = NullPointerException.class)
     public void nullForeignKeySerdeTest() {
-        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("someTopic", Serdes.String(), Serdes.Integer());
+        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("fkTopic", Serdes.String(),
+                                                                               "pkTopic", Serdes.Integer());
         cks.toBytes(null, 10);
     }
 
     @Test
     public void prefixKeySerdeTest() {
-        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("someTopic", Serdes.String(), Serdes.Integer());
+        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("fkTopic", Serdes.String(),
+                                                                               "pkTopic", Serdes.Integer());
         final String foreignKey = "someForeignKey";
-        final byte[] foreignKeySerializedData = Serdes.String().serializer().serialize("someTopic", foreignKey);
+        final byte[] foreignKeySerializedData =
+            Serdes.String().serializer().serialize("fkTopic", foreignKey);
         final Bytes prefix = cks.prefixBytes(foreignKey);
 
         final ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES + foreignKeySerializedData.length);
@@ -66,7 +71,8 @@ public class CombinedKeySchemaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullPrefixKeySerdeTest() {
-        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("someTopic", Serdes.String(), Serdes.Integer());
+        final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>("fkTopic", Serdes.String(),
+                                                                               "pkTopic", Serdes.Integer());
         final String foreignKey = null;
         cks.prefixBytes(foreignKey);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
@@ -31,7 +31,7 @@ public class SubscriptionWrapperSerdeTest {
     @SuppressWarnings("unchecked")
     public void shouldSerdeTest() {
         final String originalKey = "originalKey";
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(Serdes.String());
+        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>("pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
         final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, SubscriptionWrapper.Instruction.DELETE_KEY_AND_PROPAGATE, originalKey);
         final byte[] serialized = swSerde.serializer().serialize(null, wrapper);
@@ -46,7 +46,7 @@ public class SubscriptionWrapperSerdeTest {
     @SuppressWarnings("unchecked")
     public void shouldSerdeNullHashTest() {
         final String originalKey = "originalKey";
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(Serdes.String());
+        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>("pkTopic", Serdes.String());
         final long[] hashedValue = null;
         final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE, originalKey);
         final byte[] serialized = swSerde.serializer().serialize(null, wrapper);
@@ -61,7 +61,7 @@ public class SubscriptionWrapperSerdeTest {
     @SuppressWarnings("unchecked")
     public void shouldThrowExceptionOnNullKeyTest() {
         final String originalKey = null;
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(Serdes.String());
+        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>("pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
         final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE, originalKey);
         swSerde.serializer().serialize(null, wrapper);
@@ -71,7 +71,7 @@ public class SubscriptionWrapperSerdeTest {
     @SuppressWarnings("unchecked")
     public void shouldThrowExceptionOnNullInstructionTest() {
         final String originalKey = "originalKey";
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(Serdes.String());
+        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>("pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
         final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, null, originalKey);
         swSerde.serializer().serialize(null, wrapper);

--- a/streams/src/test/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
+++ b/streams/src/test/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
@@ -104,7 +104,6 @@ public class UniqueTopicSerdeScope {
                 if (topicTypeRegistry.containsKey(key)) {
                     assertThat(String.format("key[%s] data[%s][%s]", key, data, data.getClass()), topicTypeRegistry.get(key), equalTo(data.getClass()));
                 } else {
-                    System.out.printf("storing key[%s] data[%s][%s]%n", key, data, data.getClass());
                     topicTypeRegistry.put(key, data.getClass());
                 }
             }

--- a/streams/src/test/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
+++ b/streams/src/test/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.utils;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class UniqueTopicSerdeScope {
+    private final Map<String, Class<?>> topicTypeRegistry = new TreeMap<>();
+
+    public <T> UniqueTopicSerdeDecorator<T> decorateSerde(final Serde<T> delegate,
+                                                          final Properties config,
+                                                          final boolean isKey) {
+        final UniqueTopicSerdeDecorator<T> decorator = new UniqueTopicSerdeDecorator<>(delegate);
+        decorator.configure(config.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)), isKey);
+        return decorator;
+    }
+
+    public class UniqueTopicSerdeDecorator<T> implements Serde<T> {
+        private final AtomicBoolean isKey = new AtomicBoolean(false);
+        private final Serde<T> delegate;
+
+        public UniqueTopicSerdeDecorator(final Serde<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs, final boolean isKey) {
+            delegate.configure(configs, isKey);
+            this.isKey.set(isKey);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        @Override
+        public Serializer<T> serializer() {
+            return new UniqueTopicSerializerDecorator<>(isKey, delegate.serializer());
+        }
+
+        @Override
+        public Deserializer<T> deserializer() {
+            return new UniqueTopicDeserializerDecorator<>(isKey, delegate.deserializer());
+        }
+    }
+
+    public class UniqueTopicSerializerDecorator<T> implements Serializer<T> {
+        private final AtomicBoolean isKey;
+        private final Serializer<T> delegate;
+
+        public UniqueTopicSerializerDecorator(final AtomicBoolean isKey, final Serializer<T> delegate) {
+            this.isKey = isKey;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs, final boolean isKey) {
+            delegate.configure(configs, isKey);
+            this.isKey.set(isKey);
+        }
+
+        @Override
+        public byte[] serialize(final String topic, final T data) {
+            verifyTopic(topic, data);
+            return delegate.serialize(topic, data);
+        }
+
+        @Override
+        public byte[] serialize(final String topic, final Headers headers, final T data) {
+            verifyTopic(topic, data);
+            return delegate.serialize(topic, headers, data);
+        }
+
+        private void verifyTopic(final String topic, final T data) {
+            if (data != null) {
+                final String key = topic + (isKey.get() ? "--key" : "--value");
+                if (topicTypeRegistry.containsKey(key)) {
+                    assertThat(String.format("key[%s] data[%s][%s]", key, data, data.getClass()), topicTypeRegistry.get(key), equalTo(data.getClass()));
+                } else {
+                    System.out.printf("storing key[%s] data[%s][%s]%n", key, data, data.getClass());
+                    topicTypeRegistry.put(key, data.getClass());
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+
+    public class UniqueTopicDeserializerDecorator<T> implements Deserializer<T> {
+        private final AtomicBoolean isKey;
+        private final Deserializer<T> delegate;
+
+        public UniqueTopicDeserializerDecorator(final AtomicBoolean isKey, final Deserializer<T> delegate) {
+            this.isKey = isKey;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs, final boolean isKey) {
+            delegate.configure(configs, isKey);
+            this.isKey.set(isKey);
+        }
+
+        @Override
+        public T deserialize(final String topic, final byte[] data) {
+            return delegate.deserialize(topic, data);
+        }
+
+        @Override
+        public T deserialize(final String topic, final Headers headers, final byte[] data) {
+            return delegate.deserialize(topic, headers, data);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+}


### PR DESCRIPTION
During the discussion for KIP-213, we decided to pass "pseudo-topics"
to the internal serdes we use to construct the wrapper serdes for
CombinedKey and hashing the left-hand-side value. However, during
the implementation, this strategy wasn't fully implemented, and we wound
up using the same topic name for a few different data types.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
