### PR TITLE
KAFKA-9441: Add internal StreamsProducer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -67,10 +67,19 @@ public class MockProducer<K, V> implements Producer<K, V> {
     private boolean transactionCommitted;
     private boolean transactionAborted;
     private boolean producerFenced;
-    private boolean producerFencedOnCommitTxn;
     private boolean sentOffsets;
     private long commitCount = 0L;
     private Map<MetricName, Metric> mockMetrics;
+
+    public RuntimeException initTransactionException = null;
+    public RuntimeException beginTransactionException = null;
+    public RuntimeException sendOffsetsToTransactionException = null;
+    public RuntimeException commitTransactionException = null;
+    public RuntimeException abortTransactionException = null;
+    public RuntimeException sendException = null;
+    public RuntimeException flushException = null;
+    public RuntimeException partitionsForException = null;
+    public RuntimeException closeException = null;
 
     /**
      * Create a mock producer
@@ -141,13 +150,29 @@ public class MockProducer<K, V> implements Producer<K, V> {
         if (this.transactionInitialized) {
             throw new IllegalStateException("MockProducer has already been initialized for transactions.");
         }
+        if (this.initTransactionException != null) {
+            throw this.initTransactionException;
+        }
         this.transactionInitialized = true;
+        this.transactionInFlight = false;
+        this.transactionCommitted = false;
+        this.transactionAborted = false;
+        this.sentOffsets = false;
     }
 
     @Override
     public void beginTransaction() throws ProducerFencedException {
         verifyProducerState();
         verifyTransactionsInitialized();
+
+        if (this.beginTransactionException != null) {
+            throw this.beginTransactionException;
+        }
+
+        if (transactionInFlight) {
+            throw new IllegalStateException("Transaction already started");
+        }
+
         this.transactionInFlight = true;
         this.transactionCommitted = false;
         this.transactionAborted = false;
@@ -160,15 +185,17 @@ public class MockProducer<K, V> implements Producer<K, V> {
         Objects.requireNonNull(consumerGroupId);
         verifyProducerState();
         verifyTransactionsInitialized();
-        verifyNoTransactionInFlight();
+        verifyTransactionInFlight();
+
+        if (this.sendOffsetsToTransactionException != null) {
+            throw this.sendOffsetsToTransactionException;
+        }
+
         if (offsets.size() == 0) {
             return;
         }
-        Map<TopicPartition, OffsetAndMetadata> uncommittedOffsets = this.uncommittedConsumerGroupOffsets.get(consumerGroupId);
-        if (uncommittedOffsets == null) {
-            uncommittedOffsets = new HashMap<>();
-            this.uncommittedConsumerGroupOffsets.put(consumerGroupId, uncommittedOffsets);
-        }
+        Map<TopicPartition, OffsetAndMetadata> uncommittedOffsets =
+            this.uncommittedConsumerGroupOffsets.computeIfAbsent(consumerGroupId, k -> new HashMap<>());
         uncommittedOffsets.putAll(offsets);
         this.sentOffsets = true;
     }
@@ -182,13 +209,13 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     @Override
     public void commitTransaction() throws ProducerFencedException {
-        if (producerFencedOnCommitTxn) {
-            throw new ProducerFencedException("Producer is fenced");
-        }
-
         verifyProducerState();
         verifyTransactionsInitialized();
-        verifyNoTransactionInFlight();
+        verifyTransactionInFlight();
+
+        if (this.commitTransactionException != null) {
+            throw this.commitTransactionException;
+        }
 
         flush();
 
@@ -209,7 +236,12 @@ public class MockProducer<K, V> implements Producer<K, V> {
     public void abortTransaction() throws ProducerFencedException {
         verifyProducerState();
         verifyTransactionsInitialized();
-        verifyNoTransactionInFlight();
+        verifyTransactionInFlight();
+
+        if (this.abortTransactionException != null) {
+            throw this.abortTransactionException;
+        }
+
         flush();
         this.uncommittedSends.clear();
         this.uncommittedConsumerGroupOffsets.clear();
@@ -233,7 +265,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         }
     }
 
-    private void verifyNoTransactionInFlight() {
+    private void verifyTransactionInFlight() {
         if (!this.transactionInFlight) {
             throw new IllegalStateException("There is no open transaction.");
         }
@@ -259,9 +291,14 @@ public class MockProducer<K, V> implements Producer<K, V> {
         if (this.closed) {
             throw new IllegalStateException("MockProducer is already closed.");
         }
+
         if (this.producerFenced) {
             throw new KafkaException("MockProducer is fenced.", new ProducerFencedException("Fenced"));
         }
+        if (this.sendException != null) {
+            throw this.sendException;
+        }
+
         int partition = 0;
         if (!this.cluster.partitionsForTopic(record.topic()).isEmpty())
             partition = partition(record, this.cluster);
@@ -303,11 +340,20 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     public synchronized void flush() {
         verifyProducerState();
+
+        if (this.flushException != null) {
+            throw this.flushException;
+        }
+
         while (!this.completions.isEmpty())
             completeNext();
     }
 
     public List<PartitionInfo> partitionsFor(String topic) {
+        if (this.partitionsForException != null) {
+            throw this.partitionsForException;
+        }
+
         return this.cluster.partitionsForTopic(topic);
     }
 
@@ -329,6 +375,10 @@ public class MockProducer<K, V> implements Producer<K, V> {
 
     @Override
     public void close(Duration timeout) {
+        if (this.closeException != null) {
+            throw this.closeException;
+        }
+
         this.closed = true;
     }
 
@@ -340,12 +390,6 @@ public class MockProducer<K, V> implements Producer<K, V> {
         verifyProducerState();
         verifyTransactionsInitialized();
         this.producerFenced = true;
-    }
-
-    public void fenceProducerOnCommitTxn() {
-        verifyProducerState();
-        verifyTransactionsInitialized();
-        this.producerFencedOnCommitTxn = true;
     }
 
     public boolean transactionInitialized() {
@@ -383,27 +427,32 @@ public class MockProducer<K, V> implements Producer<K, V> {
         return new ArrayList<>(this.sent);
     }
 
+    public synchronized List<ProducerRecord<K, V>> uncommittedRecords() {
+        return new ArrayList<>(this.uncommittedSends);
+    }
+
     /**
+     *
      * Get the list of committed consumer group offsets since the last call to {@link #clear()}
      */
     public synchronized List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> consumerGroupOffsetsHistory() {
         return new ArrayList<>(this.consumerGroupOffsets);
     }
+
+    public synchronized Map<String, Map<TopicPartition, OffsetAndMetadata>> uncommittedOffsets() {
+        return this.uncommittedConsumerGroupOffsets;
+    }
+
     /**
-     *
-     * Clear the stored history of sent records, consumer group offsets, and transactional state
+     * Clear the stored history of sent records, consumer group offsets
      */
     public synchronized void clear() {
         this.sent.clear();
         this.uncommittedSends.clear();
+        this.sentOffsets = false;
         this.completions.clear();
         this.consumerGroupOffsets.clear();
         this.uncommittedConsumerGroupOffsets.clear();
-        this.transactionInitialized = false;
-        this.transactionInFlight = false;
-        this.transactionCommitted = false;
-        this.transactionAborted = false;
-        this.producerFenced = false;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -151,6 +151,14 @@ public class MockProducerTest {
     }
 
     @Test(expected = IllegalStateException.class)
+    public void shouldThrowOnBeginTransactionsIfTransactionInflight() {
+        buildMockProducer(true);
+        producer.initTransactions();
+        producer.beginTransaction();
+        producer.beginTransaction();
+    }
+
+    @Test(expected = IllegalStateException.class)
     public void shouldThrowOnSendOffsetsToTransactionIfTransactionsNotInitialized() {
         buildMockProducer(true);
         producer.sendOffsetsToTransaction(null, groupId);

--- a/streams/src/main/java/org/apache/kafka/streams/errors/TaskMigratedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/TaskMigratedException.java
@@ -27,6 +27,6 @@ public class TaskMigratedException extends StreamsException {
     private final static long serialVersionUID = 1L;
 
     public TaskMigratedException(final String message, final Throwable throwable) {
-        super(message + "; It means all tasks belonging to this thread should be migrated", throwable);
+        super(message + "; it means all tasks belonging to this thread should be migrated.", throwable);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
@@ -35,13 +34,11 @@ import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -62,160 +59,133 @@ public class RecordCollectorImpl implements RecordCollector {
 
     private final Logger log;
     private final TaskId taskId;
-    private final boolean eosEnabled;
-    private final String applicationId;
-    private final Sensor droppedRecordsSensor;
-    private final Map<TopicPartition, Long> offsets;
-    private final Consumer<byte[], byte[]> consumer;
+    private final Consumer<byte[], byte[]> mainConsumer;
+    private final StreamsProducer streamsProducer;
     private final ProductionExceptionHandler productionExceptionHandler;
+    private final Sensor droppedRecordsSensor;
+    private final boolean eosEnabled;
+    private final Map<TopicPartition, Long> offsets;
 
-    // used when eosEnabled is true only
-    private boolean transactionInFlight = false;
-    private boolean transactionInitialized = false;
-    private Producer<byte[], byte[]> producer;
     private volatile KafkaException sendException;
 
     /**
      * @throws StreamsException fatal error that should cause the thread to die (from producer.initTxn)
      */
-    public RecordCollectorImpl(final TaskId taskId,
-                               final StreamsConfig config,
-                               final LogContext logContext,
-                               final StreamsMetricsImpl streamsMetrics,
-                               final Consumer<byte[], byte[]> consumer,
-                               final StreamThread.ProducerSupplier producerSupplier) {
-        this.taskId = taskId;
-        this.consumer = consumer;
-        this.offsets = new HashMap<>();
+    public RecordCollectorImpl(final LogContext logContext,
+                               final TaskId taskId,
+                               final Consumer<byte[], byte[]> mainConsumer,
+                               final StreamsProducer streamsProducer,
+                               final ProductionExceptionHandler productionExceptionHandler,
+                               final boolean eosEnabled,
+                               final StreamsMetricsImpl streamsMetrics) {
         this.log = logContext.logger(getClass());
-
-        this.applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-        this.productionExceptionHandler = config.defaultProductionExceptionHandler();
-        this.eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.taskId = taskId;
+        this.mainConsumer = mainConsumer;
+        this.streamsProducer = streamsProducer;
+        this.productionExceptionHandler = productionExceptionHandler;
+        this.eosEnabled = eosEnabled;
 
         final String threadId = Thread.currentThread().getName();
         this.droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId.toString(), streamsMetrics);
 
-        producer = producerSupplier.get(taskId);
+        this.offsets = new HashMap<>();
     }
 
     @Override
     public void initialize() {
-        maybeInitTxns();
-    }
-
-    private void maybeInitTxns() {
-        if (eosEnabled && !transactionInitialized) {
-            // initialize transactions if eos is turned on, which will block if the previous transaction has not
-            // completed yet; do not start the first transaction until the topology has been initialized later
-            try {
-                producer.initTransactions();
-
-                transactionInitialized = true;
-            } catch (final TimeoutException exception) {
-                log.warn("Timeout exception caught when initializing transactions for task {}. " +
-                    "\nThe broker is either slow or in bad state (like not having enough replicas) in responding to the request, " +
-                    "or the connection to broker was interrupted sending the request or receiving the response. " +
-                    "Would retry initializing the task in the next loop." +
-                    "\nConsider overwriting producer config {} to a larger value to avoid timeout errors",
-                    ProducerConfig.MAX_BLOCK_MS_CONFIG, taskId);
-
-                throw exception;
-            } catch (final KafkaException exception) {
-                throw new StreamsException("Error encountered while initializing transactions for task " + taskId, exception);
-            }
-        }
-    }
-
-    private void maybeBeginTxn() {
-        if (eosEnabled && !transactionInFlight) {
-            try {
-                producer.beginTransaction();
-            } catch (final ProducerFencedException error) {
-                throw new TaskMigratedException("Producer get fenced trying to begin a new transaction", error);
-            } catch (final KafkaException error) {
-                throw new StreamsException("Producer encounter unexpected error trying to begin a new transaction", error);
-            }
-            transactionInFlight = true;
-        }
-    }
-
-    private void maybeAbortTxn() {
-        if (eosEnabled && transactionInFlight) {
-            try {
-                producer.abortTransaction();
-            } catch (final ProducerFencedException ignore) {
-                /* TODO
-                 * this should actually never happen atm as we guard the call to #abortTransaction
-                 * -> the reason for the guard is a "bug" in the Producer -- it throws IllegalStateException
-                 * instead of ProducerFencedException atm. We can remove the isZombie flag after KAFKA-5604 got
-                 * fixed and fall-back to this catch-and-swallow code
-                 */
-
-                // can be ignored: transaction got already aborted by brokers/transactional-coordinator if this happens
-            } catch (final KafkaException error) {
-                throw new StreamsException("Producer encounter unexpected error trying to abort the transaction", error);
-            }
-            transactionInFlight = false;
-        }
-    }
-
-    public void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         if (eosEnabled) {
-            maybeBeginTxn();
+            streamsProducer.initTransaction();
+        }
+    }
 
+    /**
+     * @throws StreamsException fatal error that should cause the thread to die
+     * @throws TaskMigratedException recoverable error that would cause the task to be removed
+     */
+    @Override
+    public <K, V> void send(final String topic,
+                            final K key,
+                            final V value,
+                            final Headers headers,
+                            final Long timestamp,
+                            final Serializer<K> keySerializer,
+                            final Serializer<V> valueSerializer,
+                            final StreamPartitioner<? super K, ? super V> partitioner) {
+        final Integer partition;
+
+        if (partitioner != null) {
+            final List<PartitionInfo> partitions;
             try {
-                producer.sendOffsetsToTransaction(offsets, applicationId);
-                producer.commitTransaction();
-                transactionInFlight = false;
-            } catch (final ProducerFencedException error) {
-                throw new TaskMigratedException("Producer get fenced trying to commit a transaction", error);
-            } catch (final TimeoutException error) {
-                // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
-                throw new StreamsException("Timed out while committing transaction via producer for task " + taskId, error);
-            } catch (final KafkaException error) {
-                throw new StreamsException("Error encountered sending offsets and committing transaction " +
-                    "via producer for task " + taskId, error);
+                partitions = streamsProducer.partitionsFor(topic);
+            } catch (final KafkaException e) {
+                // here we cannot drop the message on the floor even if it is a transient timeout exception,
+                // so we treat everything the same as a fatal exception
+                throw new StreamsException("Could not determine the number of partitions for topic '" + topic +
+                    "' for task " + taskId + " due to " + e.toString());
+            }
+            if (partitions.size() > 0) {
+                partition = partitioner.partition(topic, key, value, partitions.size());
+            } else {
+                throw new StreamsException("Could not get partition information for topic " + topic + " for task " + taskId +
+                    ". This can happen if the topic does not exist.");
             }
         } else {
-            try {
-                consumer.commitSync(offsets);
-            } catch (final CommitFailedException error) {
-                throw new TaskMigratedException("Consumer committing offsets failed, " +
-                    "indicating the corresponding thread is no longer part of the group.", error);
-            } catch (final TimeoutException error) {
-                // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
-                throw new StreamsException("Timed out while committing offsets via consumer for task " + taskId, error);
-            } catch (final KafkaException error) {
-                throw new StreamsException("Error encountered committing offsets via consumer for task " + taskId, error);
-            }
+            partition = null;
         }
 
+        send(topic, key, value, headers, partition, timestamp, keySerializer, valueSerializer);
     }
 
-    private boolean productionExceptionIsFatal(final Exception exception) {
-        final boolean securityException = exception instanceof AuthenticationException ||
-            exception instanceof AuthorizationException ||
-            exception instanceof SecurityDisabledException;
+    @Override
+    public <K, V> void send(final String topic,
+                            final K key,
+                            final V value,
+                            final Headers headers,
+                            final Integer partition,
+                            final Long timestamp,
+                            final Serializer<K> keySerializer,
+                            final Serializer<V> valueSerializer) {
+        checkForException();
 
-        final boolean communicationException = exception instanceof InvalidTopicException ||
-            exception instanceof UnknownServerException ||
-            exception instanceof SerializationException ||
-            exception instanceof OffsetMetadataTooLarge ||
-            exception instanceof IllegalStateException;
+        final byte[] keyBytes;
+        final byte[] valBytes;
+        try {
+            keyBytes = keySerializer.serialize(topic, headers, key);
+            valBytes = valueSerializer.serialize(topic, headers, value);
+        } catch (final RuntimeException exception) {
+            final String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, exception.toString());
+            throw new StreamsException(errorMessage, exception);
+        }
 
-        return securityException || communicationException;
+        final ProducerRecord<byte[], byte[]> serializedRecord = new ProducerRecord<>(topic, partition, timestamp, keyBytes, valBytes, headers);
+
+        streamsProducer.send(serializedRecord, (metadata, exception) -> {
+            // if there's already an exception record, skip logging offsets or new exceptions
+            if (sendException != null) {
+                return;
+            }
+
+            if (exception == null) {
+                final TopicPartition tp = new TopicPartition(metadata.topic(), metadata.partition());
+                offsets.put(tp, metadata.offset());
+            } else {
+                recordSendError(topic, exception, serializedRecord);
+
+                // KAFKA-7510 only put message key and value in TRACE level log so we don't leak data by default
+                log.trace("Failed record: (key {} value {} timestamp {}) topic=[{}] partition=[{}]", key, value, timestamp, topic, partition);
+            }
+        });
     }
 
     private void recordSendError(final String topic, final Exception exception, final ProducerRecord<byte[], byte[]> serializedRecord) {
         String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, exception.toString());
 
-        if (productionExceptionIsFatal(exception)) {
+        if (isFatalException(exception)) {
             errorMessage += "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.";
             sendException = new StreamsException(errorMessage, exception);
         } else if (exception instanceof ProducerFencedException || exception instanceof OutOfOrderSequenceException) {
             errorMessage += "\nWritten offsets would not be recorded and no more records would be sent since the producer is fenced, " +
-                "indicating the task may be migrated out.";
+                "indicating the task may be migrated out";
             sendException = new TaskMigratedException(errorMessage, exception);
         } else {
             if (exception instanceof RetriableException) {
@@ -237,101 +207,37 @@ public class RecordCollectorImpl implements RecordCollector {
         log.error(errorMessage);
     }
 
-    /**
-     * @throws StreamsException fatal error that should cause the thread to die
-     * @throws TaskMigratedException recoverable error that would cause the task to be removed
-     */
-    @Override
-    public <K, V> void send(final String topic,
-                            final K key,
-                            final V value,
-                            final Headers headers,
-                            final Long timestamp,
-                            final Serializer<K> keySerializer,
-                            final Serializer<V> valueSerializer,
-                            final StreamPartitioner<? super K, ? super V> partitioner) {
-        final Integer partition;
+    private boolean isFatalException(final Exception exception) {
+        final boolean securityException = exception instanceof AuthenticationException ||
+            exception instanceof AuthorizationException ||
+            exception instanceof SecurityDisabledException;
 
-        if (partitioner != null) {
-            final List<PartitionInfo> partitions;
-            try {
-                partitions = producer.partitionsFor(topic);
-            } catch (final KafkaException e) {
-                // here we cannot drop the message on the floor even if it is a transient timeout exception,
-                // so we treat everything the same as a fatal exception
-                throw new StreamsException("Could not determine the number of partitions for topic '" + topic +
-                    "' for task " + taskId + " due to " + e.toString());
-            }
-            if (partitions.size() > 0) {
-                partition = partitioner.partition(topic, key, value, partitions.size());
-            } else {
-                throw new StreamsException("Could not get partition information for topic '" + topic + "'  for task " + taskId +
-                    ". This can happen if the topic does not exist.");
-            }
+        final boolean communicationException = exception instanceof InvalidTopicException ||
+            exception instanceof UnknownServerException ||
+            exception instanceof SerializationException ||
+            exception instanceof OffsetMetadataTooLarge ||
+            exception instanceof IllegalStateException;
+
+        return securityException || communicationException;
+    }
+
+    public void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        if (eosEnabled) {
+            streamsProducer.commitTransaction(offsets);
         } else {
-            partition = null;
-        }
-
-        send(topic, key, value, headers, partition, timestamp, keySerializer, valueSerializer);
-    }
-
-    @Override
-    public <K, V> void send(final String topic,
-                            final K key,
-                            final V value,
-                            final Headers headers,
-                            final Integer partition,
-                            final Long timestamp,
-                            final Serializer<K> keySerializer,
-                            final Serializer<V> valueSerializer) {
-        checkForException();
-
-        maybeBeginTxn();
-
-        try {
-            final byte[] keyBytes = keySerializer.serialize(topic, headers, key);
-            final byte[] valBytes = valueSerializer.serialize(topic, headers, value);
-
-            final ProducerRecord<byte[], byte[]> serializedRecord = new ProducerRecord<>(topic, partition, timestamp, keyBytes, valBytes, headers);
-
-            producer.send(serializedRecord, (metadata, exception) -> {
-                // if there's already an exception record, skip logging offsets or new exceptions
-                if (sendException != null) {
-                    return;
-                }
-
-                if (exception == null) {
-                    final TopicPartition tp = new TopicPartition(metadata.topic(), metadata.partition());
-                    offsets.put(tp, metadata.offset());
-                } else {
-                    recordSendError(topic, exception, serializedRecord);
-
-                    // KAFKA-7510 only put message key and value in TRACE level log so we don't leak data by default
-                    log.trace("Failed record: (key {} value {} timestamp {}) topic=[{}] partition=[{}]", key, value, timestamp, topic, partition);
-                }
-            });
-        } catch (final RuntimeException uncaughtException) {
-            if (isRecoverable(uncaughtException)) {
-                // producer.send() call may throw a KafkaException which wraps a FencedException,
-                // in this case we should throw its wrapped inner cause so that it can be captured and re-wrapped as TaskMigrationException
-                throw new TaskMigratedException("Producer cannot send records anymore since it got fenced", uncaughtException.getCause());
-            } else {
-                final String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, uncaughtException.toString());
-                throw new StreamsException(errorMessage, uncaughtException);
+            try {
+                mainConsumer.commitSync(offsets);
+            } catch (final CommitFailedException error) {
+                throw new TaskMigratedException("Consumer committing offsets failed, " +
+                    "indicating the corresponding thread is no longer part of the group", error);
+            } catch (final TimeoutException error) {
+                // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
+                throw new StreamsException("Timed out while committing offsets via consumer for task " + taskId, error);
+            } catch (final KafkaException error) {
+                throw new StreamsException("Error encountered committing offsets via consumer for task " + taskId, error);
             }
         }
-    }
 
-    private static boolean isRecoverable(final RuntimeException uncaughtException) {
-        return uncaughtException instanceof KafkaException && (
-            uncaughtException.getCause() instanceof ProducerFencedException ||
-                uncaughtException.getCause() instanceof UnknownProducerIdException);
-    }
-
-    private void checkForException() {
-        if (sendException != null) {
-            throw sendException;
-        }
     }
 
     /**
@@ -341,9 +247,7 @@ public class RecordCollectorImpl implements RecordCollector {
     @Override
     public void flush() {
         log.debug("Flushing record collector");
-
-        producer.flush();
-
+        streamsProducer.flush();
         checkForException();
     }
 
@@ -354,15 +258,11 @@ public class RecordCollectorImpl implements RecordCollector {
     @Override
     public void close() {
         log.debug("Closing record collector");
-        maybeAbortTxn();
 
         if (eosEnabled) {
-            try {
-                producer.close();
-            } catch (final KafkaException e) {
-                throw new StreamsException("Caught a recoverable exception while closing", e);
-            }
+            streamsProducer.abortTransaction();
         }
+        streamsProducer.close();
 
         checkForException();
     }
@@ -372,9 +272,14 @@ public class RecordCollectorImpl implements RecordCollector {
         return Collections.unmodifiableMap(new HashMap<>(offsets));
     }
 
-    // for testing only
-    Producer<byte[], byte[]> producer() {
-        return producer;
+    private void checkForException() {
+        if (sendException != null) {
+            throw sendException;
+        }
     }
 
+    // for testing only
+    Producer<byte[], byte[]> producer() {
+        return streamsProducer.kafkaProducer();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownProducerIdException;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+/**
+ * {@code StreamsProducer} manages the producers within a Kafka Streams application.
+ * <p>
+ * If EOS is enabled, it is responsible to init and begin transactions if necessary.
+ * It also tracks the transaction status, ie, if a transaction is in-fight.
+ * <p>
+ * For non-EOS, the user should not call transaction related methods.
+ */
+public class StreamsProducer {
+    private final Logger log;
+
+    private final Producer<byte[], byte[]> producer;
+    private final String applicationId;
+    private final TaskId taskId;
+    private final String logMessage;
+    private final boolean eosEnabled;
+
+    private boolean transactionInFlight = false;
+    private boolean transactionInitialized = false;
+
+    public StreamsProducer(final LogContext logContext,
+                           final Producer<byte[], byte[]> producer) {
+        this(logContext, producer, null, null);
+    }
+
+    public StreamsProducer(final LogContext logContext,
+                           final Producer<byte[], byte[]> producer,
+                           final String applicationId,
+                           final TaskId taskId) {
+        if ((applicationId != null && taskId == null) ||
+            (applicationId == null && taskId != null)) {
+            throw new IllegalArgumentException("applicationId and taskId must either be both null or both be not null");
+        }
+
+        this.log = logContext.logger(getClass());
+
+        this.producer = Objects.requireNonNull(producer, "producer cannot be null");
+        this.applicationId = applicationId;
+        this.taskId = taskId;
+        if (taskId != null) {
+            logMessage = "task " + taskId.toString();
+            eosEnabled = true;
+        } else {
+            logMessage = "all owned active tasks";
+            eosEnabled = false;
+        }
+    }
+
+    /**
+     * @throws IllegalStateException if EOS is disabled
+     */
+    public void initTransaction() {
+        if (!eosEnabled) {
+            throw new IllegalStateException("EOS is disabled");
+        }
+        if (!transactionInitialized) {
+            // initialize transactions if eos is turned on, which will block if the previous transaction has not
+            // completed yet; do not start the first transaction until the topology has been initialized later
+            try {
+                producer.initTransactions();
+                transactionInitialized = true;
+            } catch (final TimeoutException exception) {
+                log.warn("Timeout exception caught when initializing transactions for {}. " +
+                    "\nThe broker is either slow or in bad state (like not having enough replicas) in responding to the request, " +
+                    "or the connection to broker was interrupted sending the request or receiving the response. " +
+                    "Will retry initializing the task in the next loop. " +
+                    "\nConsider overwriting {} to a larger value to avoid timeout errors",
+                    logMessage,
+                    ProducerConfig.MAX_BLOCK_MS_CONFIG);
+
+                throw exception;
+            } catch (final KafkaException exception) {
+                throw new StreamsException("Error encountered while initializing transactions for " + logMessage, exception);
+            }
+        }
+    }
+
+    private void maybeBeginTransaction() throws ProducerFencedException {
+        if (eosEnabled && !transactionInFlight) {
+            try {
+                producer.beginTransaction();
+                transactionInFlight = true;
+            } catch (final ProducerFencedException error) {
+                throw new TaskMigratedException("Producer get fenced trying to begin a new transaction", error);
+            } catch (final KafkaException error) {
+                throw new StreamsException("Producer encounter unexpected error trying to begin a new transaction for " + logMessage, error);
+            }
+        }
+    }
+
+    public Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record,
+                                       final Callback callback) {
+        maybeBeginTransaction();
+        try {
+            return producer.send(record, callback);
+        } catch (final KafkaException uncaughtException) {
+            if (isRecoverable(uncaughtException)) {
+                // producer.send() call may throw a KafkaException which wraps a FencedException,
+                // in this case we should throw its wrapped inner cause so that it can be captured and re-wrapped as TaskMigrationException
+                throw new TaskMigratedException("Producer cannot send records anymore since it got fenced", uncaughtException.getCause());
+            } else {
+                final String errorMessage = String.format(
+                    "Error encountered sending record to topic %s%s due to:%n%s",
+                    record.topic(),
+                    taskId == null ? "" : " " + logMessage,
+                    uncaughtException.toString());
+                throw new StreamsException(errorMessage, uncaughtException);
+            }
+        }
+    }
+
+    private static boolean isRecoverable(final KafkaException uncaughtException) {
+        return uncaughtException.getCause() instanceof ProducerFencedException ||
+            uncaughtException.getCause() instanceof UnknownProducerIdException;
+    }
+
+    /**
+     * @throws IllegalStateException if EOS is disabled
+     * @throws TaskMigratedException
+     */
+    public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
+        if (!eosEnabled) {
+            throw new IllegalStateException("EOS is disabled");
+        }
+        maybeBeginTransaction();
+        try {
+            producer.sendOffsetsToTransaction(offsets, applicationId);
+            producer.commitTransaction();
+            transactionInFlight = false;
+        } catch (final ProducerFencedException error) {
+            throw new TaskMigratedException("Producer get fenced trying to commit a transaction", error);
+        } catch (final TimeoutException error) {
+            // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
+            throw new StreamsException("Timed out while committing a transaction for " + logMessage, error);
+        } catch (final KafkaException error) {
+            throw new StreamsException("Producer encounter unexpected error trying to commit a transaction for " + logMessage, error);
+        }
+    }
+
+    /**
+     * @throws IllegalStateException if EOS is disabled
+     */
+    public void abortTransaction() throws ProducerFencedException {
+        if (!eosEnabled) {
+            throw new IllegalStateException("EOS is disabled");
+        }
+        if (transactionInFlight) {
+            try {
+                producer.abortTransaction();
+            } catch (final ProducerFencedException ignore) {
+                /* TODO
+                 * this should actually never happen atm as we guard the call to #abortTransaction
+                 * -> the reason for the guard is a "bug" in the Producer -- it throws IllegalStateException
+                 * instead of ProducerFencedException atm. We can remove the isZombie flag after KAFKA-5604 got
+                 * fixed and fall-back to this catch-and-swallow code
+                 */
+
+                // can be ignored: transaction got already aborted by brokers/transactional-coordinator if this happens
+            } catch (final KafkaException error) {
+                throw new StreamsException("Producer encounter unexpected error trying to abort a transaction for " + logMessage, error);
+            }
+            transactionInFlight = false;
+        }
+    }
+
+    public List<PartitionInfo> partitionsFor(final String topic) throws TimeoutException {
+        return producer.partitionsFor(topic);
+    }
+
+    public void flush() {
+        producer.flush();
+    }
+
+    public void close() {
+        try {
+            producer.close();
+        } catch (final KafkaException error) {
+            throw new StreamsException("Producer encounter unexpected error trying to close" + (taskId == null ? "" : " " + logMessage), error);
+        }
+    }
+
+    // for testing only
+    Producer<byte[], byte[]> kafkaProducer() {
+        return producer;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -246,7 +246,7 @@ public class KafkaStreamsTest {
         globalStreamThread.shutdown();
         EasyMock.expectLastCall().andAnswer(() -> {
             supplier.restoreConsumer.close();
-            for (final MockProducer producer : supplier.producers) {
+            for (final MockProducer<byte[], byte[]> producer : supplier.producers) {
                 producer.close();
             }
             globalThreadState.set(GlobalStreamThread.State.DEAD);
@@ -302,7 +302,7 @@ public class KafkaStreamsTest {
         EasyMock.expectLastCall().andAnswer(() -> {
             supplier.consumer.close();
             supplier.restoreConsumer.close();
-            for (final MockProducer producer : supplier.producers) {
+            for (final MockProducer<byte[], byte[]> producer : supplier.producers) {
                 producer.close();
             }
             state.set(StreamThread.State.DEAD);
@@ -478,7 +478,7 @@ public class KafkaStreamsTest {
 
         assertTrue(supplier.consumer.closed());
         assertTrue(supplier.restoreConsumer.closed());
-        for (final MockProducer p : supplier.producers) {
+        for (final MockProducer<byte[], byte[]> p : supplier.producers) {
             assertTrue(p.closed());
         }
     }
@@ -920,7 +920,7 @@ public class KafkaStreamsTest {
             Serdes.String().deserializer(),
             globalTopicName,
             globalTopicName + "-processor",
-            new MockProcessorSupplier());
+            new MockProcessorSupplier<byte[], byte[]>());
         return topology;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -556,7 +556,7 @@ public class ProcessorStateManagerTest {
         };
         stateManager.registerStore(stateStore, stateStore.stateRestoreCallback);
 
-        final ProcessorStateException thrown = assertThrows(ProcessorStateException.class, () -> stateManager.close());
+        final ProcessorStateException thrown = assertThrows(ProcessorStateException.class, stateManager::close);
         assertEquals(exception, thrown.getCause());
     }
 
@@ -572,7 +572,7 @@ public class ProcessorStateManagerTest {
         };
         stateManager.registerStore(stateStore, stateStore.stateRestoreCallback);
 
-        final StreamsException thrown = assertThrows(StreamsException.class, () -> stateManager.close());
+        final StreamsException thrown = assertThrows(StreamsException.class, stateManager::close);
         assertEquals(exception, thrown);
     }
 
@@ -724,7 +724,7 @@ public class ProcessorStateManagerTest {
         return new ConverterStore(persistentStoreName, true);
     }
 
-    private class ConverterStore extends MockKeyValueStore implements TimestampedBytesStore {
+    private static class ConverterStore extends MockKeyValueStore implements TimestampedBytesStore {
         ConverterStore(final String name, final boolean persistent) {
             super(name, persistent);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -35,7 +36,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -45,15 +45,15 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.AlwaysContinueProductionExceptionHandler;
+import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
-import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,10 +62,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -73,10 +78,10 @@ import static org.junit.Assert.assertTrue;
 
 public class RecordCollectorTest {
 
-    private final TaskId taskId = new TaskId(0, 0);
     private final LogContext logContext = new LogContext("test ");
+    private final TaskId taskId = new TaskId(0, 0);
+    private final ProductionExceptionHandler productionExceptionHandler = new DefaultProductionExceptionHandler();
     private final StreamsMetricsImpl streamsMetrics = new MockStreamsMetrics(new Metrics());
-    private final StreamsConfig streamsConfig = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test"));
 
     private final String topic = "topic";
     private final Cluster cluster = new Cluster(
@@ -93,15 +98,26 @@ public class RecordCollectorTest {
 
     private final StringSerializer stringSerializer = new StringSerializer();
     private final ByteArraySerializer byteArraySerializer = new ByteArraySerializer();
-    private final MockProducer<byte[], byte[]> producer = new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
-    private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
     private final StreamPartitioner<String, Object> streamPartitioner = (topic, key, value, numPartitions) -> Integer.parseInt(key) % numPartitions;
+
+    private final MockConsumer<byte[], byte[]> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    private final MockProducer<byte[], byte[]> mockProducer = new MockProducer<>(
+        cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
+    private final StreamsProducer streamsProducer = new StreamsProducer(logContext, mockProducer);
 
     private RecordCollectorImpl collector;
 
     @Before
     public void setup() {
-        collector = new RecordCollectorImpl(taskId, streamsConfig, logContext, streamsMetrics, consumer, id -> producer);
+        collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics);
     }
 
     @After
@@ -125,7 +141,7 @@ public class RecordCollectorTest {
         assertEquals(2L, (long) offsets.get(new TopicPartition(topic, 0)));
         assertEquals(1L, (long) offsets.get(new TopicPartition(topic, 1)));
         assertEquals(0L, (long) offsets.get(new TopicPartition(topic, 2)));
-        assertEquals(6, producer.history().size());
+        assertEquals(6, mockProducer.history().size());
 
         collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer);
         collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer);
@@ -136,7 +152,7 @@ public class RecordCollectorTest {
         assertEquals(3L, (long) offsets.get(new TopicPartition(topic, 0)));
         assertEquals(2L, (long) offsets.get(new TopicPartition(topic, 1)));
         assertEquals(1L, (long) offsets.get(new TopicPartition(topic, 2)));
-        assertEquals(9, producer.history().size());
+        assertEquals(9, mockProducer.history().size());
     }
 
     @Test
@@ -158,7 +174,7 @@ public class RecordCollectorTest {
         assertEquals(4L, (long) offsets.get(new TopicPartition(topic, 0)));
         assertEquals(2L, (long) offsets.get(new TopicPartition(topic, 1)));
         assertEquals(0L, (long) offsets.get(new TopicPartition(topic, 2)));
-        assertEquals(9, producer.history().size());
+        assertEquals(9, mockProducer.history().size());
 
         // returned offsets should not be modified
         final TopicPartition topicPartition = new TopicPartition(topic, 0);
@@ -185,27 +201,18 @@ public class RecordCollectorTest {
         assertEquals(3L, (long) offsets.get(new TopicPartition(topic, 0)));
         assertEquals(2L, (long) offsets.get(new TopicPartition(topic, 1)));
         assertEquals(1L, (long) offsets.get(new TopicPartition(topic, 2)));
-        assertEquals(9, producer.history().size());
+        assertEquals(9, mockProducer.history().size());
     }
 
     @Test
     public void shouldUpdateOffsetsUponCompletion() {
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<>(cluster, false, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer)
-        );
-
         Map<TopicPartition, Long> offsets = collector.offsets();
 
         collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer);
         collector.send(topic, "999", "0", null, 1, null, stringSerializer, stringSerializer);
         collector.send(topic, "999", "0", null, 2, null, stringSerializer, stringSerializer);
 
-        assertEquals(Collections.emptyMap(), offsets);
+        assertEquals(Collections.<TopicPartition, Long>emptyMap(), offsets);
 
         collector.flush();
 
@@ -216,194 +223,235 @@ public class RecordCollectorTest {
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnSendFatalException() {
-        final KafkaException exception = new KafkaException();
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
-                    throw exception;
-                }
-            }
-        );
+    public void shouldPassThroughRecordHeaderToSerializer() {
+        final CustomStringSerializer keySerializer = new CustomStringSerializer();
+        final CustomStringSerializer valueSerializer = new CustomStringSerializer();
+        keySerializer.configure(Collections.emptyMap(), true);
 
-        final StreamsException thrown = assertThrows(StreamsException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
-        );
-        assertEquals(exception, thrown.getCause());
+        collector.send(topic, "3", "0", new RecordHeaders(), null, keySerializer, valueSerializer, streamPartitioner);
+
+        final List<ProducerRecord<byte[], byte[]>> recordHistory = mockProducer.history();
+        for (final ProducerRecord<byte[], byte[]> sentRecord : recordHistory) {
+            final Headers headers = sentRecord.headers();
+            assertEquals(2, headers.toArray().length);
+            assertEquals(new RecordHeader("key", "key".getBytes()), headers.lastHeader("key"));
+            assertEquals(new RecordHeader("value", "value".getBytes()), headers.lastHeader("value"));
+        }
     }
 
     @Test
-    public void shouldThrowTaskMigratedExceptionOnProducerFencedException() {
-        final KafkaException exception = new ProducerFencedException("KABOOM!");
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
-                    throw new KafkaException(exception);
-                }
-            }
-        );
+    public void shouldCommitViaConsumerIfEosDisabled() {
+        final KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        consumer.commitSync((Map<TopicPartition, OffsetAndMetadata>) null);
+        expectLastCall();
+        replay(consumer);
 
-        final TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
-        );
-        assertEquals(exception, thrown.getCause());
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            consumer,
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics);
+
+        collector.commit(null);
+
+        verify(consumer);
+
     }
 
     @Test
-    public void shouldThrowTaskMigratedExceptionOnUnknownProducerIdException() {
-        final KafkaException exception = new UnknownProducerIdException("KABOOM!");
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
-                    throw new KafkaException(exception);
-                }
-            }
-        );
+    public void shouldCommitViaProducerIfEosEnabled() {
+        final StreamsProducer streamsProducer = mock(StreamsProducer.class);
+        streamsProducer.commitTransaction(null);
+        expectLastCall();
+        replay(streamsProducer);
 
-        final TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
-        );
-        assertEquals(exception, thrown.getCause());
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            streamsProducer,
+            productionExceptionHandler,
+            true,
+            streamsMetrics);
+
+        collector.commit(null);
+
+        verify(streamsProducer);
+    }
+
+    @Test
+    public void shouldForwardFlushToTransactionManager() {
+        final StreamsProducer streamsProducer = mock(StreamsProducer.class);
+        streamsProducer.flush();
+        expectLastCall();
+        replay(streamsProducer);
+
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            streamsProducer,
+            productionExceptionHandler,
+            true,
+            streamsMetrics);
+
+        collector.flush();
+
+        verify(streamsProducer);
+    }
+
+    @Test
+    public void shouldForwardCloseToTransactionManager() {
+        final StreamsProducer streamsProducer = mock(StreamsProducer.class);
+        streamsProducer.close();
+        expectLastCall();
+        replay(streamsProducer);
+
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics);
+
+        collector.close();
+
+        verify(streamsProducer);
+    }
+
+    @Test
+    public void shouldAbortTxIfEosEnabled() {
+        final StreamsProducer streamsProducer = mock(StreamsProducer.class);
+        streamsProducer.abortTransaction();
+        streamsProducer.close();
+        expectLastCall();
+        replay(streamsProducer);
+
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            streamsProducer,
+            productionExceptionHandler,
+            true,
+            streamsMetrics);
+
+        collector.close();
+
+        verify(streamsProducer);
     }
 
     @Test
     public void shouldThrowTaskMigratedExceptionOnSubsequentCallWhenProducerFencedInCallback() {
         final KafkaException exception = new ProducerFencedException("KABOOM!");
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
-                    callback.onCompletion(null, exception);
-                    return null;
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+                        callback.onCompletion(null, exception);
+                        return null;
+                    }
+                },
+                "appId",
+                taskId),
+            productionExceptionHandler,
+            true,
+            streamsMetrics
         );
+        collector.initialize();
 
         collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
 
-        TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () ->
+        TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class, () ->
             collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
         );
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.ProducerFencedException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since the producer is fenced, indicating the task may be migrated out; it means all tasks belonging to this thread should be migrated."));
 
         thrown = assertThrows(TaskMigratedException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.ProducerFencedException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since the producer is fenced, indicating the task may be migrated out; it means all tasks belonging to this thread should be migrated."));
 
         thrown = assertThrows(TaskMigratedException.class, collector::close);
         assertEquals(exception, thrown.getCause());
-    }
-
-    @Test
-    public void shouldThrowTaskMigratedExceptionOnSubsequentCallWhenProducerUnknownInCallback() {
-        final KafkaException exception = new UnknownProducerIdException("KABOOM!");
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
-                    callback.onCompletion(null, exception);
-                    return null;
-                }
-            });
-
-        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
-
-        TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
-        );
-        assertEquals(exception, thrown.getCause());
-
-        thrown = assertThrows(TaskMigratedException.class, collector::flush);
-        assertEquals(exception, thrown.getCause());
-
-        thrown = assertThrows(TaskMigratedException.class, collector::close);
-        assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.ProducerFencedException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since the producer is fenced, indicating the task may be migrated out; it means all tasks belonging to this thread should be migrated."));
     }
 
     @Test
     public void shouldThrowStreamsExceptionOnSubsequentCallIfASendFailsWithDefaultExceptionHandler() {
         final KafkaException exception = new KafkaException("KABOOM!");
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
-                    callback.onCompletion(null, exception);
-                    return null;
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+                        callback.onCompletion(null, exception);
+                        return null;
+                    }
+                }),
+            productionExceptionHandler,
+            false,
+            streamsMetrics
         );
 
         collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
 
