### PR TITLE
KAFKA-8073 Transient failure in kafka.api.UserQuotaTest.testThrottled…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -78,7 +78,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 
   @Test
   def testThrottledProducerConsumer(): Unit = {
-    val numRecords = 1000
+    val numRecords = defaultProducerQuota
     val produced = quotaTestClients.produceUntilThrottled(numRecords)
     quotaTestClients.verifyProduceThrottle(expectThrottle = true)
 


### PR DESCRIPTION
the input data in testThrottledProducerConsumer are 1000 messages and each message carries only a string bytes which is converted from int value. The quota is 8000 bytes/second so it fails to start the throttle if the machine is too slow to complete all request. It is a timer-based test case. The workaround is to increase the size of input data.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
