### PR TITLE
KAFKA-8403: Suppress needs a Materialized variant

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -715,7 +715,8 @@ public interface KTable<K, V> {
     /**
      * Suppress some updates from this changelog stream, determined by the supplied {@link Suppressed} configuration.
      *
-     * This controls what updates downstream table and stream operations will receive.
+     * This controls what updates downstream table and stream operations will receive. You can query the current (prior) values
+     * with the {@link Suppressed} instance's name iff {@link Suppressed#enableQuery()} is true.
      *
      * @param suppressed Configuration object determining what, if any, updates to suppress
      * @return A new KTable with the desired suppression characteristics.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
@@ -161,7 +161,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
      * @return a "final results" mode suppression configuration
      */
     static Suppressed<Windowed> untilWindowCloses(final StrictBufferConfig bufferConfig) {
-        return new FinalResultsSuppressionBuilder<>(null, bufferConfig);
+        return new FinalResultsSuppressionBuilder<>(null, bufferConfig, false);
     }
 
     /**
@@ -175,8 +175,20 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
      * @return a suppression configuration
      */
     static <K> Suppressed<K> untilTimeLimit(final Duration timeToWaitForMoreEvents, final BufferConfig bufferConfig) {
-        return new SuppressedInternal<>(null, timeToWaitForMoreEvents, bufferConfig, null, false);
+        return new SuppressedInternal<>(null, timeToWaitForMoreEvents, bufferConfig, null, false, false);
     }
+
+    /**
+     * Make the suppression queryable.
+     *
+     * @return The same configuration with query enabled.
+     */
+    Suppressed<K> enableQuery();
+
+    /**
+     * @return Returns true iff the query is enabled.
+     */
+    boolean isQueryEnabled();
 
     /**
      * Use the specified name for the suppression node in the topology.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -515,6 +515,8 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
     @Override
     public KTable<K, V> suppress(final Suppressed<? super K> suppressed) {
+        Objects.requireNonNull(suppressed, "suppressed can't be null");
+
         final String name;
         if (suppressed instanceof NamedSuppressed) {
             final String givenName = ((NamedSuppressed<?>) suppressed).name();
@@ -524,6 +526,13 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         }
 
         final SuppressedInternal<K> suppressedInternal = buildSuppress(suppressed, name);
+
+        final String queryableStoreName;
+        if (suppressed.isQueryEnabled()) {
+            queryableStoreName = suppressedInternal.name();
+        } else {
+            queryableStoreName = null;
+        }
 
         final String storeName =
             suppressedInternal.name() != null ? suppressedInternal.name() + "-store" : builder.newStoreName(SUPPRESS_NAME);
@@ -559,7 +568,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             keySerde,
             valueSerde,
             Collections.singleton(this.name),
-            null,
+            queryableStoreName,
             suppressionSupplier,
             node,
             builder

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
@@ -25,10 +25,12 @@ import java.util.Objects;
 public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppressed<K>, NamedSuppressed<K> {
     private final String name;
     private final StrictBufferConfig bufferConfig;
+    private final boolean isQueryEnabled;
 
-    public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig) {
+    public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig, final boolean isQueryEnabled) {
         this.name = name;
         this.bufferConfig = bufferConfig;
+        this.isQueryEnabled = isQueryEnabled;
     }
 
     public SuppressedInternal<K> buildFinalResultsSuppression(final Duration gracePeriod) {
@@ -37,13 +39,28 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
             gracePeriod,
             bufferConfig,
             TimeDefinitions.WindowEndTimeDefinition.instance(),
-            true
+            true,
+            isQueryEnabled
         );
     }
 
     @Override
+    public Suppressed<K> enableQuery() {
+        if (name == null) {
+            throw new IllegalArgumentException("This method can't be called without the name set");
+        }
+
+        return new FinalResultsSuppressionBuilder<>(name, bufferConfig, true);
+    }
+
+    @Override
+    public boolean isQueryEnabled() {
+        return isQueryEnabled;
+    }
+
+    @Override
     public Suppressed<K> withName(final String name) {
-        return new FinalResultsSuppressionBuilder<>(name, bufferConfig);
+        return new FinalResultsSuppressionBuilder<>(name, bufferConfig, isQueryEnabled);
     }
 
     @Override
@@ -56,7 +73,8 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
         }
         final FinalResultsSuppressionBuilder<?> that = (FinalResultsSuppressionBuilder<?>) o;
         return Objects.equals(name, that.name) &&
-            Objects.equals(bufferConfig, that.bufferConfig);
+            Objects.equals(bufferConfig, that.bufferConfig) &&
+            Objects.equals(isQueryEnabled, that.isQueryEnabled);
     }
 
     @Override
@@ -66,7 +84,7 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, bufferConfig);
+        return Objects.hash(name, bufferConfig, isQueryEnabled);
     }
 
     @Override
@@ -74,6 +92,7 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
         return "FinalResultsSuppressionBuilder{" +
             "name='" + name + '\'' +
             ", bufferConfig=" + bufferConfig +
+            ", isQueryEnabled=" + isQueryEnabled +
             '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
@@ -20,13 +20,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.internals.Change;
-import org.apache.kafka.streams.kstream.internals.FullChangeSerde;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -34,19 +32,14 @@ import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
-import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.RecordQueue;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBufferChangelogDeserializationHelper.DeserializationResult;
-import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -63,7 +56,8 @@ import static org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer
 import static org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBufferChangelogDeserializationHelper.deserializeV3;
 import static org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBufferChangelogDeserializationHelper.duckTypeV2;
 
-public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyValueBuffer<K, V> {
+public class InMemoryTimeOrderedKeyValueBuffer implements TimeOrderedKeyValueBuffer<Bytes, byte[]> {
+
     private static final BytesSerializer KEY_SERIALIZER = new BytesSerializer();
     private static final ByteArraySerializer VALUE_SERIALIZER = new ByteArraySerializer();
     private static final byte[] V_1_CHANGELOG_HEADER_VALUE = {(byte) 1};
@@ -71,111 +65,27 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
     private static final byte[] V_3_CHANGELOG_HEADER_VALUE = {(byte) 3};
     static final RecordHeaders CHANGELOG_HEADERS =
         new RecordHeaders(new Header[] {new RecordHeader("v", V_3_CHANGELOG_HEADER_VALUE)});
-    private static final String METRIC_SCOPE = "in-memory-suppression";
 
     private final Map<Bytes, BufferKey> index = new HashMap<>();
     private final TreeMap<BufferKey, BufferValue> sortedMap = new TreeMap<>();
-
     private final Set<Bytes> dirtyKeys = new HashSet<>();
-    private final String storeName;
-    private final boolean loggingEnabled;
-
-    private Serde<K> keySerde;
-    private FullChangeSerde<V> valueSerde;
 
     private long memBufferSize = 0L;
     private long minTimestamp = Long.MAX_VALUE;
-    private InternalProcessorContext context;
+
+    private final String storeName;
+    private final boolean loggingEnabled;
+
+    private RecordCollector recordCollector;
     private String changelogTopic;
-    private Sensor bufferSizeSensor;
-    private Sensor bufferCountSensor;
-    private StreamsMetricsImpl streamsMetrics;
-    private String threadId;
-    private String taskId;
 
     private volatile boolean open;
-
     private int partition;
 
-    public static class Builder<K, V> implements StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<K, V>> {
-
-        private final String storeName;
-        private final Serde<K> keySerde;
-        private final Serde<V> valueSerde;
-        private boolean loggingEnabled = true;
-        private Map<String, String> logConfig = new HashMap<>();
-
-        public Builder(final String storeName, final Serde<K> keySerde, final Serde<V> valueSerde) {
-            this.storeName = storeName;
-            this.keySerde = keySerde;
-            this.valueSerde = valueSerde;
-        }
-
-        /**
-         * As of 2.1, there's no way for users to directly interact with the buffer,
-         * so this method is implemented solely to be called by Streams (which
-         * it will do based on the {@code cache.max.bytes.buffering} config.
-         * <p>
-         * It's currently a no-op.
-         */
-        @Override
-        public StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<K, V>> withCachingEnabled() {
-            return this;
-        }
-
-        /**
-         * As of 2.1, there's no way for users to directly interact with the buffer,
-         * so this method is implemented solely to be called by Streams (which
-         * it will do based on the {@code cache.max.bytes.buffering} config.
-         * <p>
-         * It's currently a no-op.
-         */
-        @Override
-        public StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<K, V>> withCachingDisabled() {
-            return this;
-        }
-
-        @Override
-        public StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<K, V>> withLoggingEnabled(final Map<String, String> config) {
-            logConfig = config;
-            return this;
-        }
-
-        @Override
-        public StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<K, V>> withLoggingDisabled() {
-            loggingEnabled = false;
-            return this;
-        }
-
-        @Override
-        public InMemoryTimeOrderedKeyValueBuffer<K, V> build() {
-            return new InMemoryTimeOrderedKeyValueBuffer<>(storeName, loggingEnabled, keySerde, valueSerde);
-        }
-
-        @Override
-        public Map<String, String> logConfig() {
-            return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Collections.emptyMap();
-        }
-
-        @Override
-        public boolean loggingEnabled() {
-            return loggingEnabled;
-        }
-
-        @Override
-        public String name() {
-            return storeName;
-        }
-    }
-
-    private InMemoryTimeOrderedKeyValueBuffer(final String storeName,
-                                              final boolean loggingEnabled,
-                                              final Serde<K> keySerde,
-                                              final Serde<V> valueSerde) {
+    public InMemoryTimeOrderedKeyValueBuffer(final String storeName,
+                                             final boolean loggingEnabled) {
         this.storeName = storeName;
         this.loggingEnabled = loggingEnabled;
-        this.keySerde = keySerde;
-        this.valueSerde = FullChangeSerde.wrap(valueSerde);
     }
 
     @Override
@@ -189,50 +99,23 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         return false;
     }
 
