### PR TITLE
KAKFA-9612 CLI Dynamic Configuration with file input

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import java.io.FileWriter;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
@@ -224,6 +225,19 @@ public class TestUtils {
     public static File tempFile() throws IOException {
         final File file = File.createTempFile("kafka", ".tmp");
         file.deleteOnExit();
+
+        return file;
+    }
+
+    /**
+     * Create a file with the given contents in the default temporary-file directory,
+     * using `kafka` as the prefix and `tmp` as the suffix to generate its name.
+     */
+    public static File tempFile(final String contents) throws IOException {
+        final File file = tempFile();
+        final FileWriter writer = new FileWriter(file);
+        writer.write(contents);
+        writer.close();
 
         return file;
     }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -17,6 +17,7 @@
 
 package kafka.admin
 
+import java.io.{File, FileInputStream}
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Properties}
 
@@ -247,6 +248,15 @@ object ConfigCommand extends Config {
 
   private[admin] def parseConfigsToBeAdded(opts: ConfigCommandOptions): Properties = {
     val props = new Properties
+    if (opts.options.has(opts.addConfigFile)) {
+      val file = opts.options.valueOf(opts.addConfigFile)
+      val inputStream = new FileInputStream(file)
+      try {
+        props.load(inputStream)
+      } finally {
+        inputStream.close()
+      }
+    }
     if (opts.options.has(opts.addConfig)) {
       // Split list by commas, but avoid those in [], then into KV pairs
       // Each KV pair is of format key=value, split them into key and value, using -1 as the limit for split() to
@@ -258,10 +268,10 @@ object ConfigCommand extends Config {
       require(configsToBeAdded.forall(config => config.length == 2), "Invalid entity config: all configs to be added must be in the format \"key=val\".")
       //Create properties, parsing square brackets from values if necessary
       configsToBeAdded.foreach(pair => props.setProperty(pair(0).trim, pair(1).replaceAll("\\[?\\]?", "").trim))
-      if (props.containsKey(LogConfig.MessageFormatVersionProp)) {
-        println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
-          s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
-      }
+    }
+    if (props.containsKey(LogConfig.MessageFormatVersionProp)) {
+      println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
+        s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
     }
     props
   }
@@ -645,6 +655,9 @@ object ConfigCommand extends Config {
             s"Entity types '${ConfigType.User}' and '${ConfigType.Client}' may be specified together to update config for clients of a specific user.")
             .withRequiredArg
             .ofType(classOf[String])
+    val addConfigFile = parser.accepts("add-config-file", "Path to a properties file with configs to add. See add-config for a list of valid configurations.")
+            .withRequiredArg
+            .ofType(classOf[File])
     val deleteConfig = parser.accepts("delete-config", "config keys to remove 'k1,k2'")
             .withRequiredArg
             .ofType(classOf[String])
@@ -764,10 +777,15 @@ object ConfigCommand extends Config {
         } else if (!hasEntityName)
           throw new IllegalArgumentException(s"an entity name must be specified with --alter of ${entityTypeVals.mkString(",")}")
 
-        val isAddConfigPresent: Boolean = options.has(addConfig)
-        val isDeleteConfigPresent: Boolean = options.has(deleteConfig)
-        if (!isAddConfigPresent && !isDeleteConfigPresent)
-          throw new IllegalArgumentException("At least one of --add-config or --delete-config must be specified with --alter")
+        val isAddConfigPresent = options.has(addConfig)
+        val isAddConfigFilePresent = options.has(addConfigFile)
+        val isDeleteConfigPresent = options.has(deleteConfig)
+
+        if(isAddConfigPresent && isAddConfigFilePresent)
+          throw new IllegalArgumentException("Only one of --add-config or --add-config-file must be specified")
+
+        if(!isAddConfigPresent && !isAddConfigFilePresent && ! isDeleteConfigPresent)
+          throw new IllegalArgumentException("At least one of --add-config, --add-config-file, or --delete-config must be specified with --alter")
       }
     }
   }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -27,7 +27,6 @@ import kafka.log.LogConfig
 import kafka.server.{ConfigEntityName, ConfigType, Defaults, DynamicBrokerConfig, DynamicConfig, KafkaConfig}
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, PasswordEncoder}
 import kafka.utils.Implicits._
-import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, PasswordEncoder}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasOptions, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeClusterOptions, DescribeConfigsOptions, ListTopicsOptions, Config => JConfig}

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -17,7 +17,6 @@
 
 package kafka.admin
 
-import java.io.{File, FileInputStream, FileNotFoundException}
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Properties}
 
