### PR TITLE
MINOR: comment apikey types in generated switch

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/ApiMessageTypeGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/ApiMessageTypeGenerator.java
@@ -256,19 +256,21 @@ public final class ApiMessageTypeGenerator {
         buffer.incrementIndent();
         for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
             short apiKey = entry.getKey();
-            buffer.printf("case %d:%n", apiKey);
+            ApiData apiData = entry.getValue();
+            String name = apiData.name();
+            buffer.printf("case %d: // %s%n", apiKey, MessageGenerator.capitalizeFirst(name));
             buffer.incrementIndent();
             if (type.equals("response") && apiKey == 18) {
-                // ApiVersionsResponse always includes a v0 header.
-                // See KIP-511 for details.
+                buffer.printf("// ApiVersionsResponse always includes a v0 header.%n");
+                buffer.printf("// See KIP-511 for details.%n");
                 buffer.printf("return (short) 0;%n");
                 buffer.decrementIndent();
                 continue;
             }
             if (type.equals("request") && apiKey == 7) {
-                // Version 0 of ControlledShutdownRequest has a non-standard request header
-                // which does not include clientId.  Version 1 of ControlledShutdownRequest
-                // and later use the standard request header.
+                buffer.printf("// Version 0 of ControlledShutdownRequest has a non-standard request header%n");
+                buffer.printf("// which does not include clientId.  Version 1 of ControlledShutdownRequest%n");
+                buffer.printf("// and later use the standard request header.%n");
                 buffer.printf("if (_version == 0) {%n");
                 buffer.incrementIndent();
                 buffer.printf("return (short) 0;%n");


### PR DESCRIPTION
As a developer, it would be convenient if the generated
{request,response}HeaderVersion case statements in ApiMessageType.java
included a comment to remind me which type each of them is so I don't
need to manually cross-reference the newer/rarer ones.

Also include commented lines for the two special cases around
ApiVersionsResponse and ControllerShutdownRequest which are hardcoded in
the ApiMessageTypeGenerator.java and not covered by the message format
json files.

Before:
```java
    public short requestHeaderVersion(short _version) {
        switch (apiKey) {
            case 0:
                return (short) 1;
            case 1:
                return (short) 1;
            case 2:
                return (short) 1;
            case 3:
                if (_version >= 9) {
                    return (short) 2;
                } else {
                    return (short) 1;
                }
            // ...etc
```

After:
```java
    public short requestHeaderVersion(short _version) {
        switch (apiKey) {
            case 0: // Produce
                return (short) 1;
            case 1: // Fetch
                return (short) 1;
            case 2: // ListOffset
                return (short) 1;
            case 3: // Metadata
                if (_version >= 9) {
                    return (short) 2;
                } else {
                    return (short) 1;
                }
            // ...etc
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