-    @Override
-    public void setSerdesIfNull(final Serde<K> keySerde, final Serde<V> valueSerde) {
-        this.keySerde = this.keySerde == null ? keySerde : this.keySerde;
-        this.valueSerde = this.valueSerde == null ? FullChangeSerde.wrap(valueSerde) : this.valueSerde;
-    }
-
     @Deprecated
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
-        this.context = ProcessorContextUtils.asInternalProcessorContext(context);
-        init(root);
+        init(ProcessorContextUtils.asInternalProcessorContext(context));
     }
 
     @Override
     public void init(final StateStoreContext context, final StateStore root) {
-        this.context = ProcessorContextUtils.asInternalProcessorContext(context);
-        init(root);
+        init(ProcessorContextUtils.asInternalProcessorContext(context));
     }
 
-    private void init(final StateStore root) {
-        taskId = context.taskId().toString();
-        streamsMetrics = context.metrics();
+    private void init(final InternalProcessorContext context) {
+        this.recordCollector = ((RecordCollector.Supplier) context).recordCollector();
+        this.changelogTopic = ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName);
 
-        threadId = Thread.currentThread().getName();
-        bufferSizeSensor = StateStoreMetrics.suppressionBufferSizeSensor(
-            threadId,
-            taskId,
-            METRIC_SCOPE,
-            storeName,
-            streamsMetrics
-        );
-        bufferCountSensor = StateStoreMetrics.suppressionBufferCountSensor(
-            threadId,
-            taskId,
-            METRIC_SCOPE,
-            storeName,
-            streamsMetrics
-        );
-
-        context.register(root, (RecordBatchingStateRestoreCallback) this::restoreBatch);
-        changelogTopic = ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName);
-        updateBufferMetrics();
-        open = true;
-        partition = context.taskId().partition;
+        this.open = true;
+        this.partition = context.taskId().partition;
     }
 
     @Override
@@ -248,8 +131,6 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         dirtyKeys.clear();
         memBufferSize = 0;
         minTimestamp = Long.MAX_VALUE;
-        updateBufferMetrics();
-        streamsMetrics.removeAllStoreLevelSensorsAndMetrics(taskId, storeName);
     }
 
     @Override
@@ -279,7 +160,7 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         final ByteBuffer buffer = value.serialize(sizeOfBufferTime);
         buffer.putLong(bufferKey.time());
         final byte[] array = buffer.array();
