### PR TITLE
KAFKA-9567: Docs, system tests for ZooKeeper 3.5.7

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -1890,14 +1890,6 @@
         It is only when  using mTLS authentication alone that all the DNs must match (and SANs become critical --
         again, in the absence of writing and deploying a custom ZooKeeper authentication provider as described below).
         </p>
-    Note that ZooKeeper version 3.5.6 <strong>requires</strong> clients that connect via TLS to present their own certificate
-    (i.e. encryption and mTLS authentication are linked rather than independent of each other in this ZooKeeper version).
-    There is a ZooKeeper sever-side config <tt>ssl.clientAuth</tt> that is recognized
-    (case-insensitively: <tt>want</tt>/<tt>need</tt>/<tt>none</tt> are the valid options),
-    but this config <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-3674">is not acted upon in version 3.5.6</a>.
-    A future version of ZooKeeper will both recognize and act upon this config and allow clients to connect via a TLS-encrypted connection
-    without presenting their own certificate -- i.e. encryption and authentication will become independent of each other.
-    But for now this is not the case.
     </p>
     <p>
         Use the broker properties file to set TLS configs for brokers as described below.
@@ -1935,7 +1927,7 @@
     </p>
     Here is a sample (partial) ZooKeeper configuration for enabling TLS authentication.
     These configurations are described in the
-    <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#sc_authOptions">ZooKeeper Admin Guide</a>.
+    <a href="https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_authOptions">ZooKeeper Admin Guide</a>.
     <pre>
         secureClientPort=2182
         serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
@@ -1949,8 +1941,9 @@
     to a value different from the keystore password itself.
     Be sure to set the key password to be the same as the keystore password.
 
-    Here is a sample (partial) Kafka Broker configuration for connecting to ZooKeeper with mTLS authentication.
-    These configuration are described above in <a href="#brokerconfigs">Broker Configs</a>.
+    <p>Here is a sample (partial) Kafka Broker configuration for connecting to ZooKeeper with mTLS authentication.
+    These configurations are described above in <a href="#brokerconfigs">Broker Configs</a>.
+    </p>
     <pre>
         # connect to the ZooKeeper port configured for TLS
         zookeeper.connect=zk1:2182,zk2:2182,zk3:2182
@@ -2009,12 +2002,34 @@
     <h4><a id="zk_authz_ensemble" href="#zk_authz_ensemble">7.6.3 Migrating the ZooKeeper ensemble</a></h4>
     It is also necessary to enable SASL and/or mTLS authentication on the ZooKeeper ensemble. To do it, we need to perform a rolling restart of the server and set a few properties. See above for mTLS information.  Please refer to the ZooKeeper documentation for more detail:
     <ol>
-        <li><a href="http://zookeeper.apache.org/doc/r3.5.6/zookeeperProgrammers.html#sc_ZooKeeperAccessControl">Apache ZooKeeper documentation</a></li>
+        <li><a href="https://zookeeper.apache.org/doc/r3.5.7/zookeeperProgrammers.html#sc_ZooKeeperAccessControl">Apache ZooKeeper documentation</a></li>
         <li><a href="https://cwiki.apache.org/confluence/display/ZOOKEEPER/Zookeeper+and+SASL">Apache ZooKeeper wiki</a></li>
     </ol>
-    <h4><a id="zk_authz_quorum" href="#zk_authz_quorum">7.6.4 ZooKeeper Quorum Mutial TLS Authentication</a></h4>
+    <h4><a id="zk_authz_quorum" href="#zk_authz_quorum">7.6.4 ZooKeeper Quorum Mutual TLS Authentication</a></h4>
     It is possible to enable mTLS authentication between the ZooKeeper servers themselves.
