### PR TITLE
KAFKA-9479 Describe consumer groups with --all-groups now prints head…

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -296,11 +296,12 @@ object ConsumerGroupCommand extends Logging {
         .map(state => (state.group, s"${state.coordinator.host}:${state.coordinator.port} (${state.coordinator.idString})",
           state.assignmentStrategy, state.state, state.numMembers)).toList
 
-      val maxCoordinatorColLen =  if (stateValues.nonEmpty) Math.max(25, stateValues.map(_._1.length).max) else 25
+      val maxCoordinatorColLen = if (stateValues.nonEmpty) Math.max(25, stateValues.map(_._1.length).max) else 25
       print(s"\n%${-maxCoordinatorColLen}s %-25s %-20s %-15s %s".format("GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS"))
 
-      stateValues.foreach({case (group,coordinator,  assignmentStrategy,state, numMembers ) =>
-        print(s"\n%${-maxCoordinatorColLen}s %-25s %-20s %-15s %s".format(group, coordinator, assignmentStrategy, state, numMembers))})
+      stateValues.foreach({ case (group, coordinator, assignmentStrategy, state, numMembers) =>
+        print(s"\n%${-maxCoordinatorColLen}s %-25s %-20s %-15s %s".format(group, coordinator, assignmentStrategy, state, numMembers)) })
+      println()
     }
 
     def describeGroups(): Unit = {


### PR DESCRIPTION
KAFKA-9479 Describe consumer groups with --all-groups now prints header only once

Describing the consumer groups with --all-groups will now only print the header once, instead of once per entry. The maximum coordinator length is computed first, by looping through the GroupStates in advance, to ensure correct cormatting.