### PR TITLE
KAFKA-9478: Remove zombie partition reassignments from ZooKeeper

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -938,7 +938,7 @@ class KafkaController(val config: KafkaConfig,
 
     val reassigningPartitions = zkClient.getPartitionReassignment()
     val (removingPartitions, updatedPartitionsBeingReassigned) = reassigningPartitions.partition { case (tp, replicas) =>
-      shouldRemoveReassignment(tp, replicas)
+      shouldRemoveReassignment(tp, replicas) || !controllerContext.partitionsBeingReassigned.contains(tp)
     }
     info(s"Removing partitions $removingPartitions from the list of reassigned partitions in zookeeper")
 


### PR DESCRIPTION
The JIRA ticket explains the issue with reassignment commands concurrently issued using `/admin/reassign_partitions` ZooKeeper node.

This commit fixes this issue by deleting from `/admin/reassign_partitions` partition reassignments that otherwise would 1) not be acted upon any way; and 2) remain there forever preventing the controller from deleting the Zk node and restoring the watch on it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
