### PR TITLE
KAFKA-8507: Unify bootstrap-server flag for command line tools (KIP-499) part-2

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
@@ -105,7 +105,7 @@ public class SaslConfigs {
 
     public static final String SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS = "sasl.login.refresh.min.period.seconds";
     public static final String SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_DOC = "The desired minimum time for the login refresh thread to wait before refreshing a credential,"
-            + " in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified.  This value and "
+            + " in seconds. Legal values are between 0 and 900 (15 minutes); a default value of 60 (1 minute) is used if no value is specified. This value and "
             + " sasl.login.refresh.buffer.seconds are both ignored if their sum exceeds the remaining lifetime of a credential."
             + " Currently applies only to OAUTHBEARER.";
     public static final short DEFAULT_LOGIN_REFRESH_MIN_PERIOD_SECONDS = 60;

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -129,7 +129,7 @@ object ConsoleProducer {
       .withRequiredArg
       .describedAs("broker-list")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED. The server(s) to connect to. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
       .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("server to connect to")

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -125,7 +125,7 @@ object ConsoleProducer {
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
-    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
       .withRequiredArg
       .describedAs("broker-list")
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -202,7 +202,7 @@ object ConsumerPerformance extends LazyLogging {
   }
 
   class ConsumerPerfConfig(args: Array[String]) extends PerfConfig(args) {
-    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
       .withRequiredArg
       .describedAs("broker-list")
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -206,7 +206,7 @@ object ConsumerPerformance extends LazyLogging {
       .withRequiredArg
       .describedAs("broker-list")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to.")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED. The server(s) to connect to.")
       .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("server to connect to")

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -20,8 +20,7 @@ package kafka.tools
 
 import java.util.Properties
 
-import joptsimple._
-import kafka.utils.{CommandLineUtils, Exit, ToolsUtils}
+import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, ToolsUtils}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import org.apache.kafka.common.requests.ListOffsetRequest
@@ -32,50 +31,73 @@ import scala.collection.Seq
 
 object GetOffsetShell {
 
-  def main(args: Array[String]): Unit = {
-    val parser = new OptionParser(false)
-    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The list of hostname and port of the server to connect to.")
-                           .withRequiredArg
-                           .describedAs("hostname:port,...,hostname:port")
-                           .ofType(classOf[String])
+  val helpText = "An interactive shell for getting topic offsets."
+  val clientId = "GetOffsetShell"
+
+  class GetOffsetShellOptions(args: Array[String]) extends CommandDefaultOptions(args)  {
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. The list of hostname and port of the server to connect to in the form HOST1:PORT1,HOST2:PORT2.")
+      .withRequiredArg
+      .describedAs("HOST1:PORT1,...,HOST3:PORT3")
+      .ofType(classOf[String])
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to in the form HOST1:PORT1,HOST2:PORT2.")
+      .requiredUnless("broker-list")
+      .withRequiredArg
+      .describedAs("HOST1:PORT1,...,HOST3:PORT3")
+      .ofType(classOf[String])
     val topicOpt = parser.accepts("topic", "REQUIRED: The topic to get offset from.")
-                           .withRequiredArg
-                           .describedAs("topic")
-                           .ofType(classOf[String])
+      .withRequiredArg
+      .describedAs("topic")
+      .ofType(classOf[String])
     val partitionOpt = parser.accepts("partitions", "comma separated list of partition ids. If not specified, it will find offsets for all partitions")
-                           .withRequiredArg
-                           .describedAs("partition ids")
-                           .ofType(classOf[String])
-                           .defaultsTo("")
+      .withRequiredArg
+      .describedAs("partition ids")
+      .ofType(classOf[String])
+      .defaultsTo("")
     val timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: No offset is returned, if the timestamp greater than recently commited record timestamp is given.]")
-                           .withRequiredArg
-                           .describedAs("timestamp/-1(latest)/-2(earliest)")
-                           .ofType(classOf[java.lang.Long])
-                           .defaultsTo(-1L)
+      .withRequiredArg
+      .describedAs("timestamp/-1(latest)/-2(earliest)")
+      .ofType(classOf[java.lang.Long])
+      .defaultsTo(-1L)
     parser.accepts("offsets", "DEPRECATED AND IGNORED: number of offsets returned")
-                           .withRequiredArg
-                           .describedAs("count")
-                           .ofType(classOf[java.lang.Integer])
-                           .defaultsTo(1)
+      .withRequiredArg
+      .describedAs("count")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(1)
     parser.accepts("max-wait-ms", "DEPRECATED AND IGNORED: The max amount of time each fetch request waits.")
-                           .withRequiredArg
-                           .describedAs("ms")
-                           .ofType(classOf[java.lang.Integer])
-                           .defaultsTo(1000)
+      .withRequiredArg
+      .describedAs("ms")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(1000)
 
-   if (args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "An interactive shell for getting topic offsets.")
+    options = parser.parse(args : _*)
 
-    val options = parser.parse(args : _*)
+    def brokerList: String = {
+      val listOpt = if (options.has(bootstrapServerOpt))
+        bootstrapServerOpt
+      else
+        brokerListOpt
 
-    CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt, topicOpt)
+      options.valueOf(listOpt)
+    }
+  }
 
-    val clientId = "GetOffsetShell"
-    val brokerList = options.valueOf(brokerListOpt)
-    ToolsUtils.validatePortOrDie(parser, brokerList)
-    val topic = options.valueOf(topicOpt)
+  def validateAndParseArgs(args: Array[String]): GetOffsetShellOptions = {
+    val opts = new GetOffsetShellOptions(args)
+    CommandLineUtils.printHelpAndExitIfNeeded(opts, helpText)
+
+    CommandLineUtils.checkRequiredArgs(opts.parser, opts.options, opts.topicOpt)
+
+    ToolsUtils.validatePortOrDie(opts.parser, opts.brokerList)
+    opts
+  }
+
+  def main(args: Array[String]): Unit = {
+    val opts = validateAndParseArgs(args)
+    val options = opts.options
+
+    val topic = options.valueOf(opts.topicOpt)
     val partitionIdsRequested: Set[Int] = {
-      val partitionsString = options.valueOf(partitionOpt)
+      val partitionsString = options.valueOf(opts.partitionOpt)
       if (partitionsString.isEmpty)
         Set.empty
       else
@@ -83,15 +105,14 @@ object GetOffsetShell {
           try partitionString.toInt
           catch {
             case _: NumberFormatException =>
-              System.err.println(s"--partitions expects a comma separated list of numeric partition ids, but received: $partitionsString")
-              Exit.exit(1)
+              CommandLineUtils.printUsageAndDie(opts.parser, s"--partitions expects a comma separated list of numeric partition ids, but received: $partitionsString")
           }
         }.toSet
     }
-    val listOffsetsTimestamp = options.valueOf(timeOpt).longValue
+    val listOffsetsTimestamp = options.valueOf(opts.timeOpt).longValue
 
     val config = new Properties
-    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, opts.brokerList)
     config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
     val consumer = new KafkaConsumer(config, new ByteArrayDeserializer, new ByteArrayDeserializer)
 

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -39,7 +39,7 @@ object GetOffsetShell {
       .withRequiredArg
       .describedAs("HOST1:PORT1,...,HOST3:PORT3")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to in the form HOST1:PORT1,HOST2:PORT2.")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED. The server(s) to connect to in the form HOST1:PORT1,HOST2:PORT2.")
       .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("HOST1:PORT1,...,HOST3:PORT3")
@@ -71,7 +71,7 @@ object GetOffsetShell {
 
     options = parser.parse(args : _*)
 
-    def brokerList: String = {
+    def bootstrapServers: String = {
       val listOpt = if (options.has(bootstrapServerOpt))
         bootstrapServerOpt
       else
@@ -87,7 +87,7 @@ object GetOffsetShell {
 
     CommandLineUtils.checkRequiredArgs(opts.parser, opts.options, opts.topicOpt)
 
-    ToolsUtils.validatePortOrDie(opts.parser, opts.brokerList)
+    ToolsUtils.validatePortOrDie(opts.parser, opts.bootstrapServers)
     opts
   }
 
@@ -112,7 +112,7 @@ object GetOffsetShell {
     val listOffsetsTimestamp = options.valueOf(opts.timeOpt).longValue
 
     val config = new Properties
-    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, opts.brokerList)
+    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, opts.bootstrapServers)
     config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
     val consumer = new KafkaConsumer(config, new ByteArrayDeserializer, new ByteArrayDeserializer)
 

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -70,74 +70,85 @@ object ReplicaVerificationTool extends Logging {
   val clientId = "replicaVerificationTool"
   val dateFormatString = "yyyy-MM-dd HH:mm:ss,SSS"
   val dateFormat = new SimpleDateFormat(dateFormatString)
+  val helpText = "This tool helps verify the consistency among replicas - it validates that all replicas for a set of topics have the same data"
 
-  def getCurrentTimeString() = {
-    ReplicaVerificationTool.dateFormat.format(new Date(Time.SYSTEM.milliseconds))
+  class ReplicaVerificationToolOptions(args: Array[String]) extends CommandDefaultOptions(args)  {
+    val brokerListOpt = parser.accepts("broker-list", "DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. The list of hostname and port of the server to connect to.")
+      .withRequiredArg
+      .describedAs("hostname:port,...,hostname:port")
+      .ofType(classOf[String])
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified.")
+      .requiredUnless("broker-list")
+      .withRequiredArg
+      .describedAs("Server(s) to use for bootstrapping in the form HOST1:PORT1,HOST2:PORT2.")
+      .ofType(classOf[String])
+    val fetchSizeOpt = parser.accepts("fetch-size", "The fetch size of each request.")
+      .withRequiredArg
+      .describedAs("bytes")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES)
+    val maxWaitMsOpt = parser.accepts("max-wait-ms", "The max amount of time each fetch request waits.")
+      .withRequiredArg
+      .describedAs("ms")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(1000)
+    val topicWhiteListOpt = parser.accepts("topic-white-list", "White list of topics to verify replica consistency. Defaults to all topics.")
+      .withRequiredArg
+      .describedAs("Java regex (String)")
+      .ofType(classOf[String])
+      .defaultsTo(".*")
+    val initialOffsetTimeOpt = parser.accepts("time", "Timestamp for getting the initial offsets.")
+      .withRequiredArg
+      .describedAs("timestamp/-1(latest)/-2(earliest)")
+      .ofType(classOf[java.lang.Long])
+      .defaultsTo(-1L)
+    val reportIntervalOpt = parser.accepts("report-interval-ms", "The reporting interval.")
+      .withRequiredArg
+      .describedAs("ms")
+      .ofType(classOf[java.lang.Long])
+      .defaultsTo(30 * 1000L)
+
+    options = parser.parse(args: _*)
+
+    def brokerList: String =
+      if (options.has(bootstrapServerOpt)) {
+        options.valueOf(bootstrapServerOpt)
+      } else {
+        options.valueOf(brokerListOpt)
+      }
+  }
+
+  def validateAndParseArgs(args: Array[String]): ReplicaVerificationToolOptions = {
+    val options = new ReplicaVerificationToolOptions(args)
+
+    CommandLineUtils.printHelpAndExitIfNeeded(options, helpText)
+    CommandLineUtils.checkRequiredArgs(options.parser, options.options)
+
+    val topicWhitelistRegex = options.options.valueOf(options.topicWhiteListOpt)
+    try Pattern.compile(topicWhitelistRegex)
+    catch {
+      case _: PatternSyntaxException =>
+        CommandLineUtils.printUsageAndDie(options.parser, s"Topic whitelist $topicWhitelistRegex is not a valid regex.")
+    }
+
+    ToolsUtils.validatePortOrDie(options.parser, options.brokerList)
+
+    options
   }
 
   def main(args: Array[String]): Unit = {
-    val parser = new OptionParser(false)
-    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The list of hostname and port of the server to connect to.")
-                         .withRequiredArg
-                         .describedAs("hostname:port,...,hostname:port")
-                         .ofType(classOf[String])
-    val fetchSizeOpt = parser.accepts("fetch-size", "The fetch size of each request.")
-                         .withRequiredArg
-                         .describedAs("bytes")
-                         .ofType(classOf[java.lang.Integer])
-                         .defaultsTo(ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES)
-    val maxWaitMsOpt = parser.accepts("max-wait-ms", "The max amount of time each fetch request waits.")
-                         .withRequiredArg
-                         .describedAs("ms")
-                         .ofType(classOf[java.lang.Integer])
-                         .defaultsTo(1000)
-    val topicWhiteListOpt = parser.accepts("topic-white-list", "White list of topics to verify replica consistency. Defaults to all topics.")
-                         .withRequiredArg
-                         .describedAs("Java regex (String)")
-                         .ofType(classOf[String])
-                         .defaultsTo(".*")
-    val initialOffsetTimeOpt = parser.accepts("time", "Timestamp for getting the initial offsets.")
-                           .withRequiredArg
-                           .describedAs("timestamp/-1(latest)/-2(earliest)")
-                           .ofType(classOf[java.lang.Long])
-                           .defaultsTo(-1L)
-    val reportIntervalOpt = parser.accepts("report-interval-ms", "The reporting interval.")
-                         .withRequiredArg
-                         .describedAs("ms")
-                         .ofType(classOf[java.lang.Long])
-                         .defaultsTo(30 * 1000L)
-    val helpOpt = parser.accepts("help", "Print usage information.").forHelp()
-    val versionOpt = parser.accepts("version", "Print version information and exit.").forHelp()
+    val opts = validateAndParseArgs(args)
+    val options = opts.options
 
-    val options = parser.parse(args: _*)
+    val topicWhiteListFilter = Whitelist(options.valueOf(opts.topicWhiteListOpt))
 
-    if (args.length == 0 || options.has(helpOpt)) {
-      CommandLineUtils.printUsageAndDie(parser, "Validate that all replicas for a set of topics have the same data.")
-    }
+    val fetchSize = options.valueOf(opts.fetchSizeOpt).intValue
+    val maxWaitMs = options.valueOf(opts.maxWaitMsOpt).intValue
+    val initialOffsetTime = options.valueOf(opts.initialOffsetTimeOpt).longValue
+    val reportInterval = options.valueOf(opts.reportIntervalOpt).longValue
+    val brokerList = opts.brokerList
 
-    if (options.has(versionOpt)) {
-      CommandLineUtils.printVersionAndDie()
-    }
-    CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt)
-
-    val regex = options.valueOf(topicWhiteListOpt)
-    val topicWhiteListFiler = new Whitelist(regex)
-
-    try Pattern.compile(regex)
-    catch {
-      case _: PatternSyntaxException =>
-        throw new RuntimeException(s"$regex is an invalid regex.")
-    }
-
-    val fetchSize = options.valueOf(fetchSizeOpt).intValue
-    val maxWaitMs = options.valueOf(maxWaitMsOpt).intValue
-    val initialOffsetTime = options.valueOf(initialOffsetTimeOpt).longValue
-    val reportInterval = options.valueOf(reportIntervalOpt).longValue
-    // getting topic metadata
     info("Getting topic metadata...")
-    val brokerList = options.valueOf(brokerListOpt)
-    ToolsUtils.validatePortOrDie(parser, brokerList)
-
     val (topicsMetadata, brokerInfo) = {
       val adminClient = createAdminClient(brokerList)
       try ((listTopicsMetadata(adminClient), brokerDetails(adminClient)))
@@ -145,13 +156,11 @@ object ReplicaVerificationTool extends Logging {
     }
 
     val filteredTopicMetadata = topicsMetadata.filter { topicMetaData =>
-      topicWhiteListFiler.isTopicAllowed(topicMetaData.name, excludeInternalTopics = false)
+      topicWhiteListFilter.isTopicAllowed(topicMetaData.name, excludeInternalTopics = false)
     }
 
-    if (filteredTopicMetadata.isEmpty) {
-      error(s"No topics found. $topicWhiteListOpt if specified, is either filtering out all topics or there is no topic.")
-      Exit.exit(1)
-    }
+    if (filteredTopicMetadata.isEmpty)
+      CommandLineUtils.printUsageAndDie(opts.parser, s"No topics found. ${opts.topicWhiteListOpt} if specified, is either filtering out all topics or there is no topic.")
 
     val topicPartitionReplicas = filteredTopicMetadata.flatMap { topicMetadata =>
       topicMetadata.partitions.asScala.flatMap { partitionMetadata =>
@@ -207,6 +216,10 @@ object ReplicaVerificationTool extends Logging {
     fetcherThreads.foreach(_.start())
     println(s"${ReplicaVerificationTool.getCurrentTimeString()}: verification process is started.")
 
+  }
+
+  def getCurrentTimeString() = {
+    ReplicaVerificationTool.dateFormat.format(new Date(Time.SYSTEM.milliseconds))
   }
 
   private def listTopicsMetadata(adminClient: Admin): Seq[TopicDescription] = {

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -77,7 +77,7 @@ object ReplicaVerificationTool extends Logging {
       .withRequiredArg
       .describedAs("hostname:port,...,hostname:port")
       .ofType(classOf[String])
-    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED unless --broker-list(deprecated) is specified.")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED. The server(s) to connect to.")
       .requiredUnless("broker-list")
       .withRequiredArg
       .describedAs("Server(s) to use for bootstrapping in the form HOST1:PORT1,HOST2:PORT2.")
@@ -110,7 +110,7 @@ object ReplicaVerificationTool extends Logging {
 
     options = parser.parse(args: _*)
 
-    def brokerList: String =
+    def bootstrapServers: String =
       if (options.has(bootstrapServerOpt)) {
         options.valueOf(bootstrapServerOpt)
       } else {
@@ -131,7 +131,7 @@ object ReplicaVerificationTool extends Logging {
         CommandLineUtils.printUsageAndDie(options.parser, s"Topic whitelist $topicWhitelistRegex is not a valid regex.")
     }
 
-    ToolsUtils.validatePortOrDie(options.parser, options.brokerList)
+    ToolsUtils.validatePortOrDie(options.parser, options.bootstrapServers)
 
     options
   }
@@ -146,7 +146,7 @@ object ReplicaVerificationTool extends Logging {
     val maxWaitMs = options.valueOf(opts.maxWaitMsOpt).intValue
     val initialOffsetTime = options.valueOf(opts.initialOffsetTimeOpt).longValue
     val reportInterval = options.valueOf(opts.reportIntervalOpt).longValue
-    val brokerList = opts.brokerList
+    val brokerList = opts.bootstrapServers
 
     info("Getting topic metadata...")
     val (topicsMetadata, brokerInfo) = {

--- a/core/src/test/scala/kafka/tools/GetOffsetShellTest.scala
+++ b/core/src/test/scala/kafka/tools/GetOffsetShellTest.scala
@@ -12,6 +12,6 @@ class GetOffsetShellTest {
       "--topic", "top"
     )
     val opts = GetOffsetShell.validateAndParseArgs(args)
-    assertEquals("localhost:9092", opts.brokerList)
+    assertEquals("localhost:9092", opts.bootstrapServers)
   }
 }

--- a/core/src/test/scala/kafka/tools/GetOffsetShellTest.scala
+++ b/core/src/test/scala/kafka/tools/GetOffsetShellTest.scala
@@ -1,0 +1,17 @@
+package kafka.tools
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class GetOffsetShellTest {
+  @Test
+  def testBootstrapServerArgOverridesBrokerListArg(): Unit = {
+    val args = Array(
+      "--broker-list", "localhost:9091",
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "top"
+    )
+    val opts = GetOffsetShell.validateAndParseArgs(args)
+    assertEquals("localhost:9092", opts.brokerList)
+  }
+}

--- a/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
+++ b/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
@@ -83,7 +83,7 @@ class ReplicaVerificationToolTest {
     assertEquals(10L, opts.options.valueOf(opts.reportIntervalOpt))
     assertEquals(1000, opts.options.valueOf(opts.fetchSizeOpt))
     assertEquals(100, opts.options.valueOf(opts.maxWaitMsOpt))
-    assertEquals("localhost:9091", opts.brokerList)
+    assertEquals("localhost:9091", opts.bootstrapServers)
   }
 
   @Test
@@ -93,7 +93,7 @@ class ReplicaVerificationToolTest {
       "--bootstrap-server", "localhost:9092",
     )
     val opts = ReplicaVerificationTool.validateAndParseArgs(args)
-    assertEquals("localhost:9092", opts.brokerList)
+    assertEquals("localhost:9092", opts.bootstrapServers)
   }
 
   @Test
@@ -102,7 +102,7 @@ class ReplicaVerificationToolTest {
       "--bootstrap-server", "localhost:9092"
     )
     val opts = ReplicaVerificationTool.validateAndParseArgs(args)
-    assertEquals("localhost:9092", opts.brokerList)
+    assertEquals("localhost:9092", opts.bootstrapServers)
   }
 
   @Test
@@ -111,7 +111,7 @@ class ReplicaVerificationToolTest {
       "--broker-list", "localhost:9091"
     )
     val opts = ReplicaVerificationTool.validateAndParseArgs(args)
-    assertEquals("localhost:9091", opts.brokerList)
+    assertEquals("localhost:9091", opts.bootstrapServers)
   }
 
   @Test

--- a/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
+++ b/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
@@ -17,14 +17,23 @@
 
 package kafka.tools
 
+import kafka.utils.Exit
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.FetchResponse
-import org.junit.Test
-import org.junit.Assert.assertTrue
+import org.junit.{After, Before, Test}
+import org.junit.Assert.{assertEquals, assertTrue, fail}
 
 class ReplicaVerificationToolTest {
+
+  @Before
+  def setUp(): Unit =
+    Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
+
+  @After
+  def tearDown(): Unit =
+    Exit.resetExitProcedure()
 
   @Test
   def testReplicaBufferVerifyChecksum(): Unit = {
@@ -58,4 +67,78 @@ class ReplicaVerificationToolTest {
       output.endsWith(": max lag is 10 for partition a-1 at offset 10 among 3 partitions"))
   }
 
+  @Test
+  def testCorrectArgs(): Unit = {
+    val args = Array(
+      "--bootstrap-server", "localhost:9091",
+      "--max-wait-ms", "100",
+      "--time", "-2", // earliest
+      "--report-interval-ms", "10",
+      "--fetch-size", "1000",
+      "--topic-white-list", "topic-.+"
+    )
+    val opts = ReplicaVerificationTool.validateAndParseArgs(args)
+
+    assertEquals(-2L, opts.options.valueOf(opts.initialOffsetTimeOpt))
+    assertEquals(10L, opts.options.valueOf(opts.reportIntervalOpt))
+    assertEquals(1000, opts.options.valueOf(opts.fetchSizeOpt))
+    assertEquals(100, opts.options.valueOf(opts.maxWaitMsOpt))
+    assertEquals("localhost:9091", opts.brokerList)
+  }
+
+  @Test
+  def testBootstrapServerArgOverridesBrokerList(): Unit = {
+    val args = Array(
+      "--broker-list", "localhost:9091",
+      "--bootstrap-server", "localhost:9092",
+    )
+    val opts = ReplicaVerificationTool.validateAndParseArgs(args)
+    assertEquals("localhost:9092", opts.brokerList)
+  }
+
+  @Test
+  def testBootstrapServerArg(): Unit = {
+    val args = Array(
+      "--bootstrap-server", "localhost:9092"
+    )
+    val opts = ReplicaVerificationTool.validateAndParseArgs(args)
+    assertEquals("localhost:9092", opts.brokerList)
+  }
+
+  @Test
+  def testBrokerListArg(): Unit = {
+    val args = Array(
+      "--broker-list", "localhost:9091"
+    )
+    val opts = ReplicaVerificationTool.validateAndParseArgs(args)
+    assertEquals("localhost:9091", opts.brokerList)
+  }
+
+  @Test
+  def testInvalidTopicWhiteListRegexArg(): Unit = {
+    val args = Array(
+      "--broker-list", "localhost:9091",
+      "--topic-white-list", "topic-.+\\"
+    )
+    shouldFailWith("is not a valid regex", args)
+  }
+
+  @Test
+  def testInvalidBootstrapServerAddressArg(): Unit = {
+    val args = Array(
+      "--bootstrap-server", "localhost:"
+    )
+    shouldFailWith("Please provide valid host:port", args)
+  }
+
+  def shouldFailWith(msg: String, args: Array[String]): Unit = {
+    try {
+      ReplicaVerificationTool.validateAndParseArgs(args)
+      fail(s"Should have failed with [$msg] but no failure occurred.")
+    } catch {
+      case e: Exception =>
+        assertTrue(s"Expected exception with message that contains:\n[$msg]\nbut it did not.\n[${e.getMessage}]",
+          e.getMessage.contains(msg))
+    }
+  }
 }

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -78,8 +78,9 @@ class ConsumerPerformanceTest {
   }
 
   @Test
-  def testBrokerListOverride(): Unit = {
+  def testBootstrapServerOverridesBrokerList(): Unit = {
     //Given
+    // broker-list is deprecated in favor of bootstrap-server
     val args: Array[String] = Array(
       "--broker-list", "localhost:9094",
       "--bootstrap-server", "localhost:9092",
@@ -100,7 +101,7 @@ class ConsumerPerformanceTest {
   def testConfigWithUnrecognizedOption(): Unit = {
     //Given
     val args: Array[String] = Array(
-      "--broker-list", "localhost:9092",
+      "--bootstrap-server", "localhost:9092",
       "--topic", "test",
       "--messages", "10",
       "--new-consumer"

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/temperature/TemperatureDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/temperature/TemperatureDemo.java
@@ -56,7 +56,7 @@ import java.util.concurrent.CountDownLatch;
  * On the other side, a console producer can be used for sending temperature values (which needs to be integers)
  * to "iot-temperature" typing them on the console :
  *
- * bin/kafka-console-producer.sh --broker-list localhost:9092 --topic iot-temperature
+ * bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic iot-temperature
  * > 10
  * > 15
  * > 22

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -839,7 +839,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         cmd = self.path.script("kafka-run-class.sh", node)
         cmd += " kafka.tools.GetOffsetShell"
-        cmd += " --topic %s --broker-list %s --max-wait-ms %s --offsets %s --time %s" % (topic, self.bootstrap_servers(self.security_protocol), max_wait_ms, offsets, time)
+        cmd += " --topic %s --bootstrap-server %s --max-wait-ms %s --offsets %s --time %s" % (topic, self.bootstrap_servers(self.security_protocol), max_wait_ms, offsets, time)
 
         if partitions:
             cmd += '  --partitions %s' % partitions

--- a/tests/kafkatest/services/kafka_log4j_appender.py
+++ b/tests/kafkatest/services/kafka_log4j_appender.py
@@ -47,7 +47,7 @@ class KafkaLog4jAppender(KafkaPathResolverMixin, BackgroundThreadService):
         cmd = self.path.script("kafka-run-class.sh", node)
         cmd += " "
         cmd += self.java_class_name()
-        cmd += " --topic %s --broker-list %s" % (self.topic, self.kafka.bootstrap_servers(self.security_protocol))
+        cmd += " --topic %s --bootstrap-server %s" % (self.topic, self.kafka.bootstrap_servers(self.security_protocol))
 
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)

--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -28,7 +28,7 @@ class ConsumerPerformanceService(PerformanceService):
         "zookeeper" "The connection string for the zookeeper connection in the form host:port. Multiple URLS can
                      be given to allow fail-over. This option is only used with the old consumer."
 
-        "broker-list", "A broker list to use for connecting if using the new consumer."
+        "bootstrap-server", "A broker list to use for connecting if using the new consumer."
 
         "topic", "REQUIRED: The topic to consume from."
 
@@ -110,7 +110,7 @@ class ConsumerPerformanceService(PerformanceService):
         if self.new_consumer:
             if version <= LATEST_0_10_0:
                 args['new-consumer'] = ""
-            args['broker-list'] = self.kafka.bootstrap_servers(self.security_config.security_protocol)
+            args['bootstrap-server'] = self.kafka.bootstrap_servers(self.security_config.security_protocol)
         else:
             args['zookeeper'] = self.kafka.zk_connect_setting()
 

--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -28,7 +28,7 @@ class ConsumerPerformanceService(PerformanceService):
         "zookeeper" "The connection string for the zookeeper connection in the form host:port. Multiple URLS can
                      be given to allow fail-over. This option is only used with the old consumer."
 
-        "bootstrap-server", "A broker list to use for connecting if using the new consumer."
+        "broker-list", "A broker list to use for connecting if using the new consumer."
 
         "topic", "REQUIRED: The topic to consume from."
 
@@ -110,7 +110,7 @@ class ConsumerPerformanceService(PerformanceService):
         if self.new_consumer:
             if version <= LATEST_0_10_0:
                 args['new-consumer'] = ""
-            args['bootstrap-server'] = self.kafka.bootstrap_servers(self.security_config.security_protocol)
+            args['broker-list'] = self.kafka.bootstrap_servers(self.security_config.security_protocol)
         else:
             args['zookeeper'] = self.kafka.zk_connect_setting()
 

--- a/tests/kafkatest/services/replica_verification_tool.py
+++ b/tests/kafkatest/services/replica_verification_tool.py
@@ -71,7 +71,7 @@ class ReplicaVerificationTool(KafkaPathResolverMixin, BackgroundThreadService):
     def start_cmd(self, node):
         cmd = self.path.script("kafka-run-class.sh", node)
         cmd += " %s" % self.java_class_name()
-        cmd += " --broker-list %s --topic-white-list %s --time -2 --report-interval-ms %s" % (self.kafka.bootstrap_servers(self.security_protocol), self.topic, self.report_interval_ms)
+        cmd += " --bootstrap-server %s --topic-white-list %s --time -2 --report-interval-ms %s" % (self.kafka.bootstrap_servers(self.security_protocol), self.topic, self.report_interval_ms)
 
         cmd += " 2>> /mnt/replica_verification_tool.log | tee -a /mnt/replica_verification_tool.log &"
         return cmd

--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -115,7 +115,7 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
         cmd += " export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
         cmd += " export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % TransactionalMessageCopier.LOG4J_CONFIG
         cmd += self.path.script("kafka-run-class.sh", node) + " org.apache.kafka.tools." + "TransactionalMessageCopier"
-        cmd += " --broker-list %s" % self.kafka.bootstrap_servers(self.security_config.security_protocol)
+        cmd += " --bootstrap-server %s" % self.kafka.bootstrap_servers(self.security_config.security_protocol)
         cmd += " --transactional-id %s" % self.transactional_id
         cmd += " --consumer-group %s" % self.consumer_group
         cmd += " --input-topic %s" % self.input_topic

--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -71,7 +71,7 @@ VerifiableConsumer
 Command line arguments:
  * `--group-id <group-id>`
  * `--topic <topic>`
- * `--broker-list <brokers>`
+ * `--bootstrap-server <brokers>`
  * `--session-timeout <n>`
  * `--enable-autocommit`
  * `--max-messages <n>`
@@ -96,7 +96,7 @@ VerifiableProducer
 
 Command line arguments:
  * `--topic <topic>`
- * `--broker-list <brokers>`
+ * `--bootstrap-server <brokers>`
  * `--max-messages <n>`
  * `--throughput <msgs/s>`
  * `--producer.config <config-file>` - producer config properties (typically empty)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -312,7 +312,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.enable_autocommit:
             cmd += " --enable-autocommit "
 
-        cmd += " --reset-policy %s --group-id %s --topic %s --broker-list %s --session-timeout %s" % \
+        cmd += " --reset-policy %s --group-id %s --topic %s --bootstrap-server %s --session-timeout %s" % \
                (self.reset_policy, self.group_id, self.topic,
                 self.kafka.bootstrap_servers(self.security_config.security_protocol),
                 self.session_timeout_sec*1000)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -222,7 +222,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
 
         cmd += " export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % VerifiableProducer.LOG4J_CONFIG
         cmd += self.impl.exec_cmd(node)
-        cmd += " --topic %s --broker-list %s" % (self.topic, self.kafka.bootstrap_servers(self.security_config.security_protocol, True, self.offline_nodes))
+        cmd += " --topic %s --bootstrap-server %s" % (self.topic, self.kafka.bootstrap_servers(self.security_config.security_protocol, True, self.offline_nodes))
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
         if self.throughput > 0:

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -138,7 +138,7 @@ public class TransactionalMessageCopier {
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
             parser.addArgument("--input-partition")
                 .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -61,23 +63,84 @@ public class TransactionalMessageCopier {
 
     private static final DateFormat FORMAT = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss:SSS");
 
-    /** Get the command-line argument parser. */
-    private static ArgumentParser argParser() {
-        ArgumentParser parser = ArgumentParsers
+    public static class TransactionalMessageCopierOptions {
+        public final String inputTopic;
+        public final Integer inputPartition;
+        public final String outputTopic;
+        public final String brokerList;
+        public final Long maxMessages;
+        public final String consumerGroup;
+        public final Integer messagesPerTransaction;
+        public final Integer transactionTimeout;
+        public final String transactionalId;
+        public final Boolean enableRandomAborts;
+        public final Boolean groupMode;
+        public final Boolean useGroupMetadata;
+
+        private TransactionalMessageCopierOptions(String inputTopic, Integer inputPartition, String outputTopic,
+                                                  String brokerList, Long maxMessages, String consumerGroup,
+                                                  Integer messagesPerTransaction, Integer transactionTimeout, String transactionalId,
+                                                  Boolean enableRandomAborts, Boolean groupMode, Boolean useGroupMetadata) {
+            this.inputTopic = inputTopic;
+            this.inputPartition = inputPartition;
+            this.outputTopic = outputTopic;
+            this.brokerList = brokerList;
+            this.maxMessages = maxMessages;
+            this.consumerGroup = consumerGroup;
+            this.messagesPerTransaction = messagesPerTransaction;
+            this.transactionTimeout = transactionTimeout;
+            this.transactionalId = transactionalId;
+            this.enableRandomAborts = enableRandomAborts;
+            this.groupMode = groupMode;
+            this.useGroupMetadata = useGroupMetadata;
+        }
+
+        public static TransactionalMessageCopierOptions parse(String[] args) {
+            try {
+                Namespace parsedArgs = argParser().parseArgs(args);
+                return new TransactionalMessageCopierOptions(
+                    parsedArgs.getString("inputTopic"), parsedArgs.getInt("inputPartition"),
+                    parsedArgs.getString("outputTopic"),
+                    parsedArgs.get("bootstrapServer") != null ? parsedArgs.getString("bootstrapServer") : parsedArgs.getString("brokerList"),
+                    parsedArgs.getLong("maxMessages") == -1 ? Long.MAX_VALUE : parsedArgs.getLong("maxMessages"),
+                    parsedArgs.getString("consumerGroup"), parsedArgs.getInt("messagesPerTransaction"),
+                    parsedArgs.getInt("transactionTimeout"), parsedArgs.getString("transactionalId"),
+                    parsedArgs.getBoolean("enableRandomAborts"), parsedArgs.getBoolean("groupMode"),
+                    parsedArgs.getBoolean("useGroupMetadata")
+                );
+            } catch (ArgumentParserException ape) {
+                Exit.exit(1, ape.getMessage());
+                throw new IllegalStateException();
+            }
+        }
+
+        /** Get the command-line argument parser. */
+        private static ArgumentParser argParser() {
+            ArgumentParser parser = ArgumentParsers
                 .newArgumentParser("transactional-message-copier")
                 .defaultHelp(true)
                 .description("This tool copies messages transactionally from an input partition to an output topic, " +
-                        "committing the consumed offsets along with the output messages");
+                    "committing the consumed offsets along with the output messages");
 
-        parser.addArgument("--input-topic")
+            MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")
+                .description("Group of arguments for connection to brokers")
+                .required(true);
+            connectionGroup.addArgument("--bootstrap-server")
                 .action(store())
-                .required(true)
+                .required(false)
                 .type(String.class)
-                .metavar("INPUT-TOPIC")
-                .dest("inputTopic")
-                .help("Consume messages from this topic");
+                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+                .dest("bootstrapServer")
+                .help("REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+            connectionGroup.addArgument("--broker-list")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+                .dest("brokerList")
+                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
-        parser.addArgument("--input-partition")
+            parser.addArgument("--input-partition")
                 .action(store())
                 .required(true)
                 .type(Integer.class)
@@ -85,7 +148,7 @@ public class TransactionalMessageCopier {
                 .dest("inputPartition")
                 .help("Consume messages from this partition of the input topic.");
 
-        parser.addArgument("--output-topic")
+            parser.addArgument("--output-topic")
                 .action(store())
                 .required(true)
                 .type(String.class)
@@ -93,25 +156,17 @@ public class TransactionalMessageCopier {
                 .dest("outputTopic")
                 .help("Produce messages to this topic");
 
-        parser.addArgument("--broker-list")
-                .action(store())
-                .required(true)
-                .type(String.class)
-                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
-                .dest("brokerList")
-                .help("Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
-
-        parser.addArgument("--max-messages")
+            parser.addArgument("--max-messages")
                 .action(store())
                 .required(false)
-                .setDefault(-1)
-                .type(Integer.class)
+                .setDefault(-1L)
+                .type(Long.class)
                 .metavar("MAX-MESSAGES")
                 .dest("maxMessages")
-                .help("Process these many messages upto the end offset at the time this program was launched. If set to -1 " +
-                        "we will just read to the end offset of the input partition (as of the time the program was launched).");
+                .help("Process these many messages up to the end offset at the time this program was launched. If set to -1 " +
+                    "we will just read to the end offset of the input partition (as of the time the program was launched).");
 
-        parser.addArgument("--consumer-group")
+            parser.addArgument("--consumer-group")
                 .action(store())
                 .required(false)
                 .setDefault(-1)
@@ -120,7 +175,7 @@ public class TransactionalMessageCopier {
                 .dest("consumerGroup")
                 .help("The consumer group id to use for storing the consumer offsets.");
 
-        parser.addArgument("--transaction-size")
+            parser.addArgument("--transaction-size")
                 .action(store())
                 .required(false)
                 .setDefault(200)
@@ -129,7 +184,7 @@ public class TransactionalMessageCopier {
                 .dest("messagesPerTransaction")
                 .help("The number of messages to put in each transaction. Default is 200.");
 
-        parser.addArgument("--transaction-timeout")
+            parser.addArgument("--transaction-timeout")
                 .action(store())
                 .required(false)
                 .setDefault(60000)
@@ -138,7 +193,7 @@ public class TransactionalMessageCopier {
                 .dest("transactionTimeout")
                 .help("The transaction timeout in milliseconds. Default is 60000(1 minute).");
 
-        parser.addArgument("--transactional-id")
+            parser.addArgument("--transactional-id")
                 .action(store())
                 .required(true)
                 .type(String.class)
@@ -146,35 +201,36 @@ public class TransactionalMessageCopier {
                 .dest("transactionalId")
                 .help("The transactionalId to assign to the producer");
 
-        parser.addArgument("--enable-random-aborts")
+            parser.addArgument("--enable-random-aborts")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("ENABLE-RANDOM-ABORTS")
                 .dest("enableRandomAborts")
                 .help("Whether or not to enable random transaction aborts (for system testing)");
 
-        parser.addArgument("--group-mode")
+            parser.addArgument("--group-mode")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("GROUP-MODE")
                 .dest("groupMode")
                 .help("Whether to let consumer subscribe to the input topic or do manual assign. If we do" +
-                          " subscription based consumption, the input partition shall be ignored");
+                    " subscription based consumption, the input partition shall be ignored");
 
-        parser.addArgument("--use-group-metadata")
+            parser.addArgument("--use-group-metadata")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("USE-GROUP-METADATA")
                 .dest("useGroupMetadata")
                 .help("Whether to use the new transactional commit API with group metadata");
 
-        return parser;
+            return parser;
+        }
     }
 
-    private static KafkaProducer<String, String> createProducer(Namespace parsedArgs) {
+    private static KafkaProducer<String, String> createProducer(TransactionalMessageCopierOptions options) {
         Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, parsedArgs.getString("brokerList"));
-        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, parsedArgs.getString("transactionalId"));
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, options.brokerList);
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, options.transactionalId);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
@@ -184,15 +240,15 @@ public class TransactionalMessageCopier {
         // the case with multiple inflights.
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, "512");
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
-        props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, parsedArgs.getInt("transactionTimeout"));
+        props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, options.transactionTimeout);
 
         return new KafkaProducer<>(props);
     }
 
-    private static KafkaConsumer<String, String> createConsumer(Namespace parsedArgs) {
-        String consumerGroup = parsedArgs.getString("consumerGroup");
-        String brokerList = parsedArgs.getString("brokerList");
-        Integer numMessagesPerTransaction = parsedArgs.getInt("messagesPerTransaction");
+    private static KafkaConsumer<String, String> createConsumer(TransactionalMessageCopierOptions options) {
+        String consumerGroup = options.consumerGroup;
+        String brokerList = options.brokerList;
+        Integer numMessagesPerTransaction = options.messagesPerTransaction;
 
         Properties props = new Properties();
 
@@ -278,20 +334,19 @@ public class TransactionalMessageCopier {
     }
 
     public static void main(String[] args) {
-        Namespace parsedArgs = argParser().parseArgsOrFail(args);
-        final String transactionalId = parsedArgs.getString("transactionalId");
-        final String outputTopic = parsedArgs.getString("outputTopic");
+        TransactionalMessageCopierOptions options = TransactionalMessageCopierOptions.parse(args);
+        final String transactionalId = options.transactionalId;
+        final String outputTopic = options.outputTopic;
 
-        String consumerGroup = parsedArgs.getString("consumerGroup");
+        String consumerGroup = options.consumerGroup;
 
-        final KafkaProducer<String, String> producer = createProducer(parsedArgs);
-        final KafkaConsumer<String, String> consumer = createConsumer(parsedArgs);
+        final KafkaProducer<String, String> producer = createProducer(options);
+        final KafkaConsumer<String, String> consumer = createConsumer(options);
 
-        final AtomicLong remainingMessages = new AtomicLong(
-            parsedArgs.getInt("maxMessages") == -1 ? Long.MAX_VALUE : parsedArgs.getInt("maxMessages"));
+        final AtomicLong remainingMessages = new AtomicLong(options.maxMessages);
 
-        boolean groupMode = parsedArgs.getBoolean("groupMode");
-        String topicName = parsedArgs.getString("inputTopic");
+        boolean groupMode = options.groupMode;
+        String topicName = options.inputTopic;
         final AtomicLong numMessagesProcessedSinceLastRebalance = new AtomicLong(0);
         final AtomicLong totalMessageProcessed = new AtomicLong(0);
         if (groupMode) {
@@ -311,12 +366,12 @@ public class TransactionalMessageCopier {
                 }
             });
         } else {
-            TopicPartition inputPartition = new TopicPartition(topicName, parsedArgs.getInt("inputPartition"));
+            TopicPartition inputPartition = new TopicPartition(topicName, options.inputPartition);
             consumer.assign(singleton(inputPartition));
             remainingMessages.set(Math.min(messagesRemaining(consumer, inputPartition), remainingMessages.get()));
         }
 
-        final boolean enableRandomAborts = parsedArgs.getBoolean("enableRandomAborts");
+        final boolean enableRandomAborts = options.enableRandomAborts;
 
         producer.initTransactions();
 
@@ -333,7 +388,7 @@ public class TransactionalMessageCopier {
                 numMessagesProcessedSinceLastRebalance.get(), remainingMessages.get(), transactionalId));
         });
 
-        final boolean useGroupMetadata = parsedArgs.getBoolean("useGroupMetadata");
+        final boolean useGroupMetadata = options.useGroupMetadata;
         try {
             Random random = new Random();
             while (remainingMessages.get() > 0) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -521,7 +521,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
         parser.addArgument("--topic")
                 .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -521,7 +521,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
         parser.addArgument("--topic")
                 .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -154,7 +154,7 @@ public class VerifiableLog4jAppender {
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
             parser.addArgument("--max-messages")
                 .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -19,6 +19,7 @@ package org.apache.kafka.tools;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Exit;
@@ -52,104 +53,187 @@ public class VerifiableLog4jAppender {
     // Hook to trigger logging thread to stop logging messages
     private volatile boolean stopLogging = false;
 
-    /** Get the command-line argument parser. */
-    private static ArgumentParser argParser() {
-        ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("verifiable-log4j-appender")
-            .defaultHelp(true)
-            .description("This tool produces increasing integers to the specified topic using KafkaLog4jAppender.");
+    public static class VerifiableLog4jAppenderOptions {
+        private ArgumentParser parser;
+        public final String topic;
+        public final String brokerList;
+        public final Integer maxMessages;
+        public final String acks;
+        public final String securityProtocol;
+        public final String sslTruststoreLocation;
+        public final String sslTruststorePassword;
+        public final String saslKerberosServiceName;
+        public final String clientJaasConfPath;
+        public final String kerb5ConfPath;
+        public final String configFile;
 
-        parser.addArgument("--topic")
-            .action(store())
-            .required(true)
-            .type(String.class)
-            .metavar("TOPIC")
-            .help("Produce messages to this topic.");
+        private VerifiableLog4jAppenderOptions(ArgumentParser parser,
+                                               String topic, String brokerList, Integer maxMessages,
+                                               String acks, String securityProtocol,
+                                               String sslTruststoreLocation, String sslTruststorePassword,
+                                               String saslKerberosServiceName, String clientJaasConfPath,
+                                               String kerb5ConfPath, String configFile) {
+            this.parser = parser;
+            this.topic = topic;
+            this.brokerList = brokerList;
+            this.maxMessages = maxMessages;
+            this.acks = acks;
+            this.securityProtocol = securityProtocol;
+            this.sslTruststoreLocation = sslTruststoreLocation;
+            this.sslTruststorePassword = sslTruststorePassword;
+            this.saslKerberosServiceName = saslKerberosServiceName;
+            this.clientJaasConfPath = clientJaasConfPath;
+            this.kerb5ConfPath = kerb5ConfPath;
+            this.configFile = configFile;
+        }
 
-        parser.addArgument("--broker-list")
-            .action(store())
-            .required(true)
-            .type(String.class)
-            .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
-            .dest("brokerList")
-            .help("Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+        void handleError(Exception e) {
+            parser.handleError(new ArgumentParserException(e, parser));
+            Exit.exit(1);
+        }
 
-        parser.addArgument("--max-messages")
-            .action(store())
-            .required(false)
-            .setDefault(-1)
-            .type(Integer.class)
-            .metavar("MAX-MESSAGES")
-            .dest("maxMessages")
-            .help("Produce this many messages. If -1, produce messages until the process is killed externally.");
+        public static VerifiableLog4jAppenderOptions parse(String[] args) {
+            ArgumentParser parser = argParser();
+            try {
+                Namespace parsedArgs = argParser().parseArgs(args);
+                return new VerifiableLog4jAppenderOptions(
+                    parser,
+                    parsedArgs.getString("topic"),
+                    parsedArgs.get("bootstrapServer") != null ? parsedArgs.getString("bootstrapServer") : parsedArgs.getString("brokerList"),
+                    parsedArgs.getInt("maxMessages"),
+                    parsedArgs.getString("acks"),
+                    parsedArgs.getString("securityProtocol"),
+                    parsedArgs.getString("sslTruststoreLocation"),
+                    parsedArgs.getString("sslTruststorePassword"),
+                    parsedArgs.getString("saslKerberosServiceName"),
+                    parsedArgs.getString("clientJaasConfPath"),
+                    parsedArgs.getString("kerb5ConfPath"),
+                    parsedArgs.getString("appenderConfig")
+                );
+            } catch (ArgumentParserException ape) {
+                if (args.length == 0) {
+                    parser.printHelp();
+                    Exit.exit(0);
+                } else {
+                    parser.handleError(ape);
+                    Exit.exit(1);
+                }
+                throw new IllegalStateException();
+            }
+        }
 
-        parser.addArgument("--acks")
-            .action(store())
-            .required(false)
-            .setDefault("-1")
-            .type(String.class)
-            .choices("0", "1", "-1")
-            .metavar("ACKS")
-            .help("Acks required on each produced message. See Kafka docs on request.required.acks for details.");
+        /** Get the command-line argument parser. */
+        private static ArgumentParser argParser() {
+            ArgumentParser parser = ArgumentParsers
+                .newArgumentParser("verifiable-log4j-appender")
+                .defaultHelp(true)
+                .description("This tool produces increasing integers to the specified topic using KafkaLog4jAppender.");
 
-        parser.addArgument("--security-protocol")
-            .action(store())
-            .required(false)
-            .setDefault("PLAINTEXT")
-            .type(String.class)
-            .choices("PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL")
-            .metavar("SECURITY-PROTOCOL")
-            .dest("securityProtocol")
-            .help("Security protocol to be used while communicating with Kafka brokers.");
+            parser.addArgument("--topic")
+                .action(store())
+                .required(true)
+                .type(String.class)
+                .metavar("TOPIC")
+                .help("Produce messages to this topic.");
 
-        parser.addArgument("--ssl-truststore-location")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("SSL-TRUSTSTORE-LOCATION")
-            .dest("sslTruststoreLocation")
-            .help("Location of SSL truststore to use.");
+            MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")
+                .description("Group of arguments for connection to brokers")
+                .required(true);
 
-        parser.addArgument("--ssl-truststore-password")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("SSL-TRUSTSTORE-PASSWORD")
-            .dest("sslTruststorePassword")
-            .help("Password for SSL truststore to use.");
+            connectionGroup.addArgument("--bootstrap-server")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+                .dest("bootstrapServer")
+                .help("REQUIRED unless --broker-list(deprecated) is specified. The server(s) to connect to. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
-        parser.addArgument("--appender.config")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("CONFIG_FILE")
-            .help("Log4jAppender config properties file.");
+            connectionGroup.addArgument("--broker-list")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+                .dest("brokerList")
+                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
-        parser.addArgument("--sasl-kerberos-service-name")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("SASL-KERBEROS-SERVICE-NAME")
-            .dest("saslKerberosServiceName")
-            .help("Name of sasl kerberos service.");
+            parser.addArgument("--max-messages")
+                .action(store())
+                .required(false)
+                .setDefault(-1)
+                .type(Integer.class)
+                .metavar("MAX-MESSAGES")
+                .dest("maxMessages")
+                .help("Produce this many messages. If -1, produce messages until the process is killed externally.");
 
-        parser.addArgument("--client-jaas-conf-path")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("CLIENT-JAAS-CONF-PATH")
-            .dest("clientJaasConfPath")
-            .help("Path of JAAS config file of Kafka client.");
+            parser.addArgument("--acks")
+                .action(store())
+                .required(false)
+                .setDefault("-1")
+                .type(String.class)
+                .choices("0", "1", "-1")
+                .metavar("ACKS")
+                .help("Acks required on each produced message. See Kafka docs on request.required.acks for details.");
 
-        parser.addArgument("--kerb5-conf-path")
-            .action(store())
-            .required(false)
-            .type(String.class)
-            .metavar("KERB5-CONF-PATH")
-            .dest("kerb5ConfPath")
-            .help("Path of Kerb5 config file.");
+            parser.addArgument("--security-protocol")
+                .action(store())
+                .required(false)
+                .setDefault("PLAINTEXT")
+                .type(String.class)
+                .choices("PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL")
+                .metavar("SECURITY-PROTOCOL")
+                .dest("securityProtocol")
+                .help("Security protocol to be used while communicating with Kafka brokers.");
 
-        return parser;
+            parser.addArgument("--ssl-truststore-location")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("SSL-TRUSTSTORE-LOCATION")
+                .dest("sslTruststoreLocation")
+                .help("Location of SSL truststore to use.");
+
+            parser.addArgument("--ssl-truststore-password")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("SSL-TRUSTSTORE-PASSWORD")
+                .dest("sslTruststorePassword")
+                .help("Password for SSL truststore to use.");
+
+            parser.addArgument("--appender.config")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("CONFIG_FILE")
+                .dest("appenderConfig")
+                .help("Log4jAppender config properties file.");
+
+            parser.addArgument("--sasl-kerberos-service-name")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("SASL-KERBEROS-SERVICE-NAME")
+                .dest("saslKerberosServiceName")
+                .help("Name of sasl kerberos service.");
+
+            parser.addArgument("--client-jaas-conf-path")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("CLIENT-JAAS-CONF-PATH")
+                .dest("clientJaasConfPath")
+                .help("Path of JAAS config file of Kafka client.");
+
+            parser.addArgument("--kerb5-conf-path")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("KERB5-CONF-PATH")
+                .dest("kerb5ConfPath")
+                .help("Path of Kerb5 config file.");
+
+            return parser;
+        }
     }
 
     /**
@@ -171,61 +255,49 @@ public class VerifiableLog4jAppender {
 
     /** Construct a VerifiableLog4jAppender object from command-line arguments. */
     public static VerifiableLog4jAppender createFromArgs(String[] args) {
-        ArgumentParser parser = argParser();
+        VerifiableLog4jAppenderOptions opts = VerifiableLog4jAppenderOptions.parse(args);
         VerifiableLog4jAppender producer = null;
 
-        try {
-            Namespace res = parser.parseArgs(args);
+        int maxMessages = opts.maxMessages;
+        String topic = opts.topic;
+        String configFile = opts.configFile;
 
-            int maxMessages = res.getInt("maxMessages");
-            String topic = res.getString("topic");
-            String configFile = res.getString("appender.config");
+        Properties props = new Properties();
+        props.setProperty("log4j.rootLogger", "INFO, KAFKA");
+        props.setProperty("log4j.appender.KAFKA", "org.apache.kafka.log4jappender.KafkaLog4jAppender");
+        props.setProperty("log4j.appender.KAFKA.layout", "org.apache.log4j.PatternLayout");
+        props.setProperty("log4j.appender.KAFKA.layout.ConversionPattern", "%-5p: %c - %m%n");
+        props.setProperty("log4j.appender.KAFKA.BrokerList", opts.brokerList);
+        props.setProperty("log4j.appender.KAFKA.Topic", topic);
+        props.setProperty("log4j.appender.KAFKA.RequiredNumAcks", opts.acks);
+        props.setProperty("log4j.appender.KAFKA.SyncSend", "true");
+        final String securityProtocol = opts.securityProtocol;
+        if (securityProtocol != null && !securityProtocol.equals(SecurityProtocol.PLAINTEXT.toString())) {
+            props.setProperty("log4j.appender.KAFKA.SecurityProtocol", securityProtocol);
+        }
+        if (securityProtocol != null && securityProtocol.contains("SSL")) {
+            props.setProperty("log4j.appender.KAFKA.SslTruststoreLocation", opts.sslTruststoreLocation);
+            props.setProperty("log4j.appender.KAFKA.SslTruststorePassword", opts.sslTruststorePassword);
+        }
+        if (securityProtocol != null && securityProtocol.contains("SASL")) {
+            props.setProperty("log4j.appender.KAFKA.SaslKerberosServiceName", opts.saslKerberosServiceName);
+            props.setProperty("log4j.appender.KAFKA.clientJaasConfPath", opts.clientJaasConfPath);
+            props.setProperty("log4j.appender.KAFKA.kerb5ConfPath", opts.kerb5ConfPath);
+        }
+        props.setProperty("log4j.logger.kafka.log4j", "INFO, KAFKA");
+        // Changing log level from INFO to WARN as a temporary workaround for KAFKA-6415. This is to
+        // avoid deadlock in system tests when producer network thread appends to log while updating metadata.
+        props.setProperty("log4j.logger.org.apache.kafka.clients.Metadata", "WARN, KAFKA");
 
-            Properties props = new Properties();
-            props.setProperty("log4j.rootLogger", "INFO, KAFKA");
-            props.setProperty("log4j.appender.KAFKA", "org.apache.kafka.log4jappender.KafkaLog4jAppender");
-            props.setProperty("log4j.appender.KAFKA.layout", "org.apache.log4j.PatternLayout");
-            props.setProperty("log4j.appender.KAFKA.layout.ConversionPattern", "%-5p: %c - %m%n");
-            props.setProperty("log4j.appender.KAFKA.BrokerList", res.getString("brokerList"));
-            props.setProperty("log4j.appender.KAFKA.Topic", topic);
-            props.setProperty("log4j.appender.KAFKA.RequiredNumAcks", res.getString("acks"));
-            props.setProperty("log4j.appender.KAFKA.SyncSend", "true");
-            final String securityProtocol = res.getString("securityProtocol");
-            if (securityProtocol != null && !securityProtocol.equals(SecurityProtocol.PLAINTEXT.toString())) {
-                props.setProperty("log4j.appender.KAFKA.SecurityProtocol", securityProtocol);
-            }
-            if (securityProtocol != null && securityProtocol.contains("SSL")) {
-                props.setProperty("log4j.appender.KAFKA.SslTruststoreLocation", res.getString("sslTruststoreLocation"));
-                props.setProperty("log4j.appender.KAFKA.SslTruststorePassword", res.getString("sslTruststorePassword"));
-            }
-            if (securityProtocol != null && securityProtocol.contains("SASL")) {
-                props.setProperty("log4j.appender.KAFKA.SaslKerberosServiceName", res.getString("saslKerberosServiceName"));
-                props.setProperty("log4j.appender.KAFKA.clientJaasConfPath", res.getString("clientJaasConfPath"));
-                props.setProperty("log4j.appender.KAFKA.kerb5ConfPath", res.getString("kerb5ConfPath"));
-            }
-            props.setProperty("log4j.logger.kafka.log4j", "INFO, KAFKA");
-            // Changing log level from INFO to WARN as a temporary workaround for KAFKA-6415. This is to
-            // avoid deadlock in system tests when producer network thread appends to log while updating metadata.
-            props.setProperty("log4j.logger.org.apache.kafka.clients.Metadata", "WARN, KAFKA");
-
-            if (configFile != null) {
-                try {
-                    props.putAll(loadProps(configFile));
-                } catch (IOException e) {
-                    throw new ArgumentParserException(e.getMessage(), parser);
-                }
-            }
-
-            producer = new VerifiableLog4jAppender(props, maxMessages);
-        } catch (ArgumentParserException e) {
-            if (args.length == 0) {
-                parser.printHelp();
-                Exit.exit(0);
-            } else {
-                parser.handleError(e);
-                Exit.exit(1);
+        if (configFile != null) {
+            try {
+                props.putAll(loadProps(configFile));
+            } catch (IOException e) {
+                opts.handleError(e);
             }
         }
+
+        producer = new VerifiableLog4jAppender(props, maxMessages);
 
         return producer;
     }
@@ -237,12 +309,11 @@ public class VerifiableLog4jAppender {
     }
 
     public static void main(String[] args) throws IOException {
-
         final VerifiableLog4jAppender appender = createFromArgs(args);
         boolean infinite = appender.maxMessages < 0;
 
         // Trigger main thread to stop producing messages when shutting down
-        Exit.addShutdownHook("verifiable-log4j-appender-shutdown-hook", () -> appender.stopLogging = true);
+        Exit.addShutdownHook("verifiable-log4j-shutdown-hook", () -> appender.stopLogging = true);
 
         long maxMessages = infinite ? Long.MAX_VALUE : appender.maxMessages;
         for (long i = 0; i < maxMessages; i++) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -137,7 +137,7 @@ public class VerifiableProducer implements AutoCloseable {
                 .type(String.class)
                 .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
                 .dest("brokerList")
-                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified.  Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+                .help("DEPRECATED, use --bootstrap-server instead; ignored if --bootstrap-server is specified. Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
         parser.addArgument("--max-messages")
                 .action(store())

--- a/tools/src/test/java/org/apache/kafka/tools/TransactionalMessageCopierTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TransactionalMessageCopierTest.java
@@ -1,0 +1,119 @@
+package org.apache.kafka.tools;
+
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.tools.TransactionalMessageCopier.TransactionalMessageCopierOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TransactionalMessageCopierTest {
+
+  @Before
+  public void setUp() {
+    Exit.setExitProcedure((statusCode, message) -> {
+      throw new IllegalArgumentException(message);
+    });
+  }
+
+  @After
+  public void tearDown() {
+    Exit.resetExitProcedure();
+  }
+
+  @Test
+  public void testOptionsWorkCorrectly() {
+    String[] args = new String[]{
+        "--bootstrap-server", "localhost:9091,localhost:9092",
+        "--input-partition", "10",
+        "--output-topic", "hello",
+        "--max-messages", "200",
+        "--consumer-group", "group",
+        "--transaction-size", "2",
+        "--transaction-timeout", "1",
+        "--transactional-id", "tid",
+        "--enable-random-aborts",
+        "--group-mode",
+        "--use-group-metadata"
+    };
+
+    TransactionalMessageCopierOptions opts = TransactionalMessageCopierOptions.parse(args);
+    assertEquals("localhost:9091,localhost:9092", opts.brokerList);
+    assertEquals(Integer.valueOf(10), opts.inputPartition);
+    assertEquals("hello", opts.outputTopic);
+    assertEquals(Long.valueOf(200), opts.maxMessages);
+    assertEquals("group", opts.consumerGroup);
+    assertEquals(Integer.valueOf(2), opts.messagesPerTransaction);
+    assertEquals(Integer.valueOf(1), opts.transactionTimeout);
+    assertEquals("tid", opts.transactionalId);
+    assertTrue(opts.enableRandomAborts);
+    assertTrue(opts.groupMode);
+    assertTrue(opts.useGroupMetadata);
+  }
+
+  @Test
+  public void testOptionsDefaults() {
+    String[] args = new String[]{
+        "--bootstrap-server", "localhost:9091,localhost:9092",
+        "--input-partition", "10",
+        "--output-topic", "hello",
+        "--transactional-id", "tid",
+    };
+    TransactionalMessageCopierOptions opts = TransactionalMessageCopierOptions.parse(args);
+    assertEquals("localhost:9091,localhost:9092", opts.brokerList);
+    assertEquals(Integer.valueOf(10), opts.inputPartition);
+    assertEquals("hello", opts.outputTopic);
+    assertEquals("tid", opts.transactionalId);
+
+    // defaults
+    assertEquals(Long.valueOf(Long.MAX_VALUE), opts.maxMessages);
+    assertEquals("-1", opts.consumerGroup);
+    assertEquals(Integer.valueOf(200), opts.messagesPerTransaction);
+    assertEquals(Integer.valueOf(60000), opts.transactionTimeout);
+    assertFalse(opts.enableRandomAborts);
+    assertFalse(opts.groupMode);
+    assertFalse(opts.useGroupMetadata);
+  }
+
+  @Test
+  public void testBrokerListArg() {
+    String[] args = new String[]{
+        "--broker-list", "localhost:9091",
+        "--input-partition", "10",
+        "--output-topic", "hello",
+        "--max-messages", "200",
+        "--consumer-group", "group",
+        "--transaction-size", "2",
+        "--transaction-timeout", "1",
+        "--transactional-id", "tid",
+        "--enable-random-aborts",
+        "--group-mode",
+        "--use-group-metadata"
+    };
+
+    TransactionalMessageCopierOptions opts = TransactionalMessageCopierOptions.parse(args);
+    assertEquals("localhost:9091", opts.brokerList);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBrokerListArgAndBootstrapServerAreMutuallyExclusive() {
+    String[] args = new String[]{
+        "--broker-list", "localhost:9091",
+        "--bootstrap-server", "localhost:9091,localhost:9092",
+        "--input-partition", "10",
+        "--output-topic", "hello",
+        "--max-messages", "200",
+        "--consumer-group", "group",
+        "--transaction-size", "2",
+        "--transaction-timeout", "1",
+        "--transactional-id", "tid",
+        "--enable-random-aborts",
+        "--group-mode",
+        "--use-group-metadata"
+    };
+    TransactionalMessageCopierOptions.parse(args);
+  }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/VerifiableLog4jAppenderTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/VerifiableLog4jAppenderTest.java
@@ -1,0 +1,109 @@
+package org.apache.kafka.tools;
+
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.tools.VerifiableLog4jAppender.VerifiableLog4jAppenderOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class VerifiableLog4jAppenderTest {
+
+  private final String topic = "topic";
+  private final String brokerList = "localhost:9091";
+  private final String maxMessages = "100";
+  private final String acks = "1";
+  private final String securityProtocol = "SASL_SSL";
+  private final String sslTruststoreLocation = "/";
+  private final String sslTruststorePassword = "passw";
+  private final String appenderConfig = "/config.props";
+  private final String saslKerberosServiceName = "service";
+  private final String clientJaasConfPath = "/client.jaas";
+  private final String kerb5ConfPath = "/kerb5.conf";
+
+  private final String[] requiredArgs = new String[] {
+      "--topic", topic,
+      "--bootstrap-server", brokerList
+  };
+
+  private final String[] nonRequiredArgs = new String[] {
+      "--max-messages", maxMessages,
+      "--acks", acks,
+      "--security-protocol", securityProtocol,
+      "--ssl-truststore-location", sslTruststoreLocation,
+      "--ssl-truststore-password", sslTruststorePassword,
+      "--appender.config", appenderConfig,
+      "--sasl-kerberos-service-name", saslKerberosServiceName,
+      "--client-jaas-conf-path", clientJaasConfPath,
+      "--kerb5-conf-path", kerb5ConfPath
+  };
+
+  private final String[] args = Stream.concat(Arrays.stream(requiredArgs), Arrays.stream(nonRequiredArgs)).toArray(String[]::new);
+
+  @Before
+  public void setUp() {
+    Exit.setExitProcedure((statusCode, message) -> {
+      throw new IllegalArgumentException(message);
+    });
+  }
+
+  @After
+  public void tearDown() {
+    Exit.resetExitProcedure();
+  }
+
+  @Test
+  public void testOptionsWorkCorrectly() {
+    VerifiableLog4jAppenderOptions opts = VerifiableLog4jAppenderOptions.parse(args);
+    assertEquals(topic, opts.topic);
+    assertEquals(brokerList, opts.brokerList);
+    assertEquals(Integer.parseInt(maxMessages), (int) opts.maxMessages);
+    assertEquals(acks, opts.acks);
+    assertEquals(securityProtocol, opts.securityProtocol);
+    assertEquals(sslTruststoreLocation, opts.sslTruststoreLocation);
+    assertEquals(sslTruststorePassword, opts.sslTruststorePassword);
+    assertEquals(appenderConfig, opts.configFile);
+    assertEquals(saslKerberosServiceName, opts.saslKerberosServiceName);
+    assertEquals(clientJaasConfPath, opts.clientJaasConfPath);
+    assertEquals(kerb5ConfPath, opts.kerb5ConfPath);
+  }
+
+  @Test
+  public void testOptionsDefaults() {
+    VerifiableLog4jAppenderOptions opts = VerifiableLog4jAppenderOptions.parse(requiredArgs);
+    assertEquals(topic, opts.topic);
+    assertEquals(brokerList, opts.brokerList);
+    assertEquals(-1, (int) opts.maxMessages);
+    assertEquals("-1", opts.acks);
+    assertEquals("PLAINTEXT", opts.securityProtocol);
+    assertNull(opts.sslTruststoreLocation);
+    assertNull(opts.sslTruststorePassword);
+    assertNull(opts.configFile);
+    assertNull(opts.saslKerberosServiceName);
+    assertNull(opts.clientJaasConfPath);
+    assertNull(opts.kerb5ConfPath);
+  }
+
+  @Test
+  public void testBrokerListArg() {
+    VerifiableLog4jAppenderOptions opts = VerifiableLog4jAppenderOptions.parse(new String[] {
+        "--topic", topic,
+        "--broker-list", brokerList
+    });
+    assertEquals(brokerList, opts.brokerList);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBrokerListArgAndBootstrapServerAreMutuallyExclusive() {
+    VerifiableLog4jAppenderOptions.parse(new String[] {
+        "--topic", topic,
+        "--bootstrap-server", brokerList,
+        "--broker-list", brokerList
+    });
+  }
+}

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -54,7 +54,7 @@ You can access the brokers and zookeeper by their IP or hostname, e.g.
     bin/kafka-topics.sh --create --zookeeper 192.168.50.11:2181 --replication-factor 3 --partitions 1 --topic sandbox
 
     # Specify brokers by their hostnames: broker1, broker2, broker3
-    bin/kafka-console-producer.sh --broker-list broker1:9092,broker2:9092,broker3:9092 --topic sandbox
+    bin/kafka-console-producer.sh --bootstrap-server broker1:9092,broker2:9092,broker3:9092 --topic sandbox
 
     # Specify brokers by their IP: 192.168.50.51, 192.168.50.52, 192.168.50.53
     bin/kafka-console-consumer.sh --bootstrap-server 192.168.50.51:9092,192.168.50.52:9092,192.168.50.53:9092 --topic sandbox --from-beginning


### PR DESCRIPTION
This patch updates ReplicaVerificationTool, TransactionalMessageCopier, GetOffsetShell and VerifiableLog4jAppender to add and prefer the --bootstrap-server flag for defining the connection point of the Kafka cluster. This change is part of KIP-499: https://cwiki.apache.org/confluence/display/KAFKA/KIP-499+-+Unify+connection+name+flag+for+command+line+tool.
