### PR TITLE
MINOR: Add missing @Test annotation to MetadataTest#testMetadataMerge

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -762,6 +762,7 @@ public class MetadataTest {
         return brokers;
     }
 
+    @Test
     public void testMetadataMerge() {
         Time time = new MockTime();
 


### PR DESCRIPTION
We missed adding the @Test annotation to said method which meant it wouldn't run on unit test execution.