### PR TITLE
MINOR: don't assign standby tasks with no logged state

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -700,7 +700,7 @@ public class KafkaStreams implements AutoCloseable {
         internalTopologyBuilder.rewriteTopology(config);
 
         // sanity check to fail-fast in case we cannot build a ProcessorTopology due to an exception
-        final ProcessorTopology taskTopology = internalTopologyBuilder.build();
+        final ProcessorTopology taskTopology = internalTopologyBuilder.buildTopology();
 
         streamsMetadataState = new StreamsMetadataState(
                 internalTopologyBuilder,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -115,7 +115,6 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
                 if (shouldReuseSourceTopicForChangelog) {
                     storeBuilder.withLoggingDisabled();
                     topologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topicName);
-                    topologyBuilder.addOptimizedSourceTable(storeBuilder.name());
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -115,6 +115,7 @@ public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
                 if (shouldReuseSourceTopicForChangelog) {
                     storeBuilder.withLoggingDisabled();
                     topologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topicName);
+                    topologyBuilder.addOptimizedSourceTable(storeBuilder.name());
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -789,7 +789,10 @@ public class InternalTopologyBuilder {
         return newNodeGroupId;
     }
 
-    public synchronized ProcessorTopology build() {
+    /**
+     * @return the full topology minus any global state
+     */
+    public synchronized ProcessorTopology buildTopology() {
         final Set<String> nodeGroup = new HashSet<>();
         for (final Set<String> value : nodeGroups().values()) {
             nodeGroup.addAll(value);
@@ -800,14 +803,18 @@ public class InternalTopologyBuilder {
         return build(nodeGroup);
     }
 
-    public synchronized ProcessorTopology build(final int topicGroupId) {
+    /**
+     * @param topicGroupId group of topics corresponding to a single subtopology
+     * @return subset of the full topology
+     */
+    public synchronized ProcessorTopology buildSubtopology(final int topicGroupId) {
         final Set<String> nodeGroup = nodeGroups().get(topicGroupId);
         return build(nodeGroup);
     }
 
     /**
      * Builds the topology for any global state stores
-     * @return ProcessorTopology
+     * @return ProcessorTopology of global state
      */
     public synchronized ProcessorTopology buildGlobalStateTopology() {
         Objects.requireNonNull(applicationId, "topology has not completed optimization");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1716,6 +1716,20 @@ public class InternalTopologyBuilder {
             this.repartitionSourceTopics = repartitionSourceTopics;
         }
 
+        /**
+         * Returns the config for any changelogs that must be prepared for this topic group, ie excluding any source
+         * topics that are reused as a changelog
+         */
+        public Set<InternalTopicConfig> nonSourceChangelogTopics() {
+            final Set<InternalTopicConfig> topicConfigs = new HashSet<>();
+            for (final Map.Entry<String, InternalTopicConfig> changelogTopicEntry : stateChangelogTopics.entrySet()) {
+                if (!sourceTopics.contains(changelogTopicEntry.getKey())) {
+                    topicConfigs.add(changelogTopicEntry.getValue());
+                }
+            }
+            return topicConfigs;
+        }
+
         @Override
         public boolean equals(final Object o) {
             if (o instanceof TopicsInfo) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1036,10 +1036,8 @@ public class InternalTopologyBuilder {
                 // if the node is connected to a state store whose changelog topics are not predefined,
                 // add to the changelog topics
                 for (final StateStoreFactory stateFactory : stateFactories.values()) {
-                    if (stateFactory.users().contains(node)) {
-                        final String topicName = storeToChangelogTopic.containsKey(stateFactory.name()) ?
-                                storeToChangelogTopic.get(stateFactory.name()) :
-                                ProcessorStateManager.storeChangelogTopic(applicationId, stateFactory.name());
+                    if (stateFactory.users().contains(node) && storeToChangelogTopic.containsKey(stateFactory.name())) {
+                        final String topicName = storeToChangelogTopic.get(stateFactory.name());
                         if (!stateChangelogTopics.containsKey(topicName)) {
                             final InternalTopicConfig internalTopicConfig =
                                 createChangelogTopicConfig(stateFactory, topicName);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -30,9 +30,11 @@ public class ProcessorTopology {
     private final Map<String, SourceNode> sourcesByTopic;
     private final Map<String, SinkNode> sinksByTopic;
     private final List<StateStore> stateStores;
+    private final Set<String> repartitionTopics;
+
+    // the following contains entries for the entire topology, eg stores that do not belong to this ProcessorTopology
     private final List<StateStore> globalStateStores;
     private final Map<String, String> storeToChangelogTopic;
-    private final Set<String> repartitionTopics;
 
     public ProcessorTopology(final List<ProcessorNode> processorNodes,
                              final Map<String, SourceNode> sourcesByTopic,
@@ -70,10 +72,6 @@ public class ProcessorTopology {
         return sinksByTopic.get(topic);
     }
 
-    public Set<SinkNode> sinks() {
-        return new HashSet<>(sinksByTopic.values());
-    }
-
     public List<ProcessorNode> processors() {
         return processorNodes;
     }
@@ -92,6 +90,15 @@ public class ProcessorTopology {
 
     boolean isRepartitionTopic(final String topic) {
         return repartitionTopics.contains(topic);
+    }
+
+    boolean hasStateWithLoggingEnabled() {
+        for (final StateStore stateStore : stateStores) {
+            if (storeToChangelogTopic.containsKey(stateStore.name())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean hasPersistentLocalStore() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -92,7 +92,7 @@ public class ProcessorTopology {
         return repartitionTopics.contains(topic);
     }
 
-    boolean hasStateWithLoggingEnabled() {
+    boolean hasStateWithChangelogs() {
         for (final StateStore stateStore : stateStores) {
             if (storeToChangelogTopic.containsKey(stateStore.name())) {
                 return true;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -447,7 +447,7 @@ public class StreamThread extends Thread {
 
             final ProcessorTopology topology = builder.buildSubtopology(taskId.topicGroupId);
 
-            if (topology.hasStateWithLoggingEnabled()) {
+            if (topology.hasStateWithChangelogs()) {
                 final ProcessorStateManager stateManager = new ProcessorStateManager(
                     taskId,
                     partitions,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -358,7 +358,7 @@ public class StreamThread extends Thread {
             final String logPrefix = threadIdPrefix + String.format("%s [%s] ", "task", taskId);
             final LogContext logContext = new LogContext(logPrefix);
 
-            final ProcessorTopology topology = builder.build(taskId.topicGroupId);
+            final ProcessorTopology topology = builder.buildSubtopology(taskId.topicGroupId);
 
             final ProcessorStateManager stateManager = new ProcessorStateManager(
                 taskId,
@@ -445,9 +445,9 @@ public class StreamThread extends Thread {
             final String logPrefix = threadIdPrefix + String.format("%s [%s] ", "standby-task", taskId);
             final LogContext logContext = new LogContext(logPrefix);
 
-            final ProcessorTopology topology = builder.build(taskId.topicGroupId);
+            final ProcessorTopology topology = builder.buildSubtopology(taskId.topicGroupId);
 
-            if (!topology.stateStores().isEmpty() && !topology.storeToChangelogTopic().isEmpty()) {
+            if (topology.hasStateWithLoggingEnabled()) {
                 final ProcessorStateManager stateManager = new ProcessorStateManager(
                     taskId,
                     partitions,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -549,6 +549,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             }
         }
 
+        // We only create a standby for tasks that are stateful and have at least one changelog
+        final Set<TaskId> standbyTaskIds = new HashSet<>();
+
         // add tasks to state change log topic subscribers
         final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
         for (final Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> entry : topicGroups.entrySet()) {
@@ -560,6 +563,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 int numPartitions = UNKNOWN;
                 if (tasksByTopicGroup.get(topicGroupId) != null) {
                     for (final TaskId task : tasksByTopicGroup.get(topicGroupId)) {
+                        standbyTaskIds.add(task);
                         if (numPartitions < task.partition + 1) {
                             numPartitions = task.partition + 1;
                         }
@@ -605,7 +609,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             partitionsForTask.keySet(), states, numStandbyReplicas);
 
         // assign tasks to clients
-        final StickyTaskAssignor<UUID> taskAssignor = new StickyTaskAssignor<>(states, partitionsForTask.keySet());
+        final StickyTaskAssignor<UUID> taskAssignor =
+            new StickyTaskAssignor<>(states, partitionsForTask.keySet(), standbyTaskIds);
         taskAssignor.assign(numStandbyReplicas);
 
         log.info("Assigned tasks to clients as {}{}.", Utils.NL, states.entrySet().stream()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -557,34 +557,27 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         for (final Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> entry : topicGroups.entrySet()) {
             final int topicGroupId = entry.getKey();
             final InternalTopologyBuilder.TopicsInfo topicsInfo = entry.getValue();
-            final Map<String, InternalTopicConfig> stateChangelogTopics = topicsInfo.stateChangelogTopics;
 
             final Set<TaskId> topicGroupTasks = tasksByTopicGroup.get(topicGroupId);
             if (topicGroupTasks == null) {
                 log.debug("No tasks found for topic group {}", topicGroupId);
                 continue;
-            } else if (stateChangelogTopics.isEmpty()) {
+            } else if (topicsInfo.stateChangelogTopics.isEmpty()) {
                 continue;
             }
 
             standbyTaskIds.addAll(topicGroupTasks);
 
-            for (final Map.Entry<String, InternalTopicConfig> changelogEntry : stateChangelogTopics.entrySet()) {
-                final String changelogTopic = changelogEntry.getKey();
-
-                // stateChangelogTopics may include optimized source topics that are reused as changelogs
-                if (!topicsInfo.sourceTopics.contains(changelogTopic)) {
-                    final InternalTopicConfig topicConfig = changelogEntry.getValue();
-                    // the expected number of partitions is the max value of TaskId.partition + 1
-                    int numPartitions = UNKNOWN;
-                    for (final TaskId task : topicGroupTasks) {
-                        if (numPartitions < task.partition + 1) {
-                            numPartitions = task.partition + 1;
-                        }
+            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
+                 // the expected number of partitions is the max value of TaskId.partition + 1
+                int numPartitions = UNKNOWN;
+                for (final TaskId task : topicGroupTasks) {
+                    if (numPartitions < task.partition + 1) {
+                        numPartitions = task.partition + 1;
                     }
-                    topicConfig.setNumberOfPartitions(numPartitions);
-                    changelogTopicMetadata.put(topicConfig.name(), topicConfig);
                 }
+                topicConfig.setNumberOfPartitions(numPartitions);
+                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -35,15 +35,21 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
 
     private static final Logger log = LoggerFactory.getLogger(StickyTaskAssignor.class);
     private final Map<ID, ClientState> clients;
-    private final Set<TaskId> taskIds;
+    private final Set<TaskId> allTaskIds;
+    private final Set<TaskId> standbyTaskIds;
     private final Map<TaskId, ID> previousActiveTaskAssignment = new HashMap<>();
     private final Map<TaskId, Set<ID>> previousStandbyTaskAssignment = new HashMap<>();
     private final TaskPairs taskPairs;
 
-    public StickyTaskAssignor(final Map<ID, ClientState> clients, final Set<TaskId> taskIds) {
+    public StickyTaskAssignor(final Map<ID, ClientState> clients,
+                              final Set<TaskId> allTaskIds,
+                              final Set<TaskId> standbyTaskIds) {
         this.clients = clients;
-        this.taskIds = taskIds;
-        taskPairs = new TaskPairs(taskIds.size() * (taskIds.size() - 1) / 2);
+        this.allTaskIds = allTaskIds;
+        this.standbyTaskIds = standbyTaskIds;
+
+        final int maxPairs = standbyTaskIds.size() * (standbyTaskIds.size() - 1) / 2;
+        taskPairs = new TaskPairs(maxPairs);
         mapPreviousTaskAssignment(clients);
     }
 
@@ -54,7 +60,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
     }
 
     private void assignStandby(final int numStandbyReplicas) {
-        for (final TaskId taskId : taskIds) {
+        for (final TaskId taskId : standbyTaskIds) {
             for (int i = 0; i < numStandbyReplicas; i++) {
                 final Set<ID> ids = findClientsWithoutAssignedTask(taskId);
                 if (ids.isEmpty()) {
@@ -73,14 +79,14 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
 
     private void assignActive() {
         final int totalCapacity = sumCapacity(clients.values());
-        final int tasksPerThread = taskIds.size() / totalCapacity;
+        final int tasksPerThread = allTaskIds.size() / totalCapacity;
         final Set<TaskId> assigned = new HashSet<>();
 
         // first try and re-assign existing active tasks to clients that previously had
         // the same active task
         for (final Map.Entry<TaskId, ID> entry : previousActiveTaskAssignment.entrySet()) {
             final TaskId taskId = entry.getKey();
-            if (taskIds.contains(taskId)) {
+            if (allTaskIds.contains(taskId)) {
                 final ClientState client = clients.get(entry.getValue());
                 if (client.hasUnfulfilledQuota(tasksPerThread)) {
                     assignTaskToClient(assigned, taskId, client);
@@ -88,7 +94,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
             }
         }
 
-        final Set<TaskId> unassigned = new HashSet<>(taskIds);
+        final Set<TaskId> unassigned = new HashSet<>(allTaskIds);
         unassigned.removeAll(assigned);
 
         // try and assign any remaining unassigned tasks to clients that previously

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -48,7 +48,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
         this.allTaskIds = allTaskIds;
         this.standbyTaskIds = standbyTaskIds;
 
-        final int maxPairs = standbyTaskIds.size() * (standbyTaskIds.size() - 1) / 2;
+        final int maxPairs = allTaskIds.size() * (allTaskIds.size() - 1) / 2;
         taskPairs = new TaskPairs(maxPairs);
         mapPreviousTaskAssignment(clients);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -371,7 +371,7 @@ public class StreamsBuilderTest {
     }
 
     @Test
-    public void shouldReuseSourceTopicAsChangelogsWithOptimization20() {
+    public void shouldReuseSourceTopicAsChangelogsWithOptimization() {
         final String topic = "topic";
         builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store"));
         final Properties props = StreamsTestUtils.getStreamsConfig();
@@ -391,7 +391,7 @@ public class StreamsBuilderTest {
             internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
             equalTo(false));
         assertThat(
-            internalTopologyBuilder.topicGroups().get(0).stateChangelogTopics.isEmpty(),
+            internalTopologyBuilder.topicGroups().get(0).nonSourceChangelogTopics().isEmpty(),
             equalTo(true));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -93,10 +93,10 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(filteredKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -116,10 +116,10 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(filteredKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -140,10 +140,10 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(mappedKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -163,10 +163,10 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(mappedKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -186,10 +186,10 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(table1.join(table2, MockValueJoiner.TOSTRING_JOINER), MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -210,10 +210,10 @@ public class StreamsBuilderTest {
             .join(
                 table1.join(table2, MockValueJoiner.TOSTRING_JOINER, Materialized.as("store")),
                 MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -230,10 +230,10 @@ public class StreamsBuilderTest {
     public void shouldAllowJoinMaterializedSourceKTable() {
         final KTable<Bytes, String> table = builder.table(TABLE_TOPIC);
         builder.<Bytes, String>stream(STREAM_TOPIC).join(table, MockValueJoiner.TOSTRING_JOINER);
-        builder.build();
+        builder.buildTopology();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -254,7 +254,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> processorSupplier = new MockProcessorSupplier<>();
         source.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic("topic-source", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("A", "aa");
@@ -276,7 +276,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> throughProcessorSupplier = new MockProcessorSupplier<>();
         through.process(throughProcessorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic("topic-source", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("A", "aa");
@@ -298,7 +298,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> processorSupplier = new MockProcessorSupplier<>();
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                     driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -326,7 +326,7 @@ public class StreamsBuilderTest {
                 .withValueSerde(Serdes.String()))
                 .toStream().foreach(action);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<Long, String> inputTopic =
                     driver.createInputTopic(topic, new LongSerializer(), new StringSerializer());
             inputTopic.pipeInput(1L, "value1");
@@ -347,7 +347,7 @@ public class StreamsBuilderTest {
                 .withKeySerde(Serdes.Long())
                 .withValueSerde(Serdes.String()));
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<Long, String> inputTopic =
                     driver.createInputTopic(topic, new LongSerializer(), new StringSerializer());
             inputTopic.pipeInput(1L, "value1");
@@ -365,7 +365,7 @@ public class StreamsBuilderTest {
         builder.table(topic, Materialized.with(Serdes.Long(), Serdes.String()));
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertThat(topology.stateStores().size(), equalTo(0));
     }
@@ -382,7 +382,7 @@ public class StreamsBuilderTest {
         internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
 
         assertThat(
-            internalTopologyBuilder.build().storeToChangelogTopic(),
+            internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
             equalTo(Collections.singletonMap("store", "topic")));
         assertThat(
             internalTopologyBuilder.stateStores().keySet(),
@@ -400,11 +400,11 @@ public class StreamsBuilderTest {
         final String topic = "topic";
         builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store"));
 
-        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(builder.build());
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology());
         internalTopologyBuilder.setApplicationId("appId");
 
         assertThat(
-            internalTopologyBuilder.build().storeToChangelogTopic(),
+            internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
             equalTo(Collections.singletonMap("store", "appId-store-changelog")));
         assertThat(
             internalTopologyBuilder.stateStores().keySet(),
@@ -420,13 +420,13 @@ public class StreamsBuilderTest {
     @Test(expected = TopologyException.class)
     public void shouldThrowExceptionWhenNoTopicPresent() {
         builder.stream(Collections.emptyList());
-        builder.build();
+        builder.buildTopology();
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenTopicNamesAreNull() {
         builder.stream(Arrays.asList(null, null));
-        builder.build();
+        builder.buildTopology();
     }
 
     @Test
@@ -434,8 +434,8 @@ public class StreamsBuilderTest {
         final String expected = "source-node";
         builder.stream(STREAM_TOPIC, Consumed.as(expected));
         builder.stream(STREAM_TOPIC_TWO);
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, expected, "KSTREAM-SOURCE-0000000001");
     }
 
@@ -444,9 +444,9 @@ public class StreamsBuilderTest {
         final String expected = "source-node";
         builder.table(STREAM_TOPIC, Consumed.as(expected));
         builder.table(STREAM_TOPIC_TWO);
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertNamesForOperation(
                 topology,
@@ -461,8 +461,8 @@ public class StreamsBuilderTest {
         final String expected = "source-processor";
         builder.globalTable(STREAM_TOPIC, Consumed.as(expected));
         builder.globalTable(STREAM_TOPIC_TWO);
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertNamesForStateStore(
                 topology.globalStateStores(),
@@ -477,56 +477,56 @@ public class StreamsBuilderTest {
         final KStream<Object, Object> stream = builder.stream(STREAM_TOPIC);
         stream.to(STREAM_TOPIC_TWO, Produced.as(expected));
         stream.to(STREAM_TOPIC_TWO);
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", expected, "KSTREAM-SINK-0000000002");
     }
 
     @Test
     public void shouldUseSpecifiedNameForMapOperation() {
         builder.stream(STREAM_TOPIC).map(KeyValue::pair, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
     @Test
     public void shouldUseSpecifiedNameForMapValuesOperation() {
         builder.stream(STREAM_TOPIC).mapValues(v -> v, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
     @Test
     public void shouldUseSpecifiedNameForMapValuesWithKeyOperation() {
         builder.stream(STREAM_TOPIC).mapValues((k, v) -> v, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
     @Test
     public void shouldUseSpecifiedNameForFilterOperation() {
         builder.stream(STREAM_TOPIC).filter((k, v) -> true, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
     @Test
     public void shouldUseSpecifiedNameForForEachOperation() {
         builder.stream(STREAM_TOPIC).foreach((k, v) -> { }, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
     @Test
     public void shouldUseSpecifiedNameForTransform() {
         builder.stream(STREAM_TOPIC).transform(() -> null, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -534,8 +534,8 @@ public class StreamsBuilderTest {
     @SuppressWarnings("unchecked")
     public void shouldUseSpecifiedNameForTransformValues() {
         builder.stream(STREAM_TOPIC).transformValues(() -> (ValueTransformer) null, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -543,8 +543,8 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForTransformValuesWithKey() {
         builder.stream(STREAM_TOPIC).transformValues(() -> (ValueTransformerWithKey) null, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -554,8 +554,8 @@ public class StreamsBuilderTest {
         builder.stream(STREAM_TOPIC)
                 .branch(Named.as("branch-processor"), (k, v) -> true, (k, v) -> false);
 
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000000",
                 "branch-processor",
@@ -568,9 +568,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KTable<String, String> streamTwo = builder.table("table-topic");
         streamOne.join(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000000",
                 "KSTREAM-SOURCE-0000000002",
@@ -583,9 +583,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KTable<String, String> streamTwo = builder.table(STREAM_TOPIC_TWO);
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000000",
                 "KSTREAM-SOURCE-0000000002",
@@ -599,9 +599,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                 STREAM_OPERATION_NAME + "-this-join-store", STREAM_OPERATION_NAME + "-outer-other-join-store"
         );
@@ -622,9 +622,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
             "KSTREAM-JOINTHIS-0000000004-store",
             "KSTREAM-OUTEROTHER-0000000005-store"
@@ -645,9 +645,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.join(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                 STREAM_OPERATION_NAME + "-this-join-store",
                 STREAM_OPERATION_NAME + "-other-join-store"
@@ -669,9 +669,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.join(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
             "KSTREAM-JOINTHIS-0000000004-store",
             "KSTREAM-JOINOTHER-0000000005-store"
@@ -692,8 +692,8 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                 STREAM_OPERATION_NAME + "-outer-this-join-store",
                 STREAM_OPERATION_NAME + "-outer-other-join-store");
@@ -715,9 +715,9 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.build();
+        builder.buildTopology();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
             "KSTREAM-OUTERTHIS-0000000004-store",
             "KSTREAM-OUTEROTHER-0000000005-store"
@@ -741,8 +741,8 @@ public class StreamsBuilderTest {
         final KStream<String, String> source1 = builder.stream(topic1);
         final KStream<String, String> source2 = builder.stream(topic2);
         source1.merge(source2, Named.as("merge-processor"));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "KSTREAM-SOURCE-0000000001", "merge-processor");
     }
 
@@ -751,16 +751,16 @@ public class StreamsBuilderTest {
         builder.stream(STREAM_TOPIC)
                 .process(() -> null, Named.as("test-processor"));
 
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "test-processor");
     }
 
     @Test
     public void shouldUseSpecifiedNameForPrintOperation() {
         builder.stream(STREAM_TOPIC).print(Printed.toSysOut().withName("print-processor"));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "print-processor");
     }
 
@@ -768,8 +768,8 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForFlatTransformValueOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> (ValueTransformer) null, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -777,8 +777,8 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForFlatTransformValueWithKeyOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> (ValueTransformerWithKey) null, Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -788,8 +788,8 @@ public class StreamsBuilderTest {
         builder.table(STREAM_TOPIC)
                 .toStream(Named.as("to-stream"));
 
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000001",
                 "KTABLE-SOURCE-0000000002",
@@ -802,8 +802,8 @@ public class StreamsBuilderTest {
         builder.table(STREAM_TOPIC)
                 .toStream(KeyValue::pair, Named.as("to-stream"));
 
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000001",
                 "KTABLE-SOURCE-0000000002",
@@ -814,8 +814,8 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForAggregateOperationGivenTable() {
         builder.table(STREAM_TOPIC).groupBy(KeyValue::pair, Grouped.as("group-operation")).count(Named.as(STREAM_OPERATION_NAME));
-        builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).build();
+        builder.buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(
             topology.stateStores(),
             STREAM_TOPIC + "-STATE-STORE-0000000000",

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -93,7 +93,7 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(filteredKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -116,7 +116,7 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(filteredKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -140,7 +140,7 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(mappedKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -163,7 +163,7 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(mappedKTable, MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -186,7 +186,7 @@ public class StreamsBuilderTest {
         builder
             .<Bytes, String>stream(STREAM_TOPIC)
             .join(table1.join(table2, MockValueJoiner.TOSTRING_JOINER), MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -210,7 +210,7 @@ public class StreamsBuilderTest {
             .join(
                 table1.join(table2, MockValueJoiner.TOSTRING_JOINER, Materialized.as("store")),
                 MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -230,7 +230,7 @@ public class StreamsBuilderTest {
     public void shouldAllowJoinMaterializedSourceKTable() {
         final KTable<Bytes, String> table = builder.table(TABLE_TOPIC);
         builder.<Bytes, String>stream(STREAM_TOPIC).join(table, MockValueJoiner.TOSTRING_JOINER);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -254,7 +254,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> processorSupplier = new MockProcessorSupplier<>();
         source.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic("topic-source", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("A", "aa");
@@ -276,7 +276,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> throughProcessorSupplier = new MockProcessorSupplier<>();
         through.process(throughProcessorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic("topic-source", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("A", "aa");
@@ -298,7 +298,7 @@ public class StreamsBuilderTest {
         final MockProcessorSupplier<String, String> processorSupplier = new MockProcessorSupplier<>();
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                     driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -326,7 +326,7 @@ public class StreamsBuilderTest {
                 .withValueSerde(Serdes.String()))
                 .toStream().foreach(action);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Long, String> inputTopic =
                     driver.createInputTopic(topic, new LongSerializer(), new StringSerializer());
             inputTopic.pipeInput(1L, "value1");
@@ -347,7 +347,7 @@ public class StreamsBuilderTest {
                 .withKeySerde(Serdes.Long())
                 .withValueSerde(Serdes.String()));
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Long, String> inputTopic =
                     driver.createInputTopic(topic, new LongSerializer(), new StringSerializer());
             inputTopic.pipeInput(1L, "value1");
@@ -400,7 +400,7 @@ public class StreamsBuilderTest {
         final String topic = "topic";
         builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store"));
 
-        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology());
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(builder.build());
         internalTopologyBuilder.setApplicationId("appId");
 
         assertThat(
@@ -420,13 +420,13 @@ public class StreamsBuilderTest {
     @Test(expected = TopologyException.class)
     public void shouldThrowExceptionWhenNoTopicPresent() {
         builder.stream(Collections.emptyList());
-        builder.buildTopology();
+        builder.build();
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenTopicNamesAreNull() {
         builder.stream(Arrays.asList(null, null));
-        builder.buildTopology();
+        builder.build();
     }
 
     @Test
@@ -434,7 +434,7 @@ public class StreamsBuilderTest {
         final String expected = "source-node";
         builder.stream(STREAM_TOPIC, Consumed.as(expected));
         builder.stream(STREAM_TOPIC_TWO);
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, expected, "KSTREAM-SOURCE-0000000001");
     }
@@ -444,7 +444,7 @@ public class StreamsBuilderTest {
         final String expected = "source-node";
         builder.table(STREAM_TOPIC, Consumed.as(expected));
         builder.table(STREAM_TOPIC_TWO);
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
@@ -461,7 +461,7 @@ public class StreamsBuilderTest {
         final String expected = "source-processor";
         builder.globalTable(STREAM_TOPIC, Consumed.as(expected));
         builder.globalTable(STREAM_TOPIC_TWO);
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
         assertNamesForStateStore(
@@ -477,7 +477,7 @@ public class StreamsBuilderTest {
         final KStream<Object, Object> stream = builder.stream(STREAM_TOPIC);
         stream.to(STREAM_TOPIC_TWO, Produced.as(expected));
         stream.to(STREAM_TOPIC_TWO);
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", expected, "KSTREAM-SINK-0000000002");
     }
@@ -485,7 +485,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForMapOperation() {
         builder.stream(STREAM_TOPIC).map(KeyValue::pair, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -493,7 +493,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForMapValuesOperation() {
         builder.stream(STREAM_TOPIC).mapValues(v -> v, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -501,7 +501,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForMapValuesWithKeyOperation() {
         builder.stream(STREAM_TOPIC).mapValues((k, v) -> v, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -509,7 +509,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForFilterOperation() {
         builder.stream(STREAM_TOPIC).filter((k, v) -> true, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -517,7 +517,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForForEachOperation() {
         builder.stream(STREAM_TOPIC).foreach((k, v) -> { }, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -525,7 +525,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForTransform() {
         builder.stream(STREAM_TOPIC).transform(() -> null, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -534,7 +534,7 @@ public class StreamsBuilderTest {
     @SuppressWarnings("unchecked")
     public void shouldUseSpecifiedNameForTransformValues() {
         builder.stream(STREAM_TOPIC).transformValues(() -> (ValueTransformer) null, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -543,7 +543,7 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForTransformValuesWithKey() {
         builder.stream(STREAM_TOPIC).transformValues(() -> (ValueTransformerWithKey) null, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -554,7 +554,7 @@ public class StreamsBuilderTest {
         builder.stream(STREAM_TOPIC)
                 .branch(Named.as("branch-processor"), (k, v) -> true, (k, v) -> false);
 
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000000",
@@ -568,7 +568,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KTable<String, String> streamTwo = builder.table("table-topic");
         streamOne.join(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
@@ -583,7 +583,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KTable<String, String> streamTwo = builder.table(STREAM_TOPIC_TWO);
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
@@ -599,7 +599,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -622,7 +622,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -645,7 +645,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.join(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -669,7 +669,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.join(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -692,7 +692,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                 STREAM_OPERATION_NAME + "-outer-this-join-store",
@@ -715,7 +715,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
         streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), Joined.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -741,7 +741,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> source1 = builder.stream(topic1);
         final KStream<String, String> source2 = builder.stream(topic2);
         source1.merge(source2, Named.as("merge-processor"));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "KSTREAM-SOURCE-0000000001", "merge-processor");
     }
@@ -751,7 +751,7 @@ public class StreamsBuilderTest {
         builder.stream(STREAM_TOPIC)
                 .process(() -> null, Named.as("test-processor"));
 
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "test-processor");
     }
@@ -759,7 +759,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForPrintOperation() {
         builder.stream(STREAM_TOPIC).print(Printed.toSysOut().withName("print-processor"));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "print-processor");
     }
@@ -768,7 +768,7 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForFlatTransformValueOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> (ValueTransformer) null, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -777,7 +777,7 @@ public class StreamsBuilderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForFlatTransformValueWithKeyOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> (ValueTransformerWithKey) null, Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
@@ -788,7 +788,7 @@ public class StreamsBuilderTest {
         builder.table(STREAM_TOPIC)
                 .toStream(Named.as("to-stream"));
 
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000001",
@@ -802,7 +802,7 @@ public class StreamsBuilderTest {
         builder.table(STREAM_TOPIC)
                 .toStream(KeyValue::pair, Named.as("to-stream"));
 
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000001",
@@ -814,7 +814,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSpecifiedNameForAggregateOperationGivenTable() {
         builder.table(STREAM_TOPIC).groupBy(KeyValue::pair, Grouped.as("group-operation")).count(Named.as(STREAM_OPERATION_NAME));
-        builder.buildTopology();
+        builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(
             topology.stateStores(),

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -371,7 +371,7 @@ public class StreamsBuilderTest {
     }
 
     @Test
-    public void shouldReuseSourceTopicAsChangelogsWithOptimization() {
+    public void shouldReuseSourceTopicAsChangelogsWithOptimization20() {
         final String topic = "topic";
         builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store"));
         final Properties props = StreamsTestUtils.getStreamsConfig();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -25,8 +25,6 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.Predicate;
-import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -98,26 +98,12 @@ public class InternalStreamsBuilderTest {
         final KStream<String, String> source2 = builder.stream(Collections.singleton(topic2), consumed);
         final KStream<String, String> source3 = builder.stream(Collections.singleton(topic3), consumed);
         final KStream<String, String> processedSource1 =
-                source1.mapValues(new ValueMapper<String, String>() {
-                    @Override
-                    public String apply(final String value) {
-                        return value;
-                    }
-                }).filter(new Predicate<String, String>() {
-                    @Override
-                    public boolean test(final String key, final String value) {
-                        return true;
-                    }
-                });
-        final KStream<String, String> processedSource2 = source2.filter(new Predicate<String, String>() {
-            @Override
-            public boolean test(final String key, final String value) {
-                return true;
-            }
-        });
+                source1.mapValues(v -> v)
+                .filter((k, v) -> true);
+        final KStream<String, String> processedSource2 = source2.filter((k, v) -> true);
 
         final KStream<String, String> merged = processedSource1.merge(processedSource2).merge(source3);
-        merged.groupByKey().count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("my-table"));
+        merged.groupByKey().count(Materialized.as("my-table"));
         builder.buildAndOptimizeTopology();
         final Map<String, List<String>> actual = builder.internalTopologyBuilder.stateStoreNameToSourceTopics();
         assertEquals(asList("topic-1", "topic-2", "topic-3"), actual.get("my-table"));
@@ -132,7 +118,7 @@ public class InternalStreamsBuilderTest {
         builder.buildAndOptimizeTopology();
         final ProcessorTopology topology = builder.internalTopologyBuilder
             .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
-            .build();
+            .buildTopology();
 
         assertEquals(0, topology.stateStores().size());
         assertEquals(0, topology.storeToChangelogTopic().size());
@@ -231,7 +217,7 @@ public class InternalStreamsBuilderTest {
 
         final Map<Integer, Set<String>> nodeGroups = builder.internalTopologyBuilder.nodeGroups();
         for (final Integer groupId : nodeGroups.keySet()) {
-            final ProcessorTopology topology = builder.internalTopologyBuilder.build(groupId);
+            final ProcessorTopology topology = builder.internalTopologyBuilder.buildSubtopology(groupId);
             final List<StateStore> stateStores = topology.globalStateStores();
             final Set<String> names = new HashSet<>();
             for (final StateStore stateStore : stateStores) {
@@ -352,7 +338,7 @@ public class InternalStreamsBuilderTest {
         builder.stream(Collections.singleton("topic"), consumed);
         builder.buildAndOptimizeTopology();
         builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)));
-        final ProcessorTopology processorTopology = builder.internalTopologyBuilder.build();
+        final ProcessorTopology processorTopology = builder.internalTopologyBuilder.buildTopology();
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
 
@@ -363,7 +349,7 @@ public class InternalStreamsBuilderTest {
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
             .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
-            .build();
+            .buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
@@ -373,7 +359,7 @@ public class InternalStreamsBuilderTest {
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
             .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
-            .build();
+            .buildTopology();
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
 
@@ -384,7 +370,7 @@ public class InternalStreamsBuilderTest {
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
             .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
-            .build();
+            .buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -1340,7 +1340,7 @@ public class KStreamImplTest {
                 1 + // to
                 2 + // through
                 1, // process
-            TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build().processors().size());
+            TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology().processors().size());
     }
 
     @SuppressWarnings("rawtypes")
@@ -1444,7 +1444,7 @@ public class KStreamImplTest {
         stream1.to("topic-5");
         stream2.through("topic-6");
 
-        final ProcessorTopology processorTopology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build();
+        final ProcessorTopology processorTopology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
         assertThat(processorTopology.source("topic-6").getTimestampExtractor(), instanceOf(FailOnInvalidTimestamp.class));
         assertNull(processorTopology.source("topic-4").getTimestampExtractor());
         assertNull(processorTopology.source("topic-3").getTimestampExtractor());
@@ -1459,7 +1459,7 @@ public class KStreamImplTest {
         final KStream<String, String> stream = builder.stream(input, stringConsumed);
         stream.through("through-topic", Produced.with(Serdes.String(), Serdes.String())).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "b");
@@ -1475,7 +1475,7 @@ public class KStreamImplTest {
         stream.to("to-topic", Produced.with(Serdes.String(), Serdes.String()));
         builder.stream("to-topic", stringConsumed).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("e", "f");
@@ -1493,7 +1493,7 @@ public class KStreamImplTest {
         builder.stream(input + "-a-v", stringConsumed).process(processorSupplier);
         builder.stream(input + "-b-v", stringConsumed).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "v1");
@@ -1523,7 +1523,7 @@ public class KStreamImplTest {
                 Serdes.String()))
             .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
-        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build();
+        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
 
         final SourceNode originalSourceNode = topology.source("topic-1");
 
@@ -1553,7 +1553,7 @@ public class KStreamImplTest {
         )
             .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
-        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").build();
+        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
 
         final SourceNode originalSourceNode = topology.source("topic-1");
 
@@ -1578,7 +1578,7 @@ public class KStreamImplTest {
             .count();
 
         final Pattern repartitionTopicPattern = Pattern.compile("Sink: .*-repartition");
-        final String topology = builder.build().describe().toString();
+        final String topology = builder.buildTopology().describe().toString();
         final Matcher matcher = repartitionTopicPattern.matcher(topology);
         assertTrue(matcher.find());
         final String match = matcher.group();
@@ -1597,7 +1597,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                 driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -1629,7 +1629,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                 driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -1666,7 +1666,7 @@ public class KStreamImplTest {
 
         pattern2Source.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
                 driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
@@ -1704,7 +1704,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
                 driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
@@ -2390,7 +2390,7 @@ public class KStreamImplTest {
 
         builder.stream(input, consumed).toTable().toStream().to(output);
 
-        final String topologyDescription = builder.build().describe().toString();
+        final String topologyDescription = builder.buildTopology().describe().toString();
 
         assertThat(
             topologyDescription,
@@ -2408,7 +2408,7 @@ public class KStreamImplTest {
                 "      <-- KTABLE-TOSTREAM-0000000003\n\n")
         );
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, Serdes.String().serializer(), Serdes.String().serializer());
             final TestOutputTopic<String, String> outputTopic =
@@ -2444,7 +2444,7 @@ public class KStreamImplTest {
         builder.stream(input, consumed)
             .toTable(Materialized.as(Stores.inMemoryKeyValueStore(storeName)));
 
-        final Topology topology = builder.build();
+        final Topology topology = builder.buildTopology();
 
         final String topologyDescription = topology.describe().toString();
         assertThat(
@@ -2486,7 +2486,7 @@ public class KStreamImplTest {
             .toTable(Materialized.with(Serdes.Integer(), null))
             .toStream().to(output);
 
-        final Topology topology = builder.build();
+        final Topology topology = builder.buildTopology();
 
         final String topologyDescription = topology.describe().toString();
         assertThat(
@@ -2865,7 +2865,7 @@ public class KStreamImplTest {
                 "      <-- KTABLE-TOSTREAM-0000000008\n\n"));
 
         try (
-            final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestOutputTopic<String, Long> outputTopic =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -366,7 +366,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullNamedOnFlatMap() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.flatMap((k, v) -> Collections.emptyList(), null));
+            () -> testStream.flatMap((k, v) -> Collections.singleton(new KeyValue<>(k, v)), null));
         assertThat(exception.getMessage(), equalTo("named can't be null"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -1340,7 +1340,7 @@ public class KStreamImplTest {
                 1 + // to
                 2 + // through
                 1, // process
-            TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology().processors().size());
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").buildTopology().processors().size());
     }
 
     @SuppressWarnings("rawtypes")
@@ -1444,7 +1444,7 @@ public class KStreamImplTest {
         stream1.to("topic-5");
         stream2.through("topic-6");
 
-        final ProcessorTopology processorTopology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
+        final ProcessorTopology processorTopology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").buildTopology();
         assertThat(processorTopology.source("topic-6").getTimestampExtractor(), instanceOf(FailOnInvalidTimestamp.class));
         assertNull(processorTopology.source("topic-4").getTimestampExtractor());
         assertNull(processorTopology.source("topic-3").getTimestampExtractor());
@@ -1459,7 +1459,7 @@ public class KStreamImplTest {
         final KStream<String, String> stream = builder.stream(input, stringConsumed);
         stream.through("through-topic", Produced.with(Serdes.String(), Serdes.String())).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "b");
@@ -1475,7 +1475,7 @@ public class KStreamImplTest {
         stream.to("to-topic", Produced.with(Serdes.String(), Serdes.String()));
         builder.stream("to-topic", stringConsumed).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("e", "f");
@@ -1493,7 +1493,7 @@ public class KStreamImplTest {
         builder.stream(input + "-a-v", stringConsumed).process(processorSupplier);
         builder.stream(input + "-b-v", stringConsumed).process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             inputTopic.pipeInput("a", "v1");
@@ -1523,7 +1523,7 @@ public class KStreamImplTest {
                 Serdes.String()))
             .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
-        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
+        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").buildTopology();
 
         final SourceNode originalSourceNode = topology.source("topic-1");
 
@@ -1553,7 +1553,7 @@ public class KStreamImplTest {
         )
             .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
-        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.buildTopology()).setApplicationId("X").buildTopology();
+        final ProcessorTopology topology = TopologyWrapper.getInternalTopologyBuilder(builder.build()).setApplicationId("X").buildTopology();
 
         final SourceNode originalSourceNode = topology.source("topic-1");
 
@@ -1578,7 +1578,7 @@ public class KStreamImplTest {
             .count();
 
         final Pattern repartitionTopicPattern = Pattern.compile("Sink: .*-repartition");
-        final String topology = builder.buildTopology().describe().toString();
+        final String topology = builder.build().describe().toString();
         final Matcher matcher = repartitionTopicPattern.matcher(topology);
         assertTrue(matcher.find());
         final String match = matcher.group();
@@ -1597,7 +1597,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                 driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -1629,7 +1629,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic1 =
                 driver.createInputTopic(topic1, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic2 =
@@ -1666,7 +1666,7 @@ public class KStreamImplTest {
 
         pattern2Source.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
                 driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
@@ -1704,7 +1704,7 @@ public class KStreamImplTest {
 
         merged.process(processorSupplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic3 =
                 driver.createInputTopic("topic-3", new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<String, String> inputTopic4 =
@@ -2390,7 +2390,7 @@ public class KStreamImplTest {
 
         builder.stream(input, consumed).toTable().toStream().to(output);
 
-        final String topologyDescription = builder.buildTopology().describe().toString();
+        final String topologyDescription = builder.build().describe().toString();
 
         assertThat(
             topologyDescription,
@@ -2408,7 +2408,7 @@ public class KStreamImplTest {
                 "      <-- KTABLE-TOSTREAM-0000000003\n\n")
         );
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, Serdes.String().serializer(), Serdes.String().serializer());
             final TestOutputTopic<String, String> outputTopic =
@@ -2444,7 +2444,7 @@ public class KStreamImplTest {
         builder.stream(input, consumed)
             .toTable(Materialized.as(Stores.inMemoryKeyValueStore(storeName)));
 
-        final Topology topology = builder.buildTopology();
+        final Topology topology = builder.build();
 
         final String topologyDescription = topology.describe().toString();
         assertThat(
@@ -2486,7 +2486,7 @@ public class KStreamImplTest {
             .toTable(Materialized.with(Serdes.Integer(), null))
             .toStream().to(output);
 
-        final Topology topology = builder.buildTopology();
+        final Topology topology = builder.build();
 
         final String topologyDescription = topology.describe().toString();
         assertThat(
@@ -2865,7 +2865,7 @@ public class KStreamImplTest {
                 "      <-- KTABLE-TOSTREAM-0000000008\n\n"));
 
         try (
-            final TopologyTestDriver driver = new TopologyTestDriver(builder.buildTopology(), props)) {
+            final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(input, new StringSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestOutputTopic<String, Long> outputTopic =

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -416,9 +416,9 @@ public class InternalTopologyBuilderTest {
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
-        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap(), false));
-        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap(), false));
-        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap(), false));
+        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap()));
+        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap()));
+        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap()));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);
@@ -458,15 +458,15 @@ public class InternalTopologyBuilderTest {
         expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-1", "topic-1x", "topic-2"),
             Collections.emptyMap(),
-            Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap())), false));
+            Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap()))));
         expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-3", "topic-4"),
             Collections.emptyMap(),
-            Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap())), false));
+            Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap()))));
         expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-5"),
             Collections.emptyMap(),
-            Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap())), false));
+            Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap()))));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -416,9 +416,9 @@ public class InternalTopologyBuilderTest {
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
-        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap()));
-        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap()));
-        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap()));
+        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap(), false));
+        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap(), false));
+        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap(), false));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);
@@ -458,15 +458,15 @@ public class InternalTopologyBuilderTest {
         expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-1", "topic-1x", "topic-2"),
             Collections.emptyMap(),
-            Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap()))));
+            Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap())), false));
         expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-3", "topic-4"),
             Collections.emptyMap(),
-            Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap()))));
+            Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap())), false));
         expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-5"),
             Collections.emptyMap(),
-            Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap()))));
+            Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap())), false));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -387,11 +387,11 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addProcessor("processor-1", new MockProcessorSupplier(), "source-1");
 
-        assertEquals(0, builder.build().stateStores().size());
+        assertEquals(0, builder.buildTopology().stateStores().size());
 
         builder.connectProcessorAndStateStores("processor-1", storeBuilder.name());
 
-        final List<StateStore> suppliers = builder.build().stateStores();
+        final List<StateStore> suppliers = builder.buildTopology().stateStores();
         assertEquals(1, suppliers.size());
         assertEquals(storeBuilder.name(), suppliers.get(0).name());
     }
@@ -485,9 +485,9 @@ public class InternalTopologyBuilderTest {
         builder.addProcessor("processor-3", new MockProcessorSupplier(), "source-3", "source-4");
 
         builder.setApplicationId("X");
-        final ProcessorTopology topology0 = builder.build(0);
-        final ProcessorTopology topology1 = builder.build(1);
-        final ProcessorTopology topology2 = builder.build(2);
+        final ProcessorTopology topology0 = builder.buildSubtopology(0);
+        final ProcessorTopology topology1 = builder.buildSubtopology(1);
+        final ProcessorTopology topology2 = builder.buildSubtopology(2);
 
         assertEquals(mkSet("source-1", "source-2", "processor-1", "processor-2"), nodeNames(topology0.processors()));
         assertEquals(mkSet("source-3", "source-4", "processor-3"), nodeNames(topology1.processors()));
@@ -734,7 +734,7 @@ public class InternalTopologyBuilderTest {
     @Test
     public void shouldAddTimestampExtractorPerSource() {
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, "topic");
-        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).build();
+        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
@@ -742,7 +742,7 @@ public class InternalTopologyBuilderTest {
     public void shouldAddTimestampExtractorWithPatternPerSource() {
         final Pattern pattern = Pattern.compile("t.*");
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, pattern);
-        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).build();
+        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
         assertThat(processorTopology.source(pattern.pattern()).getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -448,6 +448,7 @@ public class InternalTopologyBuilderTest {
         builder.addProcessor("processor-5", new MockProcessorSupplier(), "source-5");
         builder.addStateStore(new MockKeyValueStoreBuilder("store-3", false));
         builder.connectProcessorAndStateStores("processor-5", "store-3");
+        builder.buildTopology();
 
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
@@ -659,6 +660,7 @@ public class InternalTopologyBuilderTest {
                 ),
                 "processor"
         );
+        builder.buildTopology();
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
         final InternalTopicConfig topicConfig1 = topicsInfo.stateChangelogTopics.get("appId-store1-changelog");
@@ -683,6 +685,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source");
         builder.addStateStore(storeBuilder, "processor");
+        builder.buildTopology();
         final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
         final InternalTopicConfig topicConfig = topicsInfo.stateChangelogTopics.get("appId-store-changelog");
@@ -698,6 +701,7 @@ public class InternalTopologyBuilderTest {
         builder.setApplicationId("appId");
         builder.addInternalTopic("foo");
         builder.addSource(null, "source", null, null, null, "foo");
+        builder.buildTopology();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = builder.topicGroups().values().iterator().next();
         final InternalTopicConfig topicConfig = topicsInfo.repartitionSourceTopics.get("appId-foo");
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 10000);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -115,7 +115,7 @@ public class ProcessorTopologyTest {
         topology.addSink("sink-1", "topic-3", "processor-1");
         topology.addSink("sink-2", "topic-4", "processor-1", "processor-2");
 
-        final ProcessorTopology processorTopology = topology.getInternalBuilder("X").build();
+        final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
 
         assertEquals(6, processorTopology.processors().size());
 
@@ -317,7 +317,7 @@ public class ProcessorTopologyTest {
     @Test
     public void shouldCreateStringWithSourceAndTopics() {
         topology.addSource("source", "topic1", "topic2");
-        final ProcessorTopology processorTopology = topology.getInternalBuilder().build();
+        final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
         assertThat(result, containsString("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
     }
@@ -326,7 +326,7 @@ public class ProcessorTopologyTest {
     public void shouldCreateStringWithMultipleSourcesAndTopics() {
         topology.addSource("source", "topic1", "topic2");
         topology.addSource("source2", "t", "t1", "t2");
-        final ProcessorTopology processorTopology = topology.getInternalBuilder().build();
+        final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
         assertThat(result, containsString("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
         assertThat(result, containsString("source2:\n\t\ttopics:\t\t[t, t1, t2]\n"));
@@ -337,7 +337,7 @@ public class ProcessorTopologyTest {
         topology.addSource("source", "t")
                 .addProcessor("processor", mockProcessorSupplier, "source")
                 .addProcessor("other", mockProcessorSupplier, "source");
-        final ProcessorTopology processorTopology = topology.getInternalBuilder().build();
+        final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
         assertThat(result, containsString("\t\tchildren:\t[processor, other]"));
         assertThat(result, containsString("processor:\n"));
@@ -353,7 +353,7 @@ public class ProcessorTopologyTest {
                 .addProcessor("child-two", mockProcessorSupplier, "processor")
                 .addProcessor("child-two-one", mockProcessorSupplier, "child-two");
 
-        final String result = topology.getInternalBuilder().build().toString();
+        final String result = topology.getInternalBuilder().buildTopology().toString();
         assertThat(result, containsString("child-one:\n\t\tchildren:\t[child-one-one]"));
         assertThat(result, containsString("child-two:\n\t\tchildren:\t[child-two-one]"));
     }
@@ -449,7 +449,7 @@ public class ProcessorTopologyTest {
     @Test
     public void statelessTopologyShouldNotHavePersistentStore() {
         final TopologyWrapper topology = new TopologyWrapper();
-        final ProcessorTopology processorTopology = topology.getInternalBuilder("anyAppId").build();
+        final ProcessorTopology processorTopology = topology.getInternalBuilder("anyAppId").buildTopology();
         assertFalse(processorTopology.hasPersistentLocalStore());
         assertFalse(processorTopology.hasPersistentGlobalStore());
     }
@@ -486,7 +486,7 @@ public class ProcessorTopologyTest {
         topology.addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, "topic")
                 .addProcessor(processor, () -> new StatefulProcessor(storeSupplier.name()), "source")
                 .addStateStore(storeBuilder, processor);
-        return topology.getInternalBuilder("anyAppId").build();
+        return topology.getInternalBuilder("anyAppId").buildTopology();
     }
 
     private ProcessorTopology createGlobalStoreTopology(final KeyValueBytesStoreSupplier storeSupplier) {
@@ -495,7 +495,7 @@ public class ProcessorTopologyTest {
                 Stores.keyValueStoreBuilder(storeSupplier, Serdes.String(), Serdes.String()).withLoggingDisabled();
         topology.addGlobalStore(storeBuilder, "global", STRING_DESERIALIZER, STRING_DESERIALIZER, "topic", "processor",
                 define(new StatefulProcessor(storeSupplier.name())));
-        return topology.getInternalBuilder("anyAppId").build();
+        return topology.getInternalBuilder("anyAppId").buildTopology();
     }
 
     private void assertNextOutputRecord(final TestRecord<String, String> record,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -189,7 +189,7 @@ public class StreamThreadTest {
             config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG)
         );
 
-        internalTopologyBuilder.build();
+        internalTopologyBuilder.buildTopology();
         
         return StreamThread.create(
             internalTopologyBuilder,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -678,7 +678,18 @@ public class StickyTaskAssignorTest {
         final List<TaskId> taskIds = Arrays.asList(tasks);
         Collections.shuffle(taskIds);
         return new StickyTaskAssignor<>(clients,
+                                        new HashSet<>(taskIds),
                                         new HashSet<>(taskIds));
+    }
+
+    private StickyTaskAssignor<Integer> createTaskAssignorWithStatelessTasks(final Set<TaskId> allTasks,
+                                                                             final TaskId... statelessTasks) {
+        final Set<TaskId> standbyTasks = new HashSet<>(allTasks);
+        for (final TaskId task : statelessTasks) {
+            standbyTasks.remove(task);
+        }
+
+        return new StickyTaskAssignor<>(clients, allTasks, standbyTasks);
     }
 
     private List<TaskId> allActiveTasks() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -682,16 +682,6 @@ public class StickyTaskAssignorTest {
                                         new HashSet<>(taskIds));
     }
 
-    private StickyTaskAssignor<Integer> createTaskAssignorWithStatelessTasks(final Set<TaskId> allTasks,
-                                                                             final TaskId... statelessTasks) {
-        final Set<TaskId> standbyTasks = new HashSet<>(allTasks);
-        for (final TaskId task : statelessTasks) {
-            standbyTasks.remove(task);
-        }
-
-        return new StickyTaskAssignor<>(clients, allTasks, standbyTasks);
-    }
-
     private List<TaskId> allActiveTasks() {
         final List<TaskId> allActive = new ArrayList<>();
         for (final ClientState client : clients.values()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -137,7 +137,7 @@ public class StreamThreadStateStoreProviderTest {
         configureRestoreConsumer(clientSupplier, "applicationId-window-store-changelog");
 
         final InternalTopologyBuilder internalTopologyBuilder = topology.getInternalBuilder(applicationId);
-        final ProcessorTopology processorTopology = internalTopologyBuilder.build();
+        final ProcessorTopology processorTopology = internalTopologyBuilder.buildTopology();
 
         tasks = new HashMap<>();
         stateDirectory = new StateDirectory(streamsConfig, new MockTime(), true);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -353,7 +353,7 @@ public class TopologyTestDriver implements Closeable {
         internalTopologyBuilder = builder;
         internalTopologyBuilder.rewriteTopology(streamsConfig);
 
-        processorTopology = internalTopologyBuilder.build();
+        processorTopology = internalTopologyBuilder.buildTopology();
         globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
 
         for (final String topic : processorTopology.sourceTopics()) {


### PR DESCRIPTION
Right now the task assignor just blindly assigns N standby tasks per active task (where N = num.standbys) and attempts to distribute them evenly across all instances/threads. But only standby tasks that are stateful, and whose stores are changelog-enabled, will ever actually be created.

This can result in a less-balanced assignment, and should be cleaned up in particular before implementing KIP-441 to remove the noise of ghost standbys