-        ((RecordCollector.Supplier) context).recordCollector().send(
+        recordCollector.send(
             changelogTopic,
             key,
             array,
@@ -292,7 +173,7 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
     }
 
     private void logTombstone(final Bytes key) {
-        ((RecordCollector.Supplier) context).recordCollector().send(
+        recordCollector.send(
             changelogTopic,
             key,
             null,
@@ -304,7 +185,7 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         );
     }
 
-    private void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> batch) {
+    public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> batch) {
         for (final ConsumerRecord<byte[], byte[]> record : batch) {
             if (record.partition() != partition) {
                 throw new IllegalStateException(
@@ -381,118 +262,35 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
                 }
             }
         }
-        updateBufferMetrics();
-    }
-
-
-    @Override
-    public void evictWhile(final Supplier<Boolean> predicate,
-                           final Consumer<Eviction<K, V>> callback) {
-        final Iterator<Map.Entry<BufferKey, BufferValue>> delegate = sortedMap.entrySet().iterator();
-        int evictions = 0;
-
-        if (predicate.get()) {
-            Map.Entry<BufferKey, BufferValue> next = null;
-            if (delegate.hasNext()) {
-                next = delegate.next();
-            }
-
-            // predicate being true means we read one record, call the callback, and then remove it
-            while (next != null && predicate.get()) {
-                if (next.getKey().time() != minTimestamp) {
-                    throw new IllegalStateException(
-                        "minTimestamp [" + minTimestamp + "] did not match the actual min timestamp [" +
-                            next.getKey().time() + "]"
-                    );
-                }
-                final K key = keySerde.deserializer().deserialize(changelogTopic, next.getKey().key().get());
-                final BufferValue bufferValue = next.getValue();
-                final Change<V> value = valueSerde.deserializeParts(
-                    changelogTopic,
-                    new Change<>(bufferValue.newValue(), bufferValue.oldValue())
-                );
-                callback.accept(new Eviction<>(key, value, bufferValue.context()));
-
-                delegate.remove();
-                index.remove(next.getKey().key());
-
-                dirtyKeys.add(next.getKey().key());
-
-                memBufferSize -= computeRecordSize(next.getKey().key(), bufferValue);
-
-                // peek at the next record so we can update the minTimestamp
-                if (delegate.hasNext()) {
-                    next = delegate.next();
-                    minTimestamp = next == null ? Long.MAX_VALUE : next.getKey().time();
-                } else {
-                    next = null;
-                    minTimestamp = Long.MAX_VALUE;
-                }
-
-                evictions++;
-            }
-        }
-        if (evictions > 0) {
-            updateBufferMetrics();
-        }
     }
 
     @Override
-    public Maybe<ValueAndTimestamp<V>> priorValueForBuffered(final K key) {
-        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, key));
-        if (index.containsKey(serializedKey)) {
-            final byte[] serializedValue = internalPriorValueForBuffered(serializedKey);
-
-            final V deserializedValue = valueSerde.innerSerde().deserializer().deserialize(
-                changelogTopic,
-                serializedValue
-            );
-
-            // it's unfortunately not possible to know this, unless we materialize the suppressed result, since our only
-            // knowledge of the prior value is what the upstream processor sends us as the "old value" when we first
-            // buffer something.
-            return Maybe.defined(ValueAndTimestamp.make(deserializedValue, RecordQueue.UNKNOWN));
-        } else {
-            return Maybe.undefined();
-        }
-    }
-
-    private byte[] internalPriorValueForBuffered(final Bytes key) {
-        final BufferKey bufferKey = index.get(key);
-        if (bufferKey == null) {
-            throw new NoSuchElementException("Key [" + key + "] is not in the buffer.");
-        } else {
-            final BufferValue bufferValue = sortedMap.get(bufferKey);
-            return bufferValue.priorValue();
-        }
+    public void setSerdesIfNull(final Serde<Bytes> keySerde, final Serde<byte[]> valueSerde) {
+        throw new UnsupportedOperationException("setSerdesIfNull() not supported in " + getClass().getName());
     }
 
     @Override
     public void put(final long time,
-                    final K key,
-                    final Change<V> value,
+                    final Bytes key,
+                    final Change<byte[]> value,
                     final ProcessorRecordContext recordContext) {
         requireNonNull(value, "value cannot be null");
         requireNonNull(recordContext, "recordContext cannot be null");
 
-        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, key));
-        final Change<byte[]> serialChange = valueSerde.serializeParts(changelogTopic, value);
-
-        final BufferValue buffered = getBuffered(serializedKey);
+        final BufferValue buffered = getBuffered(key);
         final byte[] serializedPriorValue;
         if (buffered == null) {
-            serializedPriorValue = serialChange.oldValue;
+            serializedPriorValue = value.oldValue;
         } else {
             serializedPriorValue = buffered.priorValue();
         }
 
         cleanPut(
             time,
-            serializedKey,
-            new BufferValue(serializedPriorValue, serialChange.oldValue, serialChange.newValue, recordContext)
+            key,
+            new BufferValue(serializedPriorValue, value.oldValue, value.newValue, recordContext)
         );
-        dirtyKeys.add(serializedKey);
-        updateBufferMetrics();
+        dirtyKeys.add(key);
     }
 
     private BufferValue getBuffered(final Bytes key) {
@@ -522,6 +320,76 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
     }
 
     @Override
+    public Maybe<ValueAndTimestamp<byte[]>> priorValueForBuffered(final Bytes key) {
+        if (index.containsKey(key)) {
+            final byte[] serializedValue = internalPriorValueForBuffered(key);
+            // it's unfortunately not possible to know this, unless we materialize the suppressed result, since our only
+            // knowledge of the prior value is what the upstream processor sends us as the "old value" when we first
+            // buffer something.
+            return Maybe.defined(ValueAndTimestamp.make(serializedValue, RecordQueue.UNKNOWN));
+        } else {
+            return Maybe.undefined();
+        }
+    }
+
+    private byte[] internalPriorValueForBuffered(final Bytes key) {
+        final BufferKey bufferKey = index.get(key);
+        if (bufferKey == null) {
+            throw new NoSuchElementException("Key [" + key + "] is not in the buffer.");
+        } else {
+            final BufferValue bufferValue = sortedMap.get(bufferKey);
+            return bufferValue.priorValue();
+        }
+    }
+
+    @Override
+    public int evictWhile(final Supplier<Boolean> predicate,
+                          final Consumer<Eviction<Bytes, byte[]>> callback) {
+        final Iterator<Map.Entry<BufferKey, BufferValue>> delegate = sortedMap.entrySet().iterator();
+        int evictions = 0;
+
+        if (predicate.get()) {
+            Map.Entry<BufferKey, BufferValue> next = null;
+            if (delegate.hasNext()) {
+                next = delegate.next();
+            }
+
+            // predicate being true means we read one record, call the callback, and then remove it
+            while (next != null && predicate.get()) {
+                if (next.getKey().time() != minTimestamp) {
+                    throw new IllegalStateException(
+                        "minTimestamp [" + minTimestamp + "] did not match the actual min timestamp [" +
+                            next.getKey().time() + "]"
+                    );
+                }
+
+                final Bytes key = next.getKey().key();
+                final BufferValue value = next.getValue();
+                callback.accept(new Eviction<>(key, new Change<>(value.newValue(), value.oldValue()), value.context()));
+
+                delegate.remove();
+
+                index.remove(next.getKey().key());
+                dirtyKeys.add(next.getKey().key());
+                memBufferSize -= computeRecordSize(key, value);
+
+                // peek at the next record so we can update the minTimestamp
+                if (delegate.hasNext()) {
+                    next = delegate.next();
+                    minTimestamp = next == null ? Long.MAX_VALUE : next.getKey().time();
+                } else {
+                    next = null;
+                    minTimestamp = Long.MAX_VALUE;
+                }
+
+                evictions++;
+            }
+        }
+
+        return evictions;
+    }
+
+    @Override
     public int numRecords() {
         return index.size();
     }
