### PR TITLE
[KAFKA-9644] Non-existent configs in incrementalAlterConfigs APPEND/SUBTRACT

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigOp.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigOp.java
@@ -35,7 +35,27 @@ import java.util.stream.Collectors;
 public class AlterConfigOp {
 
     public enum OpType {
-        SET((byte) 0), DELETE((byte) 1), APPEND((byte) 2), SUBTRACT((byte) 3);
+        /**
+         * Set the value of the configuration entry.
+         */
+        SET((byte) 0),
+        /**
+         * Revert the configuration entry to the default value (possibly null).
+         */
+        DELETE((byte) 1),
+        /**
+         * (For list-type configuration entries only.) Add the specified values to the
+         * current value of the configuration entry. If the configuration value has not been set,
+         * adds to the default value.
+         */
+        APPEND((byte) 2),
+        /**
+         * (For list-type configuration entries only.) Removes the specified values from the current
+         * value of the configuration entry. It is legal to remove values that are not currently in the
+         * configuration entry. Removing all entries from the current configuration value leaves an empty
+         * list and does NOT revert to the default value of the entry.
+         */
+        SUBTRACT((byte) 3);
 
         private static final Map<Byte, OpType> OP_TYPES = Collections.unmodifiableMap(
                 Arrays.stream(values()).collect(Collectors.toMap(OpType::id, Function.identity()))

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -605,16 +605,22 @@ class AdminManager(val config: KafkaConfig,
         case OpType.APPEND => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val oldValueList = configProps.getProperty(configPropName,
-            ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)).split(",").toList
+          val defaultValueList = ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST) match {
+            case null => ""
+            case d => d
+          }
+          val oldValueList = configProps.getProperty(configPropName, defaultValueList).split(",").toList
           val newValueList = oldValueList ::: alterConfigOp.configEntry().value().split(",").toList
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }
         case OpType.SUBTRACT => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value subtract is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(),
-            ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)).split(",").toList
+          val defaultValueList = ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST) match {
+            case null => ""
+            case d => d
+          }
+          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(), defaultValueList).split(",").toList
           val newValueList = oldValueList.diff(alterConfigOp.configEntry().value().split(",").toList)
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -616,7 +616,10 @@ class AdminManager(val config: KafkaConfig,
           val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(),
             ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)).split(",").toList
           val newValueList = oldValueList.diff(alterConfigOp.configEntry().value().split(",").toList)
-          configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
+          newValueList match {
+            case Nil => configProps.remove(alterConfigOp.configEntry().name())
+            case _ => configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
+          }
         }
       }
     }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -616,10 +616,7 @@ class AdminManager(val config: KafkaConfig,
           val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(),
             ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)).split(",").toList
           val newValueList = oldValueList.diff(alterConfigOp.configEntry().value().split(",").toList)
-          newValueList match {
-            case Nil => configProps.remove(alterConfigOp.configEntry().name())
-            case _ => configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
-          }
+          configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }
       }
     }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -604,14 +604,14 @@ class AdminManager(val config: KafkaConfig,
         case OpType.APPEND => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name()).split(",").toList
+          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(), "").split(",").toList.filter(_.trim.length > 0)
           val newValueList = oldValueList ::: alterConfigOp.configEntry().value().split(",").toList
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }
         case OpType.SUBTRACT => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value subtract is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name()).split(",").toList
