### PR TITLE
KAFKA-9439: add KafkaProducer API unit tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -611,7 +611,7 @@ public class KafkaProducerTest {
     }
 
     @Test
-    public void testFlush() {
+    public void testFlushCompleteSendOfInflightBatches() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
 


### PR DESCRIPTION
This PR adds unit tests for `KafkaProducer.close()`, `KafkaProducer.abortTransaction()`, and `KafkaProducer.flush()`. 
Increase KafkaProducer JUnit code coverage from 82% methods, 82% lines to 87% methods, 85% lines. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
