### PR TITLE
KAFKA-9557: correct thread process-rate sensor to measure throughput

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -855,9 +855,15 @@ public class StreamThread extends Thread {
                 for (int i = 0; i < numIterations; i++) {
                     advanceNowAndComputeLatency();
                     processed = taskManager.process(now);
-                    processRateSensor.record(processed, now);
 
                     if (processed > 0) {
+                        // It makes no difference to the outcome of these metrics when we record "0",
+                        // so we can just avoid the method call when we didn't process anything.
+                        processRateSensor.record(processed, now);
+
+                        // This metric is scaled to represent the _average_ processing time of _each_
+                        // task. Note, it's hard to interpret this as defined, but we would need a KIP
+                        // to change it to simply report the overall time spent processing all tasks.
                         final long processLatency = advanceNowAndComputeLatency();
                         processLatencySensor.record(processLatency / (double) processed, now);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_LEVEL_GROUP;
@@ -153,7 +154,9 @@ public class ThreadMetrics {
 
     public static Sensor processLatencySensor(final String threadId,
                                               final StreamsMetricsImpl streamsMetrics) {
-        final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, PROCESS, RecordingLevel.INFO);
+        final Sensor sensor = streamsMetrics.threadLevelSensor(threadId,
+                                                               PROCESS + LATENCY_SUFFIX,
+                                                               RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addAvgAndMaxToSensor(
@@ -169,12 +172,14 @@ public class ThreadMetrics {
 
     public static Sensor processRateSensor(final String threadId,
                                               final StreamsMetricsImpl streamsMetrics) {
-        final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, PROCESS, RecordingLevel.INFO);
+        final Sensor sensor = streamsMetrics.threadLevelSensor(threadId,
+                                                               PROCESS + RATE_SUFFIX,
+                                                               RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         sensor.add(
             new MetricName(
-                PROCESS + StreamsMetricsImpl.RATE_SUFFIX,
+                PROCESS + RATE_SUFFIX,
                 threadLevelGroup,
                 PROCESS_RATE_DESCRIPTION,
                 tagMap

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -16,16 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals.metrics;
 
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
-import org.apache.kafka.common.metrics.stats.CumulativeCount;
-import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
@@ -37,6 +32,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor;
 
 public class ThreadMetrics {
     private ThreadMetrics() {}
@@ -177,23 +173,13 @@ public class ThreadMetrics {
                                                                RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         final String threadLevelGroup = threadLevelGroup(streamsMetrics);
-        sensor.add(
-            new MetricName(
-                PROCESS + RATE_SUFFIX,
-                threadLevelGroup,
-                PROCESS_RATE_DESCRIPTION,
-                tagMap
-            ),
-            new Rate(TimeUnit.SECONDS, new WindowedSum())
-        );
-        sensor.add(
-            new MetricName(
-                PROCESS + StreamsMetricsImpl.TOTAL_SUFFIX,
-                threadLevelGroup,
-                PROCESS_TOTAL_DESCRIPTION,
-                tagMap
-            ),
-            new CumulativeCount()
+        addRateOfSumAndSumMetricsToSensor(
+            sensor,
+            threadLevelGroup,
+            tagMap,
+            PROCESS,
+            PROCESS_RATE_DESCRIPTION,
+            PROCESS_TOTAL_DESCRIPTION
         );
         return sensor;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -78,7 +78,6 @@ public class ThreadMetricsTest {
     @Before
     public void setUp() {
         expect(streamsMetrics.version()).andReturn(builtInMetricsVersion).anyTimes();
-        mockStatic(StreamsMetricsImpl.class);
     }
 
     @Test
@@ -88,6 +87,7 @@ public class ThreadMetricsTest {
         final String rateDescription = "The average per-second number of newly created tasks";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -111,6 +111,7 @@ public class ThreadMetricsTest {
         final String rateDescription = "The average per-second number of closed tasks";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -137,6 +138,7 @@ public class ThreadMetricsTest {
         final String maxLatencyDescription = "The maximum commit latency";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -170,6 +172,7 @@ public class ThreadMetricsTest {
         final String maxLatencyDescription = "The maximum poll latency";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -196,21 +199,23 @@ public class ThreadMetricsTest {
 
     @Test
     public void shouldGetProcessLatencySensor() {
-        final String operation = "process";
-        final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
-        final String avgLatencyDescription = "The average process latency";
-        final String maxLatencyDescription = "The maximum process latency";
-        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, "process-latency", RecordingLevel.INFO))
+            .andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
-        StreamsMetricsImpl.addAvgAndMaxToSensor(
-            expectedSensor,
+        expect(expectedSensor.add(eq(new MetricName(
+            "process-latency-avg",
             threadLevelGroup,
-            tagMap,
-            operationLatency,
-            avgLatencyDescription,
-            maxLatencyDescription
-        );
-        replay(StreamsMetricsImpl.class, streamsMetrics);
+            "The average execution time in ms for processing, across all running tasks of this thread.",
+            tagMap
+        )), anyObject())).andReturn(true);
+
+        expect(expectedSensor.add(eq(new MetricName(
+            "process-latency-max",
+            threadLevelGroup,
+            "The maximum execution time in ms for processing across all running tasks of this thread.",
+            tagMap
+        )), anyObject())).andReturn(true);
+        replay(StreamsMetricsImpl.class, streamsMetrics, expectedSensor);
 
         final Sensor sensor = ThreadMetrics.processLatencySensor(THREAD_ID, streamsMetrics);
 
@@ -219,23 +224,21 @@ public class ThreadMetricsTest {
     }
 
     @Test
-    public void shouldGetProcessSensor() {
-        final String operation = "process";
-        final String totalDescription = "The total number of calls to process";
-        final String rateDescription = "The average per-second number of calls to process";
-        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
+    public void shouldGetProcessRateSensor() {
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, "process-rate", RecordingLevel.INFO))
+            .andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         expect(expectedSensor.add(eq(new MetricName(
             "process-rate",
             threadLevelGroup,
-            rateDescription,
+            "The average per-second number of calls to process",
             tagMap
         )), anyObject())).andReturn(true);
 
         expect(expectedSensor.add(eq(new MetricName(
             "process-total",
             threadLevelGroup,
-            totalDescription,
+            "The total number of calls to process",
             tagMap
         )), anyObject())).andReturn(true);
         replay(StreamsMetricsImpl.class, streamsMetrics, expectedSensor);
@@ -256,6 +259,7 @@ public class ThreadMetricsTest {
         final String maxLatencyDescription = "The maximum punctuate latency";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO)).andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -287,6 +291,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.INFO))
             .andReturn(expectedSensor);
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             threadLevelGroup,
@@ -317,6 +322,7 @@ public class ThreadMetricsTest {
             "The maximum commit latency over all tasks assigned to one stream thread";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, ROLLUP_VALUE)).andReturn(tagMap);
+        mockStatic(StreamsMetricsImpl.class);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
             TASK_LEVEL_GROUP,


### PR DESCRIPTION
The current definition of the thread-level process-rate/total metric seems not correct by any reasonable standard.

It claims to measure the number/rate of "calls to process", but doesn't define what a "call to process" is.
I think a reasonable definition would be a "call to process a record", which in Streams is equal to a call to `task.process()`. This is exactly what the _task-level_ process-rate/total metric does.

However, the thread-level metric measures the number/rate of calls to `taskManager.process()`, in which the method processes _at least one_ record. This doesn't seem like a useful quantity for operators to measure, and it certainly doesn't seem to honor the spirit of the metric.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
