### PR TITLE
KAFKA-9544; Fix flaky test `AdminClientTest.testDefaultApiTimeoutOverride`

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2631,11 +2631,14 @@ public class KafkaAdminClientTest {
             // Wait for the request to be timed out before backing off
             TestUtils.waitForCondition(() -> !env.kafkaClient().hasInFlightRequests(),
                     "Timed out waiting for inFlightRequests to be timed out");
-            time.sleep(retryBackoffMs);
 
             // Since api timeout bound is not hit, AdminClient should retry
-            TestUtils.waitForCondition(() -> env.kafkaClient().hasInFlightRequests(),
-                    "Timed out waiting for Metadata request to be sent");
+            TestUtils.waitForCondition(() -> {
+                boolean hasInflightRequests = env.kafkaClient().hasInFlightRequests();
+                if (!hasInflightRequests)
+                    time.sleep(retryBackoffMs);
+                return hasInflightRequests;
+            }, "Timed out waiting for Metadata request to be sent");
             time.sleep(requestTimeoutMs + 1);
 
             TestUtils.assertFutureThrows(result.future, TimeoutException.class);


### PR DESCRIPTION
There is a race condition with the backoff sleep in the test case and setting the next allowed send time in the AdminClient. To fix it, we allow the test case to do the backoff sleep multiple times if needed.

The test failure was fairly easy to reproduce prior to this fix. With the fix, I could not reproduce the problem after 500 runs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
