### PR TITLE
KAFKA-9206: throw a KafkaException when encountering CORRUPT_MESSAGE

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1275,7 +1275,7 @@ public class Fetcher<K, V> implements Closeable {
             } else if (error == Errors.CORRUPT_MESSAGE) {
                 throw new KafkaException("Encountered corrupt message when fetching offset "
                         + fetchOffset
-                        + " for topic-partition {}"
+                        + " for topic-partition "
                         + tp);
             } else {
                 throw new IllegalStateException("Unexpected error code " + error.code() + " while fetching from partition " + tp);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1271,14 +1271,20 @@ public class Fetcher<K, V> implements Closeable {
             } else if (error == Errors.UNKNOWN_LEADER_EPOCH) {
                 log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
             } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
-                log.warn("Unknown error fetching data for topic-partition {}", tp);
+                log.warn("Unknown error fetching data while fetching offset "
+                        + fetchOffset
+                        + " for topic-partition " + tp);
             } else if (error == Errors.CORRUPT_MESSAGE) {
                 throw new KafkaException("Encountered corrupt message when fetching offset "
                         + fetchOffset
                         + " for topic-partition "
                         + tp);
             } else {
-                throw new IllegalStateException("Unexpected error code " + error.code() + " while fetching from partition " + tp);
+                throw new IllegalStateException("Unexpected error code "
+                        + error.code()
+                        + " while fetching at offset "
+                        + fetchOffset
+                        + " from topic-partition " + tp);
             }
         } finally {
             if (completedFetch == null)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1271,9 +1271,8 @@ public class Fetcher<K, V> implements Closeable {
             } else if (error == Errors.UNKNOWN_LEADER_EPOCH) {
                 log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
             } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
-                log.warn("Unknown error fetching data while fetching offset "
-                        + fetchOffset
-                        + " for topic-partition " + tp);
+                log.warn("Unknown server error while fetching offset {} for topic-partition {}",
+                        fetchOffset, tp);
             } else if (error == Errors.CORRUPT_MESSAGE) {
                 throw new KafkaException("Encountered corrupt message when fetching offset "
                         + fetchOffset

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1272,6 +1272,11 @@ public class Fetcher<K, V> implements Closeable {
                 log.debug("Received unknown leader epoch error in fetch for partition {}", tp);
             } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
                 log.warn("Unknown error fetching data for topic-partition {}", tp);
+            } else if (error == Errors.CORRUPT_MESSAGE) {
+                throw new KafkaException("Encountered corrupt message when fetching offset "
+                        + fetchOffset
+                        + " for topic-partition {}"
+                        + tp);
             } else {
                 throw new IllegalStateException("Unexpected error code " + error.code() + " while fetching from partition " + tp);
             }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -67,6 +67,8 @@ import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
  * - {@link Errors#KAFKA_STORAGE_ERROR} If the log directory for one of the requested partitions is offline
  * - {@link Errors#UNSUPPORTED_COMPRESSION_TYPE} If a fetched topic is using a compression type which is
  *     not supported by the fetch request version
+ * - {@link Errors#CORRUPT_MESSAGE} If corrupt message encountered, e.g. when the broker scans the log to find
+ *     the fetch offset after the index lookup
  * - {@link Errors#UNKNOWN_SERVER_ERROR} For any unexpected errors
  */
 public class FetchResponse<T extends BaseRecords> extends AbstractResponse {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -3835,6 +3835,31 @@ public class FetcherTest {
         assertEquals(1, fetcher.sendFetches());
     }
 
+    @Test
+    public void testCorruptMessageError() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, fetcher.sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Prepare a response with the CORRUPT_MESSAGE error.
+        client.prepareResponse(fullFetchResponse(
+                tp0,
+                buildRecords(1L, 1, 1),
+                Errors.CORRUPT_MESSAGE,
+                100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        // Trigger the exception.
+        assertThrows(KafkaException.class, () -> {
+            Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords =
+                    fetchedRecords();
+        });
+    }
+
     private MockClient.RequestMatcher listOffsetRequestMatcher(final long timestamp) {
         // matches any list offset request with the provided timestamp
         return new MockClient.RequestMatcher() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -3855,8 +3855,7 @@ public class FetcherTest {
 
         // Trigger the exception.
         assertThrows(KafkaException.class, () -> {
-            Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords =
-                    fetchedRecords();
+            fetchedRecords();
         });
     }
 


### PR DESCRIPTION
- If the completed fetch has an error code signifying a _corrupt message_, throw a `KafkaException` that notes the _offset and the topic-partition_.
- Also added a test that triggers the warning and verifies it is thrown.

- Jira: https://issues.apache.org/jira/browse/KAFKA-9206

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
