### PR TITLE
MINOR: Fix gradle error writing test stdout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,10 @@ subprojects {
       // code in the test (best guess is that it is tail output from last test). We won't have
       // an output file for these, so simply ignore them. If they become critical for debugging,
       // they can be seen with showStandardStreams.
-      if (logStreams.get(tid) == null) {
+      if (td.name == td.className) {
+        // silently ignore output unrelated to specific test methods
+        return
+      } else if (logStreams.get(tid) == null) {
         println "WARNING: unexpectedly got output for a test ${tid}" +
                 " that we didn't previously see in the beforeTest hook." +
                 " Message for debugging: [" + toe.message + "]."

--- a/build.gradle
+++ b/build.gradle
@@ -252,11 +252,11 @@ subprojects {
       // code in the test (best guess is that it is tail output from last test). We won't have
       // an output file for these, so simply ignore them. If they become critical for debugging,
       // they can be seen with showStandardStreams.
-      if (td.name == td.className) {
+      if (td.name == td.className || td.className == null) {
         // silently ignore output unrelated to specific test methods
         return
       } else if (logStreams.get(tid) == null) {
-        println "WARNING: unexpectedly got output for a test ${tid}" +
+        println "WARNING: unexpectedly got output for a test [${tid}]" +
                 " that we didn't previously see in the beforeTest hook." +
                 " Message for debugging: [" + toe.message + "]."
         return

--- a/build.gradle
+++ b/build.gradle
@@ -234,14 +234,6 @@ subprojects {
 
     def logFiles = new HashMap<String, File>()
     def logStreams = new HashMap<String, FileOutputStream>()
-    beforeTest { TestDescriptor td ->
-      def tid = testId(td)
-      def logFile = new File(
-          "${projectDir}/build/reports/testOutput/${tid}.test.stdout")
-      logFile.parentFile.mkdirs()
-      logFiles.put(tid, logFile)
-      logStreams.put(tid, new FileOutputStream(logFile))
-    }
     onOutput { TestDescriptor td, TestOutputEvent toe ->
       def tid = testId(td)
       // Some output can happen outside the context of a specific test (e.g. at the class level)
@@ -256,6 +248,14 @@ subprojects {
         return
       }
       try {
+        if (logStreams.get(tid) == null) {
+          def logFile = new File(
+                  "${projectDir}/build/reports/testOutput/${tid}.test.stdout")
+          logFile.parentFile.mkdirs()
+          logFiles.put(tid, logFile)
+          logStreams.put(tid, new FileOutputStream(logFile))
+        }
+
         logStreams.get(tid).write(toe.message.getBytes(StandardCharsets.UTF_8))
       } catch (Exception e) {
         println "ERROR: Failed to write output for test ${tid}"
@@ -264,20 +264,22 @@ subprojects {
     }
     afterTest { TestDescriptor td, TestResult tr ->
       def tid = testId(td)
-      try {
-        logStreams.get(tid).close()
-        if (tr.resultType != TestResult.ResultType.FAILURE) {
-          logFiles.get(tid).delete()
-        } else {
-          def file = logFiles.get(tid)
-          println "${tid} failed, log available in ${file}"
+      if (logStreams.get(tid) != null) {
+        try {
+          logStreams.get(tid).close()
+          if (tr.resultType != TestResult.ResultType.FAILURE) {
+            logFiles.get(tid).delete()
+          } else {
+            def file = logFiles.get(tid)
+            println "${tid} failed, log available in ${file}"
+          }
+        } catch (Exception e) {
+          println "ERROR: Failed to close stdout file for ${tid}"
+          e.printStackTrace()
+        } finally {
+          logFiles.remove(tid)
+          logStreams.remove(tid)
         }
-      } catch (Exception e) {
-        println "ERROR: Failed to close stdout file for ${tid}"
-        e.printStackTrace()
-      } finally {
-        logFiles.remove(tid)
-        logStreams.remove(tid)
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,9 @@ subprojects {
       // an output file for these, so simply ignore them. If they become critical for debugging,
       // they can be seen with showStandardStreams.
       if (logStreams.get(tid) == null) {
+        println "WARNING: unexpectedly got output for a test ${tid}" +
+                " that we didn't previously see in the beforeTest hook." +
+                " Message for debugging: [" + toe.message + "]."
         return
       }
       try {

--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,14 @@ subprojects {
 
     def logFiles = new HashMap<String, File>()
     def logStreams = new HashMap<String, FileOutputStream>()
+    beforeTest { TestDescriptor td ->
+      def tid = testId(td)
+      def logFile = new File(
+          "${projectDir}/build/reports/testOutput/${tid}.test.stdout")
+      logFile.parentFile.mkdirs()
+      logFiles.put(tid, logFile)
+      logStreams.put(tid, new FileOutputStream(logFile))
+    }
     onOutput { TestDescriptor td, TestOutputEvent toe ->
       def tid = testId(td)
       // Some output can happen outside the context of a specific test (e.g. at the class level)
@@ -244,18 +252,10 @@ subprojects {
       // code in the test (best guess is that it is tail output from last test). We won't have
       // an output file for these, so simply ignore them. If they become critical for debugging,
       // they can be seen with showStandardStreams.
-      if (td.name == td.className) {
+      if (logStreams.get(tid) == null) {
         return
       }
       try {
-        if (logStreams.get(tid) == null) {
-          def logFile = new File(
-                  "${projectDir}/build/reports/testOutput/${tid}.test.stdout")
-          logFile.parentFile.mkdirs()
-          logFiles.put(tid, logFile)
-          logStreams.put(tid, new FileOutputStream(logFile))
-        }
-
         logStreams.get(tid).write(toe.message.getBytes(StandardCharsets.UTF_8))
       } catch (Exception e) {
         println "ERROR: Failed to write output for test ${tid}"
@@ -264,22 +264,20 @@ subprojects {
     }
     afterTest { TestDescriptor td, TestResult tr ->
       def tid = testId(td)
-      if (logStreams.get(tid) != null) {
-        try {
-          logStreams.get(tid).close()
-          if (tr.resultType != TestResult.ResultType.FAILURE) {
-            logFiles.get(tid).delete()
-          } else {
-            def file = logFiles.get(tid)
-            println "${tid} failed, log available in ${file}"
-          }
-        } catch (Exception e) {
-          println "ERROR: Failed to close stdout file for ${tid}"
-          e.printStackTrace()
-        } finally {
-          logFiles.remove(tid)
-          logStreams.remove(tid)
+      try {
+        logStreams.get(tid).close()
+        if (tr.resultType != TestResult.ResultType.FAILURE) {
+          logFiles.get(tid).delete()
+        } else {
+          def file = logFiles.get(tid)
+          println "${tid} failed, log available in ${file}"
         }
+      } catch (Exception e) {
+        println "ERROR: Failed to close stdout file for ${tid}"
+        e.printStackTrace()
+      } finally {
+        logFiles.remove(tid)
+        logStreams.remove(tid)
       }
     }
   }


### PR DESCRIPTION
Fix the following message we have been seeing in recent builds:

> ERROR: Failed to write output for test org.apache.kafka.streams.integration
> .QueryableStateIntegrationTest.shouldBeAbleQueryStandbyStateDuringRebalance
> java.lang.NullPointerException: Cannot invoke method write() on null object

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