+          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(), "").split(",").toList.filter(_.trim.length > 0)
           val newValueList = oldValueList.diff(alterConfigOp.configEntry().value().split(",").toList)
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -605,22 +605,20 @@ class AdminManager(val config: KafkaConfig,
         case OpType.APPEND => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value append is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val defaultValueList = ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST) match {
-            case null => ""
-            case d => d
-          }
-          val oldValueList = configProps.getProperty(configPropName, defaultValueList).split(",").toList
+          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry().name()))
+            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
+            .getOrElse("")
+            .split(",").toList
           val newValueList = oldValueList ::: alterConfigOp.configEntry().value().split(",").toList
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }
         case OpType.SUBTRACT => {
           if (!listType(alterConfigOp.configEntry().name(), configKeys))
             throw new InvalidRequestException(s"Config value subtract is not allowed for config key: ${alterConfigOp.configEntry().name()}")
-          val defaultValueList = ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST) match {
-            case null => ""
-            case d => d
-          }
-          val oldValueList = configProps.getProperty(alterConfigOp.configEntry().name(), defaultValueList).split(",").toList
+          val oldValueList = Option(configProps.getProperty(alterConfigOp.configEntry().name()))
+            .orElse(Option(ConfigDef.convertToString(configKeys(configPropName).defaultValue, ConfigDef.Type.LIST)))
+            .getOrElse("")
+            .split(",").toList
           val newValueList = oldValueList.diff(alterConfigOp.configEntry().value().split(",").toList)
           configProps.setProperty(alterConfigOp.configEntry().name(), newValueList.mkString(","))
         }

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1681,7 +1681,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
     //verify subtract operation
     topic1AlterConfigs = Seq(
-      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact), AlterConfigOp.OpType.SUBTRACT)
+      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact), AlterConfigOp.OpType.SUBTRACT),
+      new AlterConfigOp(new ConfigEntry(LogConfig.LeaderReplicationThrottledReplicasProp, "0"), AlterConfigOp.OpType.SUBTRACT)
     ).asJava
 
    alterResult = client.incrementalAlterConfigs(Map(

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1688,7 +1688,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       new AlterConfigOp(new ConfigEntry(LogConfig.LeaderReplicationThrottledReplicasProp, "0"), AlterConfigOp.OpType.SUBTRACT)
     ).asJava
 
-    // subtract all from this list property
+    // subtract all from this list property -- should revert to default
     topic2AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact + "," + LogConfig.Delete), AlterConfigOp.OpType.SUBTRACT)
     ).asJavaCollection
@@ -1709,7 +1709,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     assertEquals("delete", configs.get(topic1Resource).get(LogConfig.CleanupPolicyProp).value)
     assertEquals("1000", configs.get(topic1Resource).get(LogConfig.FlushMsProp).value) // verify previous change is still intact
     assertEquals("", configs.get(topic1Resource).get(LogConfig.LeaderReplicationThrottledReplicasProp).value)
-    assertEquals("", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value )
+    assertEquals("delete", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value )
 
     // Alter topics with validateOnly=true
     topic1AlterConfigs = Seq(

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1688,7 +1688,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       new AlterConfigOp(new ConfigEntry(LogConfig.LeaderReplicationThrottledReplicasProp, "0"), AlterConfigOp.OpType.SUBTRACT)
     ).asJava
 
-    // subtract all from this list property -- should revert to default
+    // subtract all from this list property
     topic2AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact + "," + LogConfig.Delete), AlterConfigOp.OpType.SUBTRACT)
     ).asJavaCollection
@@ -1709,7 +1709,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     assertEquals("delete", configs.get(topic1Resource).get(LogConfig.CleanupPolicyProp).value)
     assertEquals("1000", configs.get(topic1Resource).get(LogConfig.FlushMsProp).value) // verify previous change is still intact
     assertEquals("", configs.get(topic1Resource).get(LogConfig.LeaderReplicationThrottledReplicasProp).value)
-    assertEquals("delete", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value )
+    assertEquals("", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value )
 
     // Alter topics with validateOnly=true
     topic1AlterConfigs = Seq(

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1653,9 +1653,11 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       new AlterConfigOp(new ConfigEntry(LogConfig.RetentionMsProp, ""), AlterConfigOp.OpType.DELETE)
     ).asJavaCollection
 
+    // Test SET and APPEND on non-existent properties
     val topic2AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.MinCleanableDirtyRatioProp, "0.9"), AlterConfigOp.OpType.SET),