-        StreamsException thrown = assertThrows(StreamsException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
+        StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
         );
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.KafkaException: KABOOM!\nException handler choose to FAIL the processing, no more records would be sent."));
 
         thrown = assertThrows(StreamsException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.KafkaException: KABOOM!\nException handler choose to FAIL the processing, no more records would be sent."));
 
         thrown = assertThrows(StreamsException.class, collector::close);
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.KafkaException: KABOOM!\nException handler choose to FAIL the processing, no more records would be sent."));
     }
 
     @Test
     public void shouldNotThrowStreamsExceptionOnSubsequentCallIfASendFailsWithContinueExceptionHandler() {
-        final Metrics metrics = new Metrics();
         final LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister();
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, AlwaysContinueProductionExceptionHandler.class.getName());
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
             logContext,
-            new MockStreamsMetrics(metrics),
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
-                    callback.onCompletion(null, new Exception());
-                    return null;
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+                        callback.onCompletion(null, new Exception());
+                        return null;
+                    }
+                }),
+            new AlwaysContinueProductionExceptionHandler(),
+            false,
+            streamsMetrics
         );
 
         collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
         collector.flush();
 
-        final Metric metric = metrics.metrics().get(new MetricName(
+        final Metric metric = streamsMetrics.metrics().get(new MetricName(
             "dropped-records-total",
             "stream-task-metrics",
             "The total number of dropped records",
@@ -422,481 +470,188 @@ public class RecordCollectorTest {
     @Test
     public void shouldThrowStreamsExceptionOnSubsequentCallIfFatalEvenWithContinueExceptionHandler() {
         final KafkaException exception = new AuthenticationException("KABOOM!");
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, AlwaysContinueProductionExceptionHandler.class.getName());
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
-                    callback.onCompletion(null, exception);
-                    return null;
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+                        callback.onCompletion(null, exception);
+                        return null;
+                    }
+                }),
+            new AlwaysContinueProductionExceptionHandler(),
+            false,
+            streamsMetrics
         );
 
         collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
 
-        StreamsException thrown = assertThrows(StreamsException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
+        StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
         );
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error."));
 
         thrown = assertThrows(StreamsException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error."));
 
         thrown = assertThrows(StreamsException.class, collector::close);
         assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic for task 0_0 due to:\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error."));
     }
 
     @Test
-    public void shouldRethrowOnEOSInitializeTimeout() {
-        final KafkaException exception = new TimeoutException("KABOOM!");
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-
-        final RecordCollector recordCollector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void initTransactions() {
-                    throw exception;
-                }
-            }
-        );
-
-        final TimeoutException thrown = assertThrows(TimeoutException.class, recordCollector::initialize);
-        assertEquals(exception, thrown);
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionOnEOSInitializeError() {
-        final KafkaException exception = new KafkaException("KABOOM!");
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-
-        final RecordCollector recordCollector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void initTransactions() {
-                    throw exception;
-                }
-            }
-        );
-
-        final StreamsException thrown = assertThrows(StreamsException.class, recordCollector::initialize);
-        assertEquals(exception, thrown.getCause());
-    }
-
-    @Test
-    public void shouldThrowMigrateExceptionOnEOSFirstSendProducerFenced() {
-        final KafkaException exception = new ProducerFencedException("KABOOM!");
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+    public void shouldThrowTaskMigratedExceptionOnCommitFailed() {
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized void beginTransaction() {
-                    throw exception;
-                }
-            }
-        );
-
-        final TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner));
-        assertEquals(exception, thrown.getCause());
-    }
-
-    @Test
-    public void shouldThrowMigrateExceptionOnEOSFirstSendFatal() {
-        final KafkaException exception = new KafkaException("KABOOM!");
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
             taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public synchronized void beginTransaction() {
-                    throw exception;
-                }
-            }
-        );
-
-        final StreamsException thrown = assertThrows(StreamsException.class, () ->
-            collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner));
-        assertEquals(exception, thrown.getCause());
-    }
-
-    @Test
-    public void shouldFailWithMigrateExceptionOnCommitFailed() {
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
             new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
                 @Override
                 public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
                     throw new CommitFailedException();
                 }
             },
