### PR TITLE
MINOR: Update to Gradle 4.10.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   argparse4j: "0.7.0",
   bcpkix: "1.59",
   easymock: "3.6",
-  gradle: "4.8.1",
+  gradle: "4.10.3",
   jackson: "2.9.7",
   jetty: "9.2.24.v20180105",
   jersey: "2.25.1",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -98,7 +98,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v4.8.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v4.10.3/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5


### PR DESCRIPTION
Aligns with the 2.1 branch and fixes the
TLS handshake error when executed with
Java 7. This is necessary for the 1.0
and 1.1 branches and we do it in 2.0
too for consistency.

(cherry picked from commit b39aa1205dd8b4e05a9ae58fd013ca50be2dd00f)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
