### PR TITLE
KAFKA-7052 Avoiding NPE in ExtractField SMT in case of non-existent fields

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
@@ -58,7 +59,13 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
             return newRecord(record, null, value == null ? null : value.get(fieldName));
         } else {
             final Struct value = requireStructOrNull(operatingValue(record), PURPOSE);
-            return newRecord(record, schema.field(fieldName).schema(), value == null ? null : value.get(fieldName));
+            Field field = schema.field(fieldName);
+
+            if (field == null) {
+                throw new IllegalArgumentException("Unknown field: " + fieldName);
+            }
+
+            return newRecord(record, field.schema(), value == null ? null : value.get(fieldName));
         }
     }
 


### PR DESCRIPTION
… in case of non-existent fields

https://issues.apache.org/jira/browse/KAFKA-7052

*More detailed description of your change
n/a

*Summary of testing strategy (including rationale)
Added JUnit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

@rhauch, hey, that's a quick first attempt for making the `ExtractField` SMT more flexible when it comes to encountering a record that doesn't contain the specified field. It's a common situation for connectors like Debezium which produce different "kinds" of records/topics; in our case e.g. actual change event topics and meta-topics such as TX data or schema history. One might want to apply the `ExtractField` SMT to the CDC records but not to those others; as that's currently not possible, a strategy is needed for more gracefully handling records without the specified field. Also see [KAFKA-7052](https://issues.apache.org/jira/browse/KAFKA-7052) for some backgrounds.

The proposal is to add a new option `behavior.on.non.existent.field` to the SMT which makes the behavior configurable. Its supported values are:

* fail: raise an exception (default for records with schema)
* return-null: return null (default for records without schema)
* pass-on: pass on the unmodified original record

The defaults are so to keep backwards compatibility with the current behavior. The "pass-on" value will address the original use case reported in KAFKA-7052.

I did a quick implementation of that proposal to foster feedback. Happy to adjust and expand as needed, e.g. to adjust with existing naming patterns for the option and/or its values as well as docs (not sure where that'd go). Thanks!

CC @rmoff, @big-andy-coates.