### PR TITLE
Minor: the configured transformations used by SourceTask/SinkTask sho…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.errors.ToleranceType;
@@ -261,6 +262,7 @@ public class ConnectorConfig extends AbstractConfig {
                 transformation.configure(originalsWithPrefix(prefix));
                 transformations.add(transformation);
             } catch (Exception e) {
+                transformations.forEach(t -> Utils.closeQuietly(t, "Transformation"));
                 throw new ConnectException(e);
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -23,11 +23,12 @@ import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-public class TransformationChain<R extends ConnectRecord<R>> {
+public class TransformationChain<R extends ConnectRecord<R>> implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(TransformationChain.class);
 
     private final List<Transformation<R>> transformations;
@@ -55,6 +56,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
         return record;
     }
 
+    @Override
     public void close() {
         for (Transformation<R> transformation : transformations) {
             transformation.close();


### PR DESCRIPTION
There are many closable objects used by building SourceTask/SinkTask but we don't close them actually when exception is thrown. A obvious issue is the configured transformations are never closed when the build of task fails. This patch introduces a collection to keep all closeable objects to make sure they are closed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