-      new AlterConfigOp(new ConfigEntry(LogConfig.CompressionTypeProp, "lz4"), AlterConfigOp.OpType.SET)
+      new AlterConfigOp(new ConfigEntry(LogConfig.CompressionTypeProp, "lz4"), AlterConfigOp.OpType.SET),
+      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact), AlterConfigOp.OpType.APPEND)
     ).asJavaCollection
 
     var alterResult = client.incrementalAlterConfigs(Map(

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1653,8 +1653,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       new AlterConfigOp(new ConfigEntry(LogConfig.RetentionMsProp, ""), AlterConfigOp.OpType.DELETE)
     ).asJavaCollection
 
-    // Test SET and APPEND on non-existent properties
-    val topic2AlterConfigs = Seq(
+    // Test SET and APPEND on previously unset properties
+    var topic2AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.MinCleanableDirtyRatioProp, "0.9"), AlterConfigOp.OpType.SET),
       new AlterConfigOp(new ConfigEntry(LogConfig.CompressionTypeProp, "lz4"), AlterConfigOp.OpType.SET),
       new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact), AlterConfigOp.OpType.APPEND)
@@ -1680,24 +1680,36 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
     assertEquals("0.9", configs.get(topic2Resource).get(LogConfig.MinCleanableDirtyRatioProp).value)
     assertEquals("lz4", configs.get(topic2Resource).get(LogConfig.CompressionTypeProp).value)
+    assertEquals("delete,compact", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value)
 
-    //verify subtract operation
+    //verify subtract operation, including from an empty property
     topic1AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact), AlterConfigOp.OpType.SUBTRACT),
       new AlterConfigOp(new ConfigEntry(LogConfig.LeaderReplicationThrottledReplicasProp, "0"), AlterConfigOp.OpType.SUBTRACT)
     ).asJava
 
-   alterResult = client.incrementalAlterConfigs(Map(
-      topic1Resource -> topic1AlterConfigs
+    // subtract all from this list property
+    topic2AlterConfigs = Seq(
+      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Compact + "," + LogConfig.Delete), AlterConfigOp.OpType.SUBTRACT)
+    ).asJavaCollection
+
+    alterResult = client.incrementalAlterConfigs(Map(
+      topic1Resource -> topic1AlterConfigs,
+      topic2Resource -> topic2AlterConfigs
     ).asJava)
+    assertEquals(Set(topic1Resource, topic2Resource).asJava, alterResult.values.keySet)
     alterResult.all.get
 
     // Verify that topics were updated correctly
-    describeResult = client.describeConfigs(Seq(topic1Resource).asJava)
+    describeResult = client.describeConfigs(Seq(topic1Resource, topic2Resource).asJava)
     configs = describeResult.all.get
+
+    assertEquals(2, configs.size)
 
     assertEquals("delete", configs.get(topic1Resource).get(LogConfig.CleanupPolicyProp).value)
     assertEquals("1000", configs.get(topic1Resource).get(LogConfig.FlushMsProp).value) // verify previous change is still intact
+    assertEquals("", configs.get(topic1Resource).get(LogConfig.LeaderReplicationThrottledReplicasProp).value)
+    assertEquals("", configs.get(topic2Resource).get(LogConfig.CleanupPolicyProp).value )
 
     // Alter topics with validateOnly=true
     topic1AlterConfigs = Seq(


### PR DESCRIPTION
Problem
----
The `incrementalAlterConfigs` API supports OpType.APPEND and OpType.SUBTRACT for configuration properties of LIST type. If an APPEND or SUBTRACT OpType is submitted for a config property which currently has no value, then the operation fails with a NullPointerException on the broker side (conveyed as an "unknown server error" to the client).

This is because the alter code does a `getProperty` of the existing configuration value
with no concern as to whether or not the property actually exists.

This change handles the case of existing null properties. 

Testing
-----
This change includes 2 test cases in the unit test that demonstrate the issue for OpType.SUBTRACT and OpType.APPEND. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