@@ -544,11 +412,6 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
             size += value.residentMemorySizeEstimate();
         }
         return size;
-    }
-
-    private void updateBufferMetrics() {
-        bufferSizeSensor.record(memBufferSize, context.currentSystemTimeMs());
-        bufferCountSensor.record(index.size(), context.currentSystemTimeMs());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimeOrderedKeyValueBuffer.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.FullChangeSerde;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+import org.apache.kafka.streams.processor.internals.RecordQueue;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class MeteredTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyValueBuffer<K, V> {
+    private final InMemoryTimeOrderedKeyValueBuffer wrapped;
+
+    private Serde<K> keySerde;
+    private FullChangeSerde<V> valueChangeSerde;
+
+    private final String metricsScope;
+    private Sensor bufferSizeSensor;
+    private Sensor bufferCountSensor;
+
+    private InternalProcessorContext context;
+    private StreamsMetricsImpl streamsMetrics;
+    private String threadId;
+    private String taskId;
+
+    private String changelogTopic;
+
+    MeteredTimeOrderedKeyValueBuffer(final InMemoryTimeOrderedKeyValueBuffer inner,
+                                     final String metricsScope,
+                                     final Serde<K> keySerde,
+                                     final Serde<V> valueSerde) {
+        this.wrapped = Objects.requireNonNull(inner);
+
+        this.keySerde = keySerde;
+        this.valueChangeSerde = FullChangeSerde.wrap(valueSerde);
+
+        this.metricsScope = metricsScope;
+    }
+
+    @Deprecated
+    @Override
+    public void init(final ProcessorContext context, final StateStore root) {
+        this.context = ProcessorContextUtils.asInternalProcessorContext(context);
+        init(root);
+    }
+
+    @Override
+    public void init(final StateStoreContext context, final StateStore root) {
+        this.context = ProcessorContextUtils.asInternalProcessorContext(context);
+        init(root);
+    }
+
+    private void init(final StateStore root) {
+        streamsMetrics = context.metrics();
+        threadId = Thread.currentThread().getName();
+        taskId = context.taskId().toString();
+
+        bufferSizeSensor = StateStoreMetrics.suppressionBufferSizeSensor(
+            threadId,
+            taskId,
+            metricsScope,
+            name(),
+            streamsMetrics
+        );
+        bufferCountSensor = StateStoreMetrics.suppressionBufferCountSensor(
+            threadId,
+            taskId,
+            metricsScope,
+            name(),
+            streamsMetrics
+        );
+
+        context.register(root, (RecordBatchingStateRestoreCallback) (final Collection<ConsumerRecord<byte[], byte[]>> records) -> {
+            wrapped.restoreBatch(records);
+            updateBufferMetrics();
+        });
+        changelogTopic = ProcessorStateManager.storeChangelogTopic(context.applicationId(), name());
+        updateBufferMetrics();
+
+        wrapped.init((StateStoreContext) context, root);
+    }
+
+    @Override
+    public String name() {
+        return wrapped.name();
+    }
+
+    @Override
+    public boolean persistent() {
+        return wrapped.persistent();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return wrapped.isOpen();
+    }
+
+    @Override
+    public void flush() {
+        wrapped.flush();
+    }
+
+    @Override
+    public void close() {
+        wrapped.close();
+
+        updateBufferMetrics();
+        streamsMetrics.removeAllStoreLevelSensorsAndMetrics(taskId, name());
+    }
+
+    @Override
+    public void setSerdesIfNull(final Serde<K> keySerde, final Serde<V> valueSerde) {
+        this.keySerde = this.keySerde == null ? keySerde : this.keySerde;
+        this.valueChangeSerde = this.valueChangeSerde == null ? FullChangeSerde.wrap(valueSerde) : this.valueChangeSerde;
+    }
+
+    @Override
+    public void put(final long time,
+                    final K key,
+                    final Change<V> value,
+                    final ProcessorRecordContext recordContext) {
+        requireNonNull(value, "value cannot be null");
+        requireNonNull(recordContext, "recordContext cannot be null");
+
+        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, key));
+        final Change<byte[]> serializedChange = valueChangeSerde.serializeParts(changelogTopic, value);
+
+        wrapped.put(time, serializedKey, serializedChange, recordContext);
+
+        updateBufferMetrics();
+    }
+
+    @Override
+    public Maybe<ValueAndTimestamp<V>> priorValueForBuffered(final K key) {
+        final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(changelogTopic, key));
+
+        final Maybe<ValueAndTimestamp<byte[]>> maybe = wrapped.priorValueForBuffered(serializedKey);
+
+        if (maybe.isDefined()) {
+            final V deserializedValue = valueChangeSerde.innerSerde().deserializer().deserialize(
+                changelogTopic,
+                maybe.getNullableValue() == null ? null : maybe.getNullableValue().value()
+            );
+
+            // it's unfortunately not possible to know this, unless we materialize the suppressed result, since our only
+            // knowledge of the prior value is what the upstream processor sends us as the "old value" when we first
+            // buffer something.
+            return Maybe.defined(ValueAndTimestamp.make(deserializedValue, RecordQueue.UNKNOWN));
+        } else {
+            return Maybe.undefined();
+        }
+    }
+
+    @Override
+    public int evictWhile(final Supplier<Boolean> predicate,
+                          final Consumer<Eviction<K, V>> callback) {
+        final int evictions = wrapped.evictWhile(predicate, (final Eviction<Bytes, byte[]> e) -> {
+            final K key = keySerde.deserializer().deserialize(changelogTopic, e.key().get());
+            final Change<V> value = valueChangeSerde.deserializeParts(changelogTopic, e.value());
+            final Eviction<K, V> eviction = new Eviction<>(key, value, e.recordContext());
+            callback.accept(eviction);
+        });
+
+        if (evictions > 0) {
+            updateBufferMetrics();
+        }
+
+        return evictions;
+    }
+
+    @Override
+    public int numRecords() {
+        return wrapped.numRecords();
+    }
+
+    @Override
+    public long bufferSize() {
+        return wrapped.bufferSize();
+    }
+
+    @Override
+    public long minTimestamp() {
+        return wrapped.minTimestamp();
+    }
+
+    private void updateBufferMetrics() {
+        bufferSizeSensor.record(bufferSize(), context.currentSystemTimeMs());
+        bufferCountSensor.record(numRecords(), context.currentSystemTimeMs());
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -72,13 +72,22 @@ public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
         }
     }
 
