### PR TITLE
MINOR: Add missing @Test annotations to miscellaneous tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -762,6 +762,7 @@ public class MetadataTest {
         return brokers;
     }
 
+    @Test
     public void testMetadataMerge() {
         Time time = new MockTime();
 

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -170,6 +170,7 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
         task.stop();
     }
 
+    @Test
     public void testInvalidFile() throws InterruptedException {
         config.put(FileStreamSourceConnector.FILE_CONFIG, "bogusfilename");
         task.start(config);

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -169,6 +169,7 @@ class GroupMetadataTest {
     group.transitionTo(CompletingRebalance)
   }
 
+  @Test
   def testDeadToDeadIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
     group.transitionTo(Dead)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -815,6 +815,7 @@ class LogCleanerTest {
                (0 until leo.toInt by 2).forall(!keys.contains(_)))
   }
 
+  @Test
   def testLogCleanerStats(): Unit = {
     // because loadFactor is 0.75, this means we can fit 2 messages in the map
     val cleaner = makeCleaner(2)
@@ -834,10 +835,10 @@ class LogCleanerTest {
     val initialLogSize = log.size
 
     val (endOffset, stats) = cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 2, log.activeSegment.baseOffset))
-    assertEquals(5, endOffset)
+    assertEquals(3, endOffset)
     assertEquals(5, stats.messagesRead)
     assertEquals(initialLogSize, stats.bytesRead)
-    assertEquals(2, stats.messagesWritten)
+    assertEquals(4, stats.messagesWritten)
     assertEquals(log.size, stats.bytesWritten)
     assertEquals(0, stats.invalidMessagesRead)
     assertTrue(stats.endTime >= stats.startTime)

--- a/core/src/test/scala/unit/kafka/server/AdvertiseBrokerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AdvertiseBrokerTest.scala
@@ -67,7 +67,7 @@ class AdvertiseBrokerTest extends ZooKeeperTestHarness {
     assertEquals("routable-listener", endpoint.host)
     assertEquals(3334, endpoint.port)
     assertEquals(SecurityProtocol.PLAINTEXT, endpoint.securityProtocol)
-    assertEquals(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT), endpoint.listenerName)
+    assertEquals(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT).value(), endpoint.listenerName.value())
   }
 
   @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -396,6 +396,7 @@ public class PartitionGroupTest {
         group.addRawRecords(partition1, list);
     }
 
+    @Test
     public void shouldCleanPartitionsOnClose() {
         final List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
             new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),


### PR DESCRIPTION
It seems like we missed adding @Test annotations to some test methods and therefore did not execute them on unit test suites.