-    Please refer to the <a href="https://zookeeper.apache.org/doc/r3.5.6/zookeeperAdmin.html#Quorum+TLS">ZooKeeper documentation</a> for more detail.
+    Please refer to the <a href="https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#Quorum+TLS">ZooKeeper documentation</a> for more detail.
+
+    <h3><a id="zk_encryption" href="#zk_encryption">7.7 ZooKeeper Encryption</a></h3>
+    ZooKeeper connections that use mutual TLS are encrypted.
+    Beginning with ZooKeeper version 3.5.7 (the version shipped with Kafka version 2.5) ZooKeeper supports a sever-side config
+    <tt>ssl.clientAuth</tt> (case-insensitively: <tt>want</tt>/<tt>need</tt>/<tt>none</tt> are the valid options, the default is <tt>need</tt>),
+    and setting this value to <tt>none</tt> in ZooKeeper allows clients to connect via a TLS-encrypted connection
+    without presenting their own certificate.  Here is a sample (partial) Kafka Broker configuration for connecting to ZooKeeper with just TLS encryption.
+    These configurations are described above in <a href="#brokerconfigs">Broker Configs</a>.
+    <pre>
+        # connect to the ZooKeeper port configured for TLS
+        zookeeper.connect=zk1:2182,zk2:2182,zk3:2182
+        # required to use TLS to ZooKeeper (default is false)
+        zookeeper.ssl.client.enable=true
+        # required to use TLS to ZooKeeper
+        zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+        # define trust stores to use TLS to ZooKeeper; ignored unless zookeeper.ssl.client.enable=true
+        # no need to set keystore information assuming ssl.clientAuth=none on ZooKeeper
+        zookeeper.ssl.truststore.location=/path/to/kafka/truststore.jks
+        zookeeper.ssl.truststore.password=kafka-ts-passwd
+        # tell broker to create ACLs on znodes (if using SASL authentication, otherwise do not set this)
+        zookeeper.set.acl=true
+    </pre>
 </script>
 
 <div class="p-security"></div>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -135,6 +135,7 @@
                     <li><a href="#zk_authz_ensemble">Migrating the ZooKeeper Ensemble</a></li>
                     <li><a href="#zk_authz_quorum">ZooKeeper Quorum Mutual TLS Authentication</a></li>
                 </ul>
+                <li><a href="#zk_encryption">7.7 ZooKeeper Encryption</a></li>
             </ul>
         </li>
         <li><a href="#connect">8. Kafka Connect</a>

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -64,6 +64,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     DATA_LOG_DIR_1 = "%s-1" % (DATA_LOG_DIR_PREFIX)
     DATA_LOG_DIR_2 = "%s-2" % (DATA_LOG_DIR_PREFIX)
     CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "kafka.properties")
+    COMMAND_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "command_config.properties")
     # Kafka Authorizer
     ACL_AUTHORIZER = "kafka.security.authorizer.AclAuthorizer"
     # Old Kafka Authorizer. This is deprecated but still supported.
@@ -375,6 +376,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if len(self.pids(node)) == 0:
             raise Exception("No process ids recorded on node %s" % node.account.hostname)
 
+        command_config = "" if self.security_protocol is SecurityConfig.PLAINTEXT else str(self.security_config.client_config())
+        self.logger.debug("%s = %s" % (KafkaService.COMMAND_CONFIG_FILE, command_config))
+        node.account.create_file(KafkaService.COMMAND_CONFIG_FILE, command_config)
+
     def pids(self, node):
         """Return process ids associated with running processes on the given node."""
         try:
@@ -434,9 +439,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                          topic_cfg["topic"], topic_cfg)
         kafka_topic_script = self.path.script("kafka-topics.sh", node)
 
