### PR TITLE
KAFKA-9540: Move "Could not find the standby task while closing it" log to debug level

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStandbyTasks.java
@@ -71,7 +71,8 @@ class AssignedStandbyTasks extends AssignedTasks<StandbyTask> {
             } else if (created.containsKey(taskId)) {
                 task = created.get(taskId);
             } else {
-                log.error("Could not find the standby task {} while closing it", taskId);
+                log.debug("Could not find the standby task {} while closing it, most likely it was not created " +
+                    "because it has no state stores in its subtopology.", taskId);
                 continue;
             }
 


### PR DESCRIPTION
As described in the ticket, this message is logged at the error level but only indicates that a standby task was not created (as is the case if its subtopology is stateless). Moving this to debug level, and clarifying the implications in the log level.

Targeting this PR against 2.4, as the issue is incidentally fixed in trunk as part of the tech debt cleanup. We should also merge this fix to 2.5 but need to wait for the release, since this is obviously not a blocker