### PR TITLE
KAFKA-5876: IQ should throw different exceptions for different errors(part 1)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
@@ -18,8 +18,8 @@ package org.apache.kafka.streams.errors;
 
 
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * {@code InvalidStateStoreException} not thrown directly but only following sub-classes.
+ * Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
+ * {@code InvalidStateStoreException} is not thrown directly but only its following sub-classes.
  */
 public class InvalidStateStoreException extends StreamsException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
@@ -19,10 +19,7 @@ package org.apache.kafka.streams.errors;
 
 /**
  * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * {@code InvalidStateStoreException} not thrown directly but only following sub-classes.
  */
 public class InvalidStateStoreException extends StreamsException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.streams.errors;
 
+import org.apache.kafka.streams.KafkaStreams;
+
 /**
  * Indicates that the specific state store being queried via
- * {@link org.apache.kafka.streams.StoreQueryParameters} used an invalid partition.
+ * {@link org.apache.kafka.streams.StoreQueryParameters} used a partitioning that is not assigned to this instance.
+ * You can use {@link KafkaStreams#allMetadata()} to discover the correct instance that hosts the requested partition.
  */
 public class InvalidStateStorePartitionException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
@@ -16,27 +16,20 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicates that the specific state store being queried via
+ * {@link org.apache.kafka.streams.StoreQueryParameters} used an invalid partition.
  */
