### PR TITLE
KAFKA-6266: Repeated occurrence of WARN Resetting first dirty offset

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -105,8 +105,8 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
             partitions.iterator.map { tp =>
               val log = logs.get(tp)
               val lastCleanOffset = lastClean.get(tp)
-              val (firstDirtyOffset, firstUncleanableDirtyOffset) = cleanableOffsets(log, lastCleanOffset, now)
-              val (_, uncleanableBytes) = calculateCleanableBytes(log, firstDirtyOffset, firstUncleanableDirtyOffset)
+              val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
+              val (_, uncleanableBytes) = calculateCleanableBytes(log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset)
               uncleanableBytes
             }.sum
           case None => 0
@@ -180,14 +180,14 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
           try {
             val lastCleanOffset = lastClean.get(topicPartition)
             val logStartOffset = log.logStartOffset
-            val (firstDirtyOffset, firstUncleanableDirtyOffset) = cleanableOffsets(log, lastCleanOffset, now)
+            val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
             // update checkpoint for logs with invalid checkpointed offsets
-            if (lastCleanOffset.getOrElse(logStartOffset) < logStartOffset && !isCompactAndDelete(log))
-              updateCheckpoints(log.dir.getParentFile(), Option(topicPartition, log.logStartOffset))
-            val compactionDelayMs = maxCompactionDelay(log, firstDirtyOffset, now)
+            if (offsetsToClean.needUpdateCheckpoint)
+              updateCheckpoints(log.dir.getParentFile(), Option(topicPartition, logStartOffset))
+            val compactionDelayMs = maxCompactionDelay(log, offsetsToClean.firstDirtyOffset, now)
             preCleanStats.updateMaxCompactionDelay(compactionDelayMs)
 
-            LogToClean(topicPartition, log, firstDirtyOffset, firstUncleanableDirtyOffset, compactionDelayMs > 0)
+            LogToClean(topicPartition, log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset, compactionDelayMs > 0)
           } catch {
             case e: Throwable => throw new LogCleaningException(log,
               s"Failed to calculate log cleaning stats for partition $topicPartition", e)
@@ -484,6 +484,14 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   }
 }
 
