### PR TITLE
KAFKA-9570: Define SSL configs in all worker config classes, not just distributed

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -336,7 +336,9 @@ public class WorkerConfig extends AbstractConfig {
                 .define(TOPIC_TRACKING_ALLOW_RESET_CONFIG, Type.BOOLEAN, TOPIC_TRACKING_ALLOW_RESET_DEFAULT,
                         Importance.LOW, TOPIC_TRACKING_ALLOW_RESET_DOC)
                 .define(RESPONSE_HTTP_HEADERS_CONFIG, Type.STRING, RESPONSE_HTTP_HEADERS_DEFAULT,
-                        new ResponseHttpHeadersValidator(), Importance.LOW, RESPONSE_HTTP_HEADERS_DOC);
+                        new ResponseHttpHeadersValidator(), Importance.LOW, RESPONSE_HTTP_HEADERS_DOC)
+                // security support
+                .withClientSslSupport();
     }
 
     private void logInternalConverterDeprecationWarnings(Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -282,7 +282,6 @@ public class DistributedConfig extends WorkerConfig {
                     CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                     ConfigDef.Importance.MEDIUM,
                     CommonClientConfigs.SECURITY_PROTOCOL_DOC)
-            .withClientSslSupport()
             .withClientSaslSupport()
             .define(WORKER_SYNC_TIMEOUT_MS_CONFIG,
                     ConfigDef.Type.INT,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfigTest.java
@@ -65,7 +65,7 @@ public class StandaloneConfigTest {
                 // Base props required for standalone mode
                 put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
                 put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-                put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/foad");
+                put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/foo");
 
                 // Custom props for test
                 putAll(httpsListenerProps);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneConfigTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.standalone;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+public class StandaloneConfigTest {
+
+    private static final String HTTPS_LISTENER_PREFIX = "listeners.https.";
+
+    @Test
+    public void testRestServerPrefixedSslConfigs() {
+        Map<String, String> httpsListenerProps = new HashMap<String, String>() {
+            {
+                put(HTTPS_LISTENER_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, "ssl_key_password");
+                put(HTTPS_LISTENER_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "ssl_keystore");
+                put(HTTPS_LISTENER_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "ssk_keystore_password");
+                put(HTTPS_LISTENER_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "ssl_truststore");
+                put(HTTPS_LISTENER_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "ssl_truststore_password");
+            }
+        };
+
+        Set<String> passwordConfigs = Stream.of(
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG
+        ).map(key -> HTTPS_LISTENER_PREFIX + key)
+            .collect(Collectors.toSet());
+
+        Map<String, Object> expectedListenerProps = httpsListenerProps.entrySet().stream()
+            .collect(Collectors.toMap(
+                entry -> entry.getKey().substring(HTTPS_LISTENER_PREFIX.length()),
+                entry -> passwordConfigs.contains(entry.getKey())
+                        ? new Password(entry.getValue())
+                        : entry.getValue()
+            ));
+
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                // Base props required for standalone mode
+                put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+                put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+                put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/foad");
+
+                // Custom props for test
+                putAll(httpsListenerProps);
+            }
+        };
+    
+        StandaloneConfig config = new StandaloneConfig(props);
+        Map<String, Object> actualHttpsListenerProps = config.valuesWithPrefixAllOrNothing(HTTPS_LISTENER_PREFIX);
+        assertEquals(expectedListenerProps, actualHttpsListenerProps);
+    }
+
+    @Test
+    public void testRestServerNonPrefixedSslConfigs() {
+        Map<String, String> httpsListenerProps = new HashMap<String, String>() {
+            {
+                put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "ssl_key_password");
+                put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "ssl_keystore");
+                put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "ssk_keystore_password");
+                put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "ssl_truststore");
+                put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "ssl_truststore_password");
+            }
+        };
+
+        Set<String> passwordConfigs = Stream.of(
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG
+        ).collect(Collectors.toSet());
+
+        Map<String, Object> expectedListenerProps = httpsListenerProps.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> passwordConfigs.contains(entry.getKey())
+                    ? new Password(entry.getValue())
+                    : entry.getValue()
+            ));
+
+        Map<String, String> props = new HashMap<String, String>() {
+            {
+                // Base props required for standalone mode
+                put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+                put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+                put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/foad");
+
+                // Custom props for test
+                putAll(httpsListenerProps);
+            }
+        };
+
+        StandaloneConfig config = new StandaloneConfig(props);
+        Map<String, Object> actualHttpsListenerProps = config.valuesWithPrefixAllOrNothing(HTTPS_LISTENER_PREFIX)
+            .entrySet().stream()
+            .filter(entry -> expectedListenerProps.containsKey(entry.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        assertEquals(expectedListenerProps, actualHttpsListenerProps);
+    }
+}


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9570)

All SSL-related configs are currently defined only in the `DistributedConfig` class, even though they are applicable for standalone mode as well (since standalone mode also supports the Connect REST API). Because of how these configs are parsed by the framework, it's currently impossible to configure Connect in standalone mode to use SSL for the REST API with a password-protected keystore, key, or truststore, and even if no password protection is required, SSL configs will not be picked up correctly by the worker if any of the worker configs start with the `listeners.https.` prefix.

These changes define the relevant SSL-related configs in the parent `WorkerConfig` class, which should fix how they are picked up in standalone mode.

A new unit test is added to verify that the `StandaloneConfig` picks up these configs correctly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
