### PR TITLE
MINOR: Allow test driver to forward headers to Deserializer

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -714,7 +714,7 @@ public class TopologyTestDriver implements Closeable {
             return null;
         }
         final K key = keyDeserializer.deserialize(record.topic(), record.key());
-        final V value = valueDeserializer.deserialize(record.topic(), record.value());
+        final V value = valueDeserializer.deserialize(record.topic(), record.headers(), record.value());
         return new ProducerRecord<>(record.topic(), record.partition(), record.timestamp(), key, value, record.headers());
     }
 
@@ -803,7 +803,7 @@ public class TopologyTestDriver implements Closeable {
             throw new NoSuchElementException("Empty topic: " + topic);
         }
         final K key = keyDeserializer.deserialize(record.topic(), record.key());
-        final V value = valueDeserializer.deserialize(record.topic(), record.value());
+        final V value = valueDeserializer.deserialize(record.topic(), record.headers(), record.value());
         return new TestRecord<>(key, value, record.headers(), record.timestamp());
     }
 


### PR DESCRIPTION
When using Kafka Streams test utils to read records from an output topic with a custom deserializer that uses headers, we should forward record headers to this serializer by calling the overloaded method that support this.