### PR TITLE
KAFKA-9591: Log clearer error messages when there is an offset out of range (Client Change)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1256,7 +1256,8 @@ public class Fetcher<K, V> implements Closeable {
                         log.debug("Discarding stale fetch response for partition {} since the fetched offset {} " +
                                 "does not match the current offset {}", tp, fetchOffset, subscriptions.position(tp));
                     } else if (subscriptions.hasDefaultOffsetResetPolicy()) {
-                        log.info("Fetch offset {} is out of range for partition {}, resetting offset", fetchOffset, tp);
+                        log.info("Fetch offset {} is out of range for partition {}. We only have log segments in " +
+                                "the range from {} to {}. Resetting offset", fetchOffset, tp, partition.logStartOffset, partition.lastStableOffset);
                         subscriptions.requestOffsetReset(tp);
                     } else {
                         throw new OffsetOutOfRangeException(Collections.singletonMap(tp, fetchOffset));


### PR DESCRIPTION
Log the partition start offset and last stable offset when the subscriptions have the default offset reset policy and the fetch offset is out of index.