+    /**
+     * In the case of join operations or the other materializations, the key/value serdes used by the statestores are
+     * provided explicitly by the user (caller), through {@link org.apache.kafka.streams.kstream.Joined} or
+     * {@link org.apache.kafka.streams.kstream.Materialized}.
+     *
+     * However, suppression operation does not have those kinds of instances. For this reason, the key/value serde can be null
+     * when the suppression buffer instance is created. To make up for these shortcomings, the key/value serdes can be explicitly
+     * set by the processor via this method.
+     */
     void setSerdesIfNull(final Serde<K> keySerde, final Serde<V> valueSerde);
 
-    void evictWhile(final Supplier<Boolean> predicate, final Consumer<Eviction<K, V>> callback);
+    void put(long time, K key, Change<V> value, ProcessorRecordContext recordContext);
 
     Maybe<ValueAndTimestamp<V>> priorValueForBuffered(K key);
 
-    void put(long time, K key, Change<V> value, ProcessorRecordContext recordContext);
+    int evictWhile(final Supplier<Boolean> predicate, final Consumer<Eviction<K, V>> callback);
 
     int numRecords();
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -20,13 +20,14 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
+public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore, ReadOnlyKeyValueStore<K, V> {
 
     final class Eviction<K, V> {
         private final K key;
@@ -94,4 +95,8 @@ public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
     long bufferSize();
 
     long minTimestamp();
+
+    default long approximateNumEntries() {
+        return numRecords();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TimeOrderedKeyValueBufferBuilder<K, V> implements StoreBuilder<TimeOrderedKeyValueBuffer<K, V>> {
+
+    private final String storeName;
+    private final Serde<K> keySerde;
+    private final Serde<V> valueSerde;
+    private boolean loggingEnabled = true;
+    private Map<String, String> logConfig = new HashMap<>();
+
+    public TimeOrderedKeyValueBufferBuilder(final String storeName, final Serde<K> keySerde, final Serde<V> valueSerde) {
+        this.storeName = storeName;
+        this.keySerde = keySerde;
+        this.valueSerde = valueSerde;
+    }
+
+    /**
+     * As of 2.1, there's no way for users to directly interact with the buffer,
+     * so this method is implemented solely to be called by Streams (which
+     * it will do based on the {@code cache.max.bytes.buffering} config.
+     * <p>
+     * It's currently a no-op.
+     */
+    @Override
+    public StoreBuilder<TimeOrderedKeyValueBuffer<K, V>> withCachingEnabled() {
+        return this;
+    }
+
+    /**
+     * As of 2.1, there's no way for users to directly interact with the buffer,
+     * so this method is implemented solely to be called by Streams (which
+     * it will do based on the {@code cache.max.bytes.buffering} config.
+     * <p>
+     * It's currently a no-op.
+     */
+    @Override
+    public StoreBuilder<TimeOrderedKeyValueBuffer<K, V>> withCachingDisabled() {
+        return this;
+    }
+
+    @Override
+    public StoreBuilder<TimeOrderedKeyValueBuffer<K, V>> withLoggingEnabled(final Map<String, String> config) {
+        logConfig = config;
+        return this;
+    }
+
+    @Override
+    public StoreBuilder<TimeOrderedKeyValueBuffer<K, V>> withLoggingDisabled() {
+        loggingEnabled = false;
+        return this;
+    }
+
+    @Override
+    public TimeOrderedKeyValueBuffer<K, V> build() {
+        final InMemoryTimeOrderedKeyValueBuffer inner = new InMemoryTimeOrderedKeyValueBuffer(storeName, loggingEnabled);
+        return new MeteredTimeOrderedKeyValueBuffer<>(inner, "in-memory-suppression", keySerde, valueSerde);
+    }
+
+    @Override
+    public Map<String, String> logConfig() {
+        return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Collections.emptyMap();
+    }
+
+    @Override
+    public boolean loggingEnabled() {
+        return loggingEnabled;
+    }
+
+    @Override
+    public String name() {
+        return storeName;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
@@ -61,37 +61,37 @@ public class SuppressedTest {
         assertThat(
             "name should be set",
             untilTimeLimit(ofMillis(2), unbounded()).withName("myname"),
-            is(new SuppressedInternal<>("myname", ofMillis(2), unbounded(), null, false))
+            is(new SuppressedInternal<>("myname", ofMillis(2), unbounded(), null, false, false))
         );
 
         assertThat(
             "time alone should be set",
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false, false))
         );
 
         assertThat(
             "time and unbounded buffer should be set",
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false, false))
         );
 
         assertThat(
             "time and keys buffer should be set",
             untilTimeLimit(ofMillis(2), maxRecords(2)),
-            is(new SuppressedInternal<>(null, ofMillis(2), maxRecords(2), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), maxRecords(2), null, false, false))
         );
 
         assertThat(
             "time and size buffer should be set",
             untilTimeLimit(ofMillis(2), maxBytes(2)),
-            is(new SuppressedInternal<>(null, ofMillis(2), maxBytes(2), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), maxBytes(2), null, false, false))
         );
 
         assertThat(
             "all constraints should be set",
             untilTimeLimit(ofMillis(2L), maxRecords(3L).withMaxBytes(2L)),
-            is(new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L), null, false, false))
         );
     }
 
