### PR TITLE
MINOR: fix ClassCastException handling

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -157,12 +157,13 @@ public class RecordCollectorImpl implements RecordCollector {
             final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             throw new StreamsException(
                 String.format(
-                    "ClassCastException while producing data to a sink topic. " +
+                    "ClassCastException while producing data to topic %s. " +
                         "A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
                         "(key type: %s / value type: %s). " +
                         "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
                         "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with " +
                         "`Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+                    topic,
                     keySerializer.getClass().getName(),
                     valueSerializer.getClass().getName(),
                     keyClass,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -152,6 +152,22 @@ public class RecordCollectorImpl implements RecordCollector {
         try {
             keyBytes = keySerializer.serialize(topic, headers, key);
             valBytes = valueSerializer.serialize(topic, headers, value);
+        } catch (final ClassCastException exception) {
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            throw new StreamsException(
+                String.format(
+                    "ClassCastException while producing data to a sink topic. " +
+                        "A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
+                        "(key type: %s / value type: %s). " +
+                        "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
+                        "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with " +
+                        "`Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+                    keySerializer.getClass().getName(),
+                    valueSerializer.getClass().getName(),
+                    keyClass,
+                    valueClass),
+                exception);
         } catch (final RuntimeException exception) {
             final String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, exception.toString());
             throw new StreamsException(errorMessage, exception);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -85,21 +85,7 @@ public class SinkNode<K, V> extends ProcessorNode<K, V> {
 
         final String topic = topicExtractor.extract(key, value, this.context.recordContext());
 
-        try {
-            collector.send(topic, key, value, context.headers(), timestamp, keySerializer, valSerializer, partitioner);
-        } catch (final ClassCastException e) {
-            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
-            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
-            throw new StreamsException(
-                    String.format("ClassCastException while producing data to a sink topic. A serializer (key: %s / value: %s) is not compatible to the actual key or value type " +
-                                    "(key type: %s / value type: %s). Change the default Serdes in StreamConfig or " +
-                                    "provide correct Serdes via method parameters (for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
-                                    keySerializer.getClass().getName(),
-                                    valSerializer.getClass().getName(),
-                                    keyClass,
-                                    valueClass),
-                    e);
-        }
+        collector.send(topic, key, value, context.headers(), timestamp, keySerializer, valSerializer, partitioner);
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -42,6 +42,8 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
@@ -71,6 +73,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -344,6 +347,118 @@ public class RecordCollectorTest {
         collector.close();
 
         verify(streamsProducer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowInformativeStreamsExceptionOnKeyClassCastException() {
+        final StreamsException expected = assertThrows(
+            StreamsException.class,
+            () -> this.collector.send(
+                "topic",
+                "key",
+                "value",
+                new RecordHeaders(),
+                0,
+                0L,
+                (Serializer) new LongSerializer(), // need to add cast to trigger `ClassCastException`
+                new StringSerializer())
+        );
+
+        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
+        assertThat(
+            expected.getMessage(),
+            equalTo(
+                "ClassCastException while producing data to a sink topic. " +
+                    "A serializer (key: org.apache.kafka.common.serialization.LongSerializer / value: org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual key or value type (key type: java.lang.String / value type: java.lang.String). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
+                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowInformativeStreamsExceptionOnKeyAndNullValueClassCastException() {
+        final StreamsException expected = assertThrows(
+            StreamsException.class,
+            () -> this.collector.send(
+                "topic",
+                "key",
+                null,
+                new RecordHeaders(),
+                0,
+                0L,
+                (Serializer) new LongSerializer(), // need to add cast to trigger `ClassCastException`
+                new StringSerializer())
+        );
+
+        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
+        assertThat(
+            expected.getMessage(),
+            equalTo(
+                "ClassCastException while producing data to a sink topic. " +
+                    "A serializer (key: org.apache.kafka.common.serialization.LongSerializer / value: org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual key or value type (key type: java.lang.String / value type: unknown because value is null). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
+                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowInformativeStreamsExceptionOnValueClassCastException() {
+        final StreamsException expected = assertThrows(
+            StreamsException.class,
+            () -> this.collector.send(
+                "topic",
+                "key",
+                "value",
+                new RecordHeaders(),
+                0,
+                0L,
+                new StringSerializer(),
+                (Serializer) new LongSerializer()) // need to add cast to trigger `ClassCastException`
+        );
+
+        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
+        assertThat(
+            expected.getMessage(),
+            equalTo(
+                "ClassCastException while producing data to a sink topic. " +
+                    "A serializer (key: org.apache.kafka.common.serialization.StringSerializer / value: org.apache.kafka.common.serialization.LongSerializer) " +
+                    "is not compatible to the actual key or value type (key type: java.lang.String / value type: java.lang.String). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
+                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowInformativeStreamsExceptionOnValueAndNullKeyClassCastException() {
+        final StreamsException expected = assertThrows(
+            StreamsException.class,
+            () -> this.collector.send(
+                "topic",
+                null,
+                "value",
+                new RecordHeaders(),
+                0,
+                0L,
+                new StringSerializer(),
+                (Serializer) new LongSerializer()) // need to add cast to trigger `ClassCastException`
+        );
+
+        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
+        assertThat(
+            expected.getMessage(),
+            equalTo(
+                "ClassCastException while producing data to a sink topic. " +
+                    "A serializer (key: org.apache.kafka.common.serialization.StringSerializer / value: org.apache.kafka.common.serialization.LongSerializer) " +
+                    "is not compatible to the actual key or value type (key type: unknown because key is null / value type: java.lang.String). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
+                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -369,7 +369,7 @@ public class RecordCollectorTest {
         assertThat(
             expected.getMessage(),
             equalTo(
-                "ClassCastException while producing data to a sink topic. " +
+                "ClassCastException while producing data to topic topic. " +
                     "A serializer (key: org.apache.kafka.common.serialization.LongSerializer / value: org.apache.kafka.common.serialization.StringSerializer) " +
                     "is not compatible to the actual key or value type (key type: java.lang.String / value type: java.lang.String). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
@@ -397,7 +397,7 @@ public class RecordCollectorTest {
         assertThat(
             expected.getMessage(),
             equalTo(
-                "ClassCastException while producing data to a sink topic. " +
+                "ClassCastException while producing data to topic topic. " +
                     "A serializer (key: org.apache.kafka.common.serialization.LongSerializer / value: org.apache.kafka.common.serialization.StringSerializer) " +
                     "is not compatible to the actual key or value type (key type: java.lang.String / value type: unknown because value is null). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
@@ -425,7 +425,7 @@ public class RecordCollectorTest {
         assertThat(
             expected.getMessage(),
             equalTo(
-                "ClassCastException while producing data to a sink topic. " +
+                "ClassCastException while producing data to topic topic. " +
                     "A serializer (key: org.apache.kafka.common.serialization.StringSerializer / value: org.apache.kafka.common.serialization.LongSerializer) " +
                     "is not compatible to the actual key or value type (key type: java.lang.String / value type: java.lang.String). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +
@@ -453,7 +453,7 @@ public class RecordCollectorTest {
         assertThat(
             expected.getMessage(),
             equalTo(
-                "ClassCastException while producing data to a sink topic. " +
+                "ClassCastException while producing data to topic topic. " +
                     "A serializer (key: org.apache.kafka.common.serialization.StringSerializer / value: org.apache.kafka.common.serialization.LongSerializer) " +
                     "is not compatible to the actual key or value type (key type: unknown because key is null / value type: java.lang.String). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters " +

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -16,40 +16,22 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class SinkNodeTest {
     private final StateSerdes<Bytes, Bytes> anyStateSerde = StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class);
     private final Serializer<byte[]> anySerializer = Serdes.ByteArray().serializer();
-    private final RecordCollector recordCollector = new MockRecordCollector() {
-        @Override
-        public <K, V> void send(final String topic,
-                                final K key,
-                                final V value,
-                                final Headers headers,
-                                final Long timestamp,
-                                final Serializer<K> keySerializer,
-                                final Serializer<V> valueSerializer,
-                                final StreamPartitioner<? super K, ? super V> partitioner) {
-            throw new ClassCastException("boom");
-        }
-    };
-
+    private final RecordCollector recordCollector = new MockRecordCollector();
     private final InternalMockProcessorContext context = new InternalMockProcessorContext(anyStateSerde, recordCollector);
     private final SinkNode<byte[], byte[]> sink = new SinkNode<>("anyNodeName",
             new StaticTopicNameExtractor<>("any-output-topic"), anySerializer, anySerializer, null);
@@ -72,44 +54,6 @@ public class SinkNodeTest {
             fail("Should have thrown StreamsException");
         } catch (final StreamsException ignored) {
             // expected
-        }
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionWithClassCastFromRecordCollector() {
-        // When/Then
-        context.setTime(0);
-        try {
-            illTypedSink.process("key", "value");
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException e) {
-            assertThat(e.getCause(), instanceOf(ClassCastException.class));
-        }
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionNullKeyWithClassCastFromRecordCollector() {
-        // When/Then
-        context.setTime(1);
-        try {
-            illTypedSink.process(null, "");
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException e) {
-            assertThat(e.getCause(), instanceOf(ClassCastException.class));
-            assertThat(e.getMessage(), containsString("unknown because key is null"));
-        }
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionNullValueWithClassCastFromRecordCollector() {
-        // When/Then
-        context.setTime(1);
-        try {
-            illTypedSink.process("", null);
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException e) {
-            assertThat(e.getCause(), instanceOf(ClassCastException.class));
-            assertThat(e.getMessage(), containsString("unknown because value is null"));
         }
     }
 


### PR DESCRIPTION
Detected this issue by chance. Seems to need a fix in older branches, too.

Originally, we put the code to handle class-cast-exception into `SinkNode` on purpose to have the error message only for sink topics (not for changelogs). But in hindsight, it seems better to pull it into the `RecordCollector` directly.

Call for review @ableegoldman @vvcephei 