### PR TITLE
MINOR:add missing quote for malformed line content

### DIFF
--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -39,7 +39,7 @@ class CheckpointReadBuffer[T](location: String,
                               formatter: CheckpointFileFormatter[T]) extends Logging {
   def read(): Seq[T] = {
     def malformedLineException(line: String) =
-      new IOException(s"Malformed line in checkpoint file ($location): $line'")
+      new IOException(s"Malformed line in checkpoint file ($location): '$line'")
 
     var line: String = null
     try {


### PR DESCRIPTION
Noticed weird extra single quote in logs but actually not in the checkpoint file:

java.io.IOException: Malformed line in checkpoint file (/var/local/kafka/data_new1/recovery-point-offset-checkpoint): aa'

Realized it should be:

java.io.IOException: Malformed line in checkpoint file (/var/local/kafka/data_new1/recovery-point-offset-checkpoint): 'aa'

*Summary of testing strategy (including rationale)
Minor logging change, not test needed.
