### PR TITLE
MINOR: Revert Jetty to 9.4.25

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,10 @@ versions += [
   easymock: "4.1",
   jackson: "2.10.2",
   jacoco: "0.8.3",
-  jetty: "9.4.26.v20200117",
+  // 9.4.25 renamed closeOutput to completeOutput (https://github.com/eclipse/jetty.project/commit/c5acf965067478784b54e2d241ec58fdb0b2c9fe)
+  // which is a method used by recent Jersey versions when this comment was written (2.30.1 was the latest). Please
+  // verify that this is fixed in some way before bumping the Jetty version.
+  jetty: "9.4.24.v20191120",
   jersey: "2.28",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
9.4.25 renamed closeOutput to completeOutput
(https://github.com/eclipse/jetty.project/commit/c5acf965067478784b54e2d241ec58fdb0b2c9fe),
which is a method used by recent Jersey versions including the
latest (2.30.1). An example of the error:

> java.lang.NoSuchMethodError: org.eclipse.jetty.server.Response.closeOutput()V
> 	at org.glassfish.jersey.jetty.JettyHttpContainer$ResponseWriter.commit(JettyHttpContainer.java:326)

The request still completes and hence why no test fails. We should think about how
to improve the testing for this kind of problem, but I want to get the fix in before
2.5 RC0.

Credit to @rigelbm for finding this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
