### PR TITLE
HOTFIX: fix failing test PlaintextAdminIntegrationTest.testElectPreferredLeaders

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1285,7 +1285,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     var electResult = client.electLeaders(ElectionType.PREFERRED, Set(partition1).asJava)
     var exception = electResult.partitions.get.get(partition1).get
     assertEquals(classOf[ElectionNotNeededException], exception.getClass)
-    assertEquals("Leader election not needed for topic partition", exception.getMessage)
+    assertEquals("Leader election not needed for topic partition.", exception.getMessage)
     TestUtils.assertLeader(client, partition1, 0)
 
     // Noop election with null partitions

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1285,7 +1285,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     var electResult = client.electLeaders(ElectionType.PREFERRED, Set(partition1).asJava)
     var exception = electResult.partitions.get.get(partition1).get
     assertEquals(classOf[ElectionNotNeededException], exception.getClass)
-    assertEquals("Leader election not needed for topic partition.", exception.getMessage)
+    assertEquals(org.apache.kafka.common.protocol.Errors.ELECTION_NOT_NEEDED.message(), exception.getMessage)
     TestUtils.assertLeader(client, partition1, 0)
 
     // Noop election with null partitions

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1285,7 +1285,6 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     var electResult = client.electLeaders(ElectionType.PREFERRED, Set(partition1).asJava)
     var exception = electResult.partitions.get.get(partition1).get
     assertEquals(classOf[ElectionNotNeededException], exception.getClass)
-    assertEquals(org.apache.kafka.common.protocol.Errors.ELECTION_NOT_NEEDED.message(), exception.getMessage)
     TestUtils.assertLeader(client, partition1, 0)
 
     // Noop election with null partitions


### PR DESCRIPTION

(broken by https://github.com/apache/kafka/pull/3909)

- Confirmed the test passes after this (minor) change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
