### PR TITLE
KAFKA-9581: Remove rebalance exception withholding

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -247,10 +247,6 @@ public class StreamThread extends Thread {
         return assignmentErrorCode.get();
     }
 
-    void setRebalanceException(final Throwable rebalanceException) {
-        this.rebalanceException = rebalanceException;
-    }
-
     static abstract class AbstractTaskCreator<T extends Task> {
         final String applicationId;
         final InternalTopologyBuilder builder;
@@ -502,7 +498,6 @@ public class StreamThread extends Thread {
     private long lastPollMs;
     private long lastCommitMs;
     private int numIterations;
-    private Throwable rebalanceException = null;
     private volatile State state = State.CREATED;
     private volatile ThreadMetadata threadMetadata;
     private StreamThread.StateListener stateListener;
@@ -927,14 +922,6 @@ public class StreamThread extends Thread {
             resetInvalidOffsets(e);
         }
 
-        if (rebalanceException != null) {
-            if (rebalanceException instanceof TaskMigratedException) {
-                throw (TaskMigratedException) rebalanceException;
-            } else {
-                throw new StreamsException(logPrefix + "Failed to rebalance.", rebalanceException);
-            }
-        }
-
         return records;
     }
 
@@ -1253,9 +1240,5 @@ public class StreamThread extends Thread {
 
     int currentNumIterations() {
         return numIterations;
-    }
-
-    Throwable rebalanceException() {
-        return rebalanceException;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -744,8 +744,13 @@ public class StreamThread extends Thread {
     private void runLoop() {
         subscribeConsumer();
 
+        boolean needRebalance = false;
         while (isRunning()) {
             try {
+                if (needRebalance) {
+                    enforceRebalance();
+                    needRebalance = false;
+                }
                 runOnce();
                 if (assignmentErrorCode.get() == AssignorError.VERSION_PROBING.code()) {
                     log.info("Version probing detected. Rejoining the consumer group to trigger a new rebalance.");
@@ -764,7 +769,7 @@ public class StreamThread extends Thread {
                     "Will close out all assigned tasks and rejoin the consumer group.");
 
                 taskManager.handleLostAll();
-                enforceRebalance();
+                needRebalance = true;
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -744,13 +744,8 @@ public class StreamThread extends Thread {
     private void runLoop() {
         subscribeConsumer();
 
-        boolean needRebalance = false;
         while (isRunning()) {
             try {
-                if (needRebalance) {
-                    enforceRebalance();
-                    needRebalance = false;
-                }
                 runOnce();
                 if (assignmentErrorCode.get() == AssignorError.VERSION_PROBING.code()) {
                     log.info("Version probing detected. Rejoining the consumer group to trigger a new rebalance.");
@@ -769,7 +764,7 @@ public class StreamThread extends Thread {
                     "Will close out all assigned tasks and rejoin the consumer group.");
 
                 taskManager.handleLostAll();
-                needRebalance = true;
+                enforceRebalance();
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.internals.StreamThread.State;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.slf4j.Logger;
@@ -91,8 +90,6 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         try {
             // close all active tasks as lost but don't try to commit offsets as we no longer own them
             taskManager.handleLostAll();
-        } catch (final Exception e) {
-            throw new TaskMigratedException("Error caught during partitions lost", e);
         } finally {
             log.info("partitions lost took {} ms.", time.milliseconds() - start);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -71,9 +71,7 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             final long start = time.milliseconds();
             try {
                 taskManager.handleRevocation(partitions);
-            } catch (final Exception t) {
-                throw new TaskMigratedException("Error caught during partitions revocation", t);
-            } finally {
+            }  finally {
                 log.info("partition revocation took {} ms.", time.milliseconds() - start);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -70,13 +70,6 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             final long start = time.milliseconds();
             try {
                 taskManager.handleRevocation(partitions);
-            } catch (final Throwable t) {
-                log.error(
-                    "Error caught during partition revocation, " +
-                        "will abort the current process and re-throw at the end of rebalance: ",
-                    t
-                );
-                streamThread.setRebalanceException(t);
             } finally {
                 log.info("partition revocation took {} ms.", time.milliseconds() - start);
             }
@@ -97,13 +90,6 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         try {
             // close all active tasks as lost but don't try to commit offsets as we no longer own them
             taskManager.handleLostAll();
-        } catch (final Throwable t) {
-            log.error(
-                "Error caught during partitions lost, " +
-                    "will abort the current process and re-throw at the end of rebalance: ",
-                t
-            );
-            streamThread.setRebalanceException(t);
         } finally {
             log.info("partitions lost took {} ms.", time.milliseconds() - start);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -71,7 +71,7 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             final long start = time.milliseconds();
             try {
                 taskManager.handleRevocation(partitions);
-            }  finally {
+            } finally {
                 log.info("partition revocation took {} ms.", time.milliseconds() - start);
             }
         }
@@ -91,11 +91,10 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         try {
             // close all active tasks as lost but don't try to commit offsets as we no longer own them
             taskManager.handleLostAll();
-        } catch (final Throwable t) {
-            throw new TaskMigratedException("Error caught during partitions lost", t);
+        } catch (final Exception e) {
+            throw new TaskMigratedException("Error caught during partitions lost", e);
         } finally {
             log.info("partitions lost took {} ms.", time.milliseconds() - start);
         }
     }
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.internals.StreamThread.State;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.slf4j.Logger;
@@ -70,6 +71,8 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             final long start = time.milliseconds();
             try {
                 taskManager.handleRevocation(partitions);
+            } catch (final Throwable t) {
+                throw new TaskMigratedException("Error caught during partitions revocation", t);
             } finally {
                 log.info("partition revocation took {} ms.", time.milliseconds() - start);
             }
@@ -90,6 +93,8 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         try {
             // close all active tasks as lost but don't try to commit offsets as we no longer own them
             taskManager.handleLostAll();
+        } catch (final Throwable t) {
+            throw new TaskMigratedException("Error caught during partitions lost", t);
         } finally {
             log.info("partitions lost took {} ms.", time.milliseconds() - start);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -71,7 +71,7 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
             final long start = time.milliseconds();
             try {
                 taskManager.handleRevocation(partitions);
-            } catch (final Throwable t) {
+            } catch (final Exception t) {
                 throw new TaskMigratedException("Error caught during partitions revocation", t);
             } finally {
                 log.info("partition revocation took {} ms.", time.milliseconds() - start);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -318,6 +318,8 @@ public class TaskManager {
      * Closes active tasks as zombies, as these partitions have been lost and are no longer owned.
      * NOTE this method assumes that when it is called, EVERY task/partition has been lost and must
      * be closed as a zombie.
+     *
+     * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
     void handleLostAll() {
         log.debug("Closing lost active tasks as zombies.");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1581,7 +1581,7 @@ public class StreamThreadTest {
 
         taskManager.handleLostAll();
         EasyMock.expectLastCall()
-            .andThrow(new RuntimeException("Task lost exception"));
+            .andThrow(new TaskMigratedException("Task lost exception", new RuntimeException()));
 
         EasyMock.replay(taskManager);
 
@@ -1591,9 +1591,10 @@ public class StreamThreadTest {
             config,
             null,
             null,
+            null,
             consumer,
             consumer,
-            changelogReader,
+            null,
             null,
             taskManager,
             streamsMetrics,
@@ -1634,9 +1635,10 @@ public class StreamThreadTest {
             config,
             null,
             null,
+            null,
             consumer,
             consumer,
-            changelogReader,
+            null,
             null,
             taskManager,
             streamsMetrics,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -107,6 +107,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -938,8 +939,7 @@ public class StreamThreadTest {
         assertThat(thread.activeTasks().size(), equalTo(1));
 
         clientSupplier.producers.get(0).commitTransactionException = new ProducerFencedException("Producer is fenced");
-        thread.rebalanceListener.onPartitionsRevoked(assignedPartitions);
-        assertTrue(thread.rebalanceException() instanceof TaskMigratedException);
+        assertThrows(TaskMigratedException.class, () -> thread.rebalanceListener.onPartitionsRevoked(assignedPartitions));
         assertFalse(clientSupplier.producers.get(0).transactionCommitted());
         assertFalse(clientSupplier.producers.get(0).closed());
         assertEquals(1, thread.activeTasks().size());


### PR DESCRIPTION
The rebalance exception withholding is no longer necessary as we have better mechanism for catching and wrapping these exceptions. Throw them directly should be fine and simplify our current error handling.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
