### PR TITLE
KAFKA-9519: Deprecating ZK for ConfigCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -82,6 +82,8 @@ object ConfigCommand extends Config {
       opts.checkArgs()
 
       if (opts.options.has(opts.zkConnectOpt)) {
+        println(s"Warning: --zookeeper is deprecated and will be removed in a future version of Kafka.")
+        println(s"Use --bootstrap-server instead to specify a broker to connect to.")
         processCommandWithZk(opts.options.valueOf(opts.zkConnectOpt), opts)
       } else {
         processCommand(opts)
@@ -535,7 +537,7 @@ object ConfigCommand extends Config {
 
   class ConfigCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
 
-    val zkConnectOpt = parser.accepts("zookeeper", "The connection string for the zookeeper connection in the form host:port. " +
+    val zkConnectOpt = parser.accepts("zookeeper", "DEPRECATED. The connection string for the zookeeper connection in the form host:port. " +
             "Multiple URLS can be given to allow fail-over.")
             .withRequiredArg
             .describedAs("urls")

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -538,7 +538,7 @@ object ConfigCommand extends Config {
   class ConfigCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
 
     val zkConnectOpt = parser.accepts("zookeeper", "DEPRECATED. The connection string for the zookeeper connection in the form host:port. " +
-            "Multiple URLS can be given to allow fail-over.")
+            "Multiple URLS can be given to allow fail-over. Replaced by --bootstrap-server, REQUIRED unless --bootstrap-server is given.")
             .withRequiredArg
             .describedAs("urls")
             .ofType(classOf[String])


### PR DESCRIPTION
As part of KIP-555, direct zookeeper access should be deprecated in the Kafka admin tools. This PR is the first of which to do so. This PR adds warnings for deprecation of the `--zookeeper` option for the `ConfigCommand` in `kafka-configs.sh.`

JIRA: https://issues.apache.org/jira/browse/KAFKA-9519

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
