### PR TITLE
KAFKA-8025: Fix flaky RocksDB test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rocksdb.AbstractCompactionFilter;
@@ -55,6 +54,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
@@ -85,11 +85,6 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         }
     };
 
-    @Mock
-    private DBOptions dbOptions;
-    @Mock
-    private ColumnFamilyOptions columnFamilyOptions;
-
     @Test
     public void shouldOverwriteAllOptionsMethods() throws Exception {
         for (final Method method : Options.class.getMethods()) {
@@ -114,8 +109,9 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
 
     @Test
     public void shouldWarnThanMethodCompactionOptionsFIFOSetTtlWillBeRemoved() {
+        final DBOptions mockedDbOptions = mock(DBOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(dbOptions, new ColumnFamilyOptions());
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         optionsFacadeDbOptions.setCompactionOptionsFIFO(new CompactionOptionsFIFO());
@@ -130,8 +126,9 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
 
     @Test
     public void shouldWarnThanMethodCompactionOptionsFIFOTtlWillBeRemoved() {
+        final DBOptions mockedDbOptions = mock(DBOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(dbOptions, new ColumnFamilyOptions());
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         optionsFacadeDbOptions.compactionOptionsFIFO();
@@ -145,14 +142,15 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
     }
 
     private void verifyDBOptionsMethodCall(final Method method) throws Exception {
+        final DBOptions mockedDbOptions = mock(DBOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(dbOptions, new ColumnFamilyOptions());
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
         final Object[] parameters = getDBOptionsParameters(method.getParameterTypes());
 
         try {
-            reset(dbOptions);
-            replay(dbOptions);
+            reset(mockedDbOptions);
+            replay(mockedDbOptions);
             method.invoke(optionsFacadeDbOptions, parameters);
             verify();
             fail("Should have called DBOptions." + method.getName() + "()");
@@ -231,14 +229,15 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
     }
 
     private void verifyColumnFamilyOptionsMethodCall(final Method method) throws Exception {
+        final ColumnFamilyOptions mockedColumnFamilyOptions = mock(ColumnFamilyOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeColumnFamilyOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), columnFamilyOptions);
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(new DBOptions(), mockedColumnFamilyOptions);
 
         final Object[] parameters = getColumnFamilyOptionsParameters(method.getParameterTypes());
 
         try {
-            reset(columnFamilyOptions);
-            replay(columnFamilyOptions);
+            reset(mockedColumnFamilyOptions);
+            replay(mockedColumnFamilyOptions);
             method.invoke(optionsFacadeColumnFamilyOptions, parameters);
             verify();
             fail("Should have called ColumnFamilyOptions." + method.getName() + "()");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -107,40 +107,6 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         }
     }
 
-    @Test
-    public void shouldWarnThanMethodCompactionOptionsFIFOSetTtlWillBeRemoved() {
-        final DBOptions mockedDbOptions = mock(DBOptions.class);
-        final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
-
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        optionsFacadeDbOptions.setCompactionOptionsFIFO(new CompactionOptionsFIFO());
-        LogCaptureAppender.unregister(appender);
-
-        assertThat(appender.getMessages(), hasItem(""
-            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
-            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
-            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
-            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
-    }
-
-    @Test
-    public void shouldWarnThanMethodCompactionOptionsFIFOTtlWillBeRemoved() {
-        final DBOptions mockedDbOptions = mock(DBOptions.class);
-        final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
-            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
-
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        optionsFacadeDbOptions.compactionOptionsFIFO();
-        LogCaptureAppender.unregister(appender);
-
-        assertThat(appender.getMessages(), hasItem(""
-            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
-            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
-            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
-            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
-    }
-
     private void verifyDBOptionsMethodCall(final Method method) throws Exception {
         final DBOptions mockedDbOptions = mock(DBOptions.class);
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
@@ -318,5 +284,39 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         }
 
         return parameters;
+    }
+
+    @Test
+    public void shouldWarnThanMethodCompactionOptionsFIFOSetTtlWillBeRemoved() {
+        final DBOptions mockedDbOptions = mock(DBOptions.class);
+        final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
+
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+        optionsFacadeDbOptions.setCompactionOptionsFIFO(new CompactionOptionsFIFO());
+        LogCaptureAppender.unregister(appender);
+
+        assertThat(appender.getMessages(), hasItem(""
+            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
+            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
+            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
+            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
+    }
+
+    @Test
+    public void shouldWarnThanMethodCompactionOptionsFIFOTtlWillBeRemoved() {
+        final DBOptions mockedDbOptions = mock(DBOptions.class);
+        final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
+            = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
+
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+        optionsFacadeDbOptions.compactionOptionsFIFO();
+        LogCaptureAppender.unregister(appender);
+
+        assertThat(appender.getMessages(), hasItem(""
+            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
+            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
+            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
+            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
     }
 }


### PR DESCRIPTION
Reading the stack trace on the Jira, I think the issue might be related to the shared mock object we use.

The test testup is a little bit upside down to allow the usage of reflection. The test verifies that a method is called, by _not_ registering an expected call, and catching the corresponding exception from `verify()` (because we use reflections, we cannot easily register an expected call and let `verify()` throw if the call was not made).

Thus, the expected message from `verify()` is something like:
```
Unexpected method call DBOptions.setEnableThreadTracking(true):
```

When the test fails the stack trace says:
```
Unexpected method call DBOptions.setEnableThreadTracking(true):\n    DBOptions.close(): expected: 1, actual: 0
```

It indicates that an expected call was registered, however, the test actually never does this. Thus, I suspect that the mocked object is not isolated and as the tests are executed in parallel some race-condition applies (eg, one thread calls a method in the actual test to eventually trigger the exception in verify, while the other thread is just calling `replay()` accidentally register the call of the other thread as expected method call). 

This fix tries to address the issue, by moving the mocked objects as local variables into the test methods.

Call for review @vvcephei @bbejeck @cadonna 