-            id -> new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer)
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics
         );
 
-        assertThrows(TaskMigratedException.class, () -> collector.commit(null));
+        final TaskMigratedException thrown = assertThrows(TaskMigratedException.class, () -> collector.commit(null));
+
+        assertThat(thrown.getMessage(), equalTo("Consumer committing offsets failed, indicating the corresponding thread is no longer part of the group; it means all tasks belonging to this thread should be migrated."));
     }
 
     @Test
-    public void shouldFailWithMigrateExceptionOnCommitUnexpected() {
+    public void shouldThrowStreamsExceptionOnCommitTimeout() {
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
             logContext,
-            streamsMetrics,
+            taskId,
+            new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
+                @Override
+                public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+                    throw new TimeoutException();
+                }
+            },
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics
+        );
+
+        final StreamsException thrown = assertThrows(StreamsException.class, () -> collector.commit(null));
+
+        assertThat(thrown.getMessage(), equalTo("Timed out while committing offsets via consumer for task 0_0"));
+    }
+
+    @Test
+    public void shouldStreamsExceptionOnCommitError() {
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
             new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
                 @Override
                 public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
                     throw new KafkaException();
                 }
             },
-            id -> new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer)
-        );
-
-        assertThrows(StreamsException.class, () -> collector.commit(null));
-    }
-
-    @Test
-    public void shouldFailWithMigrateExceptionOnEOSBeginTxnFenced() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void beginTransaction() {
-                    throw new ProducerFencedException("KABOOM!");
-                }
-            }
-        );
-
-        assertThrows(TaskMigratedException.class, () -> collector.commit(null));
-    }
-
-    @Test
-    public void shouldFailWithMigrateExceptionOnEOSSendOffsetFenced() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets, final String consumerGroupId) {
-                    throw new ProducerFencedException("KABOOM!");
-                }
-            }
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics
         );
         collector.initialize();
 
