### PR TITLE
KAFKA-9599 create unique sensor to record group rebalance

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -74,7 +74,7 @@ class GroupCoordinator(val brokerId: Int,
       "group-coordinator-metrics",
       "The total number of administrative deleted offsets")))
 
-  val groupCompletedRebalanceSensor = metrics.sensor("OffsetDeletions")
+  val groupCompletedRebalanceSensor = metrics.sensor("CompletedRebalances")
 
   groupCompletedRebalanceSensor.add(new Meter(
     metrics.metricName("group-completed-rebalance-rate",


### PR DESCRIPTION
the "offset deletion" and "group rebalance" should not be recorded by the same sensor since they are totally different.

the code is introduced by #7276

jira link: https://issues.apache.org/jira/browse/KAFKA-9599

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
