### PR TITLE
KAFKA-9583: use topic-partitions grouped by node to send OffsetsForLeaderEpoch requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -800,7 +800,7 @@ public class Fetcher<K, V> implements Closeable {
 
             subscriptions.setNextAllowedRetry(fetchPostitions.keySet(), time.milliseconds() + requestTimeoutMs);
 
-            RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future = offsetsForLeaderEpochClient.sendAsyncRequest(node, partitionsToValidate);
+            RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future = offsetsForLeaderEpochClient.sendAsyncRequest(node, fetchPostitions);
             future.addListener(new RequestFutureListener<OffsetsForLeaderEpochClient.OffsetForEpochResult>() {
                 @Override
                 public void onSuccess(OffsetsForLeaderEpochClient.OffsetForEpochResult offsetsResult) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
@@ -96,7 +96,7 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
                     partitionsToRetry.add(topicPartition);
                     break;
                 case UNKNOWN_TOPIC_OR_PARTITION:
-                    logger().warn("Received unknown topic or partition error in ListOffset request for partition {}",
+                    logger().warn("Received unknown topic or partition error in OffsetsForLeaderEpoch request for partition {}",
                             topicPartition);
                     partitionsToRetry.add(topicPartition);
                     break;


### PR DESCRIPTION
In `validateOffsetsAsync`, we group the requests by leader node for efficiency. The list of topic-partitions are grouped from `partitionsToValidate` (all partitions) to `node` => `fetchPostitions` (partitions by node). However, when actually sending the request with `OffsetsForLeaderEpochClient`, we use `partitionsToValidate`, which is the list of all topic-partitions passed into `validateOffsetsAsync`. This results in extra partitions being included in the request sent to brokers that are potentially not the leader for those partitions.

This PR fixes the issue by using `fetchPositions`, which is the proper list of partitions that we should send in the request. Additionally, a small typo of API name in `OffsetsForLeaderEpochClient` is corrected (it originally referenced `LisfOffsets` as the API name).

## Tests

Tested with the following configuration:

topic-partitions:
```
❯ kafkacat -b localhost:8080 -L
Metadata for all topics (from broker -1: localhost:8080/bootstrap):
 3 brokers:
  broker 1 at localhost:9092 (controller)
  broker 2 at localhost:9093
  broker 3 at localhost:9094
 2 topics:
  topic "broker-a.only" with 1 partitions:
    partition 0, leader 1, replicas: 1, isrs: 1
  topic "broker-b.only" with 5 partitions:
    partition 0, leader 2, replicas: 2, isrs: 2
    partition 1, leader 2, replicas: 2, isrs: 2
    partition 2, leader 2, replicas: 2, isrs: 2
    partition 3, leader 2, replicas: 2, isrs: 2
    partition 4, leader 2, replicas: 2, isrs: 2
```

before the change: `broker-a.only-1` was sent to broker 2, which is not the leader for this partition.

after the change: `broker-a.only-1` was not sent to broker 2.

Client tests are run with `./gradlew :clients:test`. Ideas for additional tests are welcome!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