-        assertThrows(TaskMigratedException.class, () -> collector.commit(null));
+        final StreamsException thrown = assertThrows(StreamsException.class, () -> collector.commit(null));
+
+        assertThat(thrown.getMessage(), equalTo("Error encountered committing offsets via consumer for task 0_0"));
     }
 
     @Test
-    public void shouldFailWithMigrateExceptionOnEOSCommitFenced() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+    public void shouldFailOnCommitFatal() {
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+            taskId,
+            new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
                 @Override
-                public void commitTransaction() {
-                    throw new ProducerFencedException("KABOOM!");
+                public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+                    throw new RuntimeException("KABOOM!");
                 }
-            }
+            },
+            streamsProducer,
+            productionExceptionHandler,
+            false,
+            streamsMetrics
         );
         collector.initialize();
 
-        assertThrows(TaskMigratedException.class, () -> collector.commit(Collections.emptyMap()));
-    }
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> collector.commit(null));
 
-    @Test
-    public void shouldFailWithMigrateExceptionOnEOSBeginTxnUnexpected() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void beginTransaction() {
-                    throw new KafkaException("KABOOM!");
-                }
-            }
-        );
-
-        assertThrows(StreamsException.class, () -> collector.commit(null));
-    }
-
-    @Test
-    public void shouldFailWithStreamsExceptionOnEOSSendOffsetUnexpected() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets, final String consumerGroupId) {
-                    throw new KafkaException("KABOOM!");
-                }
-            }
-        );
-        collector.initialize();
-
-        assertThrows(StreamsException.class, () -> collector.commit(null));
-    }
-
-    @Test
-    public void shouldFailWithMigrateExceptionOnEOSCommitUnexpected() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void commitTransaction() {
-                    throw new KafkaException("KABOOM!");
-                }
-            }
-        );
-        collector.initialize();
-
-        assertThrows(StreamsException.class, () -> collector.commit(Collections.emptyMap()));
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionOnEOSCloseFatalException() {
-        final KafkaException exception = new KafkaException();
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void close() {
-                    throw exception;
-                }
-            }
-        );
-
-        final StreamsException thrown = assertThrows(StreamsException.class, collector::close);
-        assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
     }
 
     @Test
     public void shouldNotAbortTxnOnEOSCloseIfNothingSent() {
         final AtomicBoolean functionCalled = new AtomicBoolean(false);
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
             logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void abortTransaction() {
-                    functionCalled.set(true);
-                    super.abortTransaction();
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public void abortTransaction() {
+                        functionCalled.set(true);
+                    }
+                },
+                "appId",
+                taskId),
+            productionExceptionHandler,
+            true,
+            streamsMetrics
         );
 
         collector.close();
