### PR TITLE
KAFKA-9610: Do not throw illegal state when remaining partitions are not empty

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -213,10 +213,13 @@ public class StreamsProducer {
     }
 
     public void close() {
-        try {
-            producer.close();
-        } catch (final KafkaException error) {
-            throw new StreamsException("Producer encounter unexpected error trying to close" + (taskId == null ? "" : " " + logMessage), error);
+        if (eosEnabled) {
+            try {
+                producer.close();
+            } catch (final KafkaException error) {
+                throw new StreamsException("Producer encounter unexpected " +
+                    "error trying to close" + (taskId == null ? "" : " " + logMessage), error);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -213,13 +213,10 @@ public class StreamsProducer {
     }
 
     public void close() {
-        if (eosEnabled) {
-            try {
-                producer.close();
-            } catch (final KafkaException error) {
-                throw new StreamsException("Producer encounter unexpected " +
-                    "error trying to close" + (taskId == null ? "" : " " + logMessage), error);
-            }
+        try {
+            producer.close();
+        } catch (final KafkaException error) {
+            throw new StreamsException("Producer encounter unexpected error trying to close" + (taskId == null ? "" : " " + logMessage), error);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -304,8 +304,9 @@ public class TaskManager {
         }
 
         if (!remainingPartitions.isEmpty()) {
-            log.info("The following partitions {} are missing from the task partitions. It is possible that" +
-                "they have been cleaned up by the onAssignment callback", remainingPartitions);
+            log.warn("The following partitions {} are missing from the task partitions. It could potentially " +
+                "due to race condition of consumer detecting the heartbeat failure, or the tasks " +
+                "have been cleaned up by the handleAssignment callback", remainingPartitions);
         }
 
         for (final TaskId taskId : revokedTasks) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -304,8 +304,8 @@ public class TaskManager {
         }
 
         if (!remainingPartitions.isEmpty()) {
-            throw new IllegalStateException("Some revoked partitions that do not belong " +
-                "to any tasks remain: " + remainingPartitions);
+            log.info("The following partitions {} are missing from the task partitions. It is possible that" +
+                "they have been cleaned up by the onAssignment callback", remainingPartitions);
         }
 
         for (final TaskId taskId : revokedTasks) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -306,7 +306,7 @@ public class TaskManager {
         if (!remainingPartitions.isEmpty()) {
             log.warn("The following partitions {} are missing from the task partitions. It could potentially " +
                 "due to race condition of consumer detecting the heartbeat failure, or the tasks " +
-                "have been cleaned up by the handleAssignment callback", remainingPartitions);
+                "have been cleaned up by the handleAssignment callback.", remainingPartitions);
         }
 
         for (final TaskId taskId : revokedTasks) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
@@ -48,6 +49,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -70,6 +72,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.resetToStrict;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -717,7 +720,25 @@ public class TaskManagerTest {
 
     @Test
     public void shouldHaveRemainingPartitionsUncleared() {
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
 
+        final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true);
+
+        expectRestoreToBeCompleted(consumer, changeLogReader);
+        expect(activeTaskCreator.createTasks(anyObject(), eq(taskId00Assignment))).andReturn(singletonList(task00));
+
+        replay(activeTaskCreator, consumer, changeLogReader);
+        taskManager.handleAssignment(taskId00Assignment, emptyMap());
+        assertThat(taskManager.tryToCompleteRestoration(), is(true));
+        assertThat(task00.state(), is(Task.State.RUNNING));
+
+        taskManager.handleRevocation(mkSet(t1p0, new TopicPartition("unknown", 0)));
+        assertThat(task00.state(), is(Task.State.SUSPENDED));
+
+        final List<String> messages = appender.getMessages();
+        assertThat(messages, hasItem("taskManagerTestThe following partitions [unknown-0] are missing " +
+            "from the task partitions. It could potentially due to race condition of consumer " +
+            "detecting the heartbeat failure, or the tasks have been cleaned up by the handleAssignment callback."));
     }
 
     private static void expectRestoreToBeCompleted(final Consumer<byte[], byte[]> consumer,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -715,6 +715,11 @@ public class TaskManagerTest {
         verify(consumer);
     }
 
+    @Test
+    public void shouldHaveRemainingPartitionsUncleared() {
+
+    }
+
     private static void expectRestoreToBeCompleted(final Consumer<byte[], byte[]> consumer,
                                                    final ChangelogReader changeLogReader) {
         final Set<TopicPartition> assignment = singleton(new TopicPartition("assignment", 0));


### PR DESCRIPTION
For `handleRevocation`, it is possible that previous onAssignment callback has cleaned up the stream tasks, which means no corresponding task could be found for given partitions. We should not throw here as this is expected behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
