### PR TITLE
KAFKA-9533: ValueTransform forwards `null` values

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
@@ -53,7 +53,10 @@ public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> 
 
         @Override
         public void process(final K key, final V value) {
-            context.forward(key, valueTransformer.transform(key, value));
+            final R transformedValue = valueTransformer.transform(key, value);
+            if (transformedValue != null) {
+                context.forward(key, transformedValue);
+            }
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamTransformIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamTransformIntegrationTest.java
@@ -245,43 +245,6 @@ public class KStreamTransformIntegrationTest {
     }
 
     @Test
-    public void shouldNotFowardNullTransformValuesWithValueTransformerWithKey() {
-        stream
-                .transformValues(() -> new ValueTransformerWithKey<Integer, Integer, Integer>() {
-                    private KeyValueStore<Integer, Integer> state;
-
-                    @Override
-                    public void init(final ProcessorContext context) {
-                        state = (KeyValueStore<Integer, Integer>) context.getStateStore("myTransformState");
-                    }
-
-                    @Override
-                    public Integer transform(final Integer key, final Integer value) {
-                        if (key % 2 == 1) {
-                            return null;
-                        }
-
-                        state.putIfAbsent(key, 0);
-                        Integer storedValue = state.get(key);
-                        final Integer result = value + storedValue++;
-                        state.put(key, storedValue);
-                        return result;
-                    }
-
-                    @Override
-                    public void close() {
-                    }
-                }, "myTransformState")
-                .foreach(action);
-
-        final List<KeyValue<Integer, Integer>> expected = Arrays.asList(
-                KeyValue.pair(2, 2),
-                KeyValue.pair(2, 2),
-                KeyValue.pair(2, 5));
-        verifyResult(expected);
-    }
-
-    @Test
     public void shouldFlatTransformValuesWithKey() {
         stream
             .flatTransformValues(() -> new ValueTransformerWithKey<Integer, Integer, Iterable<Integer>>() {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -147,7 +147,6 @@ public class KStreamTransformValuesTest {
         final KStreamTransformValues.KStreamTransformValuesProcessor<Integer, Integer, Integer> processor =
             new KStreamTransformValues.KStreamTransformValuesProcessor<>(valueTransformer);
         processor.init(context);
-        EasyMock.reset(valueTransformer);
 
         final Integer inputKey = 1;
         final Integer inputValue = 10;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -144,18 +144,19 @@ public class KStreamTransformValuesTest {
     public void shouldEmitNoRecordIfTransformReturnsNull() {
         final ProcessorContext context = mock(ProcessorContext.class);
         final ValueTransformerWithKey<Integer, Integer, Integer> valueTransformer = mock(ValueTransformerWithKey.class);
-        final KStreamTransformValues.KStreamTransformValuesProcessor<Integer, Integer, Integer> processor = new KStreamTransformValues.KStreamTransformValuesProcessor<>(valueTransformer);
+        final KStreamTransformValues.KStreamTransformValuesProcessor<Integer, Integer, Integer> processor =
+            new KStreamTransformValues.KStreamTransformValuesProcessor<>(valueTransformer);
         processor.init(context);
-        EasyMock.reset(context, valueTransformer);
+        EasyMock.reset(valueTransformer);
 
         final Integer inputKey = 1;
         final Integer inputValue = 10;
-        EasyMock.expect(valueTransformer.transform(inputKey, inputValue)).andReturn(null);
-        EasyMock.replay(context, valueTransformer);
+        EasyMock.expect(valueTransformer.transform(inputKey, inputValue)).andStubReturn(null);
+        EasyMock.replay(context);
 
         processor.process(inputKey, inputValue);
 
-        EasyMock.verify(context, valueTransformer);
+        EasyMock.verify(context);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes a bug where `KStream#transformValues` would forward null values from the provided `ValueTransform#transform` operation.

A test was added for verification `KStreamTransformValuesTest#shouldEmitNoRecordIfTransformReturnsNull`. A parallel test for non-key ValueTransformer was not added, as they share the same code path.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
