### PR TITLE
MINOR: trivial cleanups, javadoc errors, omitted StateStore tests, etc.

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -291,7 +291,6 @@
         <allow pkg="com.fasterxml.jackson" />
         <allow pkg="kafka.utils" />
         <allow pkg="org.apache.zookeeper" />
-        <allow pkg="org.apache.zookeeper" />
         <allow pkg="org.apache.log4j" />
         <subpackage name="testutil">
           <allow pkg="org.apache.log4j" />

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -33,7 +33,7 @@ public interface SinkTaskContext {
      * and the configuration is using variable references such as those compatible with
      * {@link org.apache.kafka.common.config.ConfigTransformer}.
      */
-    public Map<String, String> configs();
+    Map<String, String> configs();
 
     /**
      * Reset the consumer offsets for the given topic partitions. SinkTasks should use this if they manage offsets

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTaskContext.java
@@ -32,7 +32,7 @@ public interface SourceTaskContext {
      * and the configuration is using variable references such as those compatible with
      * {@link org.apache.kafka.common.config.ConfigTransformer}.
      */
-    public Map<String, String> configs();
+    Map<String, String> configs();
 
     /**
      * Get the OffsetStorageReader for this SourceTask.

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2447,7 +2447,7 @@ class Log(@volatile private var _dir: File,
 
       // replace old segment with new ones
       info(s"Replacing overflowed segment $segment with split segments $newSegments")
-      replaceSegments(newSegments.toList, List(segment), isRecoveredSwapFile = false)
+      replaceSegments(newSegments.toList, List(segment))
       newSegments.toList
     } catch {
       case e: Exception =>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
@@ -65,14 +65,6 @@ public class WindowedSerdes {
     }
 
     /**
-     * Construct a {@code TimeWindowedSerde} object to deserialize changelog topic
-     * for the specified inner class type and window size.
-     */
-    static public <T> Serde<Windowed<T>> timeWindowedSerdeFrom(final Class<T> type, final long windowSize) {
-        return new TimeWindowedSerde<>(Serdes.serdeFrom(type), windowSize);
-    }
-
-    /**
      * Construct a {@code SessionWindowedSerde} object for the specified inner class type.
      */
     static public <T> Serde<Windowed<T>> sessionWindowedSerdeFrom(final Class<T> type) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/WindowedSerdes.java
@@ -65,6 +65,14 @@ public class WindowedSerdes {
     }
 
     /**
+     * Construct a {@code TimeWindowedSerde} object to deserialize changelog topic
+     * for the specified inner class type and window size.
+     */
+    static public <T> Serde<Windowed<T>> timeWindowedSerdeFrom(final Class<T> type, final long windowSize) {
+        return new TimeWindowedSerde<>(Serdes.serdeFrom(type), windowSize);
+    }
+
+    /**
      * Construct a {@code SessionWindowedSerde} object for the specified inner class type.
      */
     static public <T> Serde<Windowed<T>> sessionWindowedSerdeFrom(final Class<T> type) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -101,7 +101,6 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         final byte[][] headerKeysBytes;
         final byte[][] headerValuesBytes;
 
-
         int size = 0;
         size += Long.BYTES; // value.context.timestamp
         size += Long.BYTES; // value.context.offset

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -150,6 +150,7 @@ public final class Stores {
      * @param maxCacheSize  maximum number of items in the LRU (cannot be negative)
      * @return an instance of a {@link KeyValueBytesStoreSupplier} that can be used to build
      * an LRU Map based store
+     * @throws IllegalArgumentException if {@code maxCacheSize} is negative
      */
     public static KeyValueBytesStoreSupplier lruMap(final String name, final int maxCacheSize) {
         Objects.requireNonNull(name, "name cannot be null");
@@ -231,6 +232,7 @@ public final class Stores {
      *                              caching and means that null values will be ignored.
      * @return an instance of {@link WindowBytesStoreSupplier}
      * @throws IllegalArgumentException if {@code retentionPeriod} or {@code windowSize} can't be represented as {@code long milliseconds}
+     * @throws IllegalArgumentException if {@code retentionPeriod} is smaller than {@code windowSize}
      */
     public static WindowBytesStoreSupplier persistentWindowStore(final String name,
                                                                  final Duration retentionPeriod,
@@ -257,6 +259,7 @@ public final class Stores {
      *                              caching and means that null values will be ignored.
      * @return an instance of {@link WindowBytesStoreSupplier}
      * @throws IllegalArgumentException if {@code retentionPeriod} or {@code windowSize} can't be represented as {@code long milliseconds}
+     * @throws IllegalArgumentException if {@code retentionPeriod} is smaller than {@code windowSize}
      */
     public static WindowBytesStoreSupplier persistentTimestampedWindowStore(final String name,
                                                                             final Duration retentionPeriod,
@@ -328,6 +331,7 @@ public final class Stores {
      *                              caching and means that null values will be ignored.
      * @return an instance of {@link WindowBytesStoreSupplier}
      * @throws IllegalArgumentException if {@code retentionPeriod} or {@code windowSize} can't be represented as {@code long milliseconds}
+     * @throws IllegalArgumentException if {@code retentionPeriod} is smaller than {@code windowSize}
      */
     public static WindowBytesStoreSupplier inMemoryWindowStore(final String name,
                                                                final Duration retentionPeriod,
@@ -481,7 +485,7 @@ public final class Stores {
      * <p>
      * The provided supplier should <strong>not</strong> be a supplier for
      * {@link WindowStore WindowStores}. For this case, passed in timestamps will be dropped and not stored in the
-     * windows-store. On read, no valid timestamp but a dummy timestamp will be returned.
+     * window-store. On read, no valid timestamp but a dummy timestamp will be returned.
      *
      * @param supplier      a {@link WindowBytesStoreSupplier} (cannot be {@code null})
      * @param keySerde      the key serde to use

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
@@ -34,6 +34,7 @@ public class KeyValueStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, KeyVa
                                 final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde, time);
         Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilder.java
@@ -33,8 +33,8 @@ public class KeyValueStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, KeyVa
                                 final Serde<V> valueSerde,
                                 final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde, time);
-        Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
-        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
+        Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStore.java
@@ -28,10 +28,11 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStore;
 
 /**
- * A Metered {@link MeteredTimestampedWindowStore} wrapper that is used for recording operation metrics, and hence its
+ * A Metered {@link TimestampedWindowStore} wrapper that is used for recording operation metrics, and hence its
  * inner WindowStore implementation do not need to provide its own metrics collecting functionality.
  * The inner {@link WindowStore} of this class is of type &lt;Bytes,byte[]&gt;, hence we use {@link Serde}s
  * to convert from &lt;K,ValueAndTimestamp&lt;V&gt&gt; to &lt;Bytes,byte[]&gt;
+ *
  * @param <K>
  * @param <V>
  */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilder.java
@@ -33,8 +33,8 @@ public class SessionStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, Sessio
                                final Serde<K> keySerde,
                                final Serde<V> valueSerde,
                                final Time time) {
-        super(Objects.requireNonNull(storeSupplier, "supplier cannot be null").name(), keySerde, valueSerde, time);
-        Objects.requireNonNull(storeSupplier.metricsScope(), "supplier's metricsScope can't be null");
+        super(Objects.requireNonNull(storeSupplier, "storeSupplier cannot be null").name(), keySerde, valueSerde, time);
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilder.java
@@ -34,6 +34,7 @@ public class SessionStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, Sessio
                                final Serde<V> valueSerde,
                                final Time time) {
         super(Objects.requireNonNull(storeSupplier, "supplier cannot be null").name(), keySerde, valueSerde, time);
+        Objects.requireNonNull(storeSupplier.metricsScope(), "supplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
@@ -46,8 +46,8 @@ public class TimestampedKeyValueStoreBuilder<K, V>
             keySerde,
             valueSerde == null ? null : new ValueAndTimestampSerde<>(valueSerde),
             time);
-        Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
-        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
+        Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilder.java
@@ -47,6 +47,7 @@ public class TimestampedKeyValueStoreBuilder<K, V>
             valueSerde == null ? null : new ValueAndTimestampSerde<>(valueSerde),
             time);
         Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
@@ -46,8 +46,8 @@ public class TimestampedWindowStoreBuilder<K, V>
                                          final Serde<V> valueSerde,
                                          final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde == null ? null : new ValueAndTimestampSerde<>(valueSerde), time);
-        Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
-        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
+        Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilder.java
@@ -47,6 +47,7 @@ public class TimestampedWindowStoreBuilder<K, V>
                                          final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde == null ? null : new ValueAndTimestampSerde<>(valueSerde), time);
         Objects.requireNonNull(storeSupplier, "bytesStoreSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "bytesStoreSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
@@ -36,6 +36,7 @@ public class WindowStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, WindowS
                               final Serde<V> valueSerde,
                               final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde, time);
+        Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
         Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
@@ -24,6 +24,8 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 public class WindowStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, WindowStore<K, V>> {
     private final Logger log = LoggerFactory.getLogger(WindowStoreBuilder.class);
 
@@ -34,6 +36,7 @@ public class WindowStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, WindowS
                               final Serde<V> valueSerde,
                               final Time time) {
         super(storeSupplier.name(), keySerde, valueSerde, time);
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
         this.storeSupplier = storeSupplier;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractJoinIntegrationTest {
             }
 
             final TestRecord<Long, String> updatedExpectedFinalResult =
-                new TestRecord<Long, String>(
+                new TestRecord<>(
                     expectedFinalResult.key(),
                     expectedFinalResult.value(),
                     null,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -441,7 +441,6 @@ public class SuppressionIntegrationTest {
         final String input = "input" + testId;
         final String outputSuppressed = "output-suppressed" + testId;
         final String outputRaw = "output-raw" + testId;
-        final String changeLog = "suppressionintegrationtest-shouldAllowDisablingChangelog-KTABLE-SUPPRESS-STATE-STORE-0000000004-changelog";
 
         cleanStateBeforeTest(CLUSTER, input, outputRaw, outputSuppressed);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
@@ -816,7 +816,7 @@ public class SuppressScenarioTest {
         for (final TestRecord<K, V> result : results) {
             final KeyValueTimestamp<K, V> expected = expectedIterator.next();
             try {
-                assertThat(result, equalTo(new TestRecord<K, V>(expected.key(), expected.value(), null, expected.timestamp())));
+                assertThat(result, equalTo(new TestRecord<>(expected.key(), expected.value(), null, expected.timestamp())));
             } catch (final AssertionError e) {
                 throw new AssertionError(printRecords(results) + " != " + expectedResults, e);
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TimestampedKeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TimestampedKeyValueStoreMaterializerTest.java
@@ -111,6 +111,7 @@ public class TimestampedKeyValueStoreMaterializerTest {
         final InMemoryKeyValueStore store = new InMemoryKeyValueStore("name");
         EasyMock.expect(supplier.name()).andReturn("name").anyTimes();
         EasyMock.expect(supplier.get()).andReturn(store);
+        EasyMock.expect(supplier.metricsScope()).andReturn("metricScope");
         EasyMock.replay(supplier);
 
         final MaterializedInternal<String, Integer, KeyValueStore<Bytes, byte[]>> materialized =

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
@@ -88,6 +89,14 @@ public class GlobalStateStoreProviderTest {
                     Duration.ofMillis(10L),
                     Duration.ofMillis(2L),
                     false),
+                Serdes.String(),
+                Serdes.String()).build());
+        stores.put(
+            "s-store",
+            Stores.sessionStoreBuilder(
+                Stores.inMemorySessionStore(
+                    "s-store",
+                    Duration.ofMillis(10L)),
                 Serdes.String(),
                 Serdes.String()).build());
 
@@ -176,6 +185,26 @@ public class GlobalStateStoreProviderTest {
     }
 
     @Test
+    public void shouldReturnWindowStore() {
+        final GlobalStateStoreProvider provider = new GlobalStateStoreProvider(stores);
+        final List<ReadOnlyWindowStore<String, String>> stores =
+                provider.stores("w-store", QueryableStoreTypes.windowStore());
+        assertEquals(1, stores.size());
+        for (final ReadOnlyWindowStore<String, String> store : stores) {
+            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
+            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
+        }
+    }
+
+    @Test
+    public void shouldNotReturnWindowStoreAsTimestampedStore() {
+        final GlobalStateStoreProvider provider = new GlobalStateStoreProvider(stores);
+        final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> stores =
+                provider.stores("w-store", QueryableStoreTypes.timestampedWindowStore());
+        assertEquals(0, stores.size());
+    }
+
+    @Test
     public void shouldReturnTimestampedWindowStoreAsWindowStore() {
         final GlobalStateStoreProvider provider = new GlobalStateStoreProvider(stores);
         final List<ReadOnlyWindowStore<String, ValueAndTimestamp<String>>> stores =
@@ -184,6 +213,17 @@ public class GlobalStateStoreProviderTest {
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store : stores) {
             assertThat(store, instanceOf(ReadOnlyWindowStore.class));
             assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
+        }
+    }
+
+    @Test
+    public void shouldReturnSessionStore() {
+        final GlobalStateStoreProvider provider = new GlobalStateStoreProvider(stores);
+        final List<ReadOnlySessionStore<String, String>> stores =
+                provider.stores("s-store", QueryableStoreTypes.sessionStore());
+        assertEquals(1, stores.size());
+        for (final ReadOnlySessionStore<String, String> store : stores) {
+            assertThat(store, instanceOf(ReadOnlySessionStore.class));
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -34,10 +34,12 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class KeyValueStoreBuilderTest {
@@ -138,13 +140,16 @@ public class KeyValueStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        final Exception e = assertThrows(NullPointerException.class,
-            () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        /*
-         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
-         * KeyValueStoreBuilder omits the MetricsScope nullity check in its constructor.
-         */
-        assertThat(e.getMessage(), equalTo("name cannot be null"));
+        reset(supplier);
+        expect(supplier.get()).andReturn(new RocksDBStore("name", null));
+        expect(supplier.name()).andReturn("name");
+        replay(supplier);
+
+        try {
+            new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        } catch (final Exception e) {
+            fail();
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -149,7 +149,7 @@ public class KeyValueStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
+        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -38,8 +38,9 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class KeyValueStoreBuilderTest {
@@ -54,6 +55,7 @@ public class KeyValueStoreBuilderTest {
     public void setUp() {
         EasyMock.expect(supplier.get()).andReturn(inner);
         EasyMock.expect(supplier.name()).andReturn("name");
+        expect(supplier.metricsScope()).andReturn("metricScope");
         EasyMock.replay(supplier);
         builder = new KeyValueStoreBuilder<>(
             supplier,
@@ -145,11 +147,9 @@ public class KeyValueStoreBuilderTest {
         expect(supplier.name()).andReturn("name");
         replay(supplier);
 
-        try {
-            new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
-        } catch (final Exception e) {
-            fail();
-        }
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -35,7 +35,9 @@ import org.junit.runner.RunWith;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class KeyValueStoreBuilderTest {
@@ -134,9 +136,15 @@ public class KeyValueStoreBuilderTest {
         new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        /*
+         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
+         * KeyValueStoreBuilder omits the MetricsScope nullity check in its constructor.
+         */
+        assertThat(e.getMessage(), equalTo("name cannot be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -120,7 +120,7 @@ public class SessionStoreBuilderTest {
     @Test
     public void shouldThrowNullPointerIfInnerIsNull() {
         final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("supplier cannot be null"));
+        assertThat(e.getMessage(), equalTo("storeSupplier cannot be null"));
     }
 
     @Test
@@ -160,7 +160,7 @@ public class SessionStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("supplier's metricsScope can't be null"));
+        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -40,7 +40,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class SessionStoreBuilderTest {
@@ -56,6 +55,7 @@ public class SessionStoreBuilderTest {
 
         expect(supplier.get()).andReturn(inner);
         expect(supplier.name()).andReturn("name");
+        expect(supplier.metricsScope()).andReturn("metricScope");
         replay(supplier);
 
         builder = new SessionStoreBuilder<>(
@@ -159,11 +159,9 @@ public class SessionStoreBuilderTest {
         expect(supplier.name()).andReturn("name");
         replay(supplier);
 
-        try {
-            new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
-        } catch (final Exception e) {
-            fail();
-        }
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        assertThat(e.getMessage(), equalTo("supplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -51,8 +51,7 @@ public class SessionStoreBuilderTest {
     private SessionStoreBuilder<String, String> builder;
 
     @Before
-    public void setUp() throws Exception {
-
+    public void setUp() {
         expect(supplier.get()).andReturn(inner);
         expect(supplier.name()).andReturn("name");
         expect(supplier.metricsScope()).andReturn("metricScope");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class SessionStoreBuilderTest {
@@ -146,13 +147,23 @@ public class SessionStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        final Exception e = assertThrows(NullPointerException.class,
-            () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        /*
-         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
-         * SessionStoreBuilder omits the MetricsScope nullity check in its constructor.
-         */
-        assertThat(e.getMessage(), equalTo("name cannot be null"));
+        reset(supplier);
+        expect(supplier.get()).andReturn(new RocksDBSessionStore(
+            new RocksDBSegmentedBytesStore(
+                "name",
+                null,
+                10L,
+                5L,
+                new SessionKeySchema())
+        ));
+        expect(supplier.name()).andReturn("name");
+        replay(supplier);
+
+        try {
+            new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        } catch (final Exception e) {
+            fail();
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -146,7 +146,12 @@ public class SessionStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        /*
+         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
+         * SessionStoreBuilder omits the MetricsScope nullity check in its constructor.
+         */
         assertThat(e.getMessage(), equalTo("name cannot be null"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
@@ -177,7 +177,7 @@ public class TimestampedKeyValueStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
+        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
@@ -36,9 +36,8 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class TimestampedKeyValueStoreBuilderTest {
@@ -169,13 +168,16 @@ public class TimestampedKeyValueStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        final Exception e = assertThrows(NullPointerException.class,
-            () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        /*
-         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
-         * TimestampedKeyValueStoreBuilder omits the MetricsScope nullity check in its constructor.
-         */
-        assertThat(e.getMessage(), equalTo("name cannot be null"));
+        reset(supplier);
+        expect(supplier.get()).andReturn(new RocksDBTimestampedStore("name", null));
+        expect(supplier.name()).andReturn("name");
+        replay(supplier);
+
+        try {
+            new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        } catch (final Exception e) {
+            fail();
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
@@ -36,6 +36,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThrows;
 
@@ -168,7 +169,13 @@ public class TimestampedKeyValueStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        assertThrows(NullPointerException.class, () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        /*
+         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
+         * TimestampedKeyValueStoreBuilder omits the MetricsScope nullity check in its constructor.
+         */
+        assertThat(e.getMessage(), equalTo("name cannot be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
@@ -36,8 +36,9 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class TimestampedKeyValueStoreBuilderTest {
@@ -52,6 +53,7 @@ public class TimestampedKeyValueStoreBuilderTest {
     public void setUp() {
         expect(supplier.get()).andReturn(inner);
         expect(supplier.name()).andReturn("name");
+        expect(supplier.metricsScope()).andReturn("metricScope");
         expect(inner.persistent()).andReturn(true).anyTimes();
         replay(supplier, inner);
 
@@ -173,11 +175,9 @@ public class TimestampedKeyValueStoreBuilderTest {
         expect(supplier.name()).andReturn("name");
         replay(supplier);
 
-        try {
-            new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
-        } catch (final Exception e) {
-            fail();
-        }
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -39,9 +39,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class TimestampedWindowStoreBuilderTest {
@@ -56,6 +57,7 @@ public class TimestampedWindowStoreBuilderTest {
     public void setUp() {
         expect(supplier.get()).andReturn(inner);
         expect(supplier.name()).andReturn("name");
+        expect(supplier.metricsScope()).andReturn("metricScope");
         expect(inner.persistent()).andReturn(true).anyTimes();
         replay(supplier, inner);
 
@@ -214,12 +216,9 @@ public class TimestampedWindowStoreBuilderTest {
             1L));
         expect(supplier.name()).andReturn("name");
         replay(supplier);
-
-        try {
-            new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
-        } catch (final Exception e) {
-            fail();
-        }
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -39,6 +39,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -200,9 +201,15 @@ public class TimestampedWindowStoreBuilderTest {
         assertThrows(NullPointerException.class, () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        /*
+        * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
+        * TimestampedWindowStoreBuilder omits the MetricsScope nullity check in its constructor.
+        */
+        assertThat(e.getMessage(), equalTo("name cannot be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -200,4 +200,9 @@ public class TimestampedWindowStoreBuilderTest {
         assertThrows(NullPointerException.class, () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerIfMetricsScopeIsNull() {
+        new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -39,10 +39,9 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class TimestampedWindowStoreBuilderTest {
@@ -203,13 +202,24 @@ public class TimestampedWindowStoreBuilderTest {
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        final Exception e = assertThrows(NullPointerException.class,
-            () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        /*
-        * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
-        * TimestampedWindowStoreBuilder omits the MetricsScope nullity check in its constructor.
-        */
-        assertThat(e.getMessage(), equalTo("name cannot be null"));
+        reset(supplier);
+        expect(supplier.get()).andReturn(new RocksDBTimestampedWindowStore(
+            new RocksDBTimestampedSegmentedBytesStore(
+                "name",
+                null,
+                10L,
+                5L,
+                new WindowKeySchema()),
+            false,
+            1L));
+        expect(supplier.name()).andReturn("name");
+        replay(supplier);
+
+        try {
+            new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        } catch (final Exception e) {
+            fail();
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -218,7 +218,7 @@ public class TimestampedWindowStoreBuilderTest {
         replay(supplier);
         final Exception e = assertThrows(NullPointerException.class,
             () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("bytesStoreSupplier's metricsScope can't be null"));
+        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
@@ -39,8 +39,10 @@ import java.util.Collections;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class WindowStoreBuilderTest {
@@ -154,9 +156,14 @@ public class WindowStoreBuilderTest {
         new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        /*
+         * TODO: The exception is thrown from the constructor of AbstractStoreBuilder, since
+         * WindowStoreBuilder omits the MetricsScope nullity check in its constructor.
+         */
+        assertThat(e.getMessage(), equalTo("name cannot be null"));
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
@@ -154,4 +154,9 @@ public class WindowStoreBuilderTest {
         new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerIfMetricsScopeIsNull() {
+        new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
@@ -40,9 +40,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class WindowStoreBuilderTest {
@@ -57,6 +58,7 @@ public class WindowStoreBuilderTest {
     public void setUp() {
         expect(supplier.get()).andReturn(inner);
         expect(supplier.name()).andReturn("name");
+        expect(supplier.metricsScope()).andReturn("metricScope");
         replay(supplier);
 
         builder = new WindowStoreBuilder<>(
@@ -171,10 +173,8 @@ public class WindowStoreBuilderTest {
         expect(supplier.name()).andReturn("name");
         replay(supplier);
 
-        try {
-            new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime());
-        } catch (final Exception e) {
-            fail();
-        }
+        final Exception e = assertThrows(NullPointerException.class,
+            () -> new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -671,7 +671,7 @@ public final class TaskManager {
     /**
      * Initiate shutdown, but do not wait for it to complete.
      */
-    public void beginShutdown(boolean stopAgents) throws ExecutionException, InterruptedException {
+    public void beginShutdown(boolean stopAgents) {
         if (shutdown.compareAndSet(false, true)) {
             executor.submit(new Shutdown(stopAgents));
         }
@@ -680,7 +680,7 @@ public final class TaskManager {
     /**
      * Wait for shutdown to complete.  May be called prior to beginShutdown.
      */
-    public void waitForShutdown() throws ExecutionException, InterruptedException {
+    public void waitForShutdown() throws InterruptedException {
         while (!executor.awaitTermination(1, TimeUnit.DAYS)) { }
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -79,7 +79,7 @@ public class ProduceBenchWorker implements TaskWorker {
 
     @Override
     public void start(Platform platform, WorkerStatusTracker status,
-                      KafkaFutureImpl<String> doneFuture) throws Exception {
+                      KafkaFutureImpl<String> doneFuture) {
         if (!running.compareAndSet(false, true)) {
             throw new IllegalStateException("ProducerBenchWorker is already running.");
         }


### PR DESCRIPTION
- Add omitted `[WindowStoreBuilderTest, TimestampedWindowStoreBuilderTest]#shouldThrowNullPointerIfMetricsScopeIsNull`: Other `StateStore`s has it.
- Improve `Stores` Javadoc
- Remove unused method + duplicated parameters
- Remove duplicated spaces
- Remove unthrown `Exception`s + align javadoc parameters
- Remove unnecessary `public` from `[Sink,Source]TaskContext`
- Add omitted `WindowStore`, `SessionStore` test cases: `GlobalStateStoreProviderTest`, `StreamThreadStateStoreProviderTest` (Compare it with `KeyValueStore` counterpart cases.)
- Fix `MeteredTimestampedWindowStore` javadoc

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
