### PR TITLE
Kafka 9626: Improve ACLAuthorizer.acls() performance

### DIFF
--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -40,7 +40,7 @@
     <allow class="kafka.utils.KafkaScheduler"/>
     <allow class="org.apache.kafka.clients.FetchSessionHandler"/>
     <allow pkg="org.mockito"/>
-
+    <allow pkg="kafka.security.authorizer"/>
 
     <subpackage name="cache">
     </subpackage>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -427,4 +427,8 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
 
+    <Match>
+        <!-- Suppress warnings related to jmh generated code -->
+        <Package name="org.apache.kafka.jmh.acl.generated"/>
+    </Match>
 </FindBugsFilter>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
@@ -43,7 +43,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.TreeMap;
-import scala.math.Ordering;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -99,7 +98,7 @@ public class AclAuthorizerBenchmark {
             }
         }
 
-        TreeMap<ResourcePattern, VersionedAcls> aclCache = new TreeMap<>(new ResourceOrdering());
+        TreeMap<ResourcePattern, VersionedAcls> aclCache = new TreeMap<>(new AclAuthorizer.ResourceOrdering());
         for (Map.Entry<ResourcePattern, Set<AclEntry>> entry : aclEntries.entrySet()) {
             aclCache = aclCache.updated(entry.getKey(),
                 new VersionedAcls(JavaConverters.asScalaSetConverter(entry.getValue()).asScala().toSet(), 1));
@@ -116,22 +115,5 @@ public class AclAuthorizerBenchmark {
     @Benchmark
     public void testAclsIterator() {
         aclAuthorizer.acls(AclBindingFilter.ANY);
-    }
-
-    private static class ResourceOrdering implements Ordering<ResourcePattern> {
-        @Override
-        public int compare(final ResourcePattern a, final ResourcePattern b) {
-            int rt = a.resourceType().compareTo(b.resourceType());
-            if (rt != 0) {
-                return rt;
-            } else {
-                int rnt = a.patternType().compareTo(b.patternType());
-                if (rnt != 0)
-                    return rnt;
-                else {
-                    return a.name().compareTo(b.name()) * -1;
-                }
-            }
-        }
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.acl;
+
+import kafka.security.authorizer.AclAuthorizer;
+import kafka.security.authorizer.AclEntry;
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.TreeMap;
+import scala.math.Ordering;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+
+public class AclAuthorizerBenchmark {
+    @Param({"5000", "10000", "50000"})
+    public static Integer resourceCount;
+    //no. of. rules per resource
+    @Param({"5", "10"})
+    public static Integer aclCount;
+
+    private AclAuthorizer aclAuthorizer = new AclAuthorizer();
+    private KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+
+    public static void main(String[] args) throws NoSuchFieldException {
+        AclAuthorizerBenchmark aclAuthorizerBenchmark = new AclAuthorizerBenchmark();
+        aclAuthorizerBenchmark.setup();
+        aclAuthorizerBenchmark.testAclsIterator();
+    }
+
+    @Setup(Level.Trial)
+    public void setup() throws NoSuchFieldException {
+        FieldSetter.setField(aclAuthorizer, AclAuthorizer.class.getDeclaredField("aclCache"),
+            prepareAclCache());
+    }
+
+    private TreeMap prepareAclCache() {
+        Random random = new Random();
+        Map<ResourcePattern, java.util.Set<AclEntry>> aclEntries = new HashMap<>();
+
+        for (int i = 0; i < resourceCount; i++) {
+            // set TOPIC, GROUP, or CLUSTER
+            int resourceCode = random.nextInt(3) + 2;
+            ResourceType resourceType = ResourceType.fromCode((byte) resourceCode);
+
+            // set LITERAL or PREFIXED
+            int pattenCode = random.nextInt(2) + 3;
+            PatternType pattenType = PatternType.fromCode((byte) pattenCode);
+
+            ResourcePattern resource = new ResourcePattern(resourceType, "resource-" + i, pattenType);
+            java.util.Set<AclEntry> entries = aclEntries.computeIfAbsent(resource, k -> new HashSet<>());
+
+            for (int j = 0; j < aclCount; j++) {
+                AccessControlEntry ace =
+                    new AccessControlEntry(principal.toString(), "*", AclOperation.READ, AclPermissionType.ALLOW);
+                entries.add(new AclEntry(ace));
+            }
+        }
+
+        TreeMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclCache = new TreeMap<>(new ResourceOrdering());
+        for (Map.Entry<ResourcePattern, java.util.Set<AclEntry>> entry : aclEntries.entrySet()) {
+            aclCache = aclCache.$plus(new Tuple2<>(entry.getKey(),
+                new AclAuthorizer.VersionedAcls(JavaConverters.asScalaSet(entry.getValue()).toSet(), 1)));
+        }
+        return aclCache;
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        aclAuthorizer.close();
+    }
+
+    @Benchmark
+    public void testAclsIterator() {
+        aclAuthorizer.acls(AclBindingFilter.ANY);
+    }
+
+    /*
+    @Benchmark
+    public void testMatchingAcls() {
+
+        aclAuthorizer.authorize()
+        AclBindingFilter filter =
+            new AclBindingFilter(new ResourcePatternFilter(ResourceType.TOPIC, "resource-10", PatternType.PREFIXED),
+                AccessControlEntryFilter.ANY);
+        //new AccessControlEntryFilter("User:ANONYMOUS", "127.0.0.1", AclOperation.READ, AclPermissionType.DENY));
+        //Iterable acls = aclAuthorizer.acls(AclBindingFilter.ANY);
+        Iterable acls = aclAuthorizer.acls(filter);
+        int counter = 0;
+        for (Object i : acls) {
+            if (((AclBinding)i).pattern().patternType() == PatternType.PREFIXED)
+                System.out.println(i);
+
+            counter++;
+        }
+        System.out.println("acls size: " + counter);
+    }
+
+    */
+
+    private class ResourceOrdering implements Ordering<ResourcePattern> {
+        @Override
+        public int compare(final ResourcePattern a, final ResourcePattern b) {
+            int rt = a.resourceType().compareTo(b.resourceType());
+            if (rt != 0) {
+                return rt;
+            } else {
+                int rnt = a.patternType().compareTo(b.patternType());
+                if (rnt != 0)
+                    return rnt;
+                else {
+                    return a.name().compareTo(b.name()) * -1;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR avoids creation of unnecessary sets in AclAuthorizer.acls() method implementation.

Perf results:
**Old**
```
Benchmark                                (aclCount)  (resourceCount)  Mode  Cnt    Score   Error  Units
AclAuthorizerBenchmark.testAclsIterator           5             5000  avgt   15    5.821 ? 0.309  ms/op
AclAuthorizerBenchmark.testAclsIterator           5            10000  avgt   15   15.303 ? 0.107  ms/op
AclAuthorizerBenchmark.testAclsIterator           5            50000  avgt   15   74.976 ? 0.543  ms/op
AclAuthorizerBenchmark.testAclsIterator          10             5000  avgt   15   15.366 ? 0.184  ms/op
AclAuthorizerBenchmark.testAclsIterator          10            10000  avgt   15   29.899 ? 0.129  ms/op
AclAuthorizerBenchmark.testAclsIterator          10            50000  avgt   15  167.301 ? 1.723  ms/op
AclAuthorizerBenchmark.testAclsIterator          15             5000  avgt   15   21.980 ? 0.114  ms/op
AclAuthorizerBenchmark.testAclsIterator          15            10000  avgt   15   44.385 ? 0.255  ms/op
AclAuthorizerBenchmark.testAclsIterator          15            50000  avgt   15  241.919 ? 3.955  ms/op
```
**New**

```
Benchmark                                (aclCount)  (resourceCount)  Mode  Cnt   Score   Error  Units
AclAuthorizerBenchmark.testAclsIterator           5             5000  avgt   15   0.666 ? 0.004  ms/op
AclAuthorizerBenchmark.testAclsIterator           5            10000  avgt   15   1.427 ? 0.015  ms/op
AclAuthorizerBenchmark.testAclsIterator           5            50000  avgt   15  21.410 ? 0.225  ms/op
AclAuthorizerBenchmark.testAclsIterator          10             5000  avgt   15   1.230 ? 0.018  ms/op
AclAuthorizerBenchmark.testAclsIterator          10            10000  avgt   15   4.303 ? 0.744  ms/op
AclAuthorizerBenchmark.testAclsIterator          10            50000  avgt   15  36.724 ? 0.409  ms/op
AclAuthorizerBenchmark.testAclsIterator          15             5000  avgt   15   2.433 ? 0.379  ms/op
AclAuthorizerBenchmark.testAclsIterator          15            10000  avgt   15   9.818 ? 0.214  ms/op
AclAuthorizerBenchmark.testAclsIterator          15            50000  avgt   15  52.886 ? 0.525  ms/op
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
