### PR TITLE
KAFKA-7906: Improve logging for failed leader elections

### DIFF
--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -337,9 +337,15 @@ class ZkPartitionStateMachine(config: KafkaConfig,
 
       finished.foreach {
         case (partition, Left(e)) =>
+          // Extract failure message, if present, to append to error log.
+          val reasonMsg = if (e.isInstanceOf[StateChangeFailedException]) {
+            s", reason: ${e.getMessage}"
+          } else {
+            ""
+          }
           logger.error(s"Controller $controllerId epoch ${controllerContext.epoch} failed to "
             + s" change state for partition $partition from ${partitionState(partition)} "
-            + s"to $OnlinePartition", e)
+            + s"to $OnlinePartition $reasonMsg", e)
         case (_, Right(_)) => // Ignore; success so no need to log failed state change
       }
 

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -337,7 +337,9 @@ class ZkPartitionStateMachine(config: KafkaConfig,
 
       finished.foreach {
         case (partition, Left(e)) =>
-          logFailedStateChange(partition, partitionState(partition), OnlinePartition, e)
+          logger.error(s"Controller $controllerId epoch ${controllerContext.epoch} failed to "
+            + s" change state for partition $partition from ${partitionState(partition)} "
+            + s"to $OnlinePartition", e)
         case (_, Right(_)) => // Ignore; success so no need to log failed state change
       }
 

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -347,7 +347,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
           if (e.isInstanceOf[StateChangeFailedException]) {
             logger.error(s"$failMsg: $reasonMsg")
           } else {
-            logger.error(failMsg, e)
+            logger.error(s"$failMsg: unknown exception: ", e)
           }
         case (_, Right(_)) => // Ignore; success so no need to log failed state change
       }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -338,16 +338,10 @@ class ZkPartitionStateMachine(config: KafkaConfig,
       finished.foreach {
         case (partition, Left(e)) =>
           // Extract failure message, if present, to append to error log.
-          val reasonMsg = if (e.isInstanceOf[StateChangeFailedException]) {
-            s", reason: ${e.getMessage}"
-          } else {
-            ""
-          }
-          val failMsg = s"Controller failed to change state for partition $partition from ${partitionState(partition)} to $OnlinePartition"
-          if (e.isInstanceOf[StateChangeFailedException]) {
-            logger.error(s"$failMsg: $reasonMsg")
-          } else {
-            logger.error(s"$failMsg: unknown exception: ", e)
+          val failMsg = s"Failed to change state for partition $partition from ${partitionState(partition)} to $OnlinePartition"
+          e match {
+            case _:StateChangeFailedException => logger.error(s"$failMsg, reason: ${e.getMessage}")
+            case _ => logger.error(s"$failMsg: unknown exception: ", e)
           }
         case (_, Right(_)) => // Ignore; success so no need to log failed state change
       }


### PR DESCRIPTION
- Log election errors within the `kafka.controller` class hierarchy instead of within `state.changed.logger`
- Log failure reason when present
- Verified existing tests pass

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