@@ -100,35 +100,35 @@ public class SuppressedTest {
 
         assertThat(
             untilWindowCloses(unbounded()),
-            is(new FinalResultsSuppressionBuilder<>(null, unbounded()))
+            is(new FinalResultsSuppressionBuilder<>(null, unbounded(), false))
         );
 
         assertThat(
             untilWindowCloses(maxRecords(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN), false)
             )
         );
 
         assertThat(
             untilWindowCloses(maxBytes(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN), false)
             )
         );
 
         assertThat(
             untilWindowCloses(unbounded()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", unbounded()))
+            is(new FinalResultsSuppressionBuilder<>("name", unbounded(), false))
         );
 
         assertThat(
             untilWindowCloses(maxRecords(2L).shutDownWhenFull()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN), false)
             )
         );
 
         assertThat(
             untilWindowCloses(maxBytes(2L).shutDownWhenFull()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN), false)
             )
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSuppressTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSuppressTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.WindowStore;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofMinutes;
+import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords;
+import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.unbounded;
+import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
+import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class KTableSuppressTest {
+    private static final Serde<String> STRING_SERDE = Serdes.String();
+
+    @Test
+    public void shouldTimeLimitSuppressionNotQueriableWithoutQueryEnabled() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<Windowed<String>, Long> valueCounts = builder
+                .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+                .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+                .windowedBy(TimeWindows.of(ofMillis(2L)).grace(ofMillis(2L)))
+                .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled().withKeySerde(STRING_SERDE));
+        final KTable<Windowed<String>, Long> suppressed = valueCounts
+                .suppress(untilTimeLimit(ofMinutes(1), maxRecords(1L).emitEarlyWhenFull()).withName("suppressed-counts"));
+        builder.build();
+
+        assertEquals("counts", valueCounts.queryableStoreName());
+        assertNull(suppressed.queryableStoreName());
+    }
+
+    @Test
+    public void shouldTimeLimitSuppressionQueriableWithMaterialized() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<Windowed<String>, Long> valueCounts = builder
+                .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+                .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+                .windowedBy(TimeWindows.of(ofMillis(2L)).grace(ofMillis(2L)))
+                .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled().withKeySerde(STRING_SERDE));
+        final KTable<Windowed<String>, Long> suppressed = valueCounts
+                .suppress(untilTimeLimit(ofMinutes(1), maxRecords(1L).emitEarlyWhenFull()).withName("suppressed-counts").enableQuery());
+        builder.build();
+
+        assertEquals("counts", valueCounts.queryableStoreName());
+        assertEquals("suppressed-counts", suppressed.queryableStoreName());
+    }
+
+    @Test
+    public void shouldWindowSuppressionNotQueriableWithoutQueryEnabled() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<Windowed<String>, Long> valueCounts = builder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+            .windowedBy(TimeWindows.of(ofMillis(2L)).grace(ofMillis(2L)))
+            .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled().withKeySerde(STRING_SERDE));
+        final KTable<Windowed<String>, Long> suppressed = valueCounts
+            .suppress(untilWindowCloses(unbounded()).withName("suppressed-counts"));
+        builder.build();
+
+        assertEquals("counts", valueCounts.queryableStoreName());
+        assertNull(suppressed.queryableStoreName());
+    }
+
+    @Test
+    public void shouldWindowSuppressionQueriableWithMaterialized() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KTable<Windowed<String>, Long> valueCounts = builder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+            .windowedBy(TimeWindows.of(ofMillis(2L)).grace(ofMillis(2L)))
+            .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled().withKeySerde(STRING_SERDE));
+        final KTable<Windowed<String>, Long> suppressed = valueCounts
+            .suppress(untilWindowCloses(unbounded()).withName("suppressed-counts").enableQuery());
+        builder.build();
+
+        assertEquals("counts", valueCounts.queryableStoreName());
+        assertEquals("suppressed-counts", suppressed.queryableStoreName());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
-import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBufferBuilder;
 import org.apache.kafka.test.MockInternalProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