-
         assertFalse(functionCalled.get());
-    }
-
-    @Test
-    public void shouldNotAbortTxnOnEOSCloseIfCommitted() {
-        final AtomicBoolean functionCalled = new AtomicBoolean(false);
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void abortTransaction() {
-                    functionCalled.set(true);
-                    super.abortTransaction();
-                }
-            }
-        );
-        collector.initialize();
-        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
-        collector.commit(Collections.emptyMap());
-
-        collector.close();
-
-        assertFalse(functionCalled.get());
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionOnEOSAbortTxnFatalException() {
-        final KafkaException exception = new KafkaException();
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void abortTransaction() {
-                    throw exception;
-                }
-            }
-        );
-        collector.initialize();
-        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
-
-        final StreamsException thrown = assertThrows(StreamsException.class, collector::close);
-        assertEquals(exception, thrown.getCause());
-    }
-
-    @Test
-    public void shouldSwallowOnEOSAbortTxnFatalException() {
-        final Properties props = StreamsTestUtils.getStreamsConfig("test");
-        props.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            new StreamsConfig(props),
-            logContext,
-            streamsMetrics,
-            consumer,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public void abortTransaction() {
-                    throw new ProducerFencedException("KABOOM!");
-                }
-            }
-        );
-        collector.initialize();
-
-        // this call is to begin an inflight txn
-        collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner);
-
-        collector.close();
     }
 
     @Test
     public void shouldThrowIfTopicIsUnknownOnSendWithPartitioner() {
         final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
             logContext,
-            streamsMetrics,
-            null,
-            id -> new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
-                @Override
-                public List<PartitionInfo> partitionsFor(final String topic) {
-                    return Collections.emptyList();
-                }
-            }
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                new MockProducer<byte[], byte[]>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public List<PartitionInfo> partitionsFor(final String topic) {
+                        return Collections.emptyList();
+                    }
+                }),
+            productionExceptionHandler,
+            false,
+            streamsMetrics
         );
+        collector.initialize();
 
-        final StreamsException thrown = assertThrows(StreamsException.class, () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner));
-        assertTrue(thrown.getMessage().startsWith("Could not get partition information for topic"));
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, streamPartitioner)
+        );
+        assertThat(thrown.getMessage(), equalTo("Could not get partition information for topic topic for task 0_0. This can happen if the topic does not exist."));
     }
 