@@ -250,15 +249,7 @@ object ConfigCommand extends Config {
     val props = new Properties
     if (opts.options.has(opts.addConfigFile)) {
       val file = opts.options.valueOf(opts.addConfigFile)
-      val inputStream = try new FileInputStream(file) catch {
-        case _: FileNotFoundException =>
-          throw new IllegalArgumentException(s"No such file: $file")
-      }
-      try {
-        props.load(inputStream)
-      } finally {
-        inputStream.close()
-      }
+      props.putAll(Utils.loadProps(file))
     }
     if (opts.options.has(opts.addConfig)) {
       // Split list by commas, but avoid those in [], then into KV pairs
@@ -660,7 +651,7 @@ object ConfigCommand extends Config {
             .ofType(classOf[String])
     val addConfigFile = parser.accepts("add-config-file", "Path to a properties file with configs to add. See add-config for a list of valid configurations.")
             .withRequiredArg
-            .ofType(classOf[File])
+            .ofType(classOf[String])
     val deleteConfig = parser.accepts("delete-config", "config keys to remove 'k1,k2'")
             .withRequiredArg
             .ofType(classOf[String])

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -252,7 +252,7 @@ object ConfigCommand extends Config {
       val file = opts.options.valueOf(opts.addConfigFile)
       val inputStream = try new FileInputStream(file) catch {
         case _: FileNotFoundException =>
-          throw new IllegalArgumentException(s"No such file or directory: $file")
+          throw new IllegalArgumentException(s"No such file: $file")
       }
       try {
         props.load(inputStream)

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -16,7 +16,6 @@
  */
 package kafka.admin
 
-import java.io.{File, FileWriter}
 import java.util
 import java.util.Properties
 
@@ -36,13 +35,14 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, 
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils
 import org.apache.kafka.common.utils.Sanitizer
+import org.apache.kafka.test.TestUtils
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.Test
 import org.scalatest.Assertions.intercept
 
-import scala.collection.JavaConverters._
 import scala.collection.{Seq, mutable}
+import scala.jdk.CollectionConverters._
 
 class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
 
@@ -262,11 +262,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
         |nested = [[1, 2], [3, 4]]
         |""".stripMargin
 
-    val file = File.createTempFile("testParseConfigsToBeAddedForAddConfigFile", ".properties")
-    file.deleteOnExit()
-    val writer = new FileWriter(file)
-    writer.write(fileContents)
-    writer.close()
+    val file = TestUtils.tempFile(fileContents)
 
     val addConfigFileArgs = Array("--add-config-file", file.getPath)
 
@@ -495,11 +491,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     var filePath = ""
     val addedConfigs = Seq("delete.retention.ms=1000000", "min.insync.replicas=2")
     if (file) {
-      val file = File.createTempFile("testParseConfigsToBeAddedForAddConfigFile", ".properties")
-      file.deleteOnExit()
-      val writer = new FileWriter(file)
-      writer.write(addedConfigs.mkString("\n"))
-      writer.close()
+      val file = TestUtils.tempFile(addedConfigs.mkString("\n"))
       filePath = file.getPath
     }
 

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -242,7 +242,6 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailIfAddAndAddFile(): Unit = {
-
     // Should not parse correctly
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "1",

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -483,12 +483,33 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldAlterTopicConfig(): Unit = {
+    doShouldAlterTopicConfig(false)
+  }
+
+  @Test
+  def shouldAlterTopicConfigFile(): Unit = {
+    doShouldAlterTopicConfig(true)
+  }
+
+  def doShouldAlterTopicConfig(file: Boolean): Unit = {
+    var filePath = ""
+    val addedConfigs = Seq("delete.retention.ms=1000000", "min.insync.replicas=2")
+    if (file) {
+      val file = File.createTempFile("testParseConfigsToBeAddedForAddConfigFile", ".properties")
+      file.deleteOnExit()
+      val writer = new FileWriter(file)
+      writer.write(addedConfigs.mkString("\n"))
+      writer.close()
+      filePath = file.getPath
+    }
+
     val resourceName = "my-topic"
     val alterOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", resourceName,
       "--entity-type", "topics",
       "--alter",
-      "--add-config", "delete.retention.ms=1000000,min.insync.replicas=2",
+      if (file) "--add-config-file" else "--add-config",
+      if (file) filePath else addedConfigs.mkString(","),
       "--delete-config", "unclean.leader.election.enable"))
     var alteredConfigs = false
 


### PR DESCRIPTION
Add an option to kafka-configs.sh `--add-config-file` that adds the configs from a properties file.
Testing: Added new tests to ConfigCommandTest.scala

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
