### PR TITLE
KAFKA-9607: Do not clear partition queues during close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -220,7 +220,7 @@ public class PartitionGroup {
 
     void close() {
         clear();
-        partitionQueues.clear();
+
         streamTime = RecordQueue.UNKNOWN;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -47,7 +47,7 @@ public class RecordQueue {
     private final ArrayDeque<ConsumerRecord<byte[], byte[]>> fifoQueue;
 
     private StampedRecord headRecord = null;
-    private long partitionTime = RecordQueue.UNKNOWN;
+    private long partitionTime;
 
     private final Sensor droppedRecordsSensor;
 
@@ -74,6 +74,7 @@ public class RecordQueue {
             droppedRecordsSensor
         );
         this.log = logContext.logger(RecordQueue.class);
+        setPartitionTime(UNKNOWN);
     }
 
     void setPartitionTime(final long partitionTime) {
@@ -166,6 +167,7 @@ public class RecordQueue {
     public void clear() {
         fifoQueue.clear();
         headRecord = null;
+        setPartitionTime(UNKNOWN);
     }
 
     private void updateHead() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -421,7 +421,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 log.warn("Encountered {} fetching records from restore consumer for partitions {}, it is likely that " +
                     "the consumer's position has fallen out of the topic partition offset range because the topic was " +
                     "truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing" +
-                    "it later.", e.getClass().getName(), e.partitions());
+                    " it later.", e.getClass().getName(), e.partitions());
 
                 final Map<TaskId, Set<TopicPartition>> taskWithCorruptedChangelogs = new HashMap<>();
                 for (final TopicPartition partition : e.partitions()) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -180,6 +180,7 @@ public class RecordQueueTest {
         assertTrue(queue.isEmpty());
         assertEquals(0, queue.size());
         assertEquals(RecordQueue.UNKNOWN, queue.headRecordTimestamp());
+        assertEquals(RecordQueue.UNKNOWN, queue.partitionTime());
         assertNull(queue.headRecordOffset());
 
         // re-insert the three records with 4, 5, 6


### PR DESCRIPTION
This PR fixes the illegal state bug where a task gets revived but has no input partition assigned anymore.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
