### PR TITLE
HOTFIX: testInitTransactionTimeout should use prepareResponse instead of respond

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -44,12 +44,7 @@ import java.util.stream.Collectors;
  * A mock network client for use testing code
  */
 public class MockClient implements KafkaClient {
-    public static final RequestMatcher ALWAYS_TRUE = new RequestMatcher() {
-        @Override
-        public boolean matches(AbstractRequest body) {
-            return true;
-        }
-    };
+    public static final RequestMatcher ALWAYS_TRUE = body -> true;
 
     private static class FutureResponse {
         private final Node node;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -767,7 +767,13 @@ public class KafkaProducerTest {
 
             assertThrows(TimeoutException.class, producer::initTransactions);
 
-            client.respond(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+            assertTrue("Should at most have one pending quest to find coordinator", client.inFlightRequestCount() <= 1);
+            if (client.inFlightRequestCount() > 0) {
+                client.respond(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+            } else {
+                client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
+            }
+
             client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
 
             // retry initialization should work

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -767,7 +767,6 @@ public class KafkaProducerTest {
 
             assertThrows(TimeoutException.class, producer::initTransactions);
 
-            assertTrue("Should at most have one pending quest to find coordinator", client.inFlightRequestCount() <= 1);
             if (client.inFlightRequestCount() > 0) {
                 client.respond(FindCoordinatorResponse.prepareResponse(Errors.NONE, host1));
             } else {


### PR DESCRIPTION
We have seen a flaky behavior due to using #respond instead of #prepareResponse call for the txn test. 

Reproduced on local as:

```
[2020-02-26 15:08:49,194] ERROR [Producer clientId=producer-bad-transaction, transactionalId=bad-transaction] Uncaught error in kafka producer I/O thread:  (org.apache.kafka.clients.producer.internals.Sender:241)
java.lang.ClassCastException: org.apache.kafka.common.requests.InitProducerIdResponse cannot be cast to org.apache.kafka.common.requests.FindCoordinatorResponse
	at org.apache.kafka.clients.producer.internals.TransactionManager$FindCoordinatorHandler.handleResponse(TransactionManager.java:1494)
	at org.apache.kafka.clients.producer.internals.TransactionManager$TxnRequestHandler.onComplete(TransactionManager.java:1260)
	at org.apache.kafka.clients.ClientResponse.onComplete(ClientResponse.java:109)
	at org.apache.kafka.clients.MockClient.poll(MockClient.java:294)
	at org.apache.kafka.clients.producer.internals.Sender.maybeSendAndPollTransactionalRequest(Sender.java:458)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:312)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:239)
```

and

```
java.lang.IllegalStateException: No requests pending for inbound response FindCoordinatorResponseData(throttleTimeMs=0, errorCode=0, errorMessage='NONE', nodeId=0, host='host1', port=1000)

	at org.apache.kafka.clients.MockClient.respond(MockClient.java:345)
	at org.apache.kafka.clients.MockClient.respond(MockClient.java:319)
	at org.apache.kafka.clients.producer.KafkaProducerTest.testInitTransactionTimeout(KafkaProducerTest.java:770)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
