### PR TITLE
KAFKA-9533: Revert  ValueTransform forwards `null` 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
@@ -53,10 +53,7 @@ public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> 
 
         @Override
         public void process(final K key, final V value) {
-            final R transformedValue = valueTransformer.transform(key, value);
-            if (transformedValue != null) {
-                context.forward(key, transformedValue);
-            }
+            context.forward(key, valueTransformer.transform(key, value));
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -34,7 +34,6 @@ import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.SingletonNoOpValueTransformer;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.MockType;
@@ -43,7 +42,6 @@ import org.junit.runner.RunWith;
 
 import java.util.Properties;
 
-import static org.easymock.EasyMock.mock;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
@@ -138,24 +136,6 @@ public class KStreamTransformValuesTest {
             new KeyValueTimestamp<>(1000, 12221, 500)};
 
         assertArrayEquals(expected, supplier.theCapturedProcessor().processed.toArray());
-    }
-
-    @Test
-    public void shouldEmitNoRecordIfTransformReturnsNull() {
-        final ProcessorContext context = mock(ProcessorContext.class);
-        final ValueTransformerWithKey<Integer, Integer, Integer> valueTransformer = mock(ValueTransformerWithKey.class);
-        final KStreamTransformValues.KStreamTransformValuesProcessor<Integer, Integer, Integer> processor =
-            new KStreamTransformValues.KStreamTransformValuesProcessor<>(valueTransformer);
-        processor.init(context);
-
-        final Integer inputKey = 1;
-        final Integer inputValue = 10;
-        EasyMock.expect(valueTransformer.transform(inputKey, inputValue)).andStubReturn(null);
-        EasyMock.replay(context);
-
-        processor.process(inputKey, inputValue);
-
-        EasyMock.verify(context);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This reverts commit a41d3d86c13a55a75e67b1635bc74361ebe6d7af.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