+/**
+ * Helper class for the cleanable segment of a log and whether to update the checkpoint associated with the log
+ */
+private case class OffsetsToClean(firstDirtyOffset: Long,
+                                  firstUncleanableDirtyOffset: Long,
+                                  needUpdateCheckpoint: Boolean = false) {
+}
+
 private[log] object LogCleanerManager extends Logging {
 
   def isCompactAndDelete(log: Log): Boolean = {
@@ -519,29 +527,32 @@ private[log] object LogCleanerManager extends Logging {
     * @param log the log
     * @param lastCleanOffset the last checkpointed offset
     * @param now the current time in milliseconds of the cleaning operation
-    * @return the lower (inclusive) and upper (exclusive) offsets
+    * @return OffsetsToClean containing offsets for cleanable portion of log and whether the log checkpoint needs updating
     */
-  def cleanableOffsets(log: Log, lastCleanOffset: Option[Long], now: Long): (Long, Long) = {
+  def cleanableOffsets(log: Log, lastCleanOffset: Option[Long], now: Long): OffsetsToClean = {
     // If the log segments are abnormally truncated and hence the checkpointed offset is no longer valid;
     // reset to the log starting offset and log the error
-    val firstDirtyOffset = {
+    val (firstDirtyOffset, needsUpdateCheckpoint) = {
       val logStartOffset = log.logStartOffset
       val checkpointDirtyOffset = lastCleanOffset.getOrElse(logStartOffset)
 
       if (checkpointDirtyOffset < logStartOffset) {
         // Don't bother with the warning if compact and delete are enabled.
-        if (!isCompactAndDelete(log))
+        if (!isCompactAndDelete(log)) {
           warn(s"Resetting first dirty offset of ${log.name} to log start offset $logStartOffset " +
             s"since the checkpointed offset $checkpointDirtyOffset is invalid.")
-        logStartOffset
+          (logStartOffset, true)
+        } else {
+          (logStartOffset, false)
+        }
       } else if (checkpointDirtyOffset > log.logEndOffset) {
         // The dirty offset has gotten ahead of the log end offset. This could happen if there was data
         // corruption at the end of the log. We conservatively assume that the full log needs cleaning.
         warn(s"The last checkpoint dirty offset for partition ${log.name} is $checkpointDirtyOffset, " +
           s"which is larger than the log end offset ${log.logEndOffset}. Resetting to the log start offset $logStartOffset.")
-        logStartOffset
+        (logStartOffset, true)
       } else {
-        checkpointDirtyOffset
+        (checkpointDirtyOffset, false)
       }
     }
 
@@ -576,7 +587,7 @@ private[log] object LogCleanerManager extends Logging {
       s"now=$now => firstDirtyOffset=$firstDirtyOffset firstUncleanableOffset=$firstUncleanableDirtyOffset " +
       s"activeSegment.baseOffset=${log.activeSegment.baseOffset}")
 
-    (firstDirtyOffset, math.max(firstDirtyOffset, firstUncleanableDirtyOffset))
+    OffsetsToClean(firstDirtyOffset, firstUncleanableDirtyOffset, needsUpdateCheckpoint)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -537,7 +537,7 @@ private[log] object LogCleanerManager extends Logging {
   def cleanableOffsets(log: Log, lastCleanOffset: Option[Long], now: Long): OffsetsToClean = {
     // If the log segments are abnormally truncated and hence the checkpointed offset is no longer valid;
     // reset to the log starting offset and log the error
-    val (firstDirtyOffset, needsUpdateCheckpoint) = {
+    val (firstDirtyOffset, forceUpdateCheckpoint) = {
       val logStartOffset = log.logStartOffset
       val checkpointDirtyOffset = lastCleanOffset.getOrElse(logStartOffset)
 
@@ -589,7 +589,7 @@ private[log] object LogCleanerManager extends Logging {
       s"now=$now => firstDirtyOffset=$firstDirtyOffset firstUncleanableOffset=$firstUncleanableDirtyOffset " +
       s"activeSegment.baseOffset=${log.activeSegment.baseOffset}")
 
-    OffsetsToClean(firstDirtyOffset, math.max(firstDirtyOffset, firstUncleanableDirtyOffset), needsUpdateCheckpoint)
+    OffsetsToClean(firstDirtyOffset, math.max(firstDirtyOffset, firstUncleanableDirtyOffset), forceUpdateCheckpoint)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -486,6 +486,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
 
 /**
  * Helper class for the cleanable segment of a log and whether to update the checkpoint associated with the log
+ * firstDirtyOffset the lower (inclusive) and firstUncleanableDirtyOffset the upper(exclusive) offsets
  */
 private case class OffsetsToClean(firstDirtyOffset: Long,
                                   firstUncleanableDirtyOffset: Long,
@@ -587,7 +588,7 @@ private[log] object LogCleanerManager extends Logging {
       s"now=$now => firstDirtyOffset=$firstDirtyOffset firstUncleanableOffset=$firstUncleanableDirtyOffset " +
       s"activeSegment.baseOffset=${log.activeSegment.baseOffset}")
 
-    OffsetsToClean(firstDirtyOffset, firstUncleanableDirtyOffset, needsUpdateCheckpoint)
+    OffsetsToClean(firstDirtyOffset, Math.max(firstDirtyOffset, firstUncleanableDirtyOffset), needsUpdateCheckpoint)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -495,15 +495,15 @@ class LogCleanerManagerTest extends Logging {
 
     var lastCleanOffset = Some(15L)
     var cleanableOffsets = LogCleanerManager.cleanableOffsets(logs.get(tp), lastCleanOffset, time.milliseconds)
-    assertEquals("Checkpoint offset should not be reset if valid", false, cleanableOffsets.forceUpdateCheckpoint)
+    assertFalse("Checkpoint offset should not be reset if valid", cleanableOffsets.forceUpdateCheckpoint)
 
     logs.get(tp).maybeIncrementLogStartOffset(20L)
     cleanableOffsets = LogCleanerManager.cleanableOffsets(logs.get(tp), lastCleanOffset, time.milliseconds)
-    assertEquals("Checkpoint offset needs to be reset if less than log start offset", true, cleanableOffsets.forceUpdateCheckpoint)
+    assertTrue("Checkpoint offset needs to be reset if less than log start offset", cleanableOffsets.forceUpdateCheckpoint)
 
     lastCleanOffset = Some(25L)
     cleanableOffsets = LogCleanerManager.cleanableOffsets(logs.get(tp), lastCleanOffset, time.milliseconds)
-    assertEquals("Checkpoint offset needs to be reset if greater than log end offset", true, cleanableOffsets.forceUpdateCheckpoint)
+    assertTrue("Checkpoint offset needs to be reset if greater than log end offset", cleanableOffsets.forceUpdateCheckpoint)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -56,7 +56,7 @@ class LogCleanerManagerTest extends Logging {
     }
 
     override def updateCheckpoints(dataDir: File, update: Option[(TopicPartition,Long)]): Unit = {
-      val (tp, offset) = update.get
+      val (tp, offset) = update.getOrElse(throw new IllegalArgumentException("update=None argument not yet handled"))
       cleanerCheckpoints.put(tp, offset)
     }
   }


### PR DESCRIPTION
Previously, checkpointed offsets for a log were only updated if the log was chosen for cleaning once the cleaning job completes. This caused issues in cases where logs with invalid checkpointed offsets would repeatedly emit warnings if the log with an invalid cleaning checkpoint wasn't chosen for cleaning.

Proposed fix is to update the checkpointed offset for logs with invalid checkpoints regardless of whether it gets chosen for cleaning.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