-public class InvalidStateStoreException extends StreamsException {
+public class InvalidStateStorePartitionException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public InvalidStateStorePartitionException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public InvalidStateStorePartitionException(final String message, final Throwable throwable) {
         super(message, throwable);
     }
 
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
@@ -16,27 +16,22 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicates that the state store being queried is closed although the Kafka Streams state is
+ * {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING} or
+ * {@link org.apache.kafka.streams.KafkaStreams.State#REBALANCING REBALANCING}.
+ * It could happen because the partition moved to some other instance during a rebalance so
+ * rediscovery of the state store is required before retrying.
  */
-public class InvalidStateStoreException extends StreamsException {
+public class StateStoreMigratedException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public StateStoreMigratedException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public StateStoreMigratedException(final String message, final Throwable throwable) {
         super(message, throwable);
-    }
-
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreMigratedException.java
@@ -20,7 +20,7 @@ package org.apache.kafka.streams.errors;
  * Indicates that the state store being queried is closed although the Kafka Streams state is
  * {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING} or
  * {@link org.apache.kafka.streams.KafkaStreams.State#REBALANCING REBALANCING}.
- * It could happen because the partition moved to some other instance during a rebalance so
+ * This could happen because the store moved to some other instance during a rebalance so
  * rediscovery of the state store is required before retrying.
  */
 public class StateStoreMigratedException extends InvalidStateStoreException {

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.errors;
 
 /**
- * Indicates that the state store being queried is already closed. It could happen when Kafka Streams is in
+ * Indicates that the state store being queried is already closed. This could happen when Kafka Streams is in
  * {@link org.apache.kafka.streams.KafkaStreams.State#PENDING_SHUTDOWN PENDING_SHUTDOWN} or
  * {@link org.apache.kafka.streams.KafkaStreams.State#NOT_RUNNING NOT_RUNNING} or
  * {@link org.apache.kafka.streams.KafkaStreams.State#ERROR ERROR} state.

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StateStoreNotAvailableException.java
@@ -16,27 +16,22 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicates that the state store being queried is already closed. It could happen when Kafka Streams is in
+ * {@link org.apache.kafka.streams.KafkaStreams.State#PENDING_SHUTDOWN PENDING_SHUTDOWN} or
+ * {@link org.apache.kafka.streams.KafkaStreams.State#NOT_RUNNING NOT_RUNNING} or
+ * {@link org.apache.kafka.streams.KafkaStreams.State#ERROR ERROR} state.
  */
-public class InvalidStateStoreException extends StreamsException {
+public class StateStoreNotAvailableException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public StateStoreNotAvailableException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public StateStoreNotAvailableException(final String message, final Throwable throwable) {
         super(message, throwable);
     }
 
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
@@ -16,27 +16,19 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicate query a state store when Kafka Streams state is {@link org.apache.kafka.streams.KafkaStreams.State#CREATED CREATED}.
+ * User can just retry and wait until to {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING}
  */
-public class InvalidStateStoreException extends StreamsException {
+public class StreamsNotStartedException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public StreamsNotStartedException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public StreamsNotStartedException(final String message, final Throwable throwable) {
         super(message, throwable);
-    }
-
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.streams.errors;
 
+import org.apache.kafka.streams.KafkaStreams;
+
 /**
- * Indicate query a state store when Kafka Streams state is {@link org.apache.kafka.streams.KafkaStreams.State#CREATED CREATED}.
- * User can just retry and wait until to {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING}
+ * Indicates that Kafka Streams is in state {@link KafkaStreams.State#CREATED CREATED} and thus state stores cannot be queries yet.
+ * To query state stores, it's required to first start Kafka Streams via {@link KafkaStreams#start()}.
+ * You can retry to query the state after the state transitioned to to {@link KafkaStreams.State#RUNNING RUNNING}
  */
 public class StreamsNotStartedException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamsNotStartedException.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.KafkaStreams;
 /**
  * Indicates that Kafka Streams is in state {@link KafkaStreams.State#CREATED CREATED} and thus state stores cannot be queries yet.
  * To query state stores, it's required to first start Kafka Streams via {@link KafkaStreams#start()}.
- * You can retry to query the state after the state transitioned to to {@link KafkaStreams.State#RUNNING RUNNING}
+ * You can retry to query the state after the state transitioned to {@link KafkaStreams.State#RUNNING RUNNING}.
  */
 public class StreamsNotStartedException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamsRebalancingException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamsRebalancingException.java
@@ -16,27 +16,21 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicate query a state store and stream thread state is not running when Kafka Streams state is
+ * {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING} or
+ * {@link org.apache.kafka.streams.KafkaStreams.State#REBALANCING REBALANCING}.
+ * User can just retry and wait until rebalance finished.
  */
-public class InvalidStateStoreException extends StreamsException {
+public class StreamsRebalancingException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public StreamsRebalancingException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public StreamsRebalancingException(final String message, final Throwable throwable) {
         super(message, throwable);
-    }
-
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/StreamsRebalancingException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/StreamsRebalancingException.java
@@ -17,10 +17,9 @@
 package org.apache.kafka.streams.errors;
 
 /**
- * Indicate query a state store and stream thread state is not running when Kafka Streams state is
- * {@link org.apache.kafka.streams.KafkaStreams.State#RUNNING RUNNING} or
- * {@link org.apache.kafka.streams.KafkaStreams.State#REBALANCING REBALANCING}.
- * User can just retry and wait until rebalance finished.
+ * Indicates that Kafka Streams is in state {@link org.apache.kafka.streams.KafkaStreams.State#REBALANCING REBALANCING} and thus
+ * cannot be queried by default. You can retry to query after the rebalance finished. As an alternative, you can also query
+ * (potentially stale) state stores during a rebalance via {@link org.apache.kafka.streams.StoreQueryParameters#enableStaleStores()}.
  */
 public class StreamsRebalancingException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/UnknownStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/UnknownStateStoreException.java
@@ -17,7 +17,8 @@
 package org.apache.kafka.streams.errors;
 
 /**
- * Indicates that the state store being queried is invalid. Hence, it will be futile to retry again.
+ * Indicates that the state store being queried is unknown, i.e., the state store does either not exist in your topology
+ * or it is not queryable.
  */
 public class UnknownStateStoreException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/errors/UnknownStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/UnknownStateStoreException.java
@@ -16,27 +16,19 @@
  */
 package org.apache.kafka.streams.errors;
 
-
 /**
- * <p>Indicates that there was a problem when trying to access a {@link org.apache.kafka.streams.processor.StateStore StateStore}.
- * InvalidStateStoreException not thrown directly but only following sub-classes:</p>
- * {@link StreamsNotStartedException}, {@link StreamsRebalancingException},
- * {@link StateStoreMigratedException}, {@link StateStoreNotAvailableException},
- * {@link UnknownStateStoreException}, {@link InvalidStateStorePartitionException}
+ * Indicates that the state store being queried is invalid. Hence, it will be futile to retry again.
  */
-public class InvalidStateStoreException extends StreamsException {
+public class UnknownStateStoreException extends InvalidStateStoreException {
 
-    private final static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-    public InvalidStateStoreException(final String message) {
+    public UnknownStateStoreException(final String message) {
         super(message);
     }
 
-    public InvalidStateStoreException(final String message, final Throwable throwable) {
+    public UnknownStateStoreException(final String message, final Throwable throwable) {
         super(message, throwable);
     }
 
-    public InvalidStateStoreException(final Throwable throwable) {
-        super(throwable);
-    }
 }


### PR DESCRIPTION
> [KIP-216: IQ should throw different exceptions for different errors](https://cwiki.apache.org/confluence/display/KAFKA/KIP-216%3A+IQ+should+throw+different+exceptions+for+different+errors)

KAFKA-5876's PR break into multiple parts. This PR is part 1: the new exceptions introduced in KIP-216

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
