### PR TITLE
MINOR: Add an extra check in StreamThreadTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1498,6 +1498,12 @@ public class StreamThreadTest {
                 }
             });
 
+            // after handling the exception and reviving the task, the position
+            // should be reset to the beginning.
+            TestUtils.waitForCondition(
+                () -> mockRestoreConsumer.position(changelogPartition) == 0L,
+                "Never restore first record");
+
             mockRestoreConsumer.addRecord(new ConsumerRecord<>(
                 "stream-thread-test-count-changelog",
                 0,


### PR DESCRIPTION
During the handle-corruption logic, we first remove the partitions from the changelog reader (and hence from the restore consumer), and then add them back during the task.revive() function. During this period the test main thread may happen to call `addRecords` which could throw IllegalStateException: a race condition.

The fix here is to wait for a position() call to return 0, which means the partitions have been added back to the restore consumer, and the seek-to-beginning has been called as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
