### PR TITLE
KAFKA-9602: Close the stream internal producer only in EOS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -213,10 +213,13 @@ public class StreamsProducer {
     }
 
     public void close() {
-        try {
-            producer.close();
-        } catch (final KafkaException error) {
-            throw new StreamsException("Producer encounter unexpected error trying to close" + (taskId == null ? "" : " " + logMessage), error);
+        if (eosEnabled) {
+            try {
+                producer.close();
+            } catch (final KafkaException error) {
+                throw new StreamsException("Producer encounter unexpected " +
+                    "error trying to close" + (taskId == null ? "" : " " + logMessage), error);
+            }
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -649,6 +649,35 @@ public class RecordCollectorTest {
         assertThat(thrown.getMessage(), equalTo("Could not get partition information for topic topic for task 0_0. This can happen if the topic does not exist."));
     }
 
+    @Test
+    public void shouldCloseInternalProducerForEOS() {
+        final RecordCollector collector = new RecordCollectorImpl(
+            logContext,
+            taskId,
+            mockConsumer,
+            new StreamsProducer(
+                logContext,
+                mockProducer,
+                "appId",
+                taskId),
+            productionExceptionHandler,
+            true,
+            streamsMetrics
+        );
+
+        collector.close();
+
+        // Flush should not throw as producer is still alive.
+        assertThrows(IllegalStateException.class, streamsProducer::flush);
+    }
+
+    @Test
+    public void shouldNotCloseInternalProducerForNonEOS() {
+        collector.close();
+
+        // Flush should not throw as producer is still alive.
+        streamsProducer.flush();
+    }
 
     private static class CustomStringSerializer extends StringSerializer {
         private boolean isKey;


### PR DESCRIPTION
This bug reproduces through the trunk stream test, the producer was closed unexpectedly when EOS is not turned on.

Will work on adding unit test to guard this logic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
