### PR TITLE
KAFKA-9374: Make connector interactions asynchronous

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -95,6 +97,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected final ConfigBackingStore configBackingStore;
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
     protected volatile boolean running = false;
+    private final ExecutorService connectorExecutor;
 
     private Map<String, Connector> tempConnectors = new ConcurrentHashMap<>();
 
@@ -111,6 +114,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.statusBackingStore = statusBackingStore;
         this.configBackingStore = configBackingStore;
         this.connectorClientConfigOverridePolicy = connectorClientConfigOverridePolicy;
+        this.connectorExecutor = Executors.newCachedThreadPool();
     }
 
     @Override
@@ -130,6 +134,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.statusBackingStore.stop();
         this.configBackingStore.stop();
         this.worker.stop();
+        this.connectorExecutor.shutdown();
     }
 
     @Override
@@ -310,12 +315,23 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     }
 
     @Override
-    public ConfigInfos validateConnectorConfig(Map<String, String> connectorProps) {
-        return validateConnectorConfig(connectorProps, true);
+    public void validateConnectorConfig(Map<String, String> connectorProps, Callback<ConfigInfos> callback) {
+        validateConnectorConfig(connectorProps, callback, true);
     }
 
     @Override
-    public ConfigInfos validateConnectorConfig(Map<String, String> connectorProps, boolean doLog) {
+    public void validateConnectorConfig(Map<String, String> connectorProps, Callback<ConfigInfos> callback, boolean doLog) {
+        connectorExecutor.submit(() -> {
+            try {
+                ConfigInfos result = validateConnectorConfig(connectorProps, doLog);
+                callback.onCompletion(null, result);
+            } catch (Throwable t) {
+                callback.onCompletion(t, null);
+            }
+        });
+    }
+
+    ConfigInfos validateConnectorConfig(Map<String, String> connectorProps, boolean doLog) {
         if (worker.configTransformer() != null) {
             connectorProps = worker.configTransformer().transform(connectorProps);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/CloseableConnectorContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/CloseableConnectorContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.io.Closeable;
+
+public interface CloseableConnectorContext extends ConnectorContext, Closeable {
+
+    /**
+     * Close this connector context, causing all future calls to it to throw {@link ConnectException}.
+     * This is useful to prevent zombie connector threads from making such calls after their connector
+     * instance should be shut down.
+     */
+    void close();
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -179,17 +179,19 @@ public interface Herder {
     /**
      * Validate the provided connector config values against the configuration definition.
      * @param connectorConfig the provided connector config values
+     * @param callback the callback to invoke after validation has completed (successfully or not)
      */
-    ConfigInfos validateConnectorConfig(Map<String, String> connectorConfig);
+    void validateConnectorConfig(Map<String, String> connectorConfig, Callback<ConfigInfos> callback);
 
     /**
      * Validate the provided connector config values against the configuration definition.
      * @param connectorConfig the provided connector config values
+     * @param callback the callback to invoke after validation has completed (successfully or not)
      * @param doLog if true log all the connector configurations at INFO level; if false, no connector configurations are logged.
      *              Note that logging of configuration is not necessary in every endpoint that uses this method.
      */
-    default ConfigInfos validateConnectorConfig(Map<String, String> connectorConfig, boolean doLog) {
-        return validateConnectorConfig(connectorConfig);
+    default void validateConnectorConfig(Map<String, String> connectorConfig, Callback<ConfigInfos> callback, boolean doLog) {
+        validateConnectorConfig(connectorConfig, callback);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/HerderConnectorContext.java
@@ -40,11 +40,9 @@ public class HerderConnectorContext implements CloseableConnectorContext {
     @Override
     public void requestTaskReconfiguration() {
         if (closed) {
-            throw new ConnectException(String.format(
-                "The request for task reconfiguration has been rejected because this instance of "
-                    + "the connector '%s' has already been shut down.",
-                connectorName
-            ));
+            throw new ConnectException("The request for task reconfiguration has been rejected " 
+                    + "because this instance of the connector '" + connectorName + "' has already " 
+                    + "been shut down.");
         }
 
         // Local herder runs in memory in this process
@@ -55,12 +53,10 @@ public class HerderConnectorContext implements CloseableConnectorContext {
     @Override
     public void raiseError(Exception e) {
         if (closed) {
-            log.warn("Connector '%s' attempted to raise error after shutdown:", e);
-            throw new ConnectException(String.format(
-                "The request to fail the connector has been rejected because this instance of the "
-                    + "connector '%s' has already been shut down.",
-                connectorName
-            ));
+            log.warn("Connector {} attempted to raise error after shutdown:", connectorName, e);
+            throw new ConnectException("The request to fail the connector has been rejected " 
+                    + "because this instance of the connector '" + connectorName + "' has already " 
+                    + "been shut down.");
         }
 
         herder.onFailure(connectorName, e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.metrics.stats.Frequencies;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
-import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigRequest;
@@ -59,6 +58,7 @@ import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
 import org.apache.kafka.connect.util.ConnectUtils;
+import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.LoggingContext;
 import org.apache.kafka.connect.util.SinkUtils;
@@ -78,6 +78,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -90,6 +91,9 @@ import java.util.stream.Collectors;
  * </p>
  */
 public class Worker {
+
+    public static final long CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5);
+
     private static final Logger log = LoggerFactory.getLogger(Worker.class);
 
     protected Herder herder;
@@ -209,7 +213,7 @@ public class Worker {
 
         if (!connectors.isEmpty()) {
             log.warn("Shutting down connectors {} uncleanly; herder should have shut down connectors before the Worker is stopped", connectors.keySet());
-            stopConnectors();
+            stopAndAwaitConnectors();
         }
 
         if (!tasks.isEmpty()) {
@@ -239,18 +243,24 @@ public class Worker {
      * @param ctx the connector runtime context.
      * @param statusListener a listener for the runtime status transitions of the connector.
      * @param initialState the initial state of the connector.
-     * @return true if the connector started successfully.
+     * @param onConnectorStateChange invoked when the initial state change of the connector is completed
      */
-    public boolean startConnector(
+    public void startConnector(
             String connName,
             Map<String, String> connProps,
-            ConnectorContext ctx,
+            CloseableConnectorContext ctx,
             ConnectorStatus.Listener statusListener,
-            TargetState initialState
+            TargetState initialState,
+            Callback<TargetState> onConnectorStateChange
     ) {
         try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
-            if (connectors.containsKey(connName))
-                throw new ConnectException("Connector with name " + connName + " already exists");
+            if (connectors.containsKey(connName)) {
+                onConnectorStateChange.onCompletion(
+                    new ConnectException("Connector with name " + connName + " already exists"),
+                    null
+                );
+                return;
+            }
 
             final WorkerConnector workerConnector;
             ClassLoader savedLoader = plugins.currentThreadLoader();
@@ -258,19 +268,34 @@ public class Worker {
                 // By the time we arrive here, CONNECTOR_CLASS_CONFIG has been validated already
                 // Getting this value from the unparsed map will allow us to instantiate the
                 // right config (source or sink)
-                final String connClassProp = connProps.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
-                log.info("Creating connector {} of type {}", connName, connClassProp);
-                final Connector connector = plugins.newConnector(connClassProp);
+                final String connClass = connProps.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+                ClassLoader connectorLoader = plugins.delegatingLoader().connectorLoader(connClass);
+                savedLoader = Plugins.compareAndSwapLoaders(connectorLoader);
+
+                log.info("Creating connector {} of type {}", connName, connClass);
+                final Connector connector = plugins.newConnector(connClass);
+                final ConnectorConfig connConfig = ConnectUtils.isSinkConnector(connector)
+                    ? new SinkConnectorConfig(plugins, connProps)
+                    : new SourceConnectorConfig(plugins, connProps, config.topicCreationEnable());
+
                 final OffsetStorageReader offsetReader = new OffsetStorageReaderImpl(
-                        offsetBackingStore, connName, internalKeyConverter, internalValueConverter);
-                workerConnector = new WorkerConnector(connName, connector, ctx, metrics, statusListener, offsetReader);
-                final ConnectorConfig connConfig = workerConnector.isSinkConnector()
-                        ? new SinkConnectorConfig(plugins, connProps)
-                        : new SourceConnectorConfig(plugins, connProps, config.topicCreationEnable());
+                    offsetBackingStore,
+                    connName,
+                    internalKeyConverter,
+                    internalValueConverter
+                );
+                workerConnector = new WorkerConnector(
+                    connName,
+                    connector,
+                    connConfig,
+                    ctx,
+                    metrics,
+                    statusListener,
+                    offsetReader,
+                    connectorLoader
+                );
                 log.info("Instantiated connector {} with version {} of type {}", connName, connector.version(), connector.getClass());
-                savedLoader = plugins.compareAndSwapLoaders(connector);
-                workerConnector.initialize(connConfig);
-                workerConnector.transitionTo(initialState);
+                workerConnector.transitionTo(initialState, onConnectorStateChange);
                 Plugins.compareAndSwapLoaders(savedLoader);
             } catch (Throwable t) {
                 log.error("Failed to start connector {}", connName, t);
@@ -279,17 +304,26 @@ public class Worker {
                 Plugins.compareAndSwapLoaders(savedLoader);
                 workerMetricsGroup.recordConnectorStartupFailure();
                 statusListener.onFailure(connName, t);
-                return false;
+                onConnectorStateChange.onCompletion(t, null);
+                return;
             }
 
             WorkerConnector existing = connectors.putIfAbsent(connName, workerConnector);
-            if (existing != null)
-                throw new ConnectException("Connector with name " + connName + " already exists");
+            if (existing != null) {
+                onConnectorStateChange.onCompletion(
+                    new ConnectException("Connector with name " + connName + " already exists"),
+                    null
+                );
+                // Don't need to do any cleanup of the WorkerConnector instance (such as calling
+                // shutdown() on it) here because it hasn't actually started running yet
+                return;
+            }
+
+            executor.submit(workerConnector);
 
             log.info("Finished creating connector {}", connName);
             workerMetricsGroup.recordConnectorStartupSuccess();
         }
-        return true;
     }
 
     /**
@@ -306,7 +340,7 @@ public class Worker {
 
         ClassLoader savedLoader = plugins.currentThreadLoader();
         try {
-            savedLoader = plugins.compareAndSwapLoaders(workerConnector.connector());
+            savedLoader = Plugins.compareAndSwapLoaders(workerConnector.loader());
             return workerConnector.isSinkConnector();
         } finally {
             Plugins.compareAndSwapLoaders(savedLoader);
@@ -334,7 +368,7 @@ public class Worker {
             Connector connector = workerConnector.connector();
             ClassLoader savedLoader = plugins.currentThreadLoader();
             try {
-                savedLoader = plugins.compareAndSwapLoaders(connector);
+                savedLoader = Plugins.compareAndSwapLoaders(workerConnector.loader());
                 String taskClassName = connector.taskClass().getName();
                 for (Map<String, String> taskProps : connector.taskConfigs(maxTasks)) {
                     // Ensure we don't modify the connector's copy of the config
@@ -356,40 +390,96 @@ public class Worker {
         return result;
     }
 
-    private void stopConnectors() {
-        // Herder is responsible for stopping connectors. This is an internal method to sequentially
-        // stop connectors that have not explicitly been stopped.
-        for (String connector: connectors.keySet())
-            stopConnector(connector);
-    }
-
     /**
      * Stop a connector managed by this worker.
      *
      * @param connName the connector name.
-     * @return true if the connector belonged to this worker and was successfully stopped.
      */
-    public boolean stopConnector(String connName) {
+    private void stopConnector(String connName) {
         try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
-            log.info("Stopping connector {}", connName);
-
-            WorkerConnector workerConnector = connectors.remove(connName);
+            WorkerConnector workerConnector = connectors.get(connName);
             if (workerConnector == null) {
                 log.warn("Ignoring stop request for unowned connector {}", connName);
-                return false;
+                return;
             }
+
+            log.info("Stopping connector {}", connName);
 
             ClassLoader savedLoader = plugins.currentThreadLoader();
             try {
-                savedLoader = plugins.compareAndSwapLoaders(workerConnector.connector());
+                savedLoader = Plugins.compareAndSwapLoaders(workerConnector.loader());
                 workerConnector.shutdown();
             } finally {
                 Plugins.compareAndSwapLoaders(savedLoader);
             }
-
-            log.info("Stopped connector {}", connName);
         }
-        return true;
+    }
+
+    private void stopConnectors(Collection<String> ids) {
+        // Herder is responsible for stopping connectors. This is an internal method to sequentially
+        // stop connectors that have not explicitly been stopped.
+        for (String connector: ids)
+            stopConnector(connector);
+    }
+
+    private void awaitStopConnector(String connName, long timeout) {
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+            WorkerConnector connector = connectors.remove(connName);
+            if (connector == null) {
+                log.warn("Ignoring await stop request for non-present connector {}", connName);
+                return;
+            }
+
+            if (!connector.awaitShutdown(timeout)) {
+                log.error(
+                    "Connector ‘{}’ failed to properly shut down, has become unresponsive, and "
+                        + "may be consuming external resources. Correct the configuration for "
+                        + "this connector or remove the connector. After fixing the connector, it "
+                        + "may be necessary to restart this worker to release any consumed "
+                        + "resources.",
+                    connName);
+                connector.cancel();
+            } else {
+                log.debug("Graceful stop of connector {} succeeded.", connName);
+            }
+        }
+    }
+
+    private void awaitStopConnectors(Collection<String> ids) {
+        long now = time.milliseconds();
+        long deadline = now + CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS;
+        for (String id : ids) {
+            long remaining = Math.max(0, deadline - time.milliseconds());
+            awaitStopConnector(id, remaining);
+        }
+    }
+
+    /**
+     * Stop asynchronously all the worker's connectors and await their termination.
+     */
+    public void stopAndAwaitConnectors() {
+        stopAndAwaitConnectors(new ArrayList<>(connectors.keySet()));
+    }
+
+    /**
+     * Stop asynchronously a collection of connectors that belong to this worker and await their
+     * termination.
+     *
+     * @param ids the collection of connectors to be stopped.
+     */
+    public void stopAndAwaitConnectors(Collection<String> ids) {
+        stopConnectors(ids);
+        awaitStopConnectors(ids);
+    }
+
+    /**
+     * Stop a connector that belongs to this worker and await its termination.
+     *
+     * @param connName the name of the connector to be stopped.
+     */
+    public void stopAndAwaitConnector(String connName) {
+        stopConnector(connName);
+        awaitStopConnectors(Collections.singletonList(connName));
     }
 
     /**
@@ -881,38 +971,31 @@ public class Worker {
         return metrics;
     }
 
-    public void setTargetState(String connName, TargetState state) {
+    public void setTargetState(String connName, TargetState state, Callback<TargetState> stateChangeCallback) {
         log.info("Setting connector {} state to {}", connName, state);
 
         WorkerConnector workerConnector = connectors.get(connName);
         if (workerConnector != null) {
             ClassLoader connectorLoader =
                     plugins.delegatingLoader().connectorLoader(workerConnector.connector());
-            transitionTo(workerConnector, state, connectorLoader);
+            executeStateTransition(
+                () -> workerConnector.transitionTo(state, stateChangeCallback),
+                connectorLoader);
         }
 
         for (Map.Entry<ConnectorTaskId, WorkerTask> taskEntry : tasks.entrySet()) {
             if (taskEntry.getKey().connector().equals(connName)) {
                 WorkerTask workerTask = taskEntry.getValue();
-                transitionTo(workerTask, state, workerTask.loader());
+                executeStateTransition(() -> workerTask.transitionTo(state), workerTask.loader);
             }
         }
     }
 
-    private void transitionTo(Object connectorOrTask, TargetState state, ClassLoader loader) {
+    private void executeStateTransition(Runnable stateTransition, ClassLoader loader) {
         ClassLoader savedLoader = plugins.currentThreadLoader();
         try {
             savedLoader = Plugins.compareAndSwapLoaders(loader);
-            if (connectorOrTask instanceof WorkerConnector) {
-                ((WorkerConnector) connectorOrTask).transitionTo(state);
-            } else if (connectorOrTask instanceof WorkerTask) {
-                ((WorkerTask) connectorOrTask).transitionTo(state);
-            } else {
-                throw new ConnectException(
-                        "Request for state transition on an object that is neither a "
-                                + "WorkerConnector nor a WorkerTask: "
-                                + connectorOrTask.getClass());
-            }
+            stateTransition.run();
         } finally {
             Plugins.compareAndSwapLoaders(savedLoader);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -256,9 +256,8 @@ public class Worker {
         try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
             if (connectors.containsKey(connName)) {
                 onConnectorStateChange.onCompletion(
-                    new ConnectException("Connector with name " + connName + " already exists"),
-                    null
-                );
+                        new ConnectException("Connector with name " + connName + " already exists"),
+                        null);
                 return;
             }
 
@@ -275,25 +274,13 @@ public class Worker {
                 log.info("Creating connector {} of type {}", connName, connClass);
                 final Connector connector = plugins.newConnector(connClass);
                 final ConnectorConfig connConfig = ConnectUtils.isSinkConnector(connector)
-                    ? new SinkConnectorConfig(plugins, connProps)
-                    : new SourceConnectorConfig(plugins, connProps, config.topicCreationEnable());
+                        ? new SinkConnectorConfig(plugins, connProps)
+                        : new SourceConnectorConfig(plugins, connProps, config.topicCreationEnable());
 
                 final OffsetStorageReader offsetReader = new OffsetStorageReaderImpl(
-                    offsetBackingStore,
-                    connName,
-                    internalKeyConverter,
-                    internalValueConverter
-                );
+                        offsetBackingStore, connName, internalKeyConverter, internalValueConverter);
                 workerConnector = new WorkerConnector(
-                    connName,
-                    connector,
-                    connConfig,
-                    ctx,
-                    metrics,
-                    statusListener,
-                    offsetReader,
-                    connectorLoader
-                );
+                        connName, connector, connConfig, ctx, metrics, statusListener, offsetReader, connectorLoader);
                 log.info("Instantiated connector {} with version {} of type {}", connName, connector.version(), connector.getClass());
                 workerConnector.transitionTo(initialState, onConnectorStateChange);
                 Plugins.compareAndSwapLoaders(savedLoader);
@@ -311,9 +298,8 @@ public class Worker {
             WorkerConnector existing = connectors.putIfAbsent(connName, workerConnector);
             if (existing != null) {
                 onConnectorStateChange.onCompletion(
-                    new ConnectException("Connector with name " + connName + " already exists"),
-                    null
-                );
+                        new ConnectException("Connector with name " + connName + " already exists"),
+                        null);
                 // Don't need to do any cleanup of the WorkerConnector instance (such as calling
                 // shutdown() on it) here because it hasn't actually started running yet
                 return;
@@ -398,12 +384,12 @@ public class Worker {
     private void stopConnector(String connName) {
         try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
             WorkerConnector workerConnector = connectors.get(connName);
+            log.info("Stopping connector {}", connName);
+
             if (workerConnector == null) {
                 log.warn("Ignoring stop request for unowned connector {}", connName);
                 return;
             }
-
-            log.info("Stopping connector {}", connName);
 
             ClassLoader savedLoader = plugins.currentThreadLoader();
             try {
@@ -431,13 +417,11 @@ public class Worker {
             }
 
             if (!connector.awaitShutdown(timeout)) {
-                log.error(
-                    "Connector ‘{}’ failed to properly shut down, has become unresponsive, and "
+                log.error("Connector ‘{}’ failed to properly shut down, has become unresponsive, and "
                         + "may be consuming external resources. Correct the configuration for "
                         + "this connector or remove the connector. After fixing the connector, it "
                         + "may be necessary to restart this worker to release any consumed "
-                        + "resources.",
-                    connName);
+                        + "resources.", connName);
                 connector.cancel();
             } else {
                 log.debug("Graceful stop of connector {} succeeded.", connName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -20,17 +20,22 @@ import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
-import org.apache.kafka.connect.sink.SinkConnector;
-import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.sink.SinkConnectorContext;
 import org.apache.kafka.connect.source.SourceConnectorContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.ConnectUtils;
+import org.apache.kafka.connect.util.LoggingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Container for connectors which is responsible for managing their lifecycle (e.g. handling startup,
@@ -44,8 +49,9 @@ import java.util.Objects;
  *
  * Note that this class is NOT thread-safe.
  */
-public class WorkerConnector {
+public class WorkerConnector implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(WorkerConnector.class);
+    private static final String THREAD_NAME_PREFIX = "connector-thread-";
 
     private enum State {
         INIT,    // initial state before startup
@@ -55,36 +61,106 @@ public class WorkerConnector {
     }
 
     private final String connName;
+    private final Map<String, String> config;
     private final ConnectorStatus.Listener statusListener;
-    private final ConnectorContext ctx;
+    private final ClassLoader loader;
+    private final CloseableConnectorContext ctx;
     private final Connector connector;
     private final ConnectorMetricsGroup metrics;
+    private final AtomicReference<TargetState> pendingTargetStateChange;
+    private final AtomicReference<Callback<TargetState>> pendingStateChangeCallback;
+    private final CountDownLatch shutdownLatch;
+    private volatile boolean stopping;  // indicates whether the Worker has asked the connector to stop
+    private volatile boolean cancelled; // indicates whether the Worker has cancelled the connector (e.g. because of slow shutdown)
 
-    private Map<String, String> config;
     private State state;
     private final OffsetStorageReader offsetStorageReader;
 
     public WorkerConnector(String connName,
                            Connector connector,
-                           ConnectorContext ctx,
+                           ConnectorConfig connectorConfig,
+                           CloseableConnectorContext ctx,
                            ConnectMetrics metrics,
                            ConnectorStatus.Listener statusListener,
-                           OffsetStorageReader offsetStorageReader) {
+                           OffsetStorageReader offsetStorageReader,
+                           ClassLoader loader) {
         this.connName = connName;
+        this.config = connectorConfig.originalsStrings();
+        this.loader = loader;
         this.ctx = ctx;
         this.connector = connector;
         this.state = State.INIT;
         this.metrics = new ConnectorMetricsGroup(metrics, AbstractStatus.State.UNASSIGNED, statusListener);
         this.statusListener = this.metrics;
         this.offsetStorageReader = offsetStorageReader;
+        this.pendingTargetStateChange = new AtomicReference<>();
+        this.pendingStateChangeCallback = new AtomicReference<>();
+        this.shutdownLatch = new CountDownLatch(1);
+        this.stopping = false;
+        this.cancelled = false;
     }
 
-    public void initialize(ConnectorConfig connectorConfig) {
+    public ClassLoader loader() {
+        return loader;
+    }
+
+    @Override
+    public void run() {
+        // Clear all MDC parameters, in case this thread is being reused
+        LoggingContext.clear();
+
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+            ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
+            String savedName = Thread.currentThread().getName();
+            try {
+                Thread.currentThread().setName(THREAD_NAME_PREFIX + connName);
+                doRun();
+            } finally {
+                Thread.currentThread().setName(savedName);
+                Plugins.compareAndSwapLoaders(savedLoader);
+            }
+        } finally {
+            // In the rare case of an exception being thrown outside the doRun() method, or an
+            // uncaught one being thrown from within it, mark the connector as shut down to avoid
+            // unnecessarily blocking and eventually timing out during awaitShutdown
+            shutdownLatch.countDown();
+        }
+    }
+
+    void doRun() {
+        initialize();
+        while (!stopping) {
+            TargetState newTargetState;
+            Callback<TargetState> stateChangeCallback;
+            synchronized (this) {
+                newTargetState = pendingTargetStateChange.getAndSet(null);
+                stateChangeCallback = pendingStateChangeCallback.getAndSet(null);
+            }
+            if (newTargetState != null && !stopping) {
+                doTransitionTo(newTargetState, stateChangeCallback);
+            }
+            synchronized (this) {
+                if (pendingTargetStateChange.get() != null || stopping) {
+                    // An update occurred before we entered the synchronized block; no big deal,
+                    // just start the loop again until we've handled everything
+                    continue;
+                } else {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        // We'll pick up any potential state changes at the top of the loop
+                    }
+                }
+            }
+        }
+        doShutdown();
+    }
+
+    void initialize() {
         try {
             if (!isSourceConnector() && !isSinkConnector()) {
                 throw new ConnectException("Connector implementations must be a subclass of either SourceConnector or SinkConnector");
             }
-            this.config = connectorConfig.originalsStrings();
             log.debug("{} Initializing connector {}", this, connName);
             if (isSinkConnector()) {
                 SinkConnectorConfig.validate(config);
@@ -98,7 +174,7 @@ public class WorkerConnector {
         }
     }
 
-    private boolean doStart() {
+    private boolean doStart() throws Throwable {
         try {
             switch (state) {
                 case STARTED:
@@ -116,7 +192,7 @@ public class WorkerConnector {
         } catch (Throwable t) {
             log.error("{} Error while starting connector", this, t);
             onFailure(t);
-            return false;
+            throw t;
         }
     }
 
@@ -125,12 +201,12 @@ public class WorkerConnector {
         this.state = State.FAILED;
     }
 
-    private void resume() {
+    private void resume() throws Throwable {
         if (doStart())
             statusListener.onResume(connName);
     }
 
-    private void start() {
+    private void start() throws Throwable {
         if (doStart())
             statusListener.onStartup(connName);
     }
@@ -165,27 +241,115 @@ public class WorkerConnector {
         }
     }
 
+    /**
+     * Stop this connector. This method does not block, it only triggers shutdown. Use
+     * #{@link #awaitShutdown} to block until completion.
+     */
     public void shutdown() {
+        synchronized (this) {
+            log.info("Scheduled shutdown for {}", this);
+            stopping = true;
+            notify();
+        }
+    }
+
+    void doShutdown() {
         try {
+            TargetState preEmptedState = pendingTargetStateChange.getAndSet(null);
+            Callback<TargetState> stateChangeCallback = pendingStateChangeCallback.getAndSet(null);
+            if (stateChangeCallback != null) {
+                stateChangeCallback.onCompletion(
+                    new ConnectException(
+                        "Could not begin changing connector state to " + preEmptedState.name()
+                            + " as the connector has been scheduled for shutdown"),
+                    null
+                );
+            }
             if (state == State.STARTED)
                 connector.stop();
             this.state = State.STOPPED;
             statusListener.onShutdown(connName);
+            log.info("Completed shutdown for {}", this);
         } catch (Throwable t) {
             log.error("{} Error while shutting down connector", this, t);
-            this.state = State.FAILED;
+            state = State.FAILED;
             statusListener.onFailure(connName, t);
         } finally {
+            ctx.close();
+            shutdownLatch.countDown();
             metrics.close();
         }
     }
 
-    public void transitionTo(TargetState targetState) {
+    public void cancel() {
+        synchronized (this) {
+            // Proactively update the status of the connector to UNASSIGNED since this connector
+            // instance is being abandoned and we won't update the status on its behalf any more
+            // after this since a new instance may be started soon
+            statusListener.onShutdown(connName);
+            ctx.close();
+            cancelled = true;
+        }
+    }
+
+    /**
+     * Wait for this connector to finish shutting down.
+     *
+     * @param timeoutMs time in milliseconds to await shutdown
+     * @return true if successful, false if the timeout was reached
+     */
+    public boolean awaitShutdown(long timeoutMs) {
+        try {
+            return shutdownLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+
+    public void transitionTo(TargetState targetState, Callback<TargetState> stateChangeCallback) {
+        Callback<TargetState> preEmptedStateChangeCallback;
+        TargetState preEmptedState;
+        synchronized (this) {
+            preEmptedStateChangeCallback = pendingStateChangeCallback.getAndSet(stateChangeCallback);
+            preEmptedState = pendingTargetStateChange.getAndSet(targetState);
+            notify();
+        }
+        if (preEmptedStateChangeCallback != null) {
+            preEmptedStateChangeCallback.onCompletion(
+                new ConnectException(
+                    "Could not begin changing connector state to " + preEmptedState.name()
+                        + " before another request to change state was made;"
+                        + " the new request (which is to change the state to " + targetState.name()
+                        + ") has pre-empted this one"),
+                null
+            );
+        }
+    }
+
+    void doTransitionTo(TargetState targetState, Callback<TargetState> stateChangeCallback) {
         if (state == State.FAILED) {
-            log.warn("{} Cannot transition connector to {} since it has failed", this, targetState);
+            stateChangeCallback.onCompletion(
+                new ConnectException(this + " Cannot transition connector to " + targetState + " since it has failed"),
+                null
+            );
             return;
         }
 
+        try {
+            doTransitionTo(targetState);
+            stateChangeCallback.onCompletion(null, targetState);
+        } catch (Throwable t) {
+            stateChangeCallback.onCompletion(
+                new ConnectException(
+                    "Failed to transition connector " + connName + " to state " + targetState,
+                    t
+                ),
+                null
+            );
+        }
+    }
+
+    private void doTransitionTo(TargetState targetState) throws Throwable {
         log.debug("{} Transition connector to {}", this, targetState);
         if (targetState == TargetState.PAUSED) {
             pause();
@@ -200,11 +364,11 @@ public class WorkerConnector {
     }
 
     public boolean isSinkConnector() {
-        return SinkConnector.class.isAssignableFrom(connector.getClass());
+        return ConnectUtils.isSinkConnector(connector);
     }
 
     public boolean isSourceConnector() {
-        return SourceConnector.class.isAssignableFrom(connector.getClass());
+        return ConnectUtils.isSourceConnector(connector);
     }
 
     protected String connectorType() {
@@ -265,31 +429,51 @@ public class WorkerConnector {
         @Override
         public void onStartup(String connector) {
             state = AbstractStatus.State.RUNNING;
-            delegate.onStartup(connector);
+            synchronized (this) {
+                if (!cancelled) {
+                    delegate.onStartup(connector);
+                }
+            }
         }
 
         @Override
         public void onShutdown(String connector) {
             state = AbstractStatus.State.UNASSIGNED;
-            delegate.onShutdown(connector);
+            synchronized (this) {
+                if (!cancelled) {
+                    delegate.onShutdown(connector);
+                }
+            }
         }
 
         @Override
         public void onPause(String connector) {
             state = AbstractStatus.State.PAUSED;
-            delegate.onPause(connector);
+            synchronized (this) {
+                if (!cancelled) {
+                    delegate.onPause(connector);
+                }
+            }
         }
 
         @Override
         public void onResume(String connector) {
             state = AbstractStatus.State.RUNNING;
-            delegate.onResume(connector);
+            synchronized (this) {
+                if (!cancelled) {
+                    delegate.onResume(connector);
+                }
+            }
         }
 
         @Override
         public void onFailure(String connector, Throwable cause) {
             state = AbstractStatus.State.FAILED;
-            delegate.onFailure(connector, cause);
+            synchronized (this) {
+                if (!cancelled) {
+                    delegate.onFailure(connector, cause);
+                }
+            }
         }
 
         @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -273,7 +273,6 @@ public class WorkerConnector implements Runnable {
             statusListener.onFailure(connName, t);
         } finally {
             ctx.close();
-            shutdownLatch.countDown();
             metrics.close();
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1328,14 +1328,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             @Override
             public Void call() throws Exception {
                 try {
-                    startConnector(
-                            connectorName,
-                            (error, result) -> {
-                                if (error != null) {
-                                    log.error("Failed to start connector '" + connectorName + "'", error);
-                                }
-                            }
-                    );
+                    startConnector(connectorName, (error, result) -> {
+                        if (error != null) {
+                            log.error("Failed to start connector '" + connectorName + "'", error);
+                        }
+                    });
                 } catch (Throwable t) {
                     log.error("Unexpected error while trying to start connector " + connectorName, t);
                     onFailure(connectorName, t);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -589,13 +589,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             worker.stopAndAwaitConnector(connectorName);
             // The update may be a deletion, so verify we actually need to restart the connector
             if (remains) {
-                startConnector(connectorName,
-                    (error, result) -> {
-                        if (error != null) {
-                            log.error("Failed to start connector '" + connectorName + "'", error);
-                        }
+                startConnector(connectorName, (error, result) -> {
+                    if (error != null) {
+                        log.error("Failed to start connector '" + connectorName + "'", error);
                     }
-                );
+                });
             }
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -426,11 +426,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
         // Let the group take any actions it needs to
         try {
-            log.trace(
-                "Polling for group activity; will wait for {}ms or until poll is interrupted by " 
+            log.trace("Polling for group activity; will wait for {}ms or until poll is interrupted by "
                     + "either config backing store updates or a new external request",
-                nextRequestTimeoutMs
-            );
+                    nextRequestTimeoutMs);
             member.poll(nextRequestTimeoutMs);
             // Ensure we're in a good state in our group. If not restart and everything should be setup to rejoin
             handleRebalanceCompleted();
@@ -575,18 +573,14 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // If we only have connector config updates, we can just bounce the updated connectors that are
         // currently assigned to this worker.
         Set<String> localConnectors = assignment == null ? Collections.<String>emptySet() : new HashSet<>(assignment.connectors());
-        log.trace(
-            "Processing connector config updates; "
+        log.trace("Processing connector config updates; "
                 + "currently-owned connectors are {}, and to-be-updated connectors are {}",
-            localConnectors,
-            connectorConfigUpdates
-        );
+                localConnectors,
+                connectorConfigUpdates);
         for (String connectorName : connectorConfigUpdates) {
             if (!localConnectors.contains(connectorName)) {
-                log.trace(
-                    "Skipping config update for connector {} as it is not owned by this worker",
-                    connectorName
-                );
+                log.trace("Skipping config update for connector {} as it is not owned by this worker",
+                        connectorName);
                 continue;
             }
             boolean remains = configState.contains(connectorName);
@@ -595,8 +589,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             worker.stopAndAwaitConnector(connectorName);
             // The update may be a deletion, so verify we actually need to restart the connector
             if (remains) {
-                startConnector(
-                    connectorName,
+                startConnector(connectorName,
                     (error, result) -> {
                         if (error != null) {
                             log.error("Failed to start connector '" + connectorName + "'", error);
@@ -608,12 +601,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     private void processTargetStateChanges(Set<String> connectorTargetStateChanges) {
-        log.trace(
-            "Processing target state updates; "
+        log.trace("Processing target state updates; "
                 + "currently-known connectors are {}, and to-be-updated connectors are {}",
-            configState.connectors(),
-            connectorTargetStateChanges
-        );
+                configState.connectors(), connectorTargetStateChanges);
         for (String connector : connectorTargetStateChanges) {
             TargetState targetState = configState.targetState(connector);
             if (!configState.connectors().contains(connector)) {
@@ -641,12 +631,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         Set<ConnectorTaskId> localTasks = assignment == null
                                           ? Collections.emptySet()
                                           : new HashSet<>(assignment.tasks());
-        log.trace(
-            "Processing task config updates with incremental cooperative rebalance protocol; "
+        log.trace("Processing task config updates with incremental cooperative rebalance protocol; "
                 + "currently-owned tasks are {}, and to-be-updated tasks are {}",
-            localTasks,
-            taskConfigUpdates
-        );
+                localTasks, taskConfigUpdates);
         Set<String> connectorsWhoseTasksToStop = taskConfigUpdates.stream()
                 .map(ConnectorTaskId::connector).collect(Collectors.toSet());
 
@@ -1316,18 +1303,18 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             // Use newState here in case the connector has been paused right after being created
             if (newState == TargetState.STARTED) {
                 addRequest(
-                    new Callable<Void>() {
-                        @Override
-                        public Void call() {
-                            // Request configuration since this could be a brand new connector. However, also only update those
-                            // task configs if they are actually different from the existing ones to avoid unnecessary updates when this is
-                            // just restoring an existing connector.
-                            reconfigureConnectorTasksWithRetry(time.milliseconds(), connectorName);
-                            callback.onCompletion(null, null);
-                            return null;
-                        }
-                    },
-                    forwardErrorCallback(callback)
+                        new Callable<Void>() {
+                            @Override
+                            public Void call() {
+                                // Request configuration since this could be a brand new connector. However, also only update those
+                                // task configs if they are actually different from the existing ones to avoid unnecessary updates when this is
+                                // just restoring an existing connector.
+                                reconfigureConnectorTasksWithRetry(time.milliseconds(), connectorName);
+                                callback.onCompletion(null, null);
+                                return null;
+                            }
+                        },
+                        forwardErrorCallback(callback)
                 );
             } else {
                 callback.onCompletion(null, null);
@@ -1342,12 +1329,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             public Void call() throws Exception {
                 try {
                     startConnector(
-                        connectorName,
-                        (error, result) -> {
-                            if (error != null) {
-                                log.error("Failed to start connector '" + connectorName + "'", error);
+                            connectorName,
+                            (error, result) -> {
+                                if (error != null) {
+                                    log.error("Failed to start connector '" + connectorName + "'", error);
+                                }
                             }
-                        }
                     );
                 } catch (Throwable t) {
                     log.error("Unexpected error while trying to start connector " + connectorName, t);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -29,12 +29,12 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.Connector;
-import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.AlreadyExistsException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.AbstractHerder;
+import org.apache.kafka.connect.runtime.CloseableConnectorContext;
 import org.apache.kafka.connect.runtime.ConnectMetrics;
 import org.apache.kafka.connect.runtime.ConnectMetrics.LiteralSupplier;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
@@ -178,7 +178,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private boolean needsReconfigRebalance;
     private volatile int generation;
     private volatile long scheduledRebalance;
-    private SecretKey sessionKey;
+    private volatile SecretKey sessionKey;
     private volatile long keyExpiration;
     private short currentProtocolVersion;
     private short backoffRetries;
@@ -319,6 +319,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             if (!canReadConfigs && !readConfigToEnd(workerSyncTimeoutMs))
                 return; // Safe to return and tick immediately because readConfigToEnd will do the backoff for us
 
+            log.debug("Ensuring group membership is still active");
             member.ensureActive();
             // Ensure we're in a good state in our group. If not restart and everything should be setup to rejoin
             if (!handleRebalanceCompleted()) return;
@@ -326,12 +327,14 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             // May be due to a request from another thread, or might be stopping. If the latter, we need to check the
             // flag immediately. If the former, we need to re-run the ensureActive call since we can't handle requests
             // unless we're in the group.
+            log.trace("Woken up while ensure group membership is still active");
             return;
         }
 
         long now = time.milliseconds();
 
         if (checkForKeyRotation(now)) {
+            log.debug("Distributing new session key");
             keyExpiration = Long.MAX_VALUE;
             configBackingStore.putSessionKey(new SessionKey(
                 keyGenerator.generateKey(),
@@ -340,6 +343,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
 
         // Process any external requests
+        // TODO: Some of these can be performed concurrently or even optimized away entirely.
+        //       For example, if three different connectors are slated to be restarted, it's fine to
+        //       restart all three at the same time instead.
+        //       Another example: if multiple configurations are submitted for the same connector,
+        //       the only one that actually has to be written to the config topic is the
+        //       most-recently one.
         long nextRequestTimeoutMs = Long.MAX_VALUE;
         while (true) {
             final DistributedHerderRequest next = peekWithoutException();
@@ -417,31 +426,44 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
         // Let the group take any actions it needs to
         try {
+            log.trace(
+                "Polling for group activity; will wait for {}ms or until poll is interrupted by " 
+                    + "either config backing store updates or a new external request",
+                nextRequestTimeoutMs
+            );
             member.poll(nextRequestTimeoutMs);
             // Ensure we're in a good state in our group. If not restart and everything should be setup to rejoin
             handleRebalanceCompleted();
         } catch (WakeupException e) { // FIXME should not be WakeupException
+            log.trace("Woken up while polling for group activity");
             // Ignore. Just indicates we need to check the exit flag, for requested actions, etc.
         }
     }
 
-    private synchronized boolean checkForKeyRotation(long now) {
+    private boolean checkForKeyRotation(long now) {
+        SecretKey key;
+        long expiration;
+        synchronized (this) {
+            key = sessionKey;
+            expiration = keyExpiration;
+        }
+
         if (internalRequestValidationEnabled()) {
             if (isLeader()) {
-                if (sessionKey == null) {
+                if (key == null) {
                     log.debug("Internal request signing is enabled but no session key has been distributed yet. "
                         + "Distributing new key now.");
                     return true;
-                } else if (keyExpiration <= now) {
+                } else if (expiration <= now) {
                     log.debug("Existing key has expired. Distributing new key now.");
                     return true;
-                } else if (!sessionKey.getAlgorithm().equals(keyGenerator.getAlgorithm())
-                        || sessionKey.getEncoded().length != keyGenerator.generateKey().getEncoded().length) {
+                } else if (!key.getAlgorithm().equals(keyGenerator.getAlgorithm())
+                        || key.getEncoded().length != keyGenerator.generateKey().getEncoded().length) {
                     log.debug("Previously-distributed key uses different algorithm/key size "
                         + "than required by current worker configuration. Distributing new key now.");
                     return true;
                 }
-            } else if (sessionKey == null && configState.sessionKey() != null) {
+            } else if (key == null && configState.sessionKey() != null) {
                 // This happens on startup for follower workers; the snapshot contains the session key,
                 // but no callback in the config update listener has been fired for it yet.
                 sessionKey = configState.sessionKey().key();
@@ -456,6 +478,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         if (needsReconfigRebalance
                 || !connectorConfigUpdates.isEmpty()
                 || !connectorTargetStateChanges.isEmpty()) {
+            log.trace("Handling config updates with eager rebalancing");
             // Connector reconfigs only need local updates since there is no coordination between workers required.
             // However, if connectors were added or removed, work needs to be rebalanced since we have more work
             // items to distribute among workers.
@@ -489,6 +512,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     connectorTargetStateChanges = new HashSet<>();
                 }
             }
+        } else {
+            log.trace("Skipping config updates with eager rebalancing "
+                + "since no config rebalance is required "
+                + "and there are no connector config, task config, or target state changes pending");
         }
         return false;
     }
@@ -502,6 +529,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 || !connectorConfigUpdates.isEmpty()
                 || !connectorTargetStateChanges.isEmpty()
                 || !taskConfigUpdates.isEmpty()) {
+            log.trace("Handling config updates with incremental cooperative rebalancing");
             // Connector reconfigs only need local updates since there is no coordination between workers required.
             // However, if connectors were added or removed, work needs to be rebalanced since we have more work
             // items to distribute among workers.
@@ -535,6 +563,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 taskConfigUpdatesCopy.set(taskConfigUpdates);
                 taskConfigUpdates = new HashSet<>();
             }
+        } else {
+            log.trace("Skipping config updates with incremental cooperative rebalancing " 
+                + "since no config rebalance is required " 
+                + "and there are no connector config, task config, or target state changes pending");
         }
         return retValue;
     }
@@ -543,20 +575,45 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // If we only have connector config updates, we can just bounce the updated connectors that are
         // currently assigned to this worker.
         Set<String> localConnectors = assignment == null ? Collections.<String>emptySet() : new HashSet<>(assignment.connectors());
+        log.trace(
+            "Processing connector config updates; "
+                + "currently-owned connectors are {}, and to-be-updated connectors are {}",
+            localConnectors,
+            connectorConfigUpdates
+        );
         for (String connectorName : connectorConfigUpdates) {
-            if (!localConnectors.contains(connectorName))
+            if (!localConnectors.contains(connectorName)) {
+                log.trace(
+                    "Skipping config update for connector {} as it is not owned by this worker",
+                    connectorName
+                );
                 continue;
+            }
             boolean remains = configState.contains(connectorName);
             log.info("Handling connector-only config update by {} connector {}",
                     remains ? "restarting" : "stopping", connectorName);
-            worker.stopConnector(connectorName);
+            worker.stopAndAwaitConnector(connectorName);
             // The update may be a deletion, so verify we actually need to restart the connector
-            if (remains)
-                startConnector(connectorName);
+            if (remains) {
+                startConnector(
+                    connectorName,
+                    (error, result) -> {
+                        if (error != null) {
+                            log.error("Failed to start connector '" + connectorName + "'", error);
+                        }
+                    }
+                );
+            }
         }
     }
 
     private void processTargetStateChanges(Set<String> connectorTargetStateChanges) {
+        log.trace(
+            "Processing target state updates; "
+                + "currently-known connectors are {}, and to-be-updated connectors are {}",
+            configState.connectors(),
+            connectorTargetStateChanges
+        );
         for (String connector : connectorTargetStateChanges) {
             TargetState targetState = configState.targetState(connector);
             if (!configState.connectors().contains(connector)) {
@@ -566,12 +623,17 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
             // we must propagate the state change to the worker so that the connector's
             // tasks can transition to the new target state
-            worker.setTargetState(connector, targetState);
-
-            // additionally, if the worker is running the connector itself, then we need to
-            // request reconfiguration to ensure that config changes while paused take effect
-            if (targetState == TargetState.STARTED)
-                reconfigureConnectorTasksWithRetry(time.milliseconds(), connector);
+            worker.setTargetState(connector, targetState, (error, newState) -> {
+                if (error != null) {
+                    log.error("Failed to transition connector to target state", error);
+                    return;
+                }
+                // additionally, if the worker is running the connector itself, then we need to
+                // request reconfiguration to ensure that config changes while paused take effect
+                if (newState == TargetState.STARTED) {
+                    requestTaskReconfiguration(connector);
+                }
+            });
         }
     }
 
@@ -579,6 +641,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         Set<ConnectorTaskId> localTasks = assignment == null
                                           ? Collections.emptySet()
                                           : new HashSet<>(assignment.tasks());
+        log.trace(
+            "Processing task config updates with incremental cooperative rebalance protocol; "
+                + "currently-owned tasks are {}, and to-be-updated tasks are {}",
+            localTasks,
+            taskConfigUpdates
+        );
         Set<String> connectorsWhoseTasksToStop = taskConfigUpdates.stream()
                 .map(ConnectorTaskId::connector).collect(Collectors.toSet());
 
@@ -695,14 +763,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     public void connectorConfig(String connName, final Callback<Map<String, String>> callback) {
         // Subset of connectorInfo, so piggy back on that implementation
         log.trace("Submitting connector config read request {}", connName);
-        connectorInfo(connName, new Callback<ConnectorInfo>() {
-            @Override
-            public void onCompletion(Throwable error, ConnectorInfo result) {
-                if (error != null)
-                    callback.onCompletion(error, null);
-                else
-                    callback.onCompletion(null, result.config());
-            }
+        connectorInfo(connName, (error, result) -> {
+            if (error != null)
+                callback.onCompletion(error, null);
+            else
+                callback.onCompletion(null, result.config());
         });
     }
 
@@ -757,31 +822,49 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 new Callable<Void>() {
                     @Override
                     public Void call() throws Exception {
-                        if (maybeAddConfigErrors(validateConnectorConfig(config), callback)) {
-                            return null;
-                        }
+                        validateConnectorConfig(config, (error, configInfos) -> {
+                            if (error != null) {
+                                callback.onCompletion(error, null);
+                                return;
+                            }
 
-                        log.trace("Handling connector config request {}", connName);
-                        if (!isLeader()) {
-                            callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
-                            return null;
-                        }
+                            // Complete the connector config write via another herder request in order to
+                            // perform the write to the backing store (or forward to the leader) during
+                            // the "external request" portion of the tick loop
+                            addRequest(
+                                    new Callable<Void>() {
+                                        @Override
+                                        public Void call() {
+                                            if (maybeAddConfigErrors(configInfos, callback)) {
+                                                return null;
+                                            }
 
-                        boolean exists = configState.contains(connName);
-                        if (!allowReplace && exists) {
-                            callback.onCompletion(new AlreadyExistsException("Connector " + connName + " already exists"), null);
-                            return null;
-                        }
+                                            log.trace("Handling connector config request {}", connName);
+                                            if (!isLeader()) {
+                                                callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
+                                                return null;
+                                            }
+                                            boolean exists = configState.contains(connName);
+                                            if (!allowReplace && exists) {
+                                                callback.onCompletion(new AlreadyExistsException("Connector " + connName + " already exists"), null);
+                                                return null;
+                                            }
 
-                        log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
-                        configBackingStore.putConnectorConfig(connName, config);
+                                            log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
+                                            configBackingStore.putConnectorConfig(connName, config);
 
-                        // Note that we use the updated connector config despite the fact that we don't have an updated
-                        // snapshot yet. The existing task info should still be accurate.
-                        ConnectorInfo info = new ConnectorInfo(connName, config, configState.tasks(connName),
-                                // validateConnectorConfig have checked the existence of CONNECTOR_CLASS_CONFIG
-                                connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)));
-                        callback.onCompletion(null, new Created<>(!exists, info));
+                                            // Note that we use the updated connector config despite the fact that we don't have an updated
+                                            // snapshot yet. The existing task info should still be accurate.
+                                            ConnectorInfo info = new ConnectorInfo(connName, config, configState.tasks(connName),
+                                                // validateConnectorConfig have checked the existence of CONNECTOR_CLASS_CONFIG
+                                                connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)));
+                                            callback.onCompletion(null, new Created<>(!exists, info));
+                                            return null;
+                                        }
+                                    },
+                                    forwardErrorCallback(callback)
+                            );
+                        });
                         return null;
                     }
                 },
@@ -794,22 +877,19 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         log.trace("Submitting connector task reconfiguration request {}", connName);
 
         addRequest(
-                new Callable<Void>() {
-                    @Override
-                    public Void call() throws Exception {
-                        reconfigureConnectorTasksWithRetry(time.milliseconds(), connName);
-                        return null;
-                    }
-                },
-                new Callback<Void>() {
-                    @Override
-                    public void onCompletion(Throwable error, Void result) {
-                        if (error != null) {
-                            log.error("Unexpected error during task reconfiguration: ", error);
-                            log.error("Task reconfiguration for {} failed unexpectedly, this connector will not be properly reconfigured unless manually triggered.", connName);
-                        }
-                    }
+            new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    reconfigureConnectorTasksWithRetry(time.milliseconds(), connName);
+                    return null;
                 }
+            },
+            (error, result) -> {
+                if (error != null) {
+                    log.error("Unexpected error during task reconfiguration: ", error);
+                    log.error("Task reconfiguration for {} failed unexpectedly, this connector will not be properly reconfigured unless manually triggered.", connName);
+                }
+            }
         );
     }
 
@@ -858,13 +938,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     keySignatureVerificationAlgorithms
                 ));
             } else {
-                synchronized (this) {
-                    if (!requestSignature.isValid(sessionKey)) {
-                        requestValidationError = new ConnectRestException(
-                            Response.Status.FORBIDDEN,
-                            "Internal request contained invalid signature."
-                        );
-                    }
+                if (!requestSignature.isValid(sessionKey)) {
+                    requestValidationError = new ConnectRestException(
+                        Response.Status.FORBIDDEN,
+                        "Internal request contained invalid signature."
+                    );
                 }
             }
             if (requestValidationError != null) {
@@ -912,11 +990,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
                 if (assignment.connectors().contains(connName)) {
                     try {
-                        worker.stopConnector(connName);
-                        if (startConnector(connName))
-                            callback.onCompletion(null, null);
-                        else
-                            callback.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
+                        worker.stopAndAwaitConnector(connName);
+                        startConnector(connName, callback);
                     } catch (Throwable t) {
                         callback.onCompletion(t, null);
                     }
@@ -998,6 +1073,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.trace("Returning early because rebalance is marked as resolved (rebalanceResolved: true)");
             return true;
         }
+        log.debug("Handling completed but unresolved rebalance");
 
         // We need to handle a variety of cases after a rebalance:
         // 1. Assignment failed
@@ -1225,20 +1301,39 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     // Helper for starting a connector with the given name, which will extract & parse the config, generate connector
     // context and add to the worker. This needs to be called from within the main worker thread for this herder.
-    private boolean startConnector(String connectorName) {
+    // The callback is invoked after the connector has finished startup and generated task configs, or failed in the process.
+    private void startConnector(String connectorName, Callback<Void> callback) {
         log.info("Starting connector {}", connectorName);
         final Map<String, String> configProps = configState.connectorConfig(connectorName);
-        final ConnectorContext ctx = new HerderConnectorContext(this, connectorName);
+        final CloseableConnectorContext ctx = new HerderConnectorContext(this, connectorName);
         final TargetState initialState = configState.targetState(connectorName);
-        boolean started = worker.startConnector(connectorName, configProps, ctx, this, initialState);
+        final Callback<TargetState> onInitialStateChange = (error, newState) -> {
+            if (error != null) {
+                callback.onCompletion(new ConnectException("Failed to start connector: " + connectorName), null);
+                return;
+            }
 
-        // Immediately request configuration since this could be a brand new connector. However, also only update those
-        // task configs if they are actually different from the existing ones to avoid unnecessary updates when this is
-        // just restoring an existing connector.
-        if (started && initialState == TargetState.STARTED)
-            reconfigureConnectorTasksWithRetry(time.milliseconds(), connectorName);
-
-        return started;
+            // Use newState here in case the connector has been paused right after being created
+            if (newState == TargetState.STARTED) {
+                addRequest(
+                    new Callable<Void>() {
+                        @Override
+                        public Void call() {
+                            // Request configuration since this could be a brand new connector. However, also only update those
+                            // task configs if they are actually different from the existing ones to avoid unnecessary updates when this is
+                            // just restoring an existing connector.
+                            reconfigureConnectorTasksWithRetry(time.milliseconds(), connectorName);
+                            callback.onCompletion(null, null);
+                            return null;
+                        }
+                    },
+                    forwardErrorCallback(callback)
+                );
+            } else {
+                callback.onCompletion(null, null);
+            }
+        };
+        worker.startConnector(connectorName, configProps, ctx, this, initialState, onInitialStateChange);
     }
 
     private Callable<Void> getConnectorStartingCallable(final String connectorName) {
@@ -1246,10 +1341,16 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             @Override
             public Void call() throws Exception {
                 try {
-                    startConnector(connectorName);
+                    startConnector(
+                        connectorName,
+                        (error, result) -> {
+                            if (error != null) {
+                                log.error("Failed to start connector '" + connectorName + "'", error);
+                            }
+                        }
+                    );
                 } catch (Throwable t) {
-                    log.error("Couldn't instantiate connector " + connectorName + " because it has an invalid connector " +
-                            "configuration. This connector will not execute until reconfigured.", t);
+                    log.error("Unexpected error while trying to start connector " + connectorName, t);
                     onFailure(connectorName, t);
                 }
                 return null;
@@ -1262,7 +1363,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             @Override
             public Void call() throws Exception {
                 try {
-                    worker.stopConnector(connectorName);
+                    worker.stopAndAwaitConnector(connectorName);
                 } catch (Throwable t) {
                     log.error("Failed to shut down connector " + connectorName, t);
                 }
@@ -1359,25 +1460,22 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 } else {
                     // We cannot forward the request on the same thread because this reconfiguration can happen as a result of connector
                     // addition or removal. If we blocked waiting for the response from leader, we may be kicked out of the worker group.
-                    forwardRequestExecutor.submit(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                String leaderUrl = leaderUrl();
-                                if (leaderUrl == null || leaderUrl.trim().isEmpty()) {
-                                    cb.onCompletion(new ConnectException("Request to leader to " +
-                                            "reconfigure connector tasks failed " +
-                                            "because the URL of the leader's REST interface is empty!"), null);
-                                    return;
-                                }
-                                String reconfigUrl = RestServer.urlJoin(leaderUrl, "/connectors/" + connName + "/tasks");
-                                log.trace("Forwarding task configurations for connector {} to leader", connName);
-                                RestClient.httpRequest(reconfigUrl, "POST", null, rawTaskProps, null, config, sessionKey, requestSignatureAlgorithm);
-                                cb.onCompletion(null, null);
-                            } catch (ConnectException e) {
-                                log.error("Request to leader to reconfigure connector tasks failed", e);
-                                cb.onCompletion(e, null);
+                    forwardRequestExecutor.submit(() -> {
+                        try {
+                            String leaderUrl = leaderUrl();
+                            if (leaderUrl == null || leaderUrl.trim().isEmpty()) {
+                                cb.onCompletion(new ConnectException("Request to leader to " +
+                                        "reconfigure connector tasks failed " +
+                                        "because the URL of the leader's REST interface is empty!"), null);
+                                return;
                             }
+                            String reconfigUrl = RestServer.urlJoin(leaderUrl, "/connectors/" + connName + "/tasks");
+                            log.trace("Forwarding task configurations for connector {} to leader", connName);
+                            RestClient.httpRequest(reconfigUrl, "POST", null, rawTaskProps, null, config, sessionKey, requestSignatureAlgorithm);
+                            cb.onCompletion(null, null);
+                        } catch (ConnectException e) {
+                            log.error("Request to leader to reconfigure connector tasks failed", e);
+                            cb.onCompletion(e, null);
                         }
                     });
                 }
@@ -1492,7 +1590,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             synchronized (DistributedHerder.this) {
                 DistributedHerder.this.sessionKey = sessionKey.key();
                 // Track the expiration of the key if and only if this worker is the leader
-                // Followers will receive rotated keys from the follower and won't be responsible for
+                // Followers will receive rotated keys from the leader and won't be responsible for
                 // tracking expiration and distributing new keys themselves
                 if (isLeader() && keyRotationIntervalMs > 0) {
                     DistributedHerder.this.keyExpiration = sessionKey.creationTimestamp() + keyRotationIntervalMs;
@@ -1548,13 +1646,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
     }
 
-    private static final Callback<Void> forwardErrorCallback(final Callback<?> callback) {
-        return new Callback<Void>() {
-            @Override
-            public void onCompletion(Throwable error, Void result) {
-                if (error != null)
-                    callback.onCompletion(error, null);
-            }
+    private static Callback<Void> forwardErrorCallback(final Callback<?> callback) {
+        return (error, result) -> {
+            if (error != null)
+                callback.onCompletion(error, null);
         };
     }
 
@@ -1676,7 +1771,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     callables.add(getTaskStoppingCallable(taskId));
                 }
 
-                // The actual timeout for graceful task stop is applied in worker's stopAndAwaitTask method.
+                // The actual timeout for graceful task/connector stop is applied in worker's
+                // stopAndAwaitTask/stopAndAwaitConnector methods.
                 startAndStop(callables);
                 log.info("Finished stopping tasks in preparation for rebalance");
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -22,12 +22,14 @@ import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.tools.MockConnector;
 import org.apache.kafka.connect.tools.MockSinkConnector;
 import org.apache.kafka.connect.tools.MockSourceConnector;
 import org.apache.kafka.connect.tools.SchemaSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
+import org.apache.kafka.connect.util.FutureCallback;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -37,11 +39,14 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Path("/connector-plugins")
 @Produces(MediaType.APPLICATION_JSON)
@@ -79,7 +84,18 @@ public class ConnectorPluginsResource {
         }
 
         // the validated configs don't need to be logged
-        return herder.validateConnectorConfig(connectorConfig, false);
+        FutureCallback<ConfigInfos> validationCallback = new FutureCallback<>();
+        herder.validateConnectorConfig(connectorConfig, validationCallback, false);
+
+        try {
+            return validationCallback.get(ConnectorsResource.REQUEST_TIMEOUT_MS, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
+            // error is the best option
+            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request timed out");
+        } catch (InterruptedException e) {
+            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
+        }
     }
 
     @GET

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -82,6 +82,9 @@ public class ConnectorsResource {
     // we need to consider all possible scenarios this could fail. It might be ok to fail with a timeout in rare cases,
     // but currently a worker simply leaving the group can take this long as well.
     public static final long REQUEST_TIMEOUT_MS = 90 * 1000;
+    // Mutable for integration testing; otherwise, some tests would take at least REQUEST_TIMEOUT_MS
+    // to run
+    private static long requestTimeoutMs = REQUEST_TIMEOUT_MS;
 
     private final Herder herder;
     private final WorkerConfig config;
@@ -95,6 +98,15 @@ public class ConnectorsResource {
         this.config = config;
         isTopicTrackingDisabled = !config.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
         isTopicTrackingResetDisabled = !config.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG);
+    }
+
+    // For testing purposes only
+    public static void setRequestTimeout(long requestTimeoutMs) {
+        ConnectorsResource.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    public static void resetRequestTimeout() {
+        ConnectorsResource.requestTimeoutMs = REQUEST_TIMEOUT_MS;
     }
 
     @GET
@@ -330,7 +342,7 @@ public class ConnectorsResource {
                                               Translator<T, U> translator,
                                               Boolean forward) throws Throwable {
         try {
-            return cb.get(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            return cb.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -305,8 +305,7 @@ public class StandaloneHerder extends AbstractHerder {
     @Override
     public synchronized HerderRequest restartConnector(long delayMs, final String connName, final Callback<Void> cb) {
         ScheduledFuture<?> future = requestExecutorService.schedule(
-            () -> restartConnector(connName, cb), delayMs, TimeUnit.MILLISECONDS
-        );
+            () -> restartConnector(connName, cb), delayMs, TimeUnit.MILLISECONDS);
 
         return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -230,7 +230,6 @@ public class StandaloneHerder extends AbstractHerder {
 
             configBackingStore.putConnectorConfig(connName, config);
 
-            // startConnector(connName, onStart);
             startConnector(connName, (error, result) -> {
                 if (error != null) {
                     callback.onCompletion(error, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
@@ -112,7 +113,7 @@ public class StandaloneHerder extends AbstractHerder {
         // the tasks.
         for (String connName : connectors()) {
             removeConnectorTasks(connName);
-            worker.stopConnector(connName);
+            worker.stopAndAwaitConnector(connName);
         }
         stopServices();
         running = false;
@@ -139,7 +140,7 @@ public class StandaloneHerder extends AbstractHerder {
         callback.onCompletion(null, connectorInfo);
     }
 
-    private ConnectorInfo createConnectorInfo(String connector) {
+    private synchronized ConnectorInfo createConnectorInfo(String connector) {
         if (!configState.contains(connector))
             return null;
         Map<String, String> config = configState.rawConnectorConfig(connector);
@@ -148,22 +149,19 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
-    protected Map<String, String> config(String connName) {
+    protected synchronized Map<String, String> config(String connName) {
         return configState.connectorConfig(connName);
     }
 
     @Override
     public void connectorConfig(String connName, final Callback<Map<String, String>> callback) {
         // Subset of connectorInfo, so piggy back on that implementation
-        connectorInfo(connName, new Callback<ConnectorInfo>() {
-            @Override
-            public void onCompletion(Throwable error, ConnectorInfo result) {
-                if (error != null) {
-                    callback.onCompletion(error, null);
-                    return;
-                }
-                callback.onCompletion(null, result.config());
+        connectorInfo(connName, (error, result) -> {
+            if (error != null) {
+                callback.onCompletion(error, null);
+                return;
             }
+            callback.onCompletion(null, result.config());
         });
     }
 
@@ -177,7 +175,7 @@ public class StandaloneHerder extends AbstractHerder {
             }
 
             removeConnectorTasks(connName);
-            worker.stopConnector(connName);
+            worker.stopAndAwaitConnector(connName);
             configBackingStore.removeConnectorConfig(connName);
             onDeletion(connName);
             callback.onCompletion(null, new Created<ConnectorInfo>(false, null));
@@ -193,32 +191,59 @@ public class StandaloneHerder extends AbstractHerder {
                                                 boolean allowReplace,
                                                 final Callback<Created<ConnectorInfo>> callback) {
         try {
-            if (maybeAddConfigErrors(validateConnectorConfig(config), callback)) {
+            validateConnectorConfig(config, (error, configInfos) -> {
+                if (error != null) {
+                    callback.onCompletion(error, null);
+                    return;
+                }
+
+                requestExecutorService.submit(
+                    () -> putConnectorConfig(connName, config, allowReplace, callback, configInfos)
+                );
+            });
+        } catch (Throwable t) {
+            callback.onCompletion(t, null);
+        }
+    }
+
+    private synchronized void putConnectorConfig(String connName,
+                                                 final Map<String, String> config,
+                                                 boolean allowReplace,
+                                                 final Callback<Created<ConnectorInfo>> callback,
+                                                 ConfigInfos configInfos) {
+        try {
+            if (maybeAddConfigErrors(configInfos, callback)) {
                 return;
             }
 
-            boolean created = false;
+            final boolean created;
             if (configState.contains(connName)) {
                 if (!allowReplace) {
                     callback.onCompletion(new AlreadyExistsException("Connector " + connName + " already exists"), null);
                     return;
                 }
-                worker.stopConnector(connName);
+                worker.stopAndAwaitConnector(connName);
+                created = false;
             } else {
                 created = true;
             }
 
             configBackingStore.putConnectorConfig(connName, config);
 
-            if (!startConnector(connName)) {
-                callback.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
-                return;
-            }
+            // startConnector(connName, onStart);
+            startConnector(connName, (error, result) -> {
+                if (error != null) {
+                    callback.onCompletion(error, null);
+                    return;
+                }
 
-            updateConnectorTasks(connName);
-            callback.onCompletion(null, new Created<>(created, createConnectorInfo(connName)));
-        } catch (ConnectException e) {
-            callback.onCompletion(e, null);
+                requestExecutorService.submit(() -> {
+                    updateConnectorTasks(connName);
+                    callback.onCompletion(null, new Created<>(created, createConnectorInfo(connName)));
+                });
+            });
+        } catch (Throwable t) {
+            callback.onCompletion(t, null);
         }
     }
 
@@ -272,29 +297,24 @@ public class StandaloneHerder extends AbstractHerder {
         if (!configState.contains(connName))
             cb.onCompletion(new NotFoundException("Connector " + connName + " not found", null), null);
 
-        worker.stopConnector(connName);
-        if (startConnector(connName))
-            cb.onCompletion(null, null);
-        else
-            cb.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
+        worker.stopAndAwaitConnector(connName);
+
+        startConnector(connName, (error, result) -> cb.onCompletion(error, null));
     }
 
     @Override
     public synchronized HerderRequest restartConnector(long delayMs, final String connName, final Callback<Void> cb) {
-        ScheduledFuture<?> future = requestExecutorService.schedule(new Runnable() {
-            @Override
-            public void run() {
-                restartConnector(connName, cb);
-            }
-        }, delayMs, TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> future = requestExecutorService.schedule(
+            () -> restartConnector(connName, cb), delayMs, TimeUnit.MILLISECONDS
+        );
 
         return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
     }
 
-    private boolean startConnector(String connName) {
+    private void startConnector(String connName, Callback<TargetState> onStart) {
         Map<String, String> connConfigs = configState.connectorConfig(connName);
         TargetState targetState = configState.targetState(connName);
-        return worker.startConnector(connName, connConfigs, new HerderConnectorContext(this, connName), this, targetState);
+        worker.startConnector(connName, connConfigs, new HerderConnectorContext(this, connName), this, targetState, onStart);
     }
 
     private List<Map<String, String>> recomputeTaskConfigs(String connName) {
@@ -379,9 +399,18 @@ public class StandaloneHerder extends AbstractHerder {
             synchronized (StandaloneHerder.this) {
                 configState = configBackingStore.snapshot();
                 TargetState targetState = configState.targetState(connector);
-                worker.setTargetState(connector, targetState);
-                if (targetState == TargetState.STARTED)
-                    updateConnectorTasks(connector);
+                worker.setTargetState(connector, targetState, (error, newState) -> {
+                    if (error != null) {
+                        log.error("Failed to transition connector {} to target state {}", connector, targetState, error);
+                        return;
+                    }
+
+                    if (newState == TargetState.STARTED) {
+                        requestExecutorService.submit(() -> {
+                            updateConnectorTasks(connector);
+                        });
+                    }
+                });
             }
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -21,9 +21,12 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,5 +81,13 @@ public final class ConnectUtils {
         if (groupId != null) {
             prop.put(CommonClientConfigs.METRICS_CONTEXT_PREFIX + WorkerConfig.CONNECT_GROUP_ID, groupId);
         }
+    }
+
+    public static boolean isSinkConnector(Connector connector) {
+        return SinkConnector.class.isAssignableFrom(connector.getClass());
+    }
+
+    public static boolean isSourceConnector(Connector connector) {
+        return SourceConnector.class.isAssignableFrom(connector.getClass());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.runtime.Worker;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.junit.Assert.assertThrows;
+
+public class BlockingConnectorTest {
+
+    private static final Logger log = LoggerFactory.getLogger(BlockingConnectorTest.class);
+
+    private static final int NUM_WORKERS = 1;
+    private static final String BLOCKING_CONNECTOR_NAME = "blocking-connector";
+    private static final String NORMAL_CONNECTOR_NAME = "normal-connector";
+    private static final long REST_REQUEST_TIMEOUT = Worker.CONNECTOR_GRACEFUL_SHUTDOWN_TIMEOUT_MS * 2;
+
+    private EmbeddedConnectCluster connect;
+
+    @Before
+    public void setup() {
+        // Artificially reduce the REST request timeout so that these don't take forever
+        ConnectorsResource.setRequestTimeout(REST_REQUEST_TIMEOUT);
+        // build a Connect cluster backed by Kafka and Zk
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("connect-cluster")
+                .numWorkers(NUM_WORKERS)
+                .numBrokers(1)
+                .workerProps(new HashMap<>())
+                .brokerProps(new Properties())
+                .build();
+
+        // start the clusters
+        connect.start();
+    }
+
+    @After
+    public void close() {
+        // stop all Connect, Kafka and Zk threads.
+        connect.stop();
+        ConnectorsResource.resetRequestTimeout();
+        BlockingConnector.resetBlockLatch();
+    }
+
+    @Test
+    public void testBlockInConnectorValidate() throws Exception {
+        log.info("Starting test testBlockInConnectorValidate");
+        assertThrows(ConnectRestException.class, () -> createConnectorWithBlock(ValidateBlockingConnector.class));
+        // Will NOT assert that connector has failed, since the request should fail before it's even created
+
+        // Connector should already be blocked so this should return immediately, but check just to
+        // make sure that it actually did block
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testBlockInConnectorConfig() throws Exception {
+        log.info("Starting test testBlockInConnectorConfig");
+        assertThrows(ConnectRestException.class, () -> createConnectorWithBlock(ConfigBlockingConnector.class));
+        // Will NOT assert that connector has failed, since the request should fail before it's even created
+
+        // Connector should already be blocked so this should return immediately, but check just to
+        // make sure that it actually did block
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testBlockInConnectorInitialize() throws Exception {
+        log.info("Starting test testBlockInConnectorInitialize");
+        createConnectorWithBlock(InitializeBlockingConnector.class);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testBlockInConnectorStart() throws Exception {
+        log.info("Starting test testBlockInConnectorStart");
+        createConnectorWithBlock(BlockingConnector.START);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testBlockInConnectorStop() throws Exception {
+        log.info("Starting test testBlockInConnectorStop");
+        createConnectorWithBlock(BlockingConnector.STOP);
+        waitForConnectorStart(BLOCKING_CONNECTOR_NAME);
+        connect.deleteConnector(BLOCKING_CONNECTOR_NAME);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testWorkerRestartWithBlockInConnectorStart() throws Exception {
+        log.info("Starting test testWorkerRestartWithBlockInConnectorStart");
+        createNormalConnector();
+        createConnectorWithBlock(BlockingConnector.START);
+        // First instance of the connector should block on startup
+        BlockingConnector.waitForBlock();
+        connect.removeWorker();
+
+        connect.addWorker();
+        // After stopping the only worker and restarting it, a new instance of the blocking
+        // connector should be created and we can ensure that it blocks again
+        BlockingConnector.waitForBlock();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testWorkerRestartWithBlockInConnectorStop() throws Exception {
+        log.info("Starting test testWorkerRestartWithBlockInConnectorStop");
+        createNormalConnector();
+        createConnectorWithBlock(BlockingConnector.STOP);
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+        waitForConnectorStart(BLOCKING_CONNECTOR_NAME);
+        connect.removeWorker();
+        BlockingConnector.waitForBlock();
+
+        connect.addWorker();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+        waitForConnectorStart(BLOCKING_CONNECTOR_NAME);
+    }
+
+    @Test
+    @Ignore("Interaction with this connector method has not been made asynchronous yet and this test will fail")
+    public void testBlockInConnectorTaskClass() throws Exception {
+        createConnectorWithBlock(BlockingConnector.TASK_CLASS);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    @Ignore("Interaction with this connector method has not been made asynchronous yet and this test will fail")
+    public void testBlockInConnectorTaskConfigs() throws Exception {
+        createConnectorWithBlock(BlockingConnector.TASK_CONFIGS);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    @Ignore("Interaction with this connector method has not been made asynchronous yet and this test will fail")
+    public void testConnectorRestartWithBlockInConnectorTaskConfigs() throws Exception {
+        createConnectorWithBlock(BlockingConnector.TASK_CONFIGS);
+        // Test both explicit restart and implicit (pause then resume) restart
+        connect.restartConnector(BLOCKING_CONNECTOR_NAME);
+        connect.pauseConnector(BLOCKING_CONNECTOR_NAME);
+        connect.resumeConnector(BLOCKING_CONNECTOR_NAME);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    // TODO: Consider patching plugin scanning to handle connectors that block in their version methods
+    // @Test
+    // public void testBlockInConnectorVersion() throws Exception {
+    //     createConnectorWithBlock(VersionBlockingConnector.class);
+    //     createNormalConnector();
+    //     waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    // }
+
+    @Test
+    @Ignore("This connector method is never invoked by the framework")
+    public void testBlockInConnectorInitializeWithTaskConfigs() throws Exception {
+        createConnectorWithBlock(BlockingConnector.INITIALIZE_WITH_TASK_CONFIGS);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    @Test
+    @Ignore("This connector method is never invoked by the framework")
+    public void testBlockInConnectorReconfigure() throws Exception {
+        createConnectorWithBlock(BlockingConnector.RECONFIGURE);
+        Map<String, String> newProps = baseBlockingConnectorProps();
+        newProps.put("foo", "bar");
+
+        connect.configureConnector(BLOCKING_CONNECTOR_NAME, newProps);
+        BlockingConnector.waitForBlock();
+
+        createNormalConnector();
+        waitForConnectorStart(NORMAL_CONNECTOR_NAME);
+    }
+
+    private void createConnectorWithBlock(String block) {
+        Map<String, String> props = baseBlockingConnectorProps();
+        props.put(BlockingConnector.BLOCK_CONFIG, block);
+        log.info("Creating connector with block during {}", block);
+        try {
+            connect.configureConnector(BLOCKING_CONNECTOR_NAME, props);
+        } catch (RuntimeException e) {
+            log.info("Failed to create connector", e);
+            throw e;
+        }
+    }
+
+    private void createConnectorWithBlock(Class<? extends BlockingConnector> connectorClass) {
+        Map<String, String> props = baseBlockingConnectorProps();
+        props.put(CONNECTOR_CLASS_CONFIG, connectorClass.getName());
+        log.info("Creating blocking connector of type {}", connectorClass.getSimpleName());
+        try {
+            connect.configureConnector(BLOCKING_CONNECTOR_NAME, props);
+        } catch (RuntimeException e) {
+            log.info("Failed to create connector", e);
+            throw e;
+        }
+    }
+
+    private Map<String, String> baseBlockingConnectorProps() {
+        Map<String, String> result = new HashMap<>();
+        result.put(CONNECTOR_CLASS_CONFIG, BlockingConnector.class.getName());
+        result.put(TASKS_MAX_CONFIG, "1");
+        return result;
+    }
+
+    private void createNormalConnector() {
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getName());
+        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TOPICS_CONFIG, "normal-topic");
+        log.info("Creating normal connector");
+        try {
+            connect.configureConnector(NORMAL_CONNECTOR_NAME, props);
+        } catch (RuntimeException e) {
+            log.info("Failed to create connector", e);
+            throw e;
+        }
+    }
+
+    private void waitForConnectorStart(String connector) throws InterruptedException {
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(
+            connector,
+            0,
+            String.format(
+                "Failed to observe transition to 'RUNNING' state for connector '%s' in time",
+                connector
+            )
+        );
+    }
+
+    public static class BlockingConnector extends SourceConnector {
+
+        private static CountDownLatch blockLatch;
+
+        private String block;
+
+        public static final String BLOCK_CONFIG = "block";
+
+        public static final String INITIALIZE = "initialize";
+        public static final String INITIALIZE_WITH_TASK_CONFIGS = "initializeWithTaskConfigs";
+        public static final String START = "start";
+        public static final String RECONFIGURE = "reconfigure";
+        public static final String TASK_CLASS = "taskClass";
+        public static final String TASK_CONFIGS = "taskConfigs";
+        public static final String STOP = "stop";
+        public static final String VALIDATE = "validate";
+        public static final String CONFIG = "config";
+        public static final String VERSION = "version";
+
+        private static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(
+                BLOCK_CONFIG,
+                ConfigDef.Type.STRING,
+                "",
+                ConfigDef.Importance.MEDIUM,
+                "Where to block indefinitely, e.g., 'start', 'initialize', 'taskConfigs', 'version'"
+            );
+
+        // No-args constructor required by the framework
+        public BlockingConnector() {
+            this(null);
+        }
+
+        protected BlockingConnector(String block) {
+            this.block = block;
+            synchronized (BlockingConnector.class) {
+                if (blockLatch != null) {
+                    blockLatch.countDown();
+                }
+                blockLatch = new CountDownLatch(1);
+            }
+        }
+
+        public static void waitForBlock() throws InterruptedException {
+            synchronized (BlockingConnector.class) {
+                if (blockLatch == null) {
+                    throw new IllegalArgumentException("No connector has been created yet");
+                }
+            }
+            
+            log.debug("Waiting for connector to block");
+            blockLatch.await();
+            log.debug("Connector should now be blocked");
+        }
+
+        public static void resetBlockLatch() {
+            synchronized (BlockingConnector.class) {
+                if (blockLatch != null) {
+                    blockLatch.countDown();
+                    blockLatch = null;
+                }
+            }
+        }
+
+        @Override
+        public void initialize(ConnectorContext ctx) {
+            maybeBlockOn(INITIALIZE);
+            super.initialize(ctx);
+        }
+
+        @Override
+        public void initialize(ConnectorContext ctx, List<Map<String, String>> taskConfigs) {
+            maybeBlockOn(INITIALIZE_WITH_TASK_CONFIGS);
+            super.initialize(ctx, taskConfigs);
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            this.block = new AbstractConfig(CONFIG_DEF, props).getString(BLOCK_CONFIG);
+            maybeBlockOn(START);
+        }
+
+        @Override
+        public void reconfigure(Map<String, String> props) {
+            super.reconfigure(props);
+            maybeBlockOn(RECONFIGURE);
+        }
+
+        @Override
+        public Class<? extends Task> taskClass() {
+            maybeBlockOn(TASK_CLASS);
+            return BlockingTask.class;
+        }
+
+        @Override
+        public List<Map<String, String>> taskConfigs(int maxTasks) {
+            maybeBlockOn(TASK_CONFIGS);
+            return Collections.singletonList(Collections.emptyMap());
+        }
+
+        @Override
+        public void stop() {
+            maybeBlockOn(STOP);
+        }
+
+        @Override
+        public Config validate(Map<String, String> connectorConfigs) {
+            maybeBlockOn(VALIDATE);
+            return super.validate(connectorConfigs);
+        }
+
+        @Override
+        public ConfigDef config() {
+            maybeBlockOn(CONFIG);
+            return CONFIG_DEF;
+        }
+
+        @Override
+        public String version() {
+            maybeBlockOn(VERSION);
+            return "0.0.0";
+        }
+
+        protected void maybeBlockOn(String block) {
+            if (block.equals(this.block)) {
+                log.info("Will block on {}", block);
+                blockLatch.countDown();
+                while (true) {
+                    try {
+                        Thread.sleep(Long.MAX_VALUE);
+                    } catch (InterruptedException e) {
+                        // No-op. Just keep blocking.
+                    }
+                }
+            } else {
+                log.debug("Will not block on {}", block);
+            }
+        }
+
+        public static class BlockingTask extends SourceTask {
+            @Override
+            public void start(Map<String, String> props) {
+            }
+
+            @Override
+            public List<SourceRecord> poll() {
+                return null;
+            }
+
+            @Override
+            public void stop() {
+            }
+
+            @Override
+            public String version() {
+                return "0.0.0";
+            }
+        }
+    }
+
+    // Some methods are called before Connector::start, so we use this as a workaround
+    public static class InitializeBlockingConnector extends BlockingConnector {
+        public InitializeBlockingConnector() {
+            super(INITIALIZE);
+        }
+    }
+
+    public static class ConfigBlockingConnector extends BlockingConnector {
+        public ConfigBlockingConnector() {
+            super(CONFIG);
+        }
+    }
+
+    public static class ValidateBlockingConnector extends BlockingConnector {
+        public ValidateBlockingConnector() {
+            super(VALIDATE);
+        }
+    }
+
+    // Commented out in order for class not to be picked up during plugin scanning (otherwise, it
+    // will be picked up with every test run, even those that are not meant to test blocks in the
+    // Connector::version method, and since the worker does not yet gracefully handle connectors
+    // that block in that method during plugin scanning, all of those tests would fail as their
+    // workers would hang indefinitely during plugin scanning)
+    // public static class VersionBlockingConnector extends BlockingConnector {
+    //     public VersionBlockingConnector() {
+    //         super(VERSION);
+    //     }
+    // }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -271,22 +271,22 @@ public class AbstractHerderTest {
 
 
     @Test(expected = BadRequestException.class)
-    public void testConfigValidationEmptyConfig() {
+    public void testConfigValidationEmptyConfig() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy);
         replayAll();
 
-        herder.validateConnectorConfig(new HashMap<String, String>());
+        herder.validateConnectorConfig(Collections.emptyMap(), false);
 
         verifyAll();
     }
 
     @Test()
-    public void testConfigValidationMissingName() {
+    public void testConfigValidationMissingName() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy);
         replayAll();
 
         Map<String, String> config = Collections.singletonMap(ConnectorConfig.CONNECTOR_CLASS_CONFIG, TestSourceConnector.class.getName());
-        ConfigInfos result = herder.validateConnectorConfig(config);
+        ConfigInfos result = herder.validateConnectorConfig(config, false);
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
         // the config fields for SourceConnectorConfig, but we expect these to change rarely.
@@ -310,7 +310,7 @@ public class AbstractHerderTest {
     }
 
     @Test(expected = ConfigException.class)
-    public void testConfigValidationInvalidTopics() {
+    public void testConfigValidationInvalidTopics() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSinkConnector.class, noneConnectorClientConfigOverridePolicy);
         replayAll();
 
@@ -319,7 +319,7 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1,topic2");
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
 
-        herder.validateConnectorConfig(config);
+        herder.validateConnectorConfig(config, false);
 
         verifyAll();
     }
@@ -334,7 +334,7 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        herder.validateConnectorConfig(config);
+        herder.validateConnectorConfig(config, false);
 
         verifyAll();
     }
@@ -349,13 +349,13 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        herder.validateConnectorConfig(config);
+        herder.validateConnectorConfig(config, false);
 
         verifyAll();
     }
 
     @Test()
-    public void testConfigValidationTransformsExtendResults() {
+    public void testConfigValidationTransformsExtendResults() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy);
 
         // 2 transform aliases defined -> 2 plugin lookups
@@ -373,7 +373,7 @@ public class AbstractHerderTest {
         config.put(ConnectorConfig.TRANSFORMS_CONFIG, "xformA,xformB");
         config.put(ConnectorConfig.TRANSFORMS_CONFIG + ".xformA.type", SampleTransformation.class.getName());
         config.put("required", "value"); // connector required config
-        ConfigInfos result = herder.validateConnectorConfig(config);
+        ConfigInfos result = herder.validateConnectorConfig(config, false);
         assertEquals(herder.connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)), ConnectorType.SOURCE);
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
@@ -432,7 +432,7 @@ public class AbstractHerderTest {
         config.put(ConnectorConfig.PREDICATES_CONFIG, "predX,predY");
         config.put(ConnectorConfig.PREDICATES_CONFIG + ".predX.type", SamplePredicate.class.getName());
         config.put("required", "value"); // connector required config
-        ConfigInfos result = herder.validateConnectorConfig(config);
+        ConfigInfos result = herder.validateConnectorConfig(config, false);
         assertEquals(herder.connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)), ConnectorType.SOURCE);
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
@@ -479,7 +479,7 @@ public class AbstractHerderTest {
     }
 
     @Test()
-    public void testConfigValidationPrincipalOnlyOverride() {
+    public void testConfigValidationPrincipalOnlyOverride() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, new PrincipalConnectorClientConfigOverridePolicy());
         replayAll();
 
@@ -492,7 +492,7 @@ public class AbstractHerderTest {
         config.put(ackConfigKey, "none");
         config.put(saslConfigKey, "jaas_config");
 
-        ConfigInfos result = herder.validateConnectorConfig(config);
+        ConfigInfos result = herder.validateConnectorConfig(config, false);
         assertEquals(herder.connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)), ConnectorType.SOURCE);
 
         // We expect there to be errors due to now allowed override policy for ACKS.... Note that these assertions depend heavily on
@@ -519,7 +519,7 @@ public class AbstractHerderTest {
     }
 
     @Test
-    public void testConfigValidationAllOverride() {
+    public void testConfigValidationAllOverride() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, new AllConnectorClientConfigOverridePolicy());
         replayAll();
 
@@ -549,7 +549,7 @@ public class AbstractHerderTest {
         overriddenClientConfigs.add(bootstrapServersConfigKey);
         overriddenClientConfigs.add(loginCallbackHandlerConfigKey);
 
-        ConfigInfos result = herder.validateConnectorConfig(config);
+        ConfigInfos result = herder.validateConnectorConfig(config, false);
         assertEquals(herder.connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)), ConnectorType.SOURCE);
 
         Map<String, String> validatedOverriddenClientConfigs = new HashMap<>();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -63,6 +63,7 @@ import org.apache.kafka.connect.storage.OffsetStorageWriter;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.FutureCallback;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.apache.kafka.connect.util.TopicAdmin;
 import org.apache.kafka.connect.util.TopicCreationGroup;
@@ -92,12 +93,17 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABLE_CONFIG;
 import static org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperatorTest.NOOP_OPERATOR;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -140,7 +146,7 @@ public class WorkerTest extends ThreadedTest {
     @Mock private StatusBackingStore statusBackingStore;
     @Mock private SourceConnector sourceConnector;
     @Mock private SinkConnector sinkConnector;
-    @Mock private ConnectorContext ctx;
+    @Mock private CloseableConnectorContext ctx;
     @Mock private TestSourceTask task;
     @Mock private WorkerSourceTask workerTask;
     @Mock private Converter keyConverter;
@@ -161,10 +167,6 @@ public class WorkerTest extends ThreadedTest {
         super.setup();
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.key.converter.schemas.enable", "false");
-        workerProps.put("internal.value.converter.schemas.enable", "false");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
         workerProps.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
         workerProps.put("config.providers", "file");
@@ -199,32 +201,35 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartAndStopConnector() {
+    public void testStartAndStopConnector() throws Throwable {
         expectConverters();
         expectStartStorage();
 
+        final String connectorClass = WorkerTestConnector.class.getName();
+
         // Create
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector(WorkerTestConnector.class.getName()))
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorClass)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorClass))
                 .andReturn(sourceConnector);
         EasyMock.expect(sourceConnector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
 
         EasyMock.expect(sourceConnector.version()).andReturn("1.0");
 
         expectFileConfigProvider();
-        EasyMock.expect(plugins.compareAndSwapLoaders(sourceConnector))
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
                 .andReturn(delegatingLoader)
-                .times(2);
-
+                .times(3);
         sourceConnector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         sourceConnector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader).times(2);
+                .andReturn(pluginLoader).times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -236,6 +241,9 @@ public class WorkerTest extends ThreadedTest {
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
+        ctx.close();
+        expectLastCall();
+
         expectStopStorage();
         expectClusterId();
 
@@ -246,17 +254,25 @@ public class WorkerTest extends ThreadedTest {
         worker.start();
 
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+
+        FutureCallback<TargetState> onFirstStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onFirstStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onFirstStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+
+        FutureCallback<TargetState> onSecondStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onSecondStart);
         try {
-            worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
-            fail("Should have thrown exception when trying to add connector with same name.");
-        } catch (ConnectException e) {
-            // expected
+            onSecondStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed while trying to start second connector with same name");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(ConnectException.class));
         }
+
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -279,19 +295,22 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartConnectorFailure() {
+    public void testStartConnectorFailure() throws Exception {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "java.util.HashMap"); // Bad connector class name
+        final String nonConnectorClass = "java.util.HashMap";
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, nonConnectorClass); // Bad connector class name
 
+        Exception exception = new ConnectException("Failed to find Connector");
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString()))
-                .andThrow(new ConnectException("Failed to find Connector"));
-
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(nonConnectorClass)).andReturn(delegatingLoader);
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader);
+                .andReturn(delegatingLoader).times(2);
+        EasyMock.expect(plugins.newConnector(EasyMock.anyString()))
+                .andThrow(exception);
 
         connectorStatusListener.onFailure(
                 EasyMock.eq(CONNECTOR_ID),
@@ -308,14 +327,21 @@ public class WorkerTest extends ThreadedTest {
         worker.start();
 
         assertStatistics(worker, 0, 0);
-        assertFalse(worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED));
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        try {
+            onStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed to start connector");
+        } catch (ExecutionException e) {
+            assertEquals(exception, e.getCause());
+        }
 
         assertStartupStatistics(worker, 1, 1, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
 
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
-        assertFalse(worker.stopConnector(CONNECTOR_ID));
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
 
@@ -323,39 +349,47 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByAlias() {
+    public void testAddConnectorByAlias() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String connectorAlias = "WorkerTestConnector";
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector("WorkerTestConnector")).andReturn(sourceConnector);
-        EasyMock.expect(sourceConnector.version()).andReturn("1.0");
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorAlias)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorAlias)).andReturn(sinkConnector);
+        EasyMock.expect(sinkConnector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTestConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorAlias);
+        connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "gfieyls, wfru");
 
-        EasyMock.expect(sourceConnector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(sourceConnector))
+        EasyMock.expect(sinkConnector.version()).andReturn("1.0");
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
                 .andReturn(delegatingLoader)
-                .times(2);
-        sourceConnector.initialize(anyObject(ConnectorContext.class));
+                .times(3);
+        sinkConnector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
-        sourceConnector.start(connectorProps);
+        sinkConnector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
                 .andReturn(pluginLoader)
-                .times(2);
+                .times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
         // Remove
-        sourceConnector.stop();
+        sinkConnector.stop();
         EasyMock.expectLastCall();
 
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
+
+        ctx.close();
+        expectLastCall();
 
         expectStopStorage();
         expectClusterId();
@@ -368,12 +402,15 @@ public class WorkerTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -386,39 +423,47 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByShortAlias() {
+    public void testAddConnectorByShortAlias() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String shortConnectorAlias = "WorkerTest";
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector("WorkerTest")).andReturn(sourceConnector);
-        EasyMock.expect(sourceConnector.version()).andReturn("1.0");
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(shortConnectorAlias)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(shortConnectorAlias)).andReturn(sinkConnector);
+        EasyMock.expect(sinkConnector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTest");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, shortConnectorAlias);
+        connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "gfieyls, wfru");
 
-        EasyMock.expect(sourceConnector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(sourceConnector))
+        EasyMock.expect(sinkConnector.version()).andReturn("1.0");
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
                 .andReturn(delegatingLoader)
-                .times(2);
-        sourceConnector.initialize(anyObject(ConnectorContext.class));
+                .times(3);
+        sinkConnector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
-        sourceConnector.start(connectorProps);
+        sinkConnector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
                 .andReturn(pluginLoader)
-                .times(2);
+                .times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
         // Remove
-        sourceConnector.stop();
+        sinkConnector.stop();
         EasyMock.expectLastCall();
 
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
+
+        ctx.close();
+        expectLastCall();
 
         expectStopStorage();
         expectClusterId();
@@ -431,11 +476,14 @@ public class WorkerTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         assertStatistics(worker, 1, 0);
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
@@ -458,29 +506,33 @@ public class WorkerTest extends ThreadedTest {
         worker.herder = herder;
         worker.start();
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
 
         PowerMock.verifyAll();
     }
 
     @Test
-    public void testReconfigureConnectorTasks() {
+    public void testReconfigureConnectorTasks() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String connectorClass = WorkerTestConnector.class.getName();
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(3);
-        EasyMock.expect(plugins.newConnector(WorkerTestConnector.class.getName()))
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader).times(1);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorClass)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorClass))
                 .andReturn(sinkConnector);
         EasyMock.expect(sinkConnector.version()).andReturn("1.0");
 
         connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "foo,bar");
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
 
         EasyMock.expect(sinkConnector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(sinkConnector))
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
                 .andReturn(delegatingLoader)
-                .times(3);
+                .times(4);
         sinkConnector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         sinkConnector.start(connectorProps);
@@ -488,7 +540,7 @@ public class WorkerTest extends ThreadedTest {
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
                 .andReturn(pluginLoader)
-                .times(3);
+                .times(4);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -506,6 +558,9 @@ public class WorkerTest extends ThreadedTest {
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
+        ctx.close();
+        expectLastCall();
+
         expectStopStorage();
         expectClusterId();
 
@@ -517,15 +572,22 @@ public class WorkerTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onFirstStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onFirstStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onFirstStart.get(1000, TimeUnit.MILLISECONDS));
         assertStatistics(worker, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+
+        FutureCallback<TargetState> onSecondStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onSecondStart);
         try {
-            worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
-            fail("Should have thrown exception when trying to add connector with same name.");
-        } catch (ConnectException e) {
-            // expected
+            onSecondStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed while trying to start second connector with same name");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(ConnectException.class));
         }
+
         Map<String, String> connProps = new HashMap<>(connectorProps);
         connProps.put(ConnectorConfig.TASKS_MAX_CONFIG, "2");
         ConnectorConfig connConfig = new SinkConnectorConfig(plugins, connProps);
@@ -539,7 +601,7 @@ public class WorkerTest extends ThreadedTest {
         assertEquals(expectedTaskProps, taskConfigs.get(1));
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -549,7 +611,6 @@ public class WorkerTest extends ThreadedTest {
 
         PowerMock.verifyAll();
     }
-
 
     @Test
     public void testAddRemoveTask() throws Exception {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerWithTopicCreationTest.java
@@ -59,6 +59,7 @@ import org.apache.kafka.connect.storage.OffsetStorageWriter;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.FutureCallback;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.apache.kafka.connect.util.TopicAdmin;
 import org.apache.kafka.connect.util.TopicCreationGroup;
@@ -83,7 +84,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC_CREATION_PREFIX;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
@@ -92,6 +95,9 @@ import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABL
 import static org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperatorTest.NOOP_OPERATOR;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -133,7 +139,7 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
     @Mock private Herder herder;
     @Mock private StatusBackingStore statusBackingStore;
     @Mock private SourceConnector connector;
-    @Mock private ConnectorContext ctx;
+    @Mock private CloseableConnectorContext ctx;
     @Mock private TestSourceTask task;
     @Mock private WorkerSourceTask workerTask;
     @Mock private Converter keyConverter;
@@ -154,10 +160,6 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         super.setup();
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put("internal.key.converter.schemas.enable", "false");
-        workerProps.put("internal.value.converter.schemas.enable", "false");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
         workerProps.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
         workerProps.put("config.providers", "file");
@@ -192,32 +194,35 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartAndStopConnector() {
+    public void testStartAndStopConnector() throws Throwable {
         expectConverters();
         expectStartStorage();
 
+        final String connectorClass = WorkerTest.WorkerTestConnector.class.getName();
+
         // Create
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector(WorkerTestConnector.class.getName()))
-                .andReturn(connector);
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorClass)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorClass))
+            .andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
 
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         expectFileConfigProvider();
-        EasyMock.expect(plugins.compareAndSwapLoaders(connector))
-                .andReturn(delegatingLoader)
-                .times(2);
-
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
+            .andReturn(delegatingLoader)
+            .times(3);
         connector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         connector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader).times(2);
+            .andReturn(pluginLoader).times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -229,6 +234,9 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
+        ctx.close();
+        expectLastCall();
+
         expectStopStorage();
         expectClusterId();
 
@@ -239,17 +247,25 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         worker.start();
 
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+
+        FutureCallback<TargetState> onFirstStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onFirstStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onFirstStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+
+        FutureCallback<TargetState> onSecondStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onSecondStart);
         try {
-            worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
-            fail("Should have thrown exception when trying to add connector with same name.");
-        } catch (ConnectException e) {
-            // expected
+            onSecondStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed while trying to start second connector with same name");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(ConnectException.class));
         }
+
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -272,25 +288,29 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartConnectorFailure() {
+    public void testStartConnectorFailure() throws Exception {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "java.util.HashMap"); // Bad connector class name
+        final String nonConnectorClass = "java.util.HashMap";
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, nonConnectorClass); // Bad connector class name
 
+        Exception exception = new ConnectException("Failed to find Connector");
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString()))
-                .andThrow(new ConnectException("Failed to find Connector"));
-
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(nonConnectorClass)).andReturn(delegatingLoader);
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader);
+            .andReturn(delegatingLoader).times(2);
+        EasyMock.expect(plugins.newConnector(EasyMock.anyString()))
+            .andThrow(exception);
 
         connectorStatusListener.onFailure(
-                EasyMock.eq(CONNECTOR_ID),
-                EasyMock.<ConnectException>anyObject()
+            EasyMock.eq(CONNECTOR_ID),
+            EasyMock.<ConnectException>anyObject()
         );
         EasyMock.expectLastCall();
+
         expectClusterId();
 
         PowerMock.replayAll();
@@ -300,14 +320,21 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         worker.start();
 
         assertStatistics(worker, 0, 0);
-        assertFalse(worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED));
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        try {
+            onStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed to start connector");
+        } catch (ExecutionException e) {
+            assertEquals(exception, e.getCause());
+        }
 
         assertStartupStatistics(worker, 1, 1, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
 
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
-        assertFalse(worker.stopConnector(CONNECTOR_ID));
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
 
@@ -315,29 +342,33 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByAlias() {
+    public void testAddConnectorByAlias() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String connectorAlias = "WorkerTestConnector";
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector("WorkerTestConnector")).andReturn(connector);
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorAlias)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorAlias)).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTestConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorAlias);
 
         EasyMock.expect(connector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(connector))
-                .andReturn(delegatingLoader)
-                .times(2);
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
+            .andReturn(delegatingLoader)
+            .times(3);
         connector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         connector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader)
-                .times(2);
+            .andReturn(pluginLoader)
+            .times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -348,6 +379,9 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
+
+        ctx.close();
+        expectLastCall();
 
         expectStopStorage();
         expectClusterId();
@@ -360,12 +394,15 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -378,29 +415,33 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByShortAlias() {
+    public void testAddConnectorByShortAlias() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String shortConnectorAlias = "WorkerTest";
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
-        EasyMock.expect(plugins.newConnector("WorkerTest")).andReturn(connector);
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(shortConnectorAlias)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(shortConnectorAlias)).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTest");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, shortConnectorAlias);
 
         EasyMock.expect(connector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(connector))
-                .andReturn(delegatingLoader)
-                .times(2);
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
+            .andReturn(delegatingLoader)
+            .times(3);
         connector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         connector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader)
-                .times(2);
+            .andReturn(pluginLoader)
+            .times(3);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -411,6 +452,9 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
+
+        ctx.close();
+        expectLastCall();
 
         expectStopStorage();
         expectClusterId();
@@ -423,11 +467,14 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onStart.get(1000, TimeUnit.MILLISECONDS));
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         assertStatistics(worker, 1, 0);
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
@@ -450,37 +497,41 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         worker.herder = herder;
         worker.start();
 
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
 
         PowerMock.verifyAll();
     }
 
     @Test
-    public void testReconfigureConnectorTasks() {
+    public void testReconfigureConnectorTasks() throws Throwable {
         expectConverters();
         expectStartStorage();
         expectFileConfigProvider();
 
+        final String connectorClass = WorkerTest.WorkerTestConnector.class.getName();
+
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(3);
-        EasyMock.expect(plugins.newConnector(WorkerTestConnector.class.getName()))
-                .andReturn(connector);
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader).times(1);
+        EasyMock.expect(delegatingLoader.connectorLoader(connectorClass)).andReturn(pluginLoader);
+        EasyMock.expect(plugins.newConnector(connectorClass))
+            .andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         connectorProps.put(SinkConnectorConfig.TOPICS_CONFIG, "foo,bar");
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
 
         EasyMock.expect(connector.version()).andReturn("1.0");
-        EasyMock.expect(plugins.compareAndSwapLoaders(connector))
-                .andReturn(delegatingLoader)
-                .times(3);
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader))
+            .andReturn(delegatingLoader)
+            .times(4);
         connector.initialize(anyObject(ConnectorContext.class));
         EasyMock.expectLastCall();
         connector.start(connectorProps);
         EasyMock.expectLastCall();
 
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader))
-                .andReturn(pluginLoader)
-                .times(3);
+            .andReturn(pluginLoader)
+            .times(4);
 
         connectorStatusListener.onStartup(CONNECTOR_ID);
         EasyMock.expectLastCall();
@@ -498,6 +549,9 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         connectorStatusListener.onShutdown(CONNECTOR_ID);
         EasyMock.expectLastCall();
 
+        ctx.close();
+        expectLastCall();
+
         expectStopStorage();
         expectClusterId();
 
@@ -509,15 +563,22 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
+        FutureCallback<TargetState> onFirstStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onFirstStart);
+        // Wait for the connector to actually start
+        assertEquals(TargetState.STARTED, onFirstStart.get(1000, TimeUnit.MILLISECONDS));
         assertStatistics(worker, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+
+        FutureCallback<TargetState> onSecondStart = new FutureCallback<>();
+        worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED, onSecondStart);
         try {
-            worker.startConnector(CONNECTOR_ID, connectorProps, ctx, connectorStatusListener, TargetState.STARTED);
-            fail("Should have thrown exception when trying to add connector with same name.");
-        } catch (ConnectException e) {
-            // expected
+            onSecondStart.get(0, TimeUnit.MILLISECONDS);
+            fail("Should have failed while trying to start second connector with same name");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(ConnectException.class));
         }
+
         Map<String, String> connProps = new HashMap<>(connectorProps);
         connProps.put(ConnectorConfig.TASKS_MAX_CONFIG, "2");
         ConnectorConfig connConfig = new SinkConnectorConfig(plugins, connProps);
@@ -531,7 +592,7 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         assertEquals(expectedTaskProps, taskConfigs.get(1));
         assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
-        worker.stopConnector(CONNECTOR_ID);
+        worker.stopAndAwaitConnector(CONNECTOR_ID);
         assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
@@ -541,7 +602,6 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
 
         PowerMock.verifyAll();
     }
-
 
     @Test
     public void testAddRemoveTask() throws Exception {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -254,6 +254,7 @@ public class DistributedHerderTest {
             }
         });
         member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         PowerMock.expectLastCall();
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
@@ -291,6 +292,7 @@ public class DistributedHerderTest {
             }
         });
         member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         worker.startTask(EasyMock.eq(TASK1), EasyMock.<ClusterConfigState>anyObject(), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
@@ -476,6 +478,7 @@ public class DistributedHerderTest {
             }
         });
         member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -1188,6 +1191,7 @@ public class DistributedHerderTest {
 
         // apply config
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
         // Checks for config updates and starts rebalance
@@ -1258,6 +1262,7 @@ public class DistributedHerderTest {
 
         // apply config
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT); // for this test, it doesn't matter if we use the same config snapshot
@@ -1330,6 +1335,7 @@ public class DistributedHerderTest {
 
         // handle the state change
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -1392,6 +1398,7 @@ public class DistributedHerderTest {
 
         // handle the state change
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -1450,6 +1457,7 @@ public class DistributedHerderTest {
 
         // state change is ignored since we have no target state
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -1488,6 +1496,7 @@ public class DistributedHerderTest {
 
         // handle the state change
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -1538,6 +1547,7 @@ public class DistributedHerderTest {
 
         // handle the state change
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
 
@@ -1590,6 +1600,7 @@ public class DistributedHerderTest {
 
         // apply config
         member.wakeup();
+        PowerMock.expectLastCall();
         member.ensureActive();
         PowerMock.expectLastCall();
         // Checks for config updates and starts rebalance

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -17,16 +17,14 @@
 package org.apache.kafka.connect.runtime.distributed;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.Config;
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.connector.Connector;
-import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.AlreadyExistsException;
 import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.runtime.CloseableConnectorContext;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
@@ -43,6 +41,7 @@ import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
@@ -92,6 +91,7 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.newCapture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -135,6 +135,8 @@ public class DistributedHerderTest {
     static {
         CONN1_CONFIG_UPDATED.put(SinkConnectorConfig.TOPICS_CONFIG, String.join(",", FOO_TOPIC, BAR_TOPIC, BAZ_TOPIC));
     }
+    private static final ConfigInfos CONN1_CONFIG_INFOS =
+        new ConfigInfos(CONN1, 0, Collections.emptyList(), Collections.emptyList());
     private static final Map<String, String> CONN2_CONFIG = new HashMap<>();
     static {
         CONN2_CONFIG.put(ConnectorConfig.NAME_CONFIG, CONN2);
@@ -142,6 +144,10 @@ public class DistributedHerderTest {
         CONN2_CONFIG.put(SinkConnectorConfig.TOPICS_CONFIG, String.join(",", FOO_TOPIC, BAR_TOPIC));
         CONN2_CONFIG.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, BogusSourceConnector.class.getName());
     }
+    private static final ConfigInfos CONN2_CONFIG_INFOS =
+        new ConfigInfos(CONN2, 0, Collections.emptyList(), Collections.emptyList());
+    private static final ConfigInfos CONN2_INVALID_CONFIG_INFOS =
+        new ConfigInfos(CONN2, 1, Collections.emptyList(), Collections.emptyList());
     private static final Map<String, String> TASK_CONFIG = new HashMap<>();
     static {
         TASK_CONFIG.put(TaskConfig.TASK_CLASS_CONFIG, BogusSourceTask.class.getName());
@@ -182,12 +188,9 @@ public class DistributedHerderTest {
     @Mock private Worker worker;
     @Mock private WorkerConfigTransformer transformer;
     @Mock private Callback<Herder.Created<ConnectorInfo>> putConnectorCallback;
-    @Mock
-    private Plugins plugins;
-    @Mock
-    private PluginClassLoader pluginLoader;
-    @Mock
-    private DelegatingClassLoader delegatingLoader;
+    @Mock private Plugins plugins;
+    @Mock private PluginClassLoader pluginLoader;
+    @Mock private DelegatingClassLoader delegatingLoader;
 
     private ConfigBackingStore.UpdateListener configUpdateListener;
     private WorkerRebalanceListener rebalanceListener;
@@ -210,7 +213,7 @@ public class DistributedHerderTest {
         connectProtocolVersion = CONNECT_PROTOCOL_V0;
 
         herder = PowerMock.createPartialMock(DistributedHerder.class,
-                new String[]{"connectorTypeForClass", "updateDeletedConnectorStatus", "updateDeletedTaskStatus"},
+                new String[]{"connectorTypeForClass", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig"},
                 new DistributedConfig(HERDER_CONFIG), worker, WORKER_ID, KAFKA_CLUSTER_ID,
                 statusBackingStore, configBackingStore, member, MEMBER_URL, metrics, time, noneConnectorClientConfigOverridePolicy);
 
@@ -240,11 +243,19 @@ public class DistributedHerderTest {
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
-
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         worker.startTask(EasyMock.eq(TASK1), EasyMock.<ClusterConfigState>anyObject(), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
@@ -269,9 +280,17 @@ public class DistributedHerderTest {
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onFirstStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         worker.startTask(EasyMock.eq(TASK1), EasyMock.<ClusterConfigState>anyObject(), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
@@ -285,9 +304,18 @@ public class DistributedHerderTest {
                 1, Arrays.asList(CONN1), Arrays.<ConnectorTaskId>asList());
 
         // and the new assignment started
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onSecondStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
@@ -329,9 +357,18 @@ public class DistributedHerderTest {
 
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         // and the new assignment started
+        Capture<Callback<TargetState>> onStart = newCapture();
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -368,7 +405,6 @@ public class DistributedHerderTest {
                 Collections.emptyList(), Collections.emptyList(), 0);
         member.requestRejoin();
         PowerMock.expectLastCall();
-
 
         // In the second rebalance the new member gets its assignment and this member has no
         // assignments or revocations
@@ -429,9 +465,17 @@ public class DistributedHerderTest {
 
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         // and the new assignment started
+        Capture<Callback<TargetState>> onStart = newCapture();
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -463,9 +507,18 @@ public class DistributedHerderTest {
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onFirstStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         worker.startTask(EasyMock.eq(TASK1), EasyMock.<ClusterConfigState>anyObject(), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
@@ -478,9 +531,18 @@ public class DistributedHerderTest {
                 1, Arrays.asList(CONN1), Arrays.<ConnectorTaskId>asList());
 
         // and the new assignment started
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onSecondStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(false);
 
         // worker is not running, so we should see no call to connectorTaskConfigs()
@@ -504,8 +566,8 @@ public class DistributedHerderTest {
     @Test
     public void testHaltCleansUpWorker() {
         EasyMock.expect(worker.connectorNames()).andReturn(Collections.singleton(CONN1));
-        worker.stopConnector(CONN1);
-        PowerMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONN1);
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.taskIds()).andReturn(Collections.singleton(TASK1));
         worker.stopAndAwaitTask(TASK1);
         PowerMock.expectLastCall();
@@ -535,17 +597,17 @@ public class DistributedHerderTest {
         member.wakeup();
         PowerMock.expectLastCall();
 
-        // config validation
-        Connector connectorMock = PowerMock.createMock(SourceConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-        EasyMock.expect(connectorMock.config()).andReturn(new ConfigDef());
-        EasyMock.expect(connectorMock.validate(CONN2_CONFIG)).andReturn(new Config(Collections.<ConfigValue>emptyList()));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
+        // mock the actual validation since its asynchronous nature is difficult to test and should
+        // be covered sufficiently by the unit tests for the AbstractHerder class
+        Capture<Callback<ConfigInfos>> validateCallback = newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(CONN2_CONFIG), capture(validateCallback));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                validateCallback.getValue().onCompletion(null, CONN2_CONFIG_INFOS);
+                return null;
+            }
+        });
 
         // CONN2 is new, should succeed
         configBackingStore.putConnectorConfig(CONN2, CONN2_CONFIG);
@@ -556,11 +618,25 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+        // These will occur just before/during the second tick
+        member.wakeup();
+        PowerMock.expectLastCall();
+        member.ensureActive();
+        PowerMock.expectLastCall();
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
         // No immediate action besides this -- change will be picked up via the config log
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONN2, CONN2_CONFIG, false, putConnectorCallback);
+        // First tick runs the initial herder request, which issues an asynchronous request for
+        // connector validation
+        herder.tick();
+
+        // Once that validation is complete, another request is added to the herder request queue
+        // for actually performing the config write; this tick is for that request
         herder.tick();
 
         time.sleep(1000L);
@@ -570,7 +646,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testCreateConnectorFailedBasicValidation() throws Exception {
+    public void testCreateConnectorFailedValidation() throws Exception {
         EasyMock.expect(member.memberId()).andStubReturn("leader");
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList());
@@ -582,86 +658,41 @@ public class DistributedHerderTest {
         member.wakeup();
         PowerMock.expectLastCall();
 
-        // config validation
-        Connector connectorMock = PowerMock.createMock(SourceConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-
-        EasyMock.expect(connectorMock.config()).andStubReturn(new ConfigDef());
-        ConfigValue validatedValue = new ConfigValue("foo.bar");
-        EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(singletonList(validatedValue)));
-
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
-
-        // CONN2 creation should fail
+        // mock the actual validation since its asynchronous nature is difficult to test and should
+        // be covered sufficiently by the unit tests for the AbstractHerder class
+        Capture<Callback<ConfigInfos>> validateCallback = newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(config), capture(validateCallback));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                // CONN2 creation should fail
+                validateCallback.getValue().onCompletion(null, CONN2_INVALID_CONFIG_INFOS);
+                return null;
+            }
+        });
 
         Capture<Throwable> error = newCapture();
-        putConnectorCallback.onCompletion(EasyMock.capture(error), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
+        putConnectorCallback.onCompletion(capture(error), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
         PowerMock.expectLastCall();
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        // These will occur just before/during the second tick
+        member.wakeup();
+        PowerMock.expectLastCall();
+
+        member.ensureActive();
+        PowerMock.expectLastCall();
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
         // No immediate action besides this -- change will be picked up via the config log
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONN2, config, false, putConnectorCallback);
         herder.tick();
-
-        assertTrue(error.hasCaptured());
-        assertTrue(error.getValue() instanceof BadRequestException);
-
-        time.sleep(1000L);
-        assertStatistics(3, 1, 100, 1000L);
-
-        PowerMock.verifyAll();
-    }
-
-    @Test
-    public void testCreateConnectorFailedCustomValidation() throws Exception {
-        EasyMock.expect(member.memberId()).andStubReturn("leader");
-        EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        expectRebalance(1, Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList());
-        expectPostRebalanceCatchup(SNAPSHOT);
-
-        member.wakeup();
-        PowerMock.expectLastCall();
-
-        // config validation
-        Connector connectorMock = PowerMock.createMock(SourceConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-
-        ConfigDef configDef = new ConfigDef();
-        configDef.define("foo.bar", ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "foo.bar doc");
-        EasyMock.expect(connectorMock.config()).andReturn(configDef);
-
-        ConfigValue validatedValue = new ConfigValue("foo.bar");
-        validatedValue.addErrorMessage("Failed foo.bar validation");
-        EasyMock.expect(connectorMock.validate(CONN2_CONFIG)).andReturn(new Config(singletonList(validatedValue)));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
-
-        // CONN2 creation should fail
-
-        Capture<Throwable> error = newCapture();
-        putConnectorCallback.onCompletion(EasyMock.capture(error), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
-        PowerMock.expectLastCall();
-
-        member.poll(EasyMock.anyInt());
-        PowerMock.expectLastCall();
-        // No immediate action besides this -- change will be picked up via the config log
-
-        PowerMock.replayAll();
-
-        herder.putConnectorConfig(CONN2, CONN2_CONFIG, false, putConnectorCallback);
         herder.tick();
 
         assertTrue(error.hasCaptured());
@@ -676,63 +707,38 @@ public class DistributedHerderTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testConnectorNameConflictsWithWorkerGroupId() throws Exception {
-        EasyMock.expect(member.memberId()).andStubReturn("leader");
-        EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        expectRebalance(1, Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList());
-        expectPostRebalanceCatchup(SNAPSHOT);
-
-        member.wakeup();
-        PowerMock.expectLastCall();
-
         Map<String, String> config = new HashMap<>(CONN2_CONFIG);
         config.put(ConnectorConfig.NAME_CONFIG, "test-group");
 
-        // config validation
         Connector connectorMock = PowerMock.createMock(SinkConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-        EasyMock.expect(connectorMock.config()).andReturn(new ConfigDef());
-        EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(Collections.<ConfigValue>emptyList()));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
 
         // CONN2 creation should fail because the worker group id (connect-test-group) conflicts with
         // the consumer group id we would use for this sink
+        Map<String, ConfigValue> validatedConfigs =
+            herder.validateBasicConnectorConfig(connectorMock, ConnectorConfig.configDef(), config);
 
-        Capture<Throwable> error = newCapture();
-        putConnectorCallback.onCompletion(EasyMock.capture(error), EasyMock.isNull(Herder.Created.class));
-        PowerMock.expectLastCall();
-
-        member.poll(EasyMock.anyInt());
-        PowerMock.expectLastCall();
-        // No immediate action besides this -- change will be picked up via the config log
-
-        PowerMock.replayAll();
-
-        herder.putConnectorConfig(CONN2, config, false, putConnectorCallback);
-        herder.tick();
-
-        assertTrue(error.hasCaptured());
-        assertTrue(error.getValue() instanceof BadRequestException);
-
-        time.sleep(1000L);
-        assertStatistics(3, 1, 100, 1000L);
-
-        PowerMock.verifyAll();
+        ConfigValue nameConfig = validatedConfigs.get(ConnectorConfig.NAME_CONFIG);
+        assertNotNull(nameConfig.errorMessages());
+        assertFalse(nameConfig.errorMessages().isEmpty());
     }
 
     @Test
     public void testCreateConnectorAlreadyExists() throws Exception {
         EasyMock.expect(member.memberId()).andStubReturn("leader");
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(null);
+
+        // mock the actual validation since its asynchronous nature is difficult to test and should
+        // be covered sufficiently by the unit tests for the AbstractHerder class
+        Capture<Callback<ConfigInfos>> validateCallback = newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(CONN1_CONFIG), capture(validateCallback));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
+                return null;
+            }
+        });
+
         expectRebalance(1, Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
 
@@ -743,11 +749,21 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
+
+        // These will occur just before/during the second tick
+        member.wakeup();
+        PowerMock.expectLastCall();
+        member.ensureActive();
+        PowerMock.expectLastCall();
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
         // No immediate action besides this -- change will be picked up via the config log
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONN1, CONN1_CONFIG, false, putConnectorCallback);
+        herder.tick();
         herder.tick();
 
         time.sleep(1000L);
@@ -764,9 +780,16 @@ public class DistributedHerderTest {
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -826,9 +849,18 @@ public class DistributedHerderTest {
         expectPostRebalanceCatchup(SNAPSHOT);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onFirstStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
         // now handle the connector restart
@@ -839,12 +871,21 @@ public class DistributedHerderTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
-        worker.stopConnector(CONN1);
-        PowerMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONN1);
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onSecondStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
         PowerMock.replayAll();
@@ -867,7 +908,6 @@ public class DistributedHerderTest {
         expectPostRebalanceCatchup(SNAPSHOT);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
-
 
         // now handle the connector restart
         member.wakeup();
@@ -1158,9 +1198,18 @@ public class DistributedHerderTest {
         expectRebalance(Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList(),
                 ConnectProtocol.Assignment.NO_ERROR, 1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
@@ -1189,9 +1238,18 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onFirstStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
@@ -1203,15 +1261,30 @@ public class DistributedHerderTest {
         member.ensureActive();
         PowerMock.expectLastCall();
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT); // for this test, it doesn't matter if we use the same config snapshot
-        worker.stopConnector(CONN1);
-        PowerMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONN1);
+        PowerMock.expectLastCall();
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onSecondStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
+        // These will occur just before/during the third tick
+        member.ensureActive();
+        PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -1220,6 +1293,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
         configUpdateListener.onConnectorConfigUpdate(CONN1); // read updated config
         herder.tick(); // apply config
+        herder.tick();
 
         PowerMock.verifyAll();
     }
@@ -1236,9 +1310,18 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
@@ -1253,9 +1336,22 @@ public class DistributedHerderTest {
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_PAUSED_CONN1);
         PowerMock.expectLastCall();
 
-        worker.setTargetState(CONN1, TargetState.PAUSED);
+        Capture<Callback<TargetState>> onPause = newCapture();
+        worker.setTargetState(EasyMock.eq(CONN1), EasyMock.eq(TargetState.PAUSED), capture(onPause));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.PAUSED);
+                return null;
+            }
+        });
+
+        member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
+        // These will occur just before/during the third tick
+        member.ensureActive();
+        PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -1264,6 +1360,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
         configUpdateListener.onConnectorTargetStateChange(CONN1); // state changes to paused
         herder.tick(); // worker should apply the state change
+        herder.tick();
 
         PowerMock.verifyAll();
     }
@@ -1278,9 +1375,16 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT_PAUSED_CONN1);
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.PAUSED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.PAUSED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.PAUSED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
 
         member.poll(EasyMock.anyInt());
@@ -1298,9 +1402,24 @@ public class DistributedHerderTest {
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
-        worker.setTargetState(CONN1, TargetState.STARTED);
+        Capture<Callback<TargetState>> onResume = newCapture();
+        worker.setTargetState(EasyMock.eq(CONN1), EasyMock.eq(TargetState.STARTED), capture(onResume));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                onResume.getValue().onCompletion(null, TargetState.STARTED);
+                return null;
+            }
+        });
+        member.wakeup();
         PowerMock.expectLastCall();
 
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
+        // These will occur just before/during the third tick
+        member.ensureActive();
+        PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -1309,6 +1428,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
         configUpdateListener.onConnectorTargetStateChange(CONN1); // state changes to started
         herder.tick(); // apply state change
+        herder.tick();
 
         PowerMock.verifyAll();
     }
@@ -1374,7 +1494,16 @@ public class DistributedHerderTest {
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_PAUSED_CONN1);
         PowerMock.expectLastCall();
 
-        worker.setTargetState(CONN1, TargetState.PAUSED);
+        Capture<Callback<TargetState>> onPause = newCapture();
+        worker.setTargetState(EasyMock.eq(CONN1), EasyMock.eq(TargetState.PAUSED), capture(onPause));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                onPause.getValue().onCompletion(null, TargetState.STARTED);
+                return null;
+            }
+        });
+        member.wakeup();
         PowerMock.expectLastCall();
 
         member.poll(EasyMock.anyInt());
@@ -1415,11 +1544,26 @@ public class DistributedHerderTest {
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT);
         PowerMock.expectLastCall();
 
-        worker.setTargetState(CONN1, TargetState.STARTED);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.setTargetState(EasyMock.eq(CONN1), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return null;
+            }
+        });
+        member.wakeup();
         PowerMock.expectLastCall();
 
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(false);
 
+        member.poll(EasyMock.anyInt());
+        PowerMock.expectLastCall();
+
+        // These will occur just before/during the third tick
+        member.ensureActive();
+        PowerMock.expectLastCall();
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -1428,6 +1572,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
         configUpdateListener.onConnectorTargetStateChange(CONN1); // state changes to paused
         herder.tick(); // apply state change
+        herder.tick();
 
         PowerMock.verifyAll();
     }
@@ -1491,9 +1636,18 @@ public class DistributedHerderTest {
         expectPostRebalanceCatchup(SNAPSHOT);
 
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
         worker.startTask(EasyMock.eq(TASK1), EasyMock.<ClusterConfigState>anyObject(), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
@@ -1542,10 +1696,18 @@ public class DistributedHerderTest {
                 1, Arrays.asList(CONN1), Arrays.asList(TASK1), 0);
 
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
-        // and the new assignment started
+        Capture<Callback<TargetState>> onStart = newCapture();
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -1629,9 +1791,18 @@ public class DistributedHerderTest {
 
         EasyMock.expect(worker.getPlugins()).andReturn(plugins);
         // and the new assignment started
+        Capture<Callback<TargetState>> onStart = newCapture();
         worker.startConnector(EasyMock.eq(CONN1), EasyMock.anyObject(), EasyMock.anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
+        member.wakeup();
+        PowerMock.expectLastCall();
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -1764,9 +1935,16 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onFirstStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onFirstStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfig)).andReturn(TASK_CONFIGS);
 
@@ -1780,19 +1958,18 @@ public class DistributedHerderTest {
         member.ensureActive();
         PowerMock.expectLastCall();
 
-        // config validation
-        Connector connectorMock = PowerMock.createMock(SourceConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
         EasyMock.expect(worker.getPlugins()).andReturn(plugins).anyTimes();
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-        EasyMock.expect(connectorMock.config()).andReturn(new ConfigDef());
-        EasyMock.expect(connectorMock.validate(CONN1_CONFIG_UPDATED)).andReturn(new Config(Collections.<ConfigValue>emptyList()));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT);
 
+        Capture<Callback<ConfigInfos>> validateCallback = newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(CONN1_CONFIG_UPDATED), capture(validateCallback));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+            @Override
+            public Void answer() throws Throwable {
+                validateCallback.getValue().onCompletion(null, CONN1_CONFIG_INFOS);
+                return null;
+            }
+        });
         configBackingStore.putConnectorConfig(CONN1, CONN1_CONFIG_UPDATED);
         PowerMock.expectLastCall().andAnswer(new IAnswer<Object>() {
             @Override
@@ -1805,12 +1982,19 @@ public class DistributedHerderTest {
         // As a result of reconfig, should need to update snapshot. With only connector updates, we'll just restart
         // connector without rebalance
         EasyMock.expect(configBackingStore.snapshot()).andReturn(SNAPSHOT_UPDATED_CONN1_CONFIG).times(2);
-        worker.stopConnector(CONN1);
-        PowerMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONN1);
+        PowerMock.expectLastCall();
         EasyMock.expect(member.currentProtocolVersion()).andStubReturn(CONNECT_PROTOCOL_V0);
-        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onSecondStart = newCapture();
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), capture(onSecondStart));
+        PowerMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onSecondStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, conn1SinkConfigUpdated)).andReturn(TASK_CONFIGS);
 
@@ -1847,6 +2031,7 @@ public class DistributedHerderTest {
         herder.tick();
         assertTrue(connectorConfigCb.isDone());
         assertEquals(CONN1_CONFIG_UPDATED, connectorConfigCb.get());
+
         PowerMock.verifyAll();
     }
 
@@ -1882,7 +2067,7 @@ public class DistributedHerderTest {
     public void testPutTaskConfigsMissingRequiredSignature() {
         Callback<Void> taskConfigCb = EasyMock.mock(Callback.class);
         Capture<Throwable> errorCapture = Capture.newInstance();
-        taskConfigCb.onCompletion(EasyMock.capture(errorCapture), EasyMock.eq(null));
+        taskConfigCb.onCompletion(capture(errorCapture), EasyMock.eq(null));
         EasyMock.expectLastCall().once();
 
         EasyMock.expect(member.currentProtocolVersion()).andReturn(CONNECT_PROTOCOL_V2).anyTimes();
@@ -1898,7 +2083,7 @@ public class DistributedHerderTest {
     public void testPutTaskConfigsDisallowedSignatureAlgorithm() {
         Callback<Void> taskConfigCb = EasyMock.mock(Callback.class);
         Capture<Throwable> errorCapture = Capture.newInstance();
-        taskConfigCb.onCompletion(EasyMock.capture(errorCapture), EasyMock.eq(null));
+        taskConfigCb.onCompletion(capture(errorCapture), EasyMock.eq(null));
         EasyMock.expectLastCall().once();
 
         EasyMock.expect(member.currentProtocolVersion()).andReturn(CONNECT_PROTOCOL_V2).anyTimes();
@@ -1918,7 +2103,7 @@ public class DistributedHerderTest {
     public void testPutTaskConfigsInvalidSignature() {
         Callback<Void> taskConfigCb = EasyMock.mock(Callback.class);
         Capture<Throwable> errorCapture = Capture.newInstance();
-        taskConfigCb.onCompletion(EasyMock.capture(errorCapture), EasyMock.eq(null));
+        taskConfigCb.onCompletion(capture(errorCapture), EasyMock.eq(null));
         EasyMock.expectLastCall().once();
 
         EasyMock.expect(member.currentProtocolVersion()).andReturn(CONNECT_PROTOCOL_V2).anyTimes();
@@ -2047,8 +2232,8 @@ public class DistributedHerderTest {
 
         if (!revokedConnectors.isEmpty()) {
             for (String connector : revokedConnectors) {
-                worker.stopConnector(connector);
-                PowerMock.expectLastCall().andReturn(true);
+                worker.stopAndAwaitConnector(connector);
+                PowerMock.expectLastCall();
             }
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -52,6 +52,8 @@ import org.apache.kafka.connect.tools.MockSourceConnector;
 import org.apache.kafka.connect.tools.SchemaSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
+import org.apache.kafka.connect.util.Callback;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.Before;
@@ -198,9 +200,10 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithSingleErrorDueToMissingConnectorClassname() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(partialProps), EasyMock.anyBoolean());
+        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(partialProps), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
 
-        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<Void>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(partialProps);
 
@@ -214,12 +217,14 @@ public class ConnectorPluginsResourceTest {
             resultConfigKeys.putAll(connectorConfigDef.configKeys());
             configValues.addAll(connectorConfigValues);
 
-            return AbstractHerder.generateResult(
-                    ConnectorPluginsResourceTestConnector.class.getName(),
-                    resultConfigKeys,
-                    configValues,
-                    Collections.singletonList("Test")
+            ConfigInfos configInfos = AbstractHerder.generateResult(
+                ConnectorPluginsResourceTestConnector.class.getName(),
+                resultConfigKeys,
+                configValues,
+                Collections.singletonList("Test")
             );
+            configInfosCallback.getValue().onCompletion(null, configInfos);
+            return null;
         });
 
         PowerMock.replayAll();
@@ -243,7 +248,8 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithSimpleName() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
+        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -259,12 +265,14 @@ public class ConnectorPluginsResourceTest {
             resultConfigKeys.putAll(connectorConfigDef.configKeys());
             configValues.addAll(connectorConfigValues);
 
-            return AbstractHerder.generateResult(
+            ConfigInfos configInfos = AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
             );
+            configInfosCallback.getValue().onCompletion(null, configInfos);
+            return null;
         });
 
         PowerMock.replayAll();
@@ -284,7 +292,8 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithAlias() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
+        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -300,12 +309,14 @@ public class ConnectorPluginsResourceTest {
             resultConfigKeys.putAll(connectorConfigDef.configKeys());
             configValues.addAll(connectorConfigValues);
 
-            return AbstractHerder.generateResult(
+            ConfigInfos configInfos = AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
             );
+            configInfosCallback.getValue().onCompletion(null, configInfos);
+            return null;
         });
 
         PowerMock.replayAll();
@@ -325,8 +336,8 @@ public class ConnectorPluginsResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void testValidateConfigWithNonExistentName() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
-
+        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
@@ -341,12 +352,14 @@ public class ConnectorPluginsResourceTest {
             resultConfigKeys.putAll(connectorConfigDef.configKeys());
             configValues.addAll(connectorConfigValues);
 
-            return AbstractHerder.generateResult(
+            ConfigInfos configInfos = AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
             );
+            configInfosCallback.getValue().onCompletion(null, configInfos);
+            return null;
         });
 
         PowerMock.replayAll();
@@ -362,7 +375,8 @@ public class ConnectorPluginsResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void testValidateConfigWithNonExistentAlias() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
+        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -378,12 +392,14 @@ public class ConnectorPluginsResourceTest {
             resultConfigKeys.putAll(connectorConfigDef.configKeys());
             configValues.addAll(connectorConfigValues);
 
-            return AbstractHerder.generateResult(
+            ConfigInfos configInfos = AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
             );
+            configInfosCallback.getValue().onCompletion(null, configInfos);
+            return null;
         });
 
         PowerMock.replayAll();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Connector;
-import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
@@ -28,6 +27,7 @@ import org.apache.kafka.connect.errors.AlreadyExistsException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.CloseableConnectorContext;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.Herder;
@@ -59,6 +59,7 @@ import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +86,7 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -113,7 +115,7 @@ public class StandaloneHerderTest {
     private PluginClassLoader pluginLoader;
     @Mock
     private DelegatingClassLoader delegatingLoader;
-    @Mock protected Callback<Herder.Created<ConnectorInfo>> createCallback;
+    protected FutureCallback<Herder.Created<ConnectorInfo>> createCallback;
     @Mock protected StatusBackingStore statusBackingStore;
 
     private final ConnectorClientConfigOverridePolicy
@@ -123,8 +125,9 @@ public class StandaloneHerderTest {
     @Before
     public void setup() {
         worker = PowerMock.createMock(Worker.class);
-        herder = PowerMock.createPartialMock(StandaloneHerder.class, new String[]{"connectorTypeForClass"},
+        herder = PowerMock.createPartialMock(StandaloneHerder.class, new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/},
             worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
+        createCallback = new FutureCallback<>();
         plugins = PowerMock.createMock(Plugins.class);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);
         delegatingLoader = PowerMock.createMock(DelegatingClassLoader.class);
@@ -146,12 +149,14 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
         PowerMock.verifyAll();
     }
 
-    @Test
-    public void testCreateConnectorFailedBasicValidation() {
+    @Test(expected = BadRequestException.class)
+    public void testCreateConnectorFailedValidation() throws Throwable {
         // Basic validation should be performed and return an error, but should still evaluate the connector's config
         connector = PowerMock.createMock(BogusSourceConnector.class);
 
@@ -172,50 +177,22 @@ public class StandaloneHerderTest {
         EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(singletonList(validatedValue)));
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
 
-        createCallback.onCompletion(EasyMock.<BadRequestException>anyObject(), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
-        PowerMock.expectLastCall();
-
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
 
-        PowerMock.verifyAll();
+        try {
+            createCallback.get(1000L, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            assertNotNull(e.getCause());
+            throw e.getCause();
+        } finally {
+            PowerMock.verifyAll();
+        }
     }
 
-    @Test
-    public void testCreateConnectorFailedCustomValidation() {
-        connector = PowerMock.createMock(BogusSourceConnector.class);
-
-        Connector connectorMock = PowerMock.createMock(SourceConnector.class);
-        EasyMock.expect(worker.configTransformer()).andReturn(transformer).times(2);
-        final Capture<Map<String, String>> configCapture = EasyMock.newCapture();
-        EasyMock.expect(transformer.transform(EasyMock.capture(configCapture))).andAnswer(configCapture::getValue);
-        EasyMock.expect(worker.getPlugins()).andReturn(plugins).times(3);
-        EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
-        EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
-
-        ConfigDef configDef = new ConfigDef();
-        configDef.define("foo.bar", ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, "foo.bar doc");
-        EasyMock.expect(connectorMock.config()).andReturn(configDef);
-
-        ConfigValue validatedValue = new ConfigValue("foo.bar");
-        validatedValue.addErrorMessage("Failed foo.bar validation");
-        Map<String, String> config = connectorConfig(SourceSink.SOURCE);
-        EasyMock.expect(connectorMock.validate(config)).andReturn(new Config(singletonList(validatedValue)));
-        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
-
-        createCallback.onCompletion(EasyMock.<BadRequestException>anyObject(), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
-        PowerMock.expectLastCall();
-
-        PowerMock.replayAll();
-
-        herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
-
-        PowerMock.verifyAll();
-    }
-
-    @Test
-    public void testCreateConnectorAlreadyExists() throws Exception {
+    @Test(expected = AlreadyExistsException.class)
+    public void testCreateConnectorAlreadyExists() throws Throwable {
         connector = PowerMock.createMock(BogusSourceConnector.class);
         // First addition should succeed
         expectAdd(SourceSink.SOURCE);
@@ -231,16 +208,25 @@ public class StandaloneHerderTest {
         EasyMock.expect(plugins.compareAndSwapLoaders(connectorMock)).andReturn(delegatingLoader);
         // No new connector is created
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
-        // Second should fail
-        createCallback.onCompletion(EasyMock.<AlreadyExistsException>anyObject(), EasyMock.<Herder.Created<ConnectorInfo>>isNull());
-        PowerMock.expectLastCall();
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
-        herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
-        PowerMock.verifyAll();
+        // Second should fail
+        FutureCallback<Herder.Created<ConnectorInfo>> failedCreateCallback = new FutureCallback<>();
+        herder.putConnectorConfig(CONNECTOR_NAME, config, false, failedCreateCallback);
+
+        try {
+            failedCreateCallback.get(1000L, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            assertNotNull(e.getCause());
+            throw e.getCause();
+        } finally {
+            PowerMock.verifyAll();
+        }
     }
 
     @Test
@@ -254,6 +240,8 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SINK), connectorInfo.result());
 
         PowerMock.verifyAll();
     }
@@ -276,15 +264,18 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
-        FutureCallback<Herder.Created<ConnectorInfo>> futureCb = new FutureCallback<>();
-        herder.deleteConnectorConfig(CONNECTOR_NAME, futureCb);
-        futureCb.get(1000L, TimeUnit.MILLISECONDS);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
+
+        FutureCallback<Herder.Created<ConnectorInfo>> deleteCallback = new FutureCallback<>();
+        herder.deleteConnectorConfig(CONNECTOR_NAME, deleteCallback);
+        deleteCallback.get(1000L, TimeUnit.MILLISECONDS);
 
         // Second deletion should fail since the connector is gone
-        futureCb = new FutureCallback<>();
-        herder.deleteConnectorConfig(CONNECTOR_NAME, futureCb);
+        FutureCallback<Herder.Created<ConnectorInfo>> failedDeleteCallback = new FutureCallback<>();
+        herder.deleteConnectorConfig(CONNECTOR_NAME, failedDeleteCallback);
         try {
-            futureCb.get(1000L, TimeUnit.MILLISECONDS);
+            failedDeleteCallback.get(1000L, TimeUnit.MILLISECONDS);
             fail("Should have thrown NotFoundException");
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof NotFoundException);
@@ -301,20 +292,29 @@ public class StandaloneHerderTest {
         Connector connectorMock = PowerMock.createMock(SourceConnector.class);
         expectConfigValidation(connectorMock, true, config);
 
-        worker.stopConnector(CONNECTOR_NAME);
-        EasyMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
 
-        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(config),
-                EasyMock.anyObject(HerderConnectorContext.class), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        EasyMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = EasyMock.newCapture();
+        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(config), EasyMock.anyObject(HerderConnectorContext.class),
+            EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), EasyMock.capture(onStart));
+        EasyMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartConnector(CONNECTOR_NAME, cb);
-        cb.get(1000L, TimeUnit.MILLISECONDS);
+        FutureCallback<Void> restartCallback = new FutureCallback<>();
+        herder.restartConnector(CONNECTOR_NAME, restartCallback);
+        restartCallback.get(1000L, TimeUnit.MILLISECONDS);
 
         PowerMock.verifyAll();
     }
@@ -327,29 +327,38 @@ public class StandaloneHerderTest {
         Connector connectorMock = PowerMock.createMock(SourceConnector.class);
         expectConfigValidation(connectorMock, true, config);
 
-        worker.stopConnector(CONNECTOR_NAME);
-        EasyMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
 
-        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(config),
-                EasyMock.anyObject(HerderConnectorContext.class), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        EasyMock.expectLastCall().andReturn(false);
+        Capture<Callback<TargetState>> onStart = EasyMock.newCapture();
+        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(config), EasyMock.anyObject(HerderConnectorContext.class),
+            EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), EasyMock.capture(onStart));
+        Exception exception = new ConnectException("Failed to start connector");
+        EasyMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(exception, null);
+                return true;
+            }
+        });
 
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartConnector(CONNECTOR_NAME, cb);
+        FutureCallback<Void> restartCallback = new FutureCallback<>();
+        herder.restartConnector(CONNECTOR_NAME, restartCallback);
         try {
-            cb.get(1000L, TimeUnit.MILLISECONDS);
+            restartCallback.get(1000L, TimeUnit.MILLISECONDS);
             fail();
-        } catch (ExecutionException exception) {
-            assertEquals(ConnectException.class, exception.getCause().getClass());
+        } catch (ExecutionException e) {
+            assertEquals(exception, e.getCause());
         }
 
         PowerMock.verifyAll();
     }
-
 
     @Test
     public void testRestartTask() throws Exception {
@@ -378,10 +387,13 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, connectorConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartTask(taskId, cb);
-        cb.get(1000L, TimeUnit.MILLISECONDS);
+        FutureCallback<Void> restartTaskCallback = new FutureCallback<>();
+        herder.restartTask(taskId, restartTaskCallback);
+        restartTaskCallback.get(1000L, TimeUnit.MILLISECONDS);
 
         PowerMock.verifyAll();
     }
@@ -413,6 +425,8 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, connectorConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.MILLISECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
         FutureCallback<Void> cb = new FutureCallback<>();
         herder.restartTask(taskId, cb);
@@ -448,6 +462,9 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, connectorConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
+
         herder.stop();
 
         PowerMock.verifyAll();
@@ -502,6 +519,8 @@ public class StandaloneHerderTest {
         herder.taskConfigs(CONNECTOR_NAME, taskConfigsCb);
 
         herder.putConnectorConfig(CONNECTOR_NAME, connConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
 
         EasyMock.reset(transformer);
         EasyMock.expect(transformer.transform(EasyMock.eq(CONNECTOR_NAME), EasyMock.anyObject()))
@@ -524,7 +543,7 @@ public class StandaloneHerderTest {
         newConnConfig.put("foo", "bar");
 
         Callback<Map<String, String>> connectorConfigCb = PowerMock.createMock(Callback.class);
-        Callback<Herder.Created<ConnectorInfo>> putConnectorConfigCb = PowerMock.createMock(Callback.class);
+        // Callback<Herder.Created<ConnectorInfo>> putConnectorConfigCb = PowerMock.createMock(Callback.class);
 
         // Create
         connector = PowerMock.createMock(BogusSourceConnector.class);
@@ -536,12 +555,19 @@ public class StandaloneHerderTest {
         connectorConfigCb.onCompletion(null, connConfig);
         EasyMock.expectLastCall();
         // Update config, which requires stopping and restarting
-        worker.stopConnector(CONNECTOR_NAME);
-        EasyMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
         Capture<Map<String, String>> capturedConfig = EasyMock.newCapture();
-        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(capturedConfig), EasyMock.<ConnectorContext>anyObject(),
-                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        EasyMock.expectLastCall().andReturn(true);
+        Capture<Callback<TargetState>> onStart = EasyMock.newCapture();
+        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(capturedConfig), EasyMock.<CloseableConnectorContext>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), EasyMock.capture(onStart));
+        EasyMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.isRunning(CONNECTOR_NAME)).andReturn(true);
         EasyMock.expect(worker.isTopicCreationEnabled()).andReturn(true);
         // Generate same task config, which should result in no additional action to restart tasks
@@ -549,11 +575,7 @@ public class StandaloneHerderTest {
                 .andReturn(singletonList(taskConfig(SourceSink.SOURCE)));
         worker.isSinkConnector(CONNECTOR_NAME);
         EasyMock.expectLastCall().andReturn(false);
-        ConnectorInfo newConnInfo = new ConnectorInfo(CONNECTOR_NAME, newConnConfig, Arrays.asList(new ConnectorTaskId(CONNECTOR_NAME, 0)),
-            ConnectorType.SOURCE);
-        putConnectorConfigCb.onCompletion(null, new Herder.Created<>(false, newConnInfo));
-        EasyMock.expectLastCall();
-        // Should get new config
+
         expectConfigValidation(connectorMock, false, newConnConfig);
         connectorConfigCb.onCompletion(null, newConnConfig);
         EasyMock.expectLastCall();
@@ -562,13 +584,22 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         herder.putConnectorConfig(CONNECTOR_NAME, connConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SOURCE), connectorInfo.result());
+
         herder.connectorConfig(CONNECTOR_NAME, connectorConfigCb);
-        herder.putConnectorConfig(CONNECTOR_NAME, newConnConfig, true, putConnectorConfigCb);
+
+        FutureCallback<Herder.Created<ConnectorInfo>> reconfigureCallback = new FutureCallback<>();
+        herder.putConnectorConfig(CONNECTOR_NAME, newConnConfig, true, reconfigureCallback);
+        Herder.Created<ConnectorInfo> newConnectorInfo = reconfigureCallback.get(1000L, TimeUnit.SECONDS);
+        ConnectorInfo newConnInfo = new ConnectorInfo(CONNECTOR_NAME, newConnConfig, Arrays.asList(new ConnectorTaskId(CONNECTOR_NAME, 0)),
+            ConnectorType.SOURCE);
+        assertEquals(newConnInfo, newConnectorInfo.result());
+
         assertEquals("bar", capturedConfig.getValue().get("foo"));
         herder.connectorConfig(CONNECTOR_NAME, connectorConfigCb);
 
         PowerMock.verifyAll();
-
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -586,7 +617,7 @@ public class StandaloneHerderTest {
     }
 
     @Test
-    public void testCorruptConfig() {
+    public void testCorruptConfig() throws Throwable {
         Map<String, String> config = new HashMap<>();
         config.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME);
         config.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, BogusSinkConnector.class.getName());
@@ -611,21 +642,24 @@ public class StandaloneHerderTest {
         EasyMock.expect(plugins.newConnector(EasyMock.anyString())).andReturn(connectorMock);
         EasyMock.expect(connectorMock.config()).andStubReturn(configDef);
         EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader);
-        Callback<Herder.Created<ConnectorInfo>> callback = PowerMock.createMock(Callback.class);
-        Capture<BadRequestException> capture = Capture.newInstance();
-        callback.onCompletion(
-            EasyMock.capture(capture), EasyMock.isNull(Herder.Created.class)
-        );
 
         PowerMock.replayAll();
 
-        herder.putConnectorConfig(CONNECTOR_NAME, config, true, callback);
-        assertEquals(
-            capture.getValue().getMessage(),
-            "Connector configuration is invalid and contains the following 1 error(s):\n" +
-                error + "\n" +
-                "You can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
-        );
+        herder.putConnectorConfig(CONNECTOR_NAME, config, true, createCallback);
+        try {
+            createCallback.get(1000L, TimeUnit.SECONDS);
+            fail("Should have failed to configure connector");
+        } catch (ExecutionException e) {
+            assertNotNull(e.getCause());
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof BadRequestException);
+            assertEquals(
+                cause.getMessage(),
+                "Connector configuration is invalid and contains the following 1 error(s):\n" +
+                    error + "\n" +
+                    "You can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
+            );
+        }
 
         PowerMock.verifyAll();
     }
@@ -636,18 +670,21 @@ public class StandaloneHerderTest {
             new SourceConnectorConfig(plugins, connectorProps, true) :
             new SinkConnectorConfig(plugins, connectorProps);
 
+        Capture<Callback<TargetState>> onStart = EasyMock.newCapture();
         worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(connectorProps), EasyMock.anyObject(HerderConnectorContext.class),
-                              EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        EasyMock.expectLastCall().andReturn(true);
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), EasyMock.capture(onStart));
+        // EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andAnswer(new IAnswer<Boolean>() {
+            @Override
+            public Boolean answer() throws Throwable {
+                onStart.getValue().onCompletion(null, TargetState.STARTED);
+                return true;
+            }
+        });
         EasyMock.expect(worker.isRunning(CONNECTOR_NAME)).andReturn(true);
         if (sourceSink == SourceSink.SOURCE) {
             EasyMock.expect(worker.isTopicCreationEnabled()).andReturn(true);
         }
-
-        ConnectorInfo connInfo = new ConnectorInfo(CONNECTOR_NAME, connectorProps, Arrays.asList(new ConnectorTaskId(CONNECTOR_NAME, 0)),
-            SourceSink.SOURCE == sourceSink ? ConnectorType.SOURCE : ConnectorType.SINK);
-        createCallback.onCompletion(null, new Herder.Created<>(true, connInfo));
-        EasyMock.expectLastCall();
 
         // And we should instantiate the tasks. For a sink task, we should see added properties for the input topic partitions
 
@@ -676,12 +713,18 @@ public class StandaloneHerderTest {
         PowerMock.expectLastCall().andReturn(sourceSink == SourceSink.SINK);
     }
 
+    private ConnectorInfo createdInfo(SourceSink sourceSink) {
+        return new ConnectorInfo(CONNECTOR_NAME, connectorConfig(sourceSink),
+            Arrays.asList(new ConnectorTaskId(CONNECTOR_NAME, 0)),
+            SourceSink.SOURCE == sourceSink ? ConnectorType.SOURCE : ConnectorType.SINK);
+    }
+
     private void expectStop() {
         ConnectorTaskId task = new ConnectorTaskId(CONNECTOR_NAME, 0);
         worker.stopAndAwaitTasks(singletonList(task));
         EasyMock.expectLastCall();
-        worker.stopConnector(CONNECTOR_NAME);
-        EasyMock.expectLastCall().andReturn(true);
+        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
     }
 
     private void expectDestroy() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -350,7 +350,7 @@ public class EmbeddedConnectCluster {
      * Delete an existing connector.
      *
      * @param connName name of the connector to be deleted
-     * @throws ConnectRestException if the REST api returns error status
+     * @throws ConnectRestException if the REST API returns error status
      * @throws ConnectException for any other error.
      */
     public void deleteConnector(String connName) {
@@ -359,6 +359,54 @@ public class EmbeddedConnectCluster {
         if (response.getStatus() >= Response.Status.BAD_REQUEST.getStatusCode()) {
             throw new ConnectRestException(response.getStatus(),
                     "Could not execute DELETE request. Error response: " + responseToString(response));
+        }
+    }
+
+    /**
+     * Pause an existing connector.
+     *
+     * @param connName name of the connector to be paused
+     * @throws ConnectRestException if the REST API returns error status
+     * @throws ConnectException for any other error.
+     */
+    public void pauseConnector(String connName) {
+        String url = endpointForResource(String.format("connectors/%s/pause", connName));
+        Response response = requestPut(url, "");
+        if (response.getStatus() >= Response.Status.BAD_REQUEST.getStatusCode()) {
+            throw new ConnectRestException(response.getStatus(),
+                "Could not execute PUT request. Error response: " + responseToString(response));
+        }
+    }
+
+    /**
+     * Resume an existing connector.
+     *
+     * @param connName name of the connector to be resumed
+     * @throws ConnectRestException if the REST API returns error status
+     * @throws ConnectException for any other error.
+     */
+    public void resumeConnector(String connName) {
+        String url = endpointForResource(String.format("connectors/%s/resume", connName));
+        Response response = requestPut(url, "");
+        if (response.getStatus() >= Response.Status.BAD_REQUEST.getStatusCode()) {
+            throw new ConnectRestException(response.getStatus(),
+                "Could not execute PUT request. Error response: " + responseToString(response));
+        }
+    }
+
+    /**
+     * Restart an existing connector.
+     *
+     * @param connName name of the connector to be restarted
+     * @throws ConnectRestException if the REST API returns error status
+     * @throws ConnectException for any other error.
+     */
+    public void restartConnector(String connName) {
+        String url = endpointForResource(String.format("connectors/%s/restart", connName));
+        Response response = requestPost(url, "", Collections.emptyMap());
+        if (response.getStatus() >= Response.Status.BAD_REQUEST.getStatusCode()) {
+            throw new ConnectRestException(response.getStatus(),
+                "Could not execute POST request. Error response: " + responseToString(response));
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://issues.apache.org/jira/browse/KAFKA-9374)

These changes allow herders to continue to function even when a connector they are running hangs in its start, stop, initialize, validate, and/or config methods.

The main idea is to make these connector interactions asynchronous and accept a callback that can be invoked upon the completion (successful or otherwise) of these interactions. The distributed herder handles any follow-up logic by adding a new herder request to its queue in that callback, which helps preserve some synchronization and ordering guarantees provided by the current tick model.

If any connector refuses to shut down within a graceful timeout period, the framework will abandon it and potentially start a new connector in its place (in cases such as connector restart or reconfiguration).

Existing unit tests for the distributed herder and worker have been modified to reflect these changes, and a new integration test named `BlockingConnectorTest` has been added to ensure that they work in practice.