@@ -222,7 +222,7 @@ public class KTableSuppressProcessorMetricsTest {
     private void shouldRecordMetrics(final String builtInMetricsVersion) {
         final String storeName = "test-store";
 
-        final StateStore buffer = new InMemoryTimeOrderedKeyValueBuffer.Builder<>(
+        final StateStore buffer = new TimeOrderedKeyValueBufferBuilder<>(
             storeName, Serdes.String(),
             Serdes.Long()
         )

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorTest.java
@@ -33,7 +33,7 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
-import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBufferBuilder;
 import org.apache.kafka.test.MockInternalProcessorContext;
 import org.easymock.EasyMock;
 import org.hamcrest.BaseMatcher;
@@ -75,7 +75,7 @@ public class KTableSuppressProcessorTest {
 
             final String storeName = "test-store";
 
-            final StateStore buffer = new InMemoryTimeOrderedKeyValueBuffer.Builder<>(storeName, keySerde, valueSerde)
+            final StateStore buffer = new TimeOrderedKeyValueBufferBuilder<>(storeName, keySerde, valueSerde)
                 .withLoggingDisabled()
                 .build();
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBufferTest.java
@@ -31,12 +31,12 @@ public class InMemoryTimeOrderedKeyValueBufferTest {
 
     @Test
     public void bufferShouldAllowCacheEnablement() {
-        new InMemoryTimeOrderedKeyValueBuffer.Builder<>(null, null, null).withCachingEnabled();
+        new TimeOrderedKeyValueBufferBuilder<>(null, null, null).withCachingEnabled();
     }
 
     @Test
     public void bufferShouldAllowCacheDisablement() {
-        new InMemoryTimeOrderedKeyValueBuffer.Builder<>(null, null, null).withCachingDisabled();
+        new TimeOrderedKeyValueBufferBuilder<>(null, null, null).withCachingDisabled();
     }
 
     @Test
@@ -44,8 +44,8 @@ public class InMemoryTimeOrderedKeyValueBufferTest {
         final String expect = "3";
         final Map<String, String> logConfig = new HashMap<>();
         logConfig.put("min.insync.replicas", expect);
-        final StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<Object, Object>> builder =
-            new InMemoryTimeOrderedKeyValueBuffer.Builder<>(null, null, null)
+        final StoreBuilder<TimeOrderedKeyValueBuffer<Object, Object>> builder =
+            new TimeOrderedKeyValueBufferBuilder<>(null, null, null)
                 .withLoggingEnabled(logConfig);
 
         assertThat(builder.logConfig(), is(singletonMap("min.insync.replicas", expect)));
@@ -54,8 +54,8 @@ public class InMemoryTimeOrderedKeyValueBufferTest {
 
     @Test
     public void bufferShouldAllowLoggingDisablement() {
-        final StoreBuilder<InMemoryTimeOrderedKeyValueBuffer<Object, Object>> builder
-            = new InMemoryTimeOrderedKeyValueBuffer.Builder<>(null, null, null)
+        final StoreBuilder<TimeOrderedKeyValueBuffer<Object, Object>> builder
+            = new TimeOrderedKeyValueBufferBuilder<>(null, null, null)
                 .withLoggingDisabled();
 
         assertThat(builder.logConfig(), is(emptyMap()));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -136,6 +136,10 @@ public class StreamThreadStateStoreProviderTest {
                 Serdes.String(),
                 Serdes.String()),
             "the-processor");
+        topology.addStateStore(
+            new TimeOrderedKeyValueBufferBuilder<>(
+                "suppression-store", Serdes.String(), Serdes.String()),
+            "the-processor");
 
         final Properties properties = new Properties();
         final String applicationId = "applicationId";
@@ -221,6 +225,18 @@ public class StreamThreadStateStoreProviderTest {
                     "[class org.apache.kafka.streams.state.internals.MeteredKeyValueStore]."
             )
         );
+    }
+
+    @Test
+    public void shouldFindTimeOrderedKeyValueBuffers() {
+        mockThread(true);
+        final List<ReadOnlyKeyValueStore<String, String>> kvStores =
+            provider.stores(StoreQueryParameters.fromNameAndType("suppression-store", QueryableStoreTypes.keyValueStore()));
+        assertEquals(2, kvStores.size());
+        for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
+            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
+            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
@@ -84,10 +84,10 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         return singletonList(
             new Object[] {
                 "in-memory buffer",
-                (Function<String, InMemoryTimeOrderedKeyValueBuffer<String, String>>) name ->
-                    new InMemoryTimeOrderedKeyValueBuffer
-                        .Builder<>(name, Serdes.String(), Serdes.serdeFrom(new NullRejectingStringSerializer(), new StringDeserializer()))
-                        .build()
+                (Function<String, TimeOrderedKeyValueBuffer<String, String>>) name ->
+                    new TimeOrderedKeyValueBufferBuilder<>(
+                        name, Serdes.String(), Serdes.serdeFrom(new NullRejectingStringSerializer(), new StringDeserializer())
+                    ).build()
             }
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer.Eviction;
 import org.apache.kafka.test.MockInternalProcessorContext;
@@ -57,8 +58,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueBuffer.CHANGELOG_HEADERS;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
@@ -287,6 +290,111 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.put(1L, "B", new Change<>("new-value", null), recordContext);
         assertThat(buffer.priorValueForBuffered("A"), is(Maybe.defined(ValueAndTimestamp.make("old-value", -1))));
         assertThat(buffer.priorValueForBuffered("B"), is(Maybe.defined(null)));
+    }
+
+    @Test
+    public void shouldIterate() {
+        final TimeOrderedKeyValueBuffer<String, String> buffer = bufferSupplier.apply(testName);
+        final MockInternalProcessorContext context = makeContext();
+        buffer.init((StateStoreContext) context, buffer);
+
+        final ProcessorRecordContext recordContext = getContext(0L);
+
+        // k1: t1, t3
+        buffer.put(1L, "k1", new Change<>("v1", "v0"), recordContext);
+        buffer.put(3L, "k1", new Change<>(null, "v1"), recordContext);
+        // k2: t2, t3
+        buffer.put(2L, "k2", new Change<>("v2", "v1"), recordContext);
+        buffer.put(3L, "k2", new Change<>("v3", "v2"), recordContext);
+        // k5: t3
+        buffer.put(3L, "k5", new Change<>(null, null), recordContext);
+
+        final KeyValueIterator<String, String> it0 = buffer.range("k1", "k0");
+        assertFalse(it0.hasNext());
+
+        final KeyValueIterator<String, String> it1 = buffer.range("k0", "k4");
+        assertThat(it1.next(), equalTo(new KeyValue<>("k1", "v0")));
+        assertThat(it1.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertFalse(it1.hasNext());
+
+        final KeyValueIterator<String, String> it2 = buffer.reverseRange("k0", "k4");
+        assertThat(it2.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it2.next(), equalTo(new KeyValue<>("k1", "v0")));
+        assertFalse(it2.hasNext());
+
+        final KeyValueIterator<String, String> it3 = buffer.all();
+        assertThat(it3.next(), equalTo(new KeyValue<>("k1", "v0")));
+        assertThat(it3.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it3.next(), equalTo(new KeyValue<>("k5", null)));
+        assertFalse(it3.hasNext());
+
+        final KeyValueIterator<String, String> it4 = buffer.reverseAll();
+        assertThat(it4.next(), equalTo(new KeyValue<>("k5", null)));
+        assertThat(it4.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it4.next(), equalTo(new KeyValue<>("k1", "v0")));
+        assertFalse(it4.hasNext());
+
+        // evict t1, t2
+        buffer.evictWhile(() -> buffer.minTimestamp() < 2L, kv -> { });
+        buffer.flush();
+
+        final KeyValueIterator<String, String> it5 = buffer.range("k1", "k0");
+        assertFalse(it5.hasNext());
+
+        final KeyValueIterator<String, String> it6 = buffer.range("k0", "k4");
+        assertThat(it6.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertFalse(it6.hasNext());
+
+        final KeyValueIterator<String, String> it7 = buffer.reverseRange("k2", "k5");
+        assertThat(it7.next(), equalTo(new KeyValue<>("k5", null)));
+        assertThat(it7.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertFalse(it7.hasNext());
+
+        final KeyValueIterator<String, String> it8 = buffer.all();
+        assertThat(it8.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it8.next(), equalTo(new KeyValue<>("k5", null)));
+        assertFalse(it8.hasNext());
+
+        final KeyValueIterator<String, String> it9 = buffer.reverseAll();
+        assertThat(it9.next(), equalTo(new KeyValue<>("k5", null)));
+        assertThat(it9.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertFalse(it9.hasNext());
+
+        // k1: t4
+        buffer.put(4L, "k1", new Change<>("v4", null), recordContext);
+        // k3: t5
+        buffer.put(5L, "k3", new Change<>("v5", null), recordContext);
+        // k4: t4, t5
+        buffer.put(4L, "k4", new Change<>("v4", "v0"), recordContext);
+        buffer.put(5L, "k4", new Change<>("v5", "v4"), recordContext);
+
+        final KeyValueIterator<String, String> it10 = buffer.range("k0", "k3");
+        assertThat(it10.next(), equalTo(new KeyValue<>("k1", null)));
+        assertThat(it10.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it10.next(), equalTo(new KeyValue<>("k3", null)));
+        assertFalse(it10.hasNext());
+
+        final KeyValueIterator<String, String> it11 = buffer.reverseRange("k3", "k5");
+        assertThat(it11.next(), equalTo(new KeyValue<>("k5", null)));
+        assertThat(it11.next(), equalTo(new KeyValue<>("k4", "v0")));
+        assertThat(it11.next(), equalTo(new KeyValue<>("k3", null)));
+        assertFalse(it11.hasNext());
+
+        final KeyValueIterator<String, String> it12 = buffer.all();
+        assertThat(it12.next(), equalTo(new KeyValue<>("k1", null)));
+        assertThat(it12.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it12.next(), equalTo(new KeyValue<>("k3", null)));
+        assertThat(it12.next(), equalTo(new KeyValue<>("k4", "v0")));
+        assertThat(it12.next(), equalTo(new KeyValue<>("k5", null)));
+        assertFalse(it12.hasNext());
+
+        final KeyValueIterator<String, String> it13 = buffer.reverseAll();
+        assertThat(it13.next(), equalTo(new KeyValue<>("k5", null)));
+        assertThat(it13.next(), equalTo(new KeyValue<>("k4", "v0")));
+        assertThat(it13.next(), equalTo(new KeyValue<>("k3", null)));
+        assertThat(it13.next(), equalTo(new KeyValue<>("k2", "v1")));
+        assertThat(it13.next(), equalTo(new KeyValue<>("k1", null)));
+        assertFalse(it13.hasNext());
     }
 
     @Test

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -309,7 +309,8 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Suppress some updates from this changelog stream, determined by the supplied [[Suppressed]] configuration.
    *
-   * This controls what updates downstream table and stream operations will receive.
+   * This controls what updates downstream table and stream operations will receive. You can query the current (prior) values
+   * with the [[org.apache.kafka.streams.kstream.Suppressed]] instance's name iff [[org.apache.kafka.streams.kstream.Suppressed#enableQuery]] is true.
    *
    * @param suppressed Configuration object determining what, if any, updates to suppress.
    * @return A new KTable with the desired suppression characteristics.

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Suppressed.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/Suppressed.scala
@@ -63,7 +63,7 @@ object Suppressed {
    * @see [[org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit]]
    */
   def untilWindowCloses[K](bufferConfig: StrictBufferConfig): SupressedJ[Windowed[K]] =
-    new FinalResultsSuppressionBuilder[Windowed[K]](null, bufferConfig)
+    new FinalResultsSuppressionBuilder[Windowed[K]](null, bufferConfig, false)
 
   /**
    * Configure the suppression to wait `timeToWaitForMoreEvents` amount of time after receiving a record
@@ -77,7 +77,7 @@ object Suppressed {
    * @see [[org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit]]
    */
   def untilTimeLimit[K](timeToWaitForMoreEvents: Duration, bufferConfig: BufferConfigJ[_]): SupressedJ[K] =
-    new SuppressedInternal[K](null, timeToWaitForMoreEvents, bufferConfig, null, false)
+    new SuppressedInternal[K](null, timeToWaitForMoreEvents, bufferConfig, null, false, false)
 
   /**
    * Duplicates the static factory methods inside the Java interface

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/SuppressedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/SuppressedTest.scala
@@ -39,15 +39,15 @@ class SuppressedTest extends FlatSpec with Matchers {
   "Suppressed.untilWindowCloses" should "produce the correct suppression" in {
     val bufferConfig = BufferConfig.unbounded()
     val suppression = Suppressed.untilWindowCloses[String](bufferConfig)
-    suppression shouldEqual new FinalResultsSuppressionBuilder(null, bufferConfig)
-    suppression.withName("soup") shouldEqual new FinalResultsSuppressionBuilder("soup", bufferConfig)
+    suppression shouldEqual new FinalResultsSuppressionBuilder(null, bufferConfig, false)
+    suppression.withName("soup") shouldEqual new FinalResultsSuppressionBuilder("soup", bufferConfig, false)
   }
 
   "Suppressed.untilTimeLimit" should "produce the correct suppression" in {
     val bufferConfig = BufferConfig.unbounded()
     val duration = Duration.ofMillis(1)
     Suppressed.untilTimeLimit[String](duration, bufferConfig) shouldEqual
-      new SuppressedInternal[String](null, duration, bufferConfig, null, false)
+      new SuppressedInternal[String](null, duration, bufferConfig, null, false, false)
   }
 
   "BufferConfig.maxRecords" should "produce the correct buffer config" in {


### PR DESCRIPTION
This is a completely new implemetation from the previous PR.

- [KAFKA-8403: Suppress needs a Materialized variant](https://issues.apache.org/jira/browse/KAFKA-8403)
- [KIP-508: Make Suppression State Queriable](https://cwiki.apache.org/confluence/display/KAFKA/KIP-508%3A+Make+Suppression+State+Queriable)

Here are some guidelines:

- 9bd279f ~ 37060b6: Refactor the `TimeOrderedKeyValueStore` into new interfaces, with separating `Serdes` from BytesStore. (see `MeteredSuppressionBuffer`)
- 798af5c ~ 0a684e0: Implement the `KTable#suppress` variant and make it queriable.
- 8f2e2c8  ~ 3387e27: Make `SuppressionBuffer` accessable by the users.
- 821014f: Implement a testing functionality.

Please have a look when you are free. Thanks in advance! :smile:

cc/ @mjsax @bbejeck @vvcephei @guozhangwang 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