-    @Test
-    public void shouldPassThroughRecordHeaderToSerializer() {
-        final CustomStringSerializer keySerializer = new CustomStringSerializer();
-        final CustomStringSerializer valueSerializer = new CustomStringSerializer();
-        keySerializer.configure(Collections.emptyMap(), true);
-
-        final MockProducer<byte[], byte[]> mockProducer =
-            new MockProducer<>(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
-        final RecordCollector collector = new RecordCollectorImpl(
-            taskId,
-            streamsConfig,
-            logContext,
-            streamsMetrics,
-            null,
-            id -> mockProducer
-        );
-
-        collector.send(topic, "3", "0", new RecordHeaders(), null, keySerializer, valueSerializer, streamPartitioner);
-
-        final List<ProducerRecord<byte[], byte[]>> recordHistory = mockProducer.history();
-        for (final ProducerRecord<byte[], byte[]> sentRecord : recordHistory) {
-            final Headers headers = sentRecord.headers();
-            assertEquals(2, headers.toArray().length);
-            assertEquals(new RecordHeader("key", "key".getBytes()), headers.lastHeader("key"));
-            assertEquals(new RecordHeader("value", "value".getBytes()), headers.lastHeader("value"));
-        }
-    }
 
     private static class CustomStringSerializer extends StringSerializer {
-
         private boolean isKey;
-
-        private CustomStringSerializer() {
-        }
 
         @Override
         public void configure(final Map<String, ?> configs, final boolean isKey) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Measurable;
@@ -249,7 +250,7 @@ public class StreamThreadTest {
         // assign single partition
         assignedPartitions = Collections.singletonList(t1p1);
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -425,6 +426,7 @@ public class StreamThreadTest {
             config,
             null,
             null,
+            null,
             consumer,
             consumer,
             null,
@@ -447,10 +449,10 @@ public class StreamThreadTest {
 
     @Test
     public void shouldRespectNumIterationsInMainLoop() {
-        final MockProcessor mockProcessor = new MockProcessor(PunctuationType.WALL_CLOCK_TIME, 10L);
+        final MockProcessor<byte[], byte[]> mockProcessor = new MockProcessor<>(PunctuationType.WALL_CLOCK_TIME, 10L);
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
         internalTopologyBuilder.addProcessor("processor1", () -> mockProcessor, "source1");
-        internalTopologyBuilder.addProcessor("processor2", () -> new MockProcessor(PunctuationType.STREAM_TIME, 10L), "source1");
+        internalTopologyBuilder.addProcessor("processor2", () -> new MockProcessor<byte[], byte[]>(PunctuationType.STREAM_TIME, 10L), "source1");
 
         final Properties properties = new Properties();
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
@@ -472,7 +474,7 @@ public class StreamThreadTest {
             Collections.emptyMap()
         );
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(Collections.singleton(t1p1));
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -554,6 +556,7 @@ public class StreamThreadTest {
             config,
             null,
             null,
+            null,
             consumer,
             consumer,
             null,
@@ -589,6 +592,7 @@ public class StreamThreadTest {
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
+            null,
             null,
             null,
             consumer,
@@ -633,7 +637,7 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         final Map<TopicPartition, Long> beginOffsets = new HashMap<>();
         beginOffsets.put(t1p1, 0L);
@@ -642,11 +646,11 @@ public class StreamThreadTest {
         thread.rebalanceListener.onPartitionsAssigned(new HashSet<>(assignedPartitions));
 
         assertEquals(1, clientSupplier.producers.size());
-        final Producer globalProducer = clientSupplier.producers.get(0);
+        final Producer<byte[], byte[]> globalProducer = clientSupplier.producers.get(0);
         for (final Task task : thread.activeTasks()) {
             assertSame(globalProducer, ((RecordCollectorImpl) ((StreamTask) task).recordCollector()).producer());
         }
-        assertSame(clientSupplier.consumer, thread.consumer);
+        assertSame(clientSupplier.consumer, thread.mainConsumer);
         assertSame(clientSupplier.restoreConsumer, thread.restoreConsumer);
     }
 
@@ -670,7 +674,7 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         final Map<TopicPartition, Long> beginOffsets = new HashMap<>();
         beginOffsets.put(t1p1, 0L);
@@ -681,7 +685,7 @@ public class StreamThreadTest {
         thread.runOnce();
 
         assertEquals(thread.activeTasks().size(), clientSupplier.producers.size());
-        assertSame(clientSupplier.consumer, thread.consumer);
+        assertSame(clientSupplier.consumer, thread.mainConsumer);
         assertSame(clientSupplier.restoreConsumer, thread.restoreConsumer);
     }
 
@@ -718,7 +722,7 @@ public class StreamThreadTest {
             "Thread never shut down.");
 
         for (final Task task : thread.activeTasks()) {
-            assertTrue(((MockProducer) ((RecordCollectorImpl) ((StreamTask) task).recordCollector()).producer()).closed());
+            assertTrue(((MockProducer<byte[], byte[]>) ((RecordCollectorImpl) ((StreamTask) task).recordCollector()).producer()).closed());
         }
     }
 
@@ -735,6 +739,7 @@ public class StreamThreadTest {
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
+            null,
             null,
             null,
             consumer,
@@ -773,6 +778,7 @@ public class StreamThreadTest {
             config,
             null,
             null,
+            null,
             consumer,
             consumer,
             null,
@@ -801,6 +807,7 @@ public class StreamThreadTest {
         final StreamThread thread = new StreamThread(
             mockTime,
             config,
+            null,
             null,
             null,
             consumer,
@@ -863,14 +870,14 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
 
         thread.runOnce();
         assertThat(thread.activeTasks().size(), equalTo(1));
-        final MockProducer producer = clientSupplier.producers.get(0);
+        final MockProducer<byte[], byte[]> producer = clientSupplier.producers.get(0);
 
         // change consumer subscription from "pattern" to "manual" to be able to call .addRecords()
         consumer.updateBeginningOffsets(Collections.singletonMap(assignedPartitions.iterator().next(), 0L));
@@ -921,7 +928,7 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -930,7 +937,7 @@ public class StreamThreadTest {
 
         assertThat(thread.activeTasks().size(), equalTo(1));
 
-        clientSupplier.producers.get(0).fenceProducerOnCommitTxn();
+        clientSupplier.producers.get(0).commitTransactionException = new ProducerFencedException("Producer is fenced");
         thread.rebalanceListener.onPartitionsRevoked(assignedPartitions);
         assertTrue(thread.rebalanceException() instanceof TaskMigratedException);
         assertFalse(clientSupplier.producers.get(0).transactionCommitted());
@@ -961,16 +968,16 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
 
         thread.runOnce();
         assertThat(thread.activeTasks().size(), equalTo(1));
-        final MockProducer producer = clientSupplier.producers.get(0);
+        final MockProducer<byte[], byte[]> producer = clientSupplier.producers.get(0);
 
-        producer.fenceProducerOnCommitTxn();
+        producer.commitTransactionException = new ProducerFencedException("Producer is fenced");
         mockTime.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) + 1L);
         consumer.addRecord(new ConsumerRecord<>(topic1, 1, 1, new byte[0], new byte[0]));
         try {
@@ -1009,7 +1016,7 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -1042,7 +1049,7 @@ public class StreamThreadTest {
 
         thread.taskManager().handleAssignment(activeTasks, Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(assignedPartitions);
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -1210,7 +1217,8 @@ public class StreamThreadTest {
     @Test
     public void shouldNotCreateStandbyTaskIfStateStoresHaveLoggingDisabled() {
         setupInternalTopologyWithoutState();
-        final StoreBuilder storeBuilder = new MockKeyValueStoreBuilder("myStore", true);
+        final StoreBuilder<KeyValueStore<Object, Object>> storeBuilder =
+            new MockKeyValueStoreBuilder("myStore", true);
         storeBuilder.withLoggingDisabled();
         internalTopologyBuilder.addStateStore(storeBuilder, "processor1");
 
@@ -1371,7 +1379,7 @@ public class StreamThreadTest {
         internalStreamsBuilder.buildAndOptimizeTopology();
 
         final StreamThread thread = createStreamThread("clientId", config, false);
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         final MockConsumer<byte[], byte[]> mockRestoreConsumer = (MockConsumer<byte[], byte[]>) thread.restoreConsumer;
 
         final TopicPartition topicPartition = new TopicPartition("topic", 0);
@@ -1506,7 +1514,7 @@ public class StreamThreadTest {
             Collections.singletonMap(task1, assignedPartitions),
             Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(Collections.singleton(t1p1));
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -1595,7 +1603,7 @@ public class StreamThreadTest {
                 assignedPartitions),
             Collections.emptyMap());
 
-        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.consumer;
+        final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(Collections.singleton(t1p1));
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
         thread.rebalanceListener.onPartitionsAssigned(assignedPartitions);
@@ -1699,6 +1707,7 @@ public class StreamThreadTest {
             config,
             producer,
             null,
+            null,
             consumer,
             consumer,
             null,
@@ -1735,6 +1744,7 @@ public class StreamThreadTest {
             new StreamsConfig(configProps(true)),
             null,       // with EOS the thread producer should be null
             null,
+            null,
             consumer,
             consumer,
             null,
@@ -1757,7 +1767,7 @@ public class StreamThreadTest {
         // without creating tasks the metrics should be empty
         producer.setMockMetrics(testMetricName, testMetric);
         final Map<MetricName, Metric> producerMetrics = thread.producerMetrics();
-        assertEquals(Collections.emptyMap(), producerMetrics);
+        assertEquals(Collections.<MetricName, Metric>emptyMap(), producerMetrics);
     }
 
     @Test
@@ -1777,6 +1787,7 @@ public class StreamThreadTest {
             mockTime,
             config,
             producer,
+            null,
             adminClient,
             consumer,
             consumer,
@@ -1815,7 +1826,7 @@ public class StreamThreadTest {
     }
 
     private void setupInternalTopologyWithoutState() {
-        final MockProcessor mockProcessor = new MockProcessor();
+        final MockProcessor<byte[], byte[]> mockProcessor = new MockProcessor<>();
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
         internalTopologyBuilder.addProcessor("processor1", () -> mockProcessor, "source1");
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -1,0 +1,638 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownProducerIdException;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class StreamsProducerTest {
+
+    private final LogContext logContext = new LogContext("test ");
+    private final String topic = "topic";
+    private final Cluster cluster = new Cluster(
+        "cluster",
+        Collections.singletonList(Node.noNode()),
+        Collections.singletonList(new PartitionInfo(topic, 0, Node.noNode(), new Node[0], new Node[0])),
+        Collections.emptySet(),
+        Collections.emptySet()
+    );
+    private final TaskId taskId = new TaskId(0, 0);
+    private final ByteArraySerializer byteArraySerializer = new ByteArraySerializer();
+    private final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = mkMap(
+        mkEntry(new TopicPartition(topic, 0), new OffsetAndMetadata(0L, null))
+    );
+
+    private final MockProducer<byte[], byte[]> mockProducer = new MockProducer<>(
+        cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
+    private final StreamsProducer streamsProducer = new StreamsProducer(logContext, mockProducer);
+
+    private final MockProducer<byte[], byte[]> eosMockProducer = new MockProducer<>(
+        cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
+    private final StreamsProducer eosStreamsProducer = new StreamsProducer(logContext, eosMockProducer, "appId", taskId);
+
+    private final ProducerRecord<byte[], byte[]> record =
+        new ProducerRecord<>(topic, 0, 0L, new byte[0], new byte[0], new RecordHeaders());
+
+    @Before
+    public void before() {
+        eosStreamsProducer.initTransaction();
+    }
+
+    @Test
+    public void shouldFailIfProducerIsNull() {
+        {
+            final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> new StreamsProducer(logContext, null)
+            );
+
+            assertThat(thrown.getMessage(), equalTo("producer cannot be null"));
+        }
+
+        {
+            final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> new StreamsProducer(logContext, null, "appId", taskId)
+            );
+
+            assertThat(thrown.getMessage(), equalTo("producer cannot be null"));
+        }
+    }
+
+    @Test
+    public void shouldThrowIfIncorrectlyInitialized() {
+        {
+            final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> new StreamsProducer(logContext, mockProducer, null, taskId)
+            );
+            assertThat(thrown.getMessage(), equalTo("applicationId and taskId must either be both null or both be not null"));
+        }
+
+        {
+            final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> new StreamsProducer(logContext, mockProducer, "appId", null)
+            );
+            assertThat(thrown.getMessage(), equalTo("applicationId and taskId must either be both null or both be not null"));
+        }
+    }
+
+    // non-eos tests
+
+    // functional tests
+
+    @Test
+    public void shouldNotInitTxIfEosDisable() {
+        assertFalse(mockProducer.transactionInitialized());
+    }
+
+    @Test
+    public void shouldNotBeginTxOnSendIfEosDisable() {
+        streamsProducer.send(record, null);
+        assertFalse(mockProducer.transactionInFlight());
+    }
+
+    @Test
+    public void shouldForwardRecordOnSend() {
+        streamsProducer.send(record, null);
+        assertThat(mockProducer.history().size(), equalTo(1));
+        assertThat(mockProducer.history().get(0), equalTo(record));
+    }
+
+    @Test
+    public void shouldForwardCallToPartitionsFor() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        final List<PartitionInfo> expectedPartitionInfo = Collections.emptyList();
+        expect(producer.partitionsFor("topic")).andReturn(expectedPartitionInfo);
+        replay(producer);
+
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, producer);
+
+        final List<PartitionInfo> partitionInfo = streamsProducer.partitionsFor(topic);
+
+        assertSame(expectedPartitionInfo, partitionInfo);
+        verify(producer);
+    }
+
+    @Test
+    public void shouldForwardCallToFlush() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.flush();
+        expectLastCall();
+        replay(producer);
+
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, producer);
+
+        streamsProducer.flush();
+
+        verify(producer);
+    }
+
+    @Test
+    public void shouldCloseProducerOnClose() {
+        streamsProducer.close();
+        assertTrue(mockProducer.closed());
+    }
+
+    // error handling tests
+
+    @Test
+    public void shouldFailOnInitTxIfEosDisabled() {
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            streamsProducer::initTransaction
+        );
+
+        assertThat(thrown.getMessage(), equalTo("EOS is disabled"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnSendError() {
+        mockProducer.sendException  = new KafkaException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> streamsProducer.send(record, null)
+        );
+
+        assertEquals(mockProducer.sendException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered sending record to topic topic due to:\norg.apache.kafka.common.KafkaException: KABOOM!"));
+    }
+
+    @Test
+    public void shouldFailOnSendFatal() {
+        mockProducer.sendException = new RuntimeException("KABOOM!");
+
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> streamsProducer.send(record, null)
+        );
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldFailOnCommitIfEosDisabled() {
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> streamsProducer.commitTransaction(null)
+        );
+
+        assertThat(thrown.getMessage(), equalTo("EOS is disabled"));
+    }
+
+    @Test
+    public void shouldFailOnAbortIfEosDisabled() {
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            streamsProducer::abortTransaction
+        );
+
+        assertThat(thrown.getMessage(), equalTo("EOS is disabled"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnCloseError() {
+        mockProducer.closeException = new KafkaException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            streamsProducer::close
+        );
+
+        assertEquals(mockProducer.closeException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer encounter unexpected error trying to close"));
+    }
+
+    @Test
+    public void shouldFailOnCloseFatal() {
+        mockProducer.closeException = new RuntimeException("KABOOM!");
+
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            streamsProducer::close
+        );
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    // EOS tests
+
+    // functional tests
+
+    @Test
+    public void shouldInitTxOnEos() {
+        assertTrue(eosMockProducer.transactionInitialized());
+    }
+
+    @Test
+    public void shouldBeginTxOnEosSend() {
+        eosStreamsProducer.send(record, null);
+        assertTrue(eosMockProducer.transactionInFlight());
+    }
+
+    @Test
+    public void shouldContinueTxnSecondEosSend() {
+        eosStreamsProducer.send(record, null);
+        eosStreamsProducer.send(record, null);
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertThat(eosMockProducer.uncommittedRecords().size(), equalTo(2));
+    }
+
+    @Test
+    public void shouldForwardRecordButNotCommitOnEosSend() {
+        eosStreamsProducer.send(record, null);
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.history().isEmpty());
+        assertThat(eosMockProducer.uncommittedRecords().size(), equalTo(1));
+        assertThat(eosMockProducer.uncommittedRecords().get(0), equalTo(record));
+    }
+
+    @Test
+    public void shouldBeginTxOnEosCommit() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.initTransactions();
+        producer.beginTransaction();
+        producer.sendOffsetsToTransaction(offsetsAndMetadata, "appId");
+        producer.commitTransaction();
+        expectLastCall();
+        replay(producer);
+
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, producer, "appId", taskId);
+        streamsProducer.initTransaction();
+
+        streamsProducer.commitTransaction(offsetsAndMetadata);
+
+        verify(producer);
+    }
+
+    @Test
+    public void shouldSendOffsetToTxOnEosCommit() {
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata);
+        assertTrue(eosMockProducer.sentOffsets());
+    }
+
+    @Test
+    public void shouldCommitTxOnEosCommit() {
+        eosStreamsProducer.send(record, null);
+        assertTrue(eosMockProducer.transactionInFlight());
+
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata);
+
+        assertFalse(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.uncommittedRecords().isEmpty());
+        assertTrue(eosMockProducer.uncommittedOffsets().isEmpty());
+        assertThat(eosMockProducer.history().size(), equalTo(1));
+        assertThat(eosMockProducer.history().get(0), equalTo(record));
+        assertThat(eosMockProducer.consumerGroupOffsetsHistory().size(), equalTo(1));
+        assertThat(eosMockProducer.consumerGroupOffsetsHistory().get(0).get("appId"), equalTo(offsetsAndMetadata));
+    }
+
+    @Test
+    public void shouldAbortTxOnEosAbort() {
+        // call `send()` to start a transaction
+        eosStreamsProducer.send(record, null);
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertThat(eosMockProducer.uncommittedRecords().size(), equalTo(1));
+        assertThat(eosMockProducer.uncommittedRecords().get(0), equalTo(record));
+
+        eosStreamsProducer.abortTransaction();
+
+        assertFalse(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.uncommittedRecords().isEmpty());
+        assertTrue(eosMockProducer.uncommittedOffsets().isEmpty());
+        assertTrue(eosMockProducer.history().isEmpty());
+        assertTrue(eosMockProducer.consumerGroupOffsetsHistory().isEmpty());
+    }
+
+    @Test
+    public void shouldSkipAbortTxOnEosAbortIfNotTxInFlight() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.initTransactions();
+        expectLastCall();
+        replay(producer);
+
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, producer, "appId", taskId);
+        streamsProducer.initTransaction();
+
+        streamsProducer.abortTransaction();
+
+        verify(producer);
+    }
+
+    // error handling tests
+
+    @Test
+    public void shouldThrowTimeoutExceptionOnEosInitTxTimeout() {
+        // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
+        mockProducer.initTransactionException = new TimeoutException("KABOOM!");
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, mockProducer, "appId", taskId);
+
+        final TimeoutException thrown = assertThrows(
+            TimeoutException.class,
+            streamsProducer::initTransaction
+        );
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnEosInitError() {
+        // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
+        mockProducer.initTransactionException = new KafkaException("KABOOM!");
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, mockProducer, "appId", taskId);
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            streamsProducer::initTransaction
+        );
+
+        assertEquals(mockProducer.initTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Error encountered while initializing transactions for task 0_0"));
+    }
+
+    @Test
+    public void shouldFailOnEosInitFatal() {
+        // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
+        mockProducer.initTransactionException = new RuntimeException("KABOOM!");
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, mockProducer, "appId", taskId);
+
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            streamsProducer::initTransaction
+        );
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldThrowTaskMigrateExceptionOnEosBeginTxnFenced() {
+        eosMockProducer.fenceProducer();
+
+        final TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class,
+            () -> eosStreamsProducer.send(null, null)
+        );
+
+        assertThat(thrown.getMessage(), equalTo("Producer get fenced trying to begin a new transaction; it means all tasks belonging to this thread should be migrated."));
+    }
+
+    @Test
+    public void shouldThrowTaskMigrateExceptionOnEosBeginTxnError() {
+        eosMockProducer.beginTransactionException = new KafkaException("KABOOM!");
+
+        // calling `send()` implicitly starts a new transaction
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> eosStreamsProducer.send(null, null));
+
+        assertEquals(eosMockProducer.beginTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer encounter unexpected error trying to begin a new transaction for task 0_0"));
+    }
+
+    @Test
+    public void shouldFailOnEosBeginTxnFatal() {
+        eosMockProducer.beginTransactionException = new RuntimeException("KABOOM!");
+
+        // calling `send()` implicitly starts a new transaction
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> eosStreamsProducer.send(null, null));
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldThrowTaskMigratedExceptionOnEosSendFenced() {
+        // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
+        final ProducerFencedException exception = new ProducerFencedException("KABOOM!");
+        // we need to mimic that `send()` always wraps error in a KafkaException
+        eosMockProducer.sendException = new KafkaException(exception);
+
+        final TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class,
+            () -> eosStreamsProducer.send(record, null)
+        );
+
+        assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer cannot send records anymore since it got fenced; it means all tasks belonging to this thread should be migrated."));
+    }
+
+    @Test
+    public void shouldThrowTaskMigratedExceptionOnEosSendUnknownPid() {
+        final UnknownProducerIdException exception = new UnknownProducerIdException("KABOOM!");
+        // we need to mimic that `send()` always wraps error in a KafkaException
+        eosMockProducer.sendException = new KafkaException(exception);
+
+        final TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class,
+            () -> eosStreamsProducer.send(record, null)
+        );
+
+        assertEquals(exception, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer cannot send records anymore since it got fenced; it means all tasks belonging to this thread should be migrated."));
+    }
+
+    @Test
+    public void shouldThrowTaskMigrateExceptionOnEosSendOffsetFenced() {
+        // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
+        eosMockProducer.sendOffsetsToTransactionException = new ProducerFencedException("KABOOM!");
+
+        final TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class,
+            // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
+            // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
+            () -> eosStreamsProducer.commitTransaction(null)
+        );
+
+        assertEquals(eosMockProducer.sendOffsetsToTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer get fenced trying to commit a transaction; it means all tasks belonging to this thread should be migrated."));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnEosSendOffsetError() {
+        eosMockProducer.sendOffsetsToTransactionException = new KafkaException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
+            // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
+            () -> eosStreamsProducer.commitTransaction(null)
+        );
+
+        assertEquals(eosMockProducer.sendOffsetsToTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer encounter unexpected error trying to commit a transaction for task 0_0"));
+    }
+
+    @Test
+    public void shouldFailOnEosSendOffsetFatal() {
+        eosMockProducer.sendOffsetsToTransactionException = new RuntimeException("KABOOM!");
+
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
+            // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
+            () -> eosStreamsProducer.commitTransaction(null)
+        );
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldThrowTaskMigrateExceptionOnEosCommitTxFenced() {
+        // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
+        eosMockProducer.commitTransactionException = new ProducerFencedException("KABOOM!");
+
+        final TaskMigratedException thrown = assertThrows(
+            TaskMigratedException.class,
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+        );
+
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals(eosMockProducer.commitTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer get fenced trying to commit a transaction; it means all tasks belonging to this thread should be migrated."));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnEosCommitTxTimeout() {
+        // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
+        eosMockProducer.commitTransactionException = new TimeoutException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+        );
+
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals(eosMockProducer.commitTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Timed out while committing a transaction for task " + taskId));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnEosCommitTxError() {
+        eosMockProducer.commitTransactionException = new KafkaException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+        );
+
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals(eosMockProducer.commitTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer encounter unexpected error trying to commit a transaction for task 0_0"));
+    }
+
+    @Test
+    public void shouldFailOnEosCommitTxFatal() {
+        eosMockProducer.commitTransactionException = new RuntimeException("KABOOM!");
+
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+        );
+
+        assertTrue(eosMockProducer.sentOffsets());
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+
+    @Test
+    public void shouldSwallowExceptionOnEosAbortTxFenced() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.initTransactions();
+        producer.beginTransaction();
+        expect(producer.send(record, null)).andReturn(null);
+        producer.abortTransaction();
+        expectLastCall().andThrow(new ProducerFencedException("KABOOM!"));
+        replay(producer);
+
+        final StreamsProducer streamsProducer = new StreamsProducer(logContext, producer, "appId", taskId);
+        streamsProducer.initTransaction();
+        // call `send()` to start a transaction
+        streamsProducer.send(record, null);
+
+        streamsProducer.abortTransaction();
+
+        verify(producer);
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnEosAbortTxError() {
+        eosMockProducer.abortTransactionException = new KafkaException("KABOOM!");
+        // call `send()` to start a transaction
+        eosStreamsProducer.send(record, null);
+
+        final StreamsException thrown = assertThrows(StreamsException.class, eosStreamsProducer::abortTransaction);
+
+        assertEquals(eosMockProducer.abortTransactionException, thrown.getCause());
+        assertThat(thrown.getMessage(), equalTo("Producer encounter unexpected error trying to abort a transaction for task 0_0"));
+    }
+
+    @Test
+    public void shouldFailOnEosAbortTxFatal() {
+        eosMockProducer.abortTransactionException = new RuntimeException("KABOOM!");
+        // call `send()` to start a transaction
+        eosStreamsProducer.send(record, null);
+
+        final RuntimeException thrown = assertThrows(RuntimeException.class, eosStreamsProducer::abortTransaction);
+
+        assertThat(thrown.getMessage(), equalTo("KABOOM!"));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -125,9 +125,10 @@ public class TaskManagerTest {
                                       streamsMetrics,
                                       activeTaskCreator,
                                       standbyTaskCreator,
+                                      new HashMap<>(),
                                       topologyBuilder,
                                       adminClient);
-        taskManager.setConsumer(consumer);
+        taskManager.setMainConsumer(consumer);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -43,7 +43,7 @@ public class MockClientSupplier implements KafkaClientSupplier {
 
     private String applicationId;
 
-    public final List<MockProducer> producers = new LinkedList<>();
+    public final List<MockProducer<byte[], byte[]>> producers = new LinkedList<>();
 
     public final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     public final MockConsumer<byte[], byte[]> restoreConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
@@ -18,6 +18,7 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -28,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class MockKeyValueStore implements KeyValueStore {
+public class MockKeyValueStore implements KeyValueStore<Object, Object> {
     // keep a global counter of flushes and a local reference to which store had which
     // flush, so we can reason about the order in which stores get flushed.
     private static final AtomicInteger GLOBAL_FLUSH_COUNTER = new AtomicInteger(0);
@@ -111,9 +112,7 @@ public class MockKeyValueStore implements KeyValueStore {
     }
 
     @Override
-    public void putAll(final List entries) {
-
-    }
+    public void putAll(final List<KeyValue<Object, Object>> entries) {}
 
     @Override
     public Object get(final Object key) {
@@ -121,12 +120,12 @@ public class MockKeyValueStore implements KeyValueStore {
     }
 
     @Override
-    public KeyValueIterator range(final Object from, final Object to) {
+    public KeyValueIterator<Object, Object> range(final Object from, final Object to) {
         return null;
     }
 
     @Override
-    public KeyValueIterator all() {
+    public KeyValueIterator<Object, Object> all() {
         return null;
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.internals.AbstractStoreBuilder;
 
-public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte[], KeyValueStore> {
+public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte[], KeyValueStore<Object, Object>> {
 
     private final boolean persistent;
 
@@ -32,7 +32,7 @@ public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte
     }
 
     @Override
-    public KeyValueStore build() {
+    public KeyValueStore<Object, Object> build() {
         return new MockKeyValueStore(name, persistent);
     }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -65,6 +65,7 @@ import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StoreChangelogReader;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -98,11 +99,12 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+
+import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 
 /**
  * This class makes it easier to write tests to verify the behavior of topologies created with {@link Topology} or
@@ -196,23 +198,23 @@ public class TopologyTestDriver implements Closeable {
 
     private static final Logger log = LoggerFactory.getLogger(TopologyTestDriver.class);
 
+    private final LogContext logContext;
     private final Time mockWallClockTime;
-    private final InternalTopologyBuilder internalTopologyBuilder;
+    private InternalTopologyBuilder internalTopologyBuilder;
 
     private final static int PARTITION_ID = 0;
     private final static TaskId TASK_ID = new TaskId(0, PARTITION_ID);
-    final StreamTask task;
-    private final GlobalStateUpdateTask globalStateTask;
-    private final GlobalStateManager globalStateManager;
+    StreamTask task;
+    private GlobalStateUpdateTask globalStateTask;
+    private GlobalStateManager globalStateManager;
 
-    private final StateDirectory stateDirectory;
-    private final Metrics metrics;
-    final ProcessorTopology processorTopology;
-    final ProcessorTopology globalTopology;
+    private StateDirectory stateDirectory;
+    private Metrics metrics;
+    ProcessorTopology processorTopology;
+    ProcessorTopology globalTopology;
 
     private final MockProducer<byte[], byte[]> producer;
 
-    private final Set<String> internalTopics = new HashSet<>();
     private final Map<String, TopicPartition> partitionsByInputTopic = new HashMap<>();
     private final Map<String, TopicPartition> globalPartitionsByInputTopic = new HashMap<>();
     private final Map<TopicPartition, AtomicLong> offsetsByTopicOrPatternPartition = new HashMap<>();
@@ -275,7 +277,6 @@ public class TopologyTestDriver implements Closeable {
             initialWallClockTime == null ? System.currentTimeMillis() : initialWallClockTime.toEpochMilli());
     }
 
-
     /**
      * Create a new test diver instance.
      *
@@ -288,15 +289,18 @@ public class TopologyTestDriver implements Closeable {
                                final long initialWallClockTimeMs) {
         final StreamsConfig streamsConfig = new QuietStreamsConfig(config);
         logIfTaskIdleEnabled(streamsConfig);
+
+        logContext = new LogContext("topology-test-driver ");
         mockWallClockTime = new MockTime(initialWallClockTimeMs);
+        eosEnabled = EXACTLY_ONCE.equals(streamsConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
 
-        internalTopologyBuilder = builder;
-        internalTopologyBuilder.rewriteTopology(streamsConfig);
+        final StreamsMetricsImpl streamsMetrics = setupMetrics(streamsConfig);
+        setupTopology(builder, streamsConfig);
 
-        processorTopology = internalTopologyBuilder.build();
-        globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
-        final boolean createStateDirectory = processorTopology.hasPersistentLocalStore() ||
-            (globalTopology != null && globalTopology.hasPersistentGlobalStore());
+        final ThreadCache cache = new ThreadCache(
+            logContext,
+            Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
+            streamsMetrics);
 
         final Serializer<byte[]> bytesSerializer = new ByteArraySerializer();
         producer = new MockProducer<byte[], byte[]>(true, bytesSerializer, bytesSerializer) {
@@ -306,17 +310,33 @@ public class TopologyTestDriver implements Closeable {
             }
         };
 
-        final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        stateDirectory = new StateDirectory(streamsConfig, mockWallClockTime, createStateDirectory);
+        setupGlobalTask(streamsConfig, streamsMetrics, cache);
+        setupTask(streamsConfig, streamsMetrics, cache);
+    }
+
+    private static void logIfTaskIdleEnabled(final StreamsConfig streamsConfig) {
+        final Long taskIdleTime = streamsConfig.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
+        if (taskIdleTime > 0) {
+            log.info("Detected {} config in use with TopologyTestDriver (set to {}ms)." +
+                         " This means you might need to use TopologyTestDriver#advanceWallClockTime()" +
+                         " or enqueue records on all partitions to allow Steams to make progress." +
+                         " TopologyTestDriver will log a message each time it cannot process enqueued" +
+                         " records due to {}.",
+                     StreamsConfig.MAX_TASK_IDLE_MS_CONFIG,
+                     taskIdleTime,
+                     StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
+        }
+    }
+
+    private StreamsMetricsImpl setupMetrics(final StreamsConfig streamsConfig) {
+        final String threadId = Thread.currentThread().getName();
 
         final MetricConfig metricConfig = new MetricConfig()
             .samples(streamsConfig.getInt(StreamsConfig.METRICS_NUM_SAMPLES_CONFIG))
             .recordLevel(Sensor.RecordingLevel.forName(streamsConfig.getString(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG)))
             .timeWindow(streamsConfig.getLong(StreamsConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS);
-
         metrics = new Metrics(metricConfig, mockWallClockTime);
 
-        final String threadId = Thread.currentThread().getName();
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,
             "test-client",
@@ -324,27 +344,32 @@ public class TopologyTestDriver implements Closeable {
         );
         streamsMetrics.setRocksDBMetricsRecordingTrigger(new RocksDBMetricsRecordingTrigger());
         TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, TASK_ID.toString(), streamsMetrics);
-        final ThreadCache cache = new ThreadCache(
-            new LogContext("topology-test-driver "),
-            Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
-            streamsMetrics);
 
-        for (final InternalTopologyBuilder.TopicsInfo topicsInfo : internalTopologyBuilder.topicGroups().values()) {
-            internalTopics.addAll(topicsInfo.repartitionSourceTopics.keySet());
-        }
+        return streamsMetrics;
+    }
+
+    private void setupTopology(final InternalTopologyBuilder builder,
+                               final StreamsConfig streamsConfig) {
+        internalTopologyBuilder = builder;
+        internalTopologyBuilder.rewriteTopology(streamsConfig);
+
+        processorTopology = internalTopologyBuilder.build();
+        globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
 
         for (final String topic : processorTopology.sourceTopics()) {
             final TopicPartition tp = new TopicPartition(topic, PARTITION_ID);
             partitionsByInputTopic.put(topic, tp);
             offsetsByTopicOrPatternPartition.put(tp, new AtomicLong());
         }
-        consumer.assign(partitionsByInputTopic.values());
-        final Map<TopicPartition, Long> startOffsets = new HashMap<>();
-        for (final TopicPartition topicPartition : partitionsByInputTopic.values()) {
-            startOffsets.put(topicPartition, 0L);
-        }
-        consumer.updateBeginningOffsets(startOffsets);
 
+        final boolean createStateDirectory = processorTopology.hasPersistentLocalStore() ||
+            (globalTopology != null && globalTopology.hasPersistentGlobalStore());
+        stateDirectory = new StateDirectory(streamsConfig, mockWallClockTime, createStateDirectory);
+    }
+
+    private void setupGlobalTask(final StreamsConfig streamsConfig,
+                                 final StreamsMetricsImpl streamsMetrics,
+                                 final ThreadCache cache) {
         if (globalTopology != null) {
             final MockConsumer<byte[], byte[]> globalConsumer = new MockConsumer<>(OffsetResetStrategy.NONE);
             for (final String topicName : globalTopology.sourceTopics()) {
@@ -358,7 +383,7 @@ public class TopologyTestDriver implements Closeable {
             }
 
             globalStateManager = new GlobalStateManagerImpl(
-                new LogContext("mock "),
+                logContext,
                 globalTopology,
                 globalConsumer,
                 stateDirectory,
@@ -374,7 +399,7 @@ public class TopologyTestDriver implements Closeable {
                 globalProcessorContext,
                 globalStateManager,
                 new LogAndContinueExceptionHandler(),
-                new LogContext()
+                logContext
             );
             globalStateTask.initialize();
             globalProcessorContext.setRecordContext(new ProcessorRecordContext(
@@ -387,9 +412,20 @@ public class TopologyTestDriver implements Closeable {
             globalStateManager = null;
             globalStateTask = null;
         }
+    }
 
+    private void setupTask(final StreamsConfig streamsConfig,
+                           final StreamsMetricsImpl streamsMetrics,
+                           final ThreadCache cache) {
         if (!partitionsByInputTopic.isEmpty()) {
-            final LogContext logContext = new LogContext("topology-test-driver ");
+            final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+            consumer.assign(partitionsByInputTopic.values());
+            final Map<TopicPartition, Long> startOffsets = new HashMap<>();
+            for (final TopicPartition topicPartition : partitionsByInputTopic.values()) {
+                startOffsets.put(topicPartition, 0L);
+            }
+            consumer.updateBeginningOffsets(startOffsets);
+
             final ProcessorStateManager stateManager = new ProcessorStateManager(
                 TASK_ID,
                 new HashSet<>(partitionsByInputTopic.values()),
@@ -404,12 +440,17 @@ public class TopologyTestDriver implements Closeable {
                     stateRestoreListener),
                 logContext);
             final RecordCollector recordCollector = new RecordCollectorImpl(
-                TASK_ID,
-                streamsConfig,
                 logContext,
-                streamsMetrics,
+                TASK_ID,
                 consumer,
-                taskId -> producer);
+                new StreamsProducer(
+                    logContext,
+                    producer,
+                    eosEnabled ? streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG) : null,
+                    eosEnabled ? TASK_ID : null),
+                streamsConfig.defaultProductionExceptionHandler(),
+                eosEnabled,
+                streamsMetrics);
             task = new StreamTask(
                 TASK_ID,
                 new HashSet<>(partitionsByInputTopic.values()),
@@ -432,21 +473,6 @@ public class TopologyTestDriver implements Closeable {
                 new RecordHeaders()));
         } else {
             task = null;
-        }
-        eosEnabled = streamsConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG).equals(StreamsConfig.EXACTLY_ONCE);
-    }
-
-    private static void logIfTaskIdleEnabled(final StreamsConfig streamsConfig) {
-        final Long taskIdleTime = streamsConfig.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
-        if (taskIdleTime > 0) {
-            log.info("Detected {} config in use with TopologyTestDriver (set to {}ms)." +
-                         " This means you might need to use TopologyTestDriver#advanceWallClockTime()" +
-                         " or enqueue records on all partitions to allow Steams to make progress." +
-                         " TopologyTestDriver will log a message each time it cannot process enqueued" +
-                         " records due to {}.",
-                     StreamsConfig.MAX_TASK_IDLE_MS_CONFIG,
-                     taskIdleTime,
-                     StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
         }
     }
 
@@ -597,10 +623,7 @@ public class TopologyTestDriver implements Closeable {
         // Capture all the records sent to the producer ...
         final List<ProducerRecord<byte[], byte[]>> output = producer.history();
         producer.clear();
-        if (eosEnabled && !producer.closed()) {
-            producer.initTransactions();
-            producer.beginTransaction();
-        }
+
         for (final ProducerRecord<byte[], byte[]> record : output) {
             outputRecordsByTopic.computeIfAbsent(record.topic(), k -> new LinkedList<>()).add(record);
 


### PR DESCRIPTION
Upfront refactoring for KIP-447.

Introduces `StreamsProducer` that allows to share a producer over multiple tasks and track the TX status.

Call for review @guozhangwang @abbccdda 
