### PR TITLE
KAFKA-9515: Upgrade ZooKeeper to 3.5.7

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -113,7 +113,7 @@ versions += [
   spotbugsPlugin: "3.0.0",
   spotlessPlugin: "3.27.1",
   testRetryPlugin: "1.1.0",
-  zookeeper: "3.5.6",
+  zookeeper: "3.5.7",
   zstd: "1.4.4-7"
 ]
 libs += [


### PR DESCRIPTION
A couple of critical fixes:

ZOOKEEPER-3644: Data loss after upgrading standalone ZK server 3.4.14 to 3.5.6 with snapshot.trust.empty=true
ZOOKEEPER-3701: Split brain on log disk full (3.5) 

Full release notes:
https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310801&version=12346098

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