-        cmd = kafka_topic_script + " "
-        cmd += "--bootstrap-server %(bootstrap_server)s --create --topic %(topic)s " % {
+        if self.security_protocol is SecurityConfig.PLAINTEXT:
+            command_config = ""
+        else:
+            command_config = "--command-config " + KafkaService.COMMAND_CONFIG_FILE
+
+        cmd = "export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+        cmd += (kafka_topic_script + " ")
+        cmd += "--bootstrap-server %(bootstrap_server)s %(command_config)s --create --topic %(topic)s " % {
                 'bootstrap_server': self.bootstrap_servers(self.security_protocol),
+                'command_config': command_config,
                 'topic': topic_cfg.get("topic"),
            }
         if 'replica-assignment' in topic_cfg:
@@ -471,9 +483,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Deleting topic %s" % topic)
         kafka_topic_script = self.path.script("kafka-topics.sh", node)
 
-        cmd = kafka_topic_script + " "
-        cmd += "--bootstrap-server %(bootstrap_servers)s --delete --topic %(topic)s " % {
+        if self.security_protocol is SecurityConfig.PLAINTEXT:
+            command_config = ""
+        else:
+            command_config = "--command-config " + KafkaService.COMMAND_CONFIG_FILE
+
+        cmd = "export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+        cmd += (kafka_topic_script + " ")
+        cmd += "--bootstrap-server %(bootstrap_servers)s %(command_config)s --delete --topic %(topic)s " % {
             'bootstrap_servers': self.bootstrap_servers(self.security_protocol),
+            'command_config': command_config,
             'topic': topic
         }
         self.logger.info("Running topic delete command...\n%s" % cmd)
@@ -482,8 +501,15 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def describe_topic(self, topic, node=None):
         if node is None:
             node = self.nodes[0]
-        cmd = "%s --bootstrap-server %s --topic %s --describe" % \
-              (self.path.script("kafka-topics.sh", node), self.bootstrap_servers(self.security_protocol), topic)
+
+        if self.security_protocol is SecurityConfig.PLAINTEXT:
+            command_config = ""
+        else:
+            command_config = "--command-config " + KafkaService.COMMAND_CONFIG_FILE
+
+        cmd = "export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+        cmd += "%s --bootstrap-server %s %s --topic %s --describe" % \
+              (self.path.script("kafka-topics.sh", node), self.bootstrap_servers(self.security_protocol), command_config, topic)
         output = ""
         for line in node.account.ssh_capture(cmd):
             output += line
@@ -492,8 +518,15 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def list_topics(self, topic=None, node=None):
         if node is None:
             node = self.nodes[0]
-        cmd = "%s --bootstrap-server %s --list" % \
-              (self.path.script("kafka-topics.sh", node), self.bootstrap_servers(self.security_protocol))
+
+        if self.security_protocol is SecurityConfig.PLAINTEXT:
+            command_config = ""
+        else:
+            command_config = "--command-config " + KafkaService.COMMAND_CONFIG_FILE
+
+        cmd = "export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+        cmd += "%s --bootstrap-server %s %s --list" % \
+              (self.path.script("kafka-topics.sh", node), self.bootstrap_servers(self.security_protocol), command_config)
         for line in node.account.ssh_capture(cmd):
             if not line.startswith("SLF4J"):
                 yield line.rstrip()

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -96,7 +96,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def __init__(self, context, num_nodes, zk, security_protocol=SecurityConfig.PLAINTEXT, interbroker_security_protocol=SecurityConfig.PLAINTEXT,
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
-                 authorizer_class_name=None, topics=None, project="kafka", dist_version=None, version=DEV_BRANCH, jmx_object_names=None,
+                 authorizer_class_name=None, topics=None, version=DEV_BRANCH, jmx_object_names=None,
                  jmx_attributes=None, zk_connect_timeout=5000, zk_session_timeout=6000, server_prop_overides=None, zk_chroot=None,
                  zk_client_secure=False,
                  listener_security_config=ListenerSecurityConfig(), per_node_server_prop_overrides=None, extra_kafka_opts=""):
@@ -126,8 +126,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                           root=KafkaService.PERSISTENT_ROOT)
 
         self.zk = zk
-        self.project = project
-        self.dist_version = dist_version
 
         self.security_protocol = security_protocol
         self.client_sasl_mechanism = client_sasl_mechanism

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -58,8 +58,10 @@ ssl.endpoint.identification.algorithm=HTTPS
 # Note that zookeeper.ssl.client.enable will be set to true or false elsewhere, as appropriate.
 # If it is false then these ZK keystore/truststore settings will have no effect.  If it is true then
 # zookeeper.clientCnxnSocket will also be set elsewhere (to org.apache.zookeeper.ClientCnxnSocketNetty)
+{% if not zk.zk_tls_encrypt_only %}
 zookeeper.ssl.keystore.location=/mnt/security/test.keystore.jks
 zookeeper.ssl.keystore.password=test-ks-passwd
+{% endif %}
 zookeeper.ssl.truststore.location=/mnt/security/test.truststore.jks
 zookeeper.ssl.truststore.password=test-ts-passwd
 #

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -76,6 +76,14 @@ class SslStores(object):
         self.runcmd("keytool -importcert -keystore %s -storepass %s -storetype JKS -keypass %s -alias kafka -file %s -noprompt" % (ks_path, self.keystore_passwd, self.key_passwd, crt_path))
         node.account.copy_to(ks_path, SecurityConfig.KEYSTORE_PATH)
 
+        # generate ZooKeeper client TLS config file for encryption-only (no client cert) use case
+        str = """zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+zookeeper.ssl.client.enable=true
+zookeeper.ssl.truststore.location=%s
+zookeeper.ssl.truststore.password=%s
+""" % (SecurityConfig.TRUSTSTORE_PATH, self.truststore_passwd)
+        node.account.create_file(SecurityConfig.ZK_CLIENT_TLS_ENCRYPT_ONLY_CONFIG_PATH, str)
+
         # also generate ZooKeeper client TLS config file for mutual authentication use case
         str = """zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 zookeeper.ssl.client.enable=true
@@ -120,6 +128,7 @@ class SecurityConfig(TemplateRenderer):
     CONFIG_DIR = "/mnt/security"
     KEYSTORE_PATH = "/mnt/security/test.keystore.jks"
     TRUSTSTORE_PATH = "/mnt/security/test.truststore.jks"
+    ZK_CLIENT_TLS_ENCRYPT_ONLY_CONFIG_PATH = "/mnt/security/zk_client_tls_encrypt_only_config.properties"
     ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH = "/mnt/security/zk_client_mutual_auth_config.properties"
     JAAS_CONF_PATH = "/mnt/security/jaas.conf"
     KRB5CONF_PATH = "/mnt/security/krb5.conf"

--- a/tests/kafkatest/services/templates/zookeeper.properties
+++ b/tests/kafkatest/services/templates/zookeeper.properties
@@ -27,6 +27,9 @@ ssl.keyStore.type=JKS
 ssl.trustStore.location=/mnt/security/test.truststore.jks
 ssl.trustStore.password=test-ts-passwd
 ssl.trustStore.type=JKS
+{% if zk_tls_encrypt_only %}
+ssl.clientAuth=none
+{% endif %}
 {% endif %}
 maxClientCnxns=0
 initLimit=5

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -44,7 +44,8 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
             "collect_default": True}
     }
 
-    def __init__(self, context, num_nodes, zk_sasl = False, zk_client_port = True, zk_client_secure_port = False):
+    def __init__(self, context, num_nodes, zk_sasl = False, zk_client_port = True, zk_client_secure_port = False,
+                 zk_tls_encrypt_only = False):
         """
         :type context
         """
@@ -54,6 +55,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
             raise Exception("Cannot disable both ZK clientPort and clientSecurePort")
         self.zk_client_port = zk_client_port
         self.zk_client_secure_port = zk_client_secure_port
+        self.zk_tls_encrypt_only = zk_tls_encrypt_only
         super(ZookeeperService, self).__init__(context, num_nodes)
 
     @property
@@ -147,6 +149,12 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         return ','.join([node.account.hostname + (':2182' if not self.zk_client_port or force_tls else ':2181') + chroot
                          for node in self.nodes])
 
+    def zkTlsConfigFileOption(self, forZooKeeperMain=False):
+        if not self.zk_client_secure_port:
+            return ""
+        return ("-zk-tls-config-file " if forZooKeeperMain else "--zk-tls-config-file ") + \
+               (SecurityConfig.ZK_CLIENT_TLS_ENCRYPT_ONLY_CONFIG_PATH if self.zk_tls_encrypt_only else SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH)
+
     #
     # This call is used to simulate a rolling upgrade to enable/disable
     # the use of ZooKeeper ACLs.
@@ -157,8 +165,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         la_migra_cmd += "%s --zookeeper.acl=%s --zookeeper.connect=%s %s" % \
                        (self.path.script("zookeeper-security-migration.sh", node), zk_acl,
                         self.connect_setting(force_tls=self.zk_client_secure_port),
-                        "--zk-tls-config-file=" + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH \
-                            if self.zk_client_secure_port else "")
+                        self.zkTlsConfigFileOption())
         node.account.ssh(la_migra_cmd)
 
     def _check_chroot(self, chroot):
@@ -176,7 +183,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
         cmd = "%s %s -server %s %s get %s" % \
               (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
-               "-zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               self.zkTlsConfigFileOption(True),
                chroot_path)
         self.logger.debug(cmd)
 
@@ -201,7 +208,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
         cmd = "%s %s -server %s %s create %s '%s'" % \
               (kafka_run_class, self.java_cli_class_name(), self.connect_setting(force_tls=self.zk_client_secure_port),
-               "-zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               self.zkTlsConfigFileOption(True),
                chroot_path, value)
         self.logger.debug(cmd)
         output = self.nodes[0].account.ssh_output(cmd)
@@ -215,7 +222,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
         cmd = "%s kafka.admin.ConfigCommand --zookeeper %s %s --describe --topic %s" % \
               (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
-               "--zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               self.zkTlsConfigFileOption(),
                topic)
         self.logger.debug(cmd)
         output = self.nodes[0].account.ssh_output(cmd)
@@ -229,7 +236,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         kafka_run_class = self.path.script("kafka-run-class.sh", DEV_BRANCH)
         cmd = "%s kafka.admin.AclCommand --authorizer-properties zookeeper.connect=%s %s --list --topic %s" % \
               (kafka_run_class, self.connect_setting(force_tls=self.zk_client_secure_port),
-               "--zk-tls-config-file " + SecurityConfig.ZK_CLIENT_MUTUAL_AUTH_CONFIG_PATH if self.zk_client_secure_port else "",
+               self.zkTlsConfigFileOption(),
                topic)
         self.logger.debug(cmd)
         output = self.nodes[0].account.ssh_output(cmd)

--- a/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
@@ -69,7 +69,9 @@ class ZookeeperTlsEncryptOnlyTest(ProduceConsumeValidateTest):
         self.zk.start()
         self.kafka.security_protocol = self.kafka.interbroker_security_protocol = "PLAINTEXT"
 
-        self.kafka.start()
+        # Cannot use --zookeeper because kafka-topics.sh is unable to connect to a TLS-enabled ZooKeeper quorum,
+        # so indicate that topics should be created via the Admin client
+        self.kafka.start(use_zk_to_create_topic=False)
 
         self.perform_produce_consume_validation()
 

--- a/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
@@ -30,7 +30,7 @@ class ZookeeperTlsEncryptOnlyTest(ProduceConsumeValidateTest):
     """
 
     def __init__(self, test_context):
-        super(ZookeeperTlsEncryptOnlyTest   , self).__init__(test_context=test_context)
+        super(ZookeeperTlsEncryptOnlyTest, self).__init__(test_context=test_context)
 
     def setUp(self):
         self.topic = "test_topic"

--- a/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark import matrix, ignore
+from ducktape.mark.resource import cluster
+
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
+
+import logging
+
+class ZookeeperTlsEncryptOnlyTest(ProduceConsumeValidateTest):
+    """Tests TLS encryption-only (ssl.clientAuth=none) connectivity to zookeeper.
+    """
+
+    def __init__(self, test_context):
+        super(ZookeeperTlsEncryptOnlyTest   , self).__init__(test_context=test_context)
+
+    def setUp(self):
+        self.topic = "test_topic"
+        self.group = "group"
+        self.producer_throughput = 100
+        self.num_producers = 1
+        self.num_consumers = 1
+
+        self.zk = ZookeeperService(self.test_context, num_nodes=3,
+                                   zk_client_port = False, zk_client_secure_port = True, zk_tls_encrypt_only = True)
+
+        self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, zk_client_secure=True, topics={self.topic: {
+            "partitions": 3,
+            "replication-factor": 3,
+            'configs': {"min.insync.replicas": 2}}})
+
+    def create_producer_and_consumer(self):
+        self.producer = VerifiableProducer(
+            self.test_context, self.num_producers, self.kafka, self.topic,
+            throughput=self.producer_throughput)
+
+        self.consumer = ConsoleConsumer(
+            self.test_context, self.num_consumers, self.kafka, self.topic,
+            consumer_timeout_ms=60000, message_validator=is_int)
+
+        self.consumer.group_id = self.group
+
+    def perform_produce_consume_validation(self):
+        self.create_producer_and_consumer()
+        self.run_produce_consume_validate()
+        self.producer.free()
+        self.consumer.free()
+
+    @cluster(num_nodes=9)
+    def test_zk_tls_encrypt_only(self):
+        self.zk.start()
+        self.kafka.security_protocol = self.kafka.interbroker_security_protocol = "PLAINTEXT"
+
+        self.kafka.start()
+
+        self.perform_produce_consume_validation()
+
+        # Make sure the ZooKeeper command line is able to talk to a TLS-enabled, encrypt-only ZooKeeper quorum
+        # Test both create() and query(), each of which leverages the ZooKeeper command line
+        # This tests the code in org.apache.zookeeper.ZooKeeperMainWithTlsSupportForKafka
+        path="/foo"
+        value="{\"bar\": 0}"
+        self.zk.create(path, value=value)
+        if self.zk.query(path) != value:
+            raise Exception("Error creating and then querying a znode using the CLI with a TLS-enabled ZooKeeper quorum")
+
+        # Make sure the ConfigCommand CLI is able to talk to a TLS-enabled, encrypt-only ZooKeeper quorum
+        # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
+        self.zk.describe(self.topic)
+
+        # Make sure the AclCommand CLI is able to talk to a TLS-enabled, encrypt-only ZooKeeper quorum
+        # This is necessary for the bootstrap use case despite direct ZooKeeper connectivity being deprecated
+        self.zk.list_acls(self.topic)

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -52,6 +52,8 @@ class KafkaVersion(LooseVersion):
     def supports_named_listeners(self):
         return self >= V_0_10_2_0
 
+    def topic_command_supports_bootstrap_server(self):
+        return self >= V_2_3_0
 
 def get_version(node=None):
     """Return the version attached to the given node.


### PR DESCRIPTION
These changes depend on [KIP-515: Enable ZK client to use the new TLS supported authentication](https://cwiki.apache.org/confluence/display/KAFKA/KIP-515%3A+Enable+ZK+client+to+use+the+new+TLS+supported+authentication), which was only added to 2.5.0. The upgrade to ZooKeeper 3.5.7 was merged to both 2.5.0 and 2.4.1 via https://issues.apache.org/jira/browse/KAFKA-9515, but this change must only be merged to 2.5.0 (it will break the system tests if merged to 2.4.1).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
