### PR TITLE
KAFKA-9541:Flaky Test DescribeConsumerGroupTest#testDescribeGroupMembersWithShortInitializationTimeout

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -582,7 +582,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       TestUtils.grabConsoleOutputAndError(service.describeGroups())
       fail(s"The consumer group command should have failed due to low initialization timeout (describe type: ${describeType.mkString(" ")})")
     } catch {
-      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
+      case e: ExecutionException if e.getCause.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }
@@ -603,7 +603,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupOffsets(group)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
-      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
+      case e: ExecutionException if e.getCause.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }
@@ -624,13 +624,13 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupMembers(group, false)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
-      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
+      case e: ExecutionException if e.getCause.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
         try {
           service.collectGroupMembers(group, true)
           fail("The consumer group command should fail due to low initialization timeout (verbose)")
         } catch {
-          case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
+          case e: ExecutionException if e.getCause.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
           case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
         }
     }
@@ -652,7 +652,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupState(group)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
-      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
+      case e: ExecutionException if e.getCause.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -22,7 +22,7 @@ import joptsimple.OptionException
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.consumer.{ConsumerConfig, RoundRobinAssignor}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.common.errors.{DisconnectException, TimeoutException}
 import org.junit.Assert._
 import org.junit.Test
 
@@ -582,6 +582,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       TestUtils.grabConsoleOutputAndError(service.describeGroups())
       fail(s"The consumer group command should have failed due to low initialization timeout (describe type: ${describeType.mkString(" ")})")
     } catch {
+      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }
@@ -602,6 +603,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupOffsets(group)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
+      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }
@@ -622,11 +624,13 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupMembers(group, false)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
+      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
         try {
           service.collectGroupMembers(group, true)
           fail("The consumer group command should fail due to low initialization timeout (verbose)")
         } catch {
+          case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
           case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
         }
     }
@@ -648,6 +652,7 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       service.collectGroupState(group)
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
+      case e: ExecutionException if e.isInstanceOf[DisconnectException] => // Ignore occasional node disconnection
       case e: ExecutionException => assertEquals(classOf[TimeoutException], e.getCause.getClass)
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9541

Occasionally the captured exception is DisconnectedException instead of TimeoutException. That might be due to an unexpected long pause that caused the node disconnection.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
