### PR TITLE
KAFKA-9441: Unify committing within TaskManager

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -181,7 +181,7 @@
               files="StreamsPartitionAssignor.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(ProcessorStateManager|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread).java"/>
+              files="(ProcessorStateManager|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread|TaskManager).java"/>
 
     <suppress checks="(FinalLocalVariable|UnnecessaryParentheses|BooleanExpressionComplexity|CyclomaticComplexity|WhitespaceAfter|LocalVariableName)"
               files="Murmur3.java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollector.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollector.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
@@ -44,8 +43,6 @@ public interface RecordCollector {
                      final Serializer<K> keySerializer,
                      final Serializer<V> valueSerializer,
                      final StreamPartitioner<? super K, ? super V> partitioner);
-
-    void commit(final Map<TopicPartition, OffsetAndMetadata> offsets);
 
     /**
      * Initialize the internal {@link Producer}; note this function should be made idempotent

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -351,7 +351,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
-        if (state() == State.CREATED || state() == State.RESTORING || state() == State.SUSPENDED) {
+        if (state() == State.CLOSED) {
+            throw new IllegalStateException("Task " + id + " is closed.");
+        }
+
+        if (state() != State.RUNNING) {
             return Collections.emptyMap();
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -351,6 +351,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
+        if (state() == State.CREATED || state() == State.RESTORING || state() == State.SUSPENDED) {
+            return Collections.emptyMap();
+        }
+
         final Map<TopicPartition, Long> partitionTimes = extractPartitionTimes();
 
         final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -42,6 +42,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.V
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
@@ -92,7 +92,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Sensor closeTaskSensor;
     private final Sensor processLatencySensor;
     private final Sensor punctuateLatencySensor;
-    private final Sensor commitSensor;
     private final Sensor enforcedProcessingSensor;
     private final InternalProcessorContext processorContext;
 
@@ -128,10 +127,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         final String taskId = id.toString();
         if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
             final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
-            commitSensor = TaskMetrics.commitSensor(threadId, taskId, streamsMetrics, parent);
             enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics, parent);
         } else {
-            commitSensor = TaskMetrics.commitSensor(threadId, taskId, streamsMetrics);
             enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
         }
         processLatencySensor = TaskMetrics.processLatencySensor(threadId, taskId, streamsMetrics);
@@ -231,19 +228,33 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      *                               or if the task producer got fenced (EOS)
      */
     @Override
-    public void suspend() {
-        if (state() == State.CREATED || state() == State.CLOSING || state() == State.SUSPENDED) {
+    public void prepareSuspend() {
+        if (state() == State.CREATED || state() == State.SUSPENDED) {
             // do nothing
-            log.trace("Skip suspending since state is {}", state());
+            log.trace("Skip prepare suspending since state is {}", state());
         } else if (state() == State.RUNNING) {
             closeTopology(true);
 
-            commitState();
-            // whenever we have successfully committed state during suspension, it is safe to checkpoint
-            // the state as well no matter if EOS is enabled or not
-            stateMgr.checkpoint(checkpointableOffsets());
+            stateMgr.flush();
+            recordCollector.flush();
 
-            // we should also clear any buffered records of a task when suspending it
+            log.info("Prepare suspending running");
+        } else if (state() == State.RESTORING) {
+            stateMgr.flush();
+
+            log.info("Prepare suspending restoring");
+        } else {
+            throw new IllegalStateException("Illegal state " + state() + " while suspending active task " + id);
+        }
+    }
+
+    @Override
+    public void suspend() {
+        if (state() == State.CREATED || state() == State.SUSPENDED) {
+            // do nothing
+            log.trace("Skip suspending since state is {}", state());
+        } else if (state() == State.RUNNING) {
+            stateMgr.checkpoint(checkpointableOffsets());
             partitionGroup.clear();
 
             transitionTo(State.SUSPENDED);
@@ -251,7 +262,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         } else if (state() == State.RESTORING) {
             // we just checkpoint the position that we've restored up to without
             // going through the commit process
-            stateMgr.flush();
             stateMgr.checkpoint(emptyMap());
 
             // we should also clear any buffered records of a task when suspending it
@@ -273,7 +283,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     public void resume() {
         switch (state()) {
             case CREATED:
-            case CLOSING:
             case RUNNING:
             case RESTORING:
                 // no need to do anything, just let them continue running / restoring / closing
@@ -293,18 +302,30 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
     }
 
-    /**
-     * @throws TaskMigratedException if committing offsets failed (non-EOS)
-     *                               or if the task producer got fenced (EOS)
-     */
     @Override
-    public void commit() {
+    public void prepareCommit() {
         switch (state()) {
             case RUNNING:
             case RESTORING:
-                commitState();
+                stateMgr.flush();
+                recordCollector.flush();
 
-                // this is an optimization for non-EOS only
+                log.info("Prepared task for committing");
+
+                break;
+
+            default:
+                throw new IllegalStateException("Illegal state " + state() + " while preparing active task " + id + " for committing");
+        }
+    }
+
+    @Override
+    public void postCommit() {
+        switch (state()) {
+            case RUNNING:
+                commitNeeded = false;
+                commitRequested = false;
+
                 if (eosDisabled) {
                     stateMgr.checkpoint(checkpointableOffsets());
                 }
@@ -313,35 +334,23 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
                 break;
 
-            case CLOSING:
-                // do nothing
+            case RESTORING:
+                commitNeeded = false;
+                commitRequested = false;
+
+                stateMgr.checkpoint(checkpointableOffsets());
+
+                log.info("Committed");
+
                 break;
 
             default:
-                throw new IllegalStateException("Illegal state " + state() + " while committing standby task " + id);
+                throw new IllegalStateException("Illegal state " + state() + " while post committing active task " + id);
         }
     }
 
-    /**
-     * <pre>
-     * the following order must be followed:
-     *  1. flush the state, send any left changelog records
-     *  2. then flush the record collector
-     *  3. then commit the record collector -- for EOS this is the synchronization barrier
-     * </pre>
-     *
-     * @throws TaskMigratedException if committing offsets failed (non-EOS)
-     *                               or if the task producer got fenced (EOS)
-     */
-    private void commitState() {
-        final long startNs = time.nanoseconds();
-
-        stateMgr.flush();
-
-        recordCollector.flush();
-
-        // we need to preserve the original partitions times before calling commit
-        // because all partition times are reset to -1 during close
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
         final Map<TopicPartition, Long> partitionTimes = extractPartitionTimes();
 
         final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
@@ -365,11 +374,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             final long partitionTime = partitionTimes.get(partition);
             consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset, encodeTimestamp(partitionTime)));
         }
-        recordCollector.commit(consumedOffsetsAndMetadata);
 
-        commitNeeded = false;
-        commitRequested = false;
-        commitSensor.record(time.nanoseconds() - startNs);
+        return consumedOffsetsAndMetadata;
     }
 
     private Map<TopicPartition, Long> extractPartitionTimes() {
@@ -381,15 +387,31 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     }
 
     @Override
-    public void closeClean() {
-        close(true);
+    public Map<TopicPartition, Long> prepareCloseClean() {
+        final Map<TopicPartition, Long> checkpoint = prepareClose(true);
+
+        log.info("Prepared clean close");
+
+        return checkpoint;
+    }
+
+    @Override
+    public void closeClean(final Map<TopicPartition, Long> checkpoint) {
+        close(true, checkpoint);
 
         log.info("Closed clean");
     }
 
     @Override
+    public void prepareCloseDirty() {
+        prepareClose(false);
+
+        log.info("Prepared dirty close");
+    }
+
+    @Override
     public void closeDirty() {
-        close(false);
+        close(false, null);
 
         log.info("Closed dirty");
     }
@@ -400,65 +422,88 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      *  1. first close topology to make sure all cached records in the topology are processed
      *  2. then flush the state, send any left changelog records
      *  3. then flush the record collector
-     *  4. then commit the record collector -- for EOS this is the synchronization barrier
-     *  5. then checkpoint the state manager -- even if we crash before this step, EOS is still guaranteed
-     *  6. then if we are closing on EOS and dirty, wipe out the state store directory
-     *  7. finally release the state manager lock
      * </pre>
      *
-     * @param clean    shut down cleanly (ie, incl. flush and commit) if {@code true} --
+     * @param clean    shut down cleanly (ie, incl. flush) if {@code true} --
      *                 otherwise, just close open resources
-     * @throws TaskMigratedException if committing offsets failed (non-EOS)
-     *                               or if the task producer got fenced (EOS)
+     * @throws TaskMigratedException if the task producer got fenced (EOS)
      */
-    private void close(final boolean clean) {
+    private Map<TopicPartition, Long> prepareClose(final boolean clean) {
+        final Map<TopicPartition, Long> checkpoint;
+
         if (state() == State.CREATED) {
             // the task is created and not initialized, just re-write the checkpoint file
-            executeAndMaybeSwallow(clean, () -> {
-                stateMgr.checkpoint(Collections.emptyMap());
-            }, "state manager checkpoint", log);
-
-            transitionTo(State.CLOSING);
+            checkpoint = Collections.emptyMap();
         } else if (state() == State.RUNNING) {
             closeTopology(clean);
 
             if (clean) {
-                commitState();
-                // whenever we have successfully committed state, it is safe to checkpoint
-                // the state as well no matter if EOS is enabled or not
-                stateMgr.checkpoint(checkpointableOffsets());
+                stateMgr.flush();
+                recordCollector.flush();
+                checkpoint = checkpointableOffsets();
             } else {
+                checkpoint = null; // `null` indicates to not write a checkpoint
                 executeAndMaybeSwallow(false, stateMgr::flush, "state manager flush", log);
             }
-
-            transitionTo(State.CLOSING);
         } else if (state() == State.RESTORING) {
-            executeAndMaybeSwallow(clean, () -> {
-                stateMgr.flush();
-                stateMgr.checkpoint(Collections.emptyMap());
-            }, "state manager flush and checkpoint", log);
-
-            transitionTo(State.CLOSING);
+            executeAndMaybeSwallow(clean, stateMgr::flush, "state manager flush", log);
+            checkpoint = Collections.emptyMap();
         } else if (state() == State.SUSPENDED) {
-            // do not need to commit / checkpoint, since when suspending we've already committed the state
-            transitionTo(State.CLOSING);
+            // if `SUSPENDED` do not need to checkpoint, since when suspending we've already committed the state
+            checkpoint = null; // `null` indicates to not write a checkpoint
+        } else {
+            throw new IllegalStateException("Illegal state " + state() + " while prepare closing active task " + id);
         }
 
-        if (state() == State.CLOSING) {
-            // if EOS is enabled, we wipe out the whole state store for unclean close
-            // since they are invalid to use anymore
-            final boolean wipeStateStore = !clean && !eosDisabled;
+        return checkpoint;
+    }
 
-            // first close state manager (which is idempotent) then close the record collector (which could throw),
-            // if the latter throws and we re-close dirty which would close the state manager again.
-            executeAndMaybeSwallow(clean, () -> {
-                StateManagerUtil.closeStateManager(log, logPrefix, clean,
-                        wipeStateStore, stateMgr, stateDirectory, TaskType.ACTIVE);
-            }, "state manager close", log);
+    /**
+     * <pre>
+     * the following order must be followed:
+     *  1. checkpoint the state manager -- even if we crash before this step, EOS is still guaranteed
+     *  2. then if we are closing on EOS and dirty, wipe out the state store directory
+     *  3. finally release the state manager lock
+     * </pre>
+     */
+    private void close(final boolean clean,
+                       final Map<TopicPartition, Long> checkpoint) {
+        if (clean && checkpoint != null) {
+            executeAndMaybeSwallow(clean, () -> stateMgr.checkpoint(checkpoint), "state manager checkpoint", log);
+        }
 
-            executeAndMaybeSwallow(clean, recordCollector::close, "record collector close", log);
-        } else {
-            throw new IllegalStateException("Illegal state " + state() + " while closing active task " + id);
+        switch (state()) {
+            case CREATED:
+            case RUNNING:
+            case RESTORING:
+            case SUSPENDED:
+                // if EOS is enabled, we wipe out the whole state store for unclean close
+                // since they are invalid to use anymore
+                final boolean wipeStateStore = !clean && !eosDisabled;
+
+                // first close state manager (which is idempotent) then close the record collector (which could throw),
+                // if the latter throws and we re-close dirty which would close the state manager again.
+                executeAndMaybeSwallow(
+                    clean,
+                    () -> {
+                        StateManagerUtil.closeStateManager(
+                            log,
+                            logPrefix,
+                            clean,
+                            wipeStateStore,
+                            stateMgr,
+                            stateDirectory,
+                            TaskType.ACTIVE);
+                    },
+                    "state manager close",
+                    log);
+
+                executeAndMaybeSwallow(clean, recordCollector::close, "record collector close", log);
+
+                break;
+
+            default:
+                throw new IllegalStateException("Illegal state " + state() + " while closing active task " + id);
         }
 
         partitionGroup.close();
@@ -472,7 +517,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * source topic partitions, or if it is enforced to be processable
      */
     public boolean isProcessable(final long wallClockTime) {
-        if (state() == State.CLOSED || state() == State.CLOSING) {
+        if (state() == State.CLOSED) {
             // a task is only closing / closed when 1) task manager is closing, 2) a rebalance is undergoing;
             // in either case we can just log it and move on without notifying the thread since the consumer
             // would soon be updated to not return any records for this task anymore.
@@ -509,8 +554,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * @return true if this method processes a record, false if it does not process a record.
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
-    @SuppressWarnings("unchecked")
-    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean process(final long wallClockTime) {
         if (!isProcessable(wallClockTime)) {
             return false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -485,16 +485,15 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 // if the latter throws and we re-close dirty which would close the state manager again.
                 executeAndMaybeSwallow(
                     clean,
-                    () -> {
-                        StateManagerUtil.closeStateManager(
-                            log,
-                            logPrefix,
-                            clean,
-                            wipeStateStore,
-                            stateMgr,
-                            stateDirectory,
-                            TaskType.ACTIVE);
-                    },
+                    () -> StateManagerUtil.closeStateManager(
+                        log,
+                        logPrefix,
+                        clean,
+                        wipeStateStore,
+                        stateMgr,
+                        stateDirectory,
+                        TaskType.ACTIVE
+                    ),
                     "state manager close",
                     log);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -57,6 +57,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
+
 public class StreamThread extends Thread {
 
     private final Admin adminClient;
@@ -338,7 +340,8 @@ public class StreamThread extends Thread {
             standbyTaskCreator,
             builder,
             adminClient,
-            stateDirectory
+            stateDirectory,
+            EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
         );
 
         log.info("Creating consumer client");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -59,24 +59,27 @@ public class StreamsProducer {
 
     public StreamsProducer(final Producer<byte[], byte[]> producer,
                            final boolean eosEnabled,
-                           final LogContext logContext,
-                           final String applicationId) {
-        log = logContext.logger(getClass());
-        logPrefix = logContext.logPrefix().trim();
-
+                           final String applicationId,
+                           final LogContext logContext) {
         this.producer = Objects.requireNonNull(producer, "producer cannot be null");
-        this.applicationId = applicationId;
         this.eosEnabled = eosEnabled;
+        this.applicationId = applicationId;
+        if (eosEnabled && applicationId == null) {
+            throw new IllegalArgumentException("applicationId cannot be null if EOS is enabled");
+        }
+
+        log = Objects.requireNonNull(logContext, "logContext cannot be null").logger(getClass());
+        logPrefix = logContext.logPrefix().trim();
     }
 
     private String formatException(final String message) {
-        return message + " [" + logPrefix + ", " + (eosEnabled ? "eos" : "alo") + "]";
+        return message + " [" + logPrefix + "]";
     }
 
     /**
      * @throws IllegalStateException if EOS is disabled
      */
-    public void initTransaction() {
+    void initTransaction() {
         if (!eosEnabled) {
             throw new IllegalStateException(formatException("EOS is disabled"));
         }
@@ -88,7 +91,7 @@ public class StreamsProducer {
                 transactionInitialized = true;
             } catch (final TimeoutException exception) {
                 log.warn(
-                    "Timeout exception caught when initializing transactions. " +
+                    "Timeout exception caught trying to initialize transactions. " +
                         "The broker is either slow or in bad state (like not having enough replicas) in " +
                         "responding to the request, or the connection to broker was interrupted sending " +
                         "the request or receiving the response. " +
@@ -100,34 +103,34 @@ public class StreamsProducer {
                 throw exception;
             } catch (final KafkaException exception) {
                 throw new StreamsException(
-                    formatException("Error encountered while initializing transactions"),
+                    formatException("Error encountered trying to initialize transactions"),
                     exception
                 );
             }
         }
     }
 
-    private void maybeBeginTransaction() throws ProducerFencedException {
+    void maybeBeginTransaction() throws ProducerFencedException {
         if (eosEnabled && !transactionInFlight) {
             try {
                 producer.beginTransaction();
                 transactionInFlight = true;
             } catch (final ProducerFencedException error) {
                 throw new TaskMigratedException(
-                    formatException("Producer get fenced trying to begin a new transaction"),
+                    formatException("Producer got fenced trying to begin a new transaction"),
                     error
                 );
             } catch (final KafkaException error) {
                 throw new StreamsException(
-                    formatException("Producer encounter unexpected error trying to begin a new transaction"),
+                    formatException("Error encountered trying to begin a new transaction"),
                     error
                 );
             }
         }
     }
 
-    public Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record,
-                                       final Callback callback) {
+    Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record,
+                                final Callback callback) {
         maybeBeginTransaction();
         try {
             return producer.send(record, callback);
@@ -137,12 +140,12 @@ public class StreamsProducer {
                 // in this case we should throw its wrapped inner cause so that it can be
                 // captured and re-wrapped as TaskMigrationException
                 throw new TaskMigratedException(
-                    formatException("Producer cannot send records anymore since it got fenced"),
+                    formatException("Producer got fenced trying to send a record"),
                     uncaughtException.getCause()
                 );
             } else {
                 throw new StreamsException(
-                    formatException(String.format("Error encountered sending record to topic %s", record.topic())),
+                    formatException(String.format("Error encountered trying to send record to topic %s", record.topic())),
                     uncaughtException
                 );
             }
@@ -158,7 +161,7 @@ public class StreamsProducer {
      * @throws IllegalStateException if EOS is disabled
      * @throws TaskMigratedException
      */
-    public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
+    void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
         if (!eosEnabled) {
             throw new IllegalStateException(formatException("EOS is disabled"));
         }
@@ -169,15 +172,15 @@ public class StreamsProducer {
             transactionInFlight = false;
         } catch (final ProducerFencedException error) {
             throw new TaskMigratedException(
-                formatException("Producer get fenced trying to commit a transaction"),
+                formatException("Producer got fenced trying to commit a transaction"),
                 error
             );
         } catch (final TimeoutException error) {
             // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
-            throw new StreamsException(formatException("Timed out while committing a transaction"), error);
+            throw new StreamsException(formatException("Timed out trying to commit a transaction"), error);
         } catch (final KafkaException error) {
             throw new StreamsException(
-                formatException("Producer encounter unexpected error trying to commit a transaction"),
+                formatException("Error encountered trying to commit a transaction"),
                 error
             );
         }
@@ -186,7 +189,7 @@ public class StreamsProducer {
     /**
      * @throws IllegalStateException if EOS is disabled
      */
-    public void abortTransaction() throws ProducerFencedException {
+    void abortTransaction() throws ProducerFencedException {
         if (!eosEnabled) {
             throw new IllegalStateException(formatException("EOS is disabled"));
         }
@@ -204,7 +207,7 @@ public class StreamsProducer {
                 // can be ignored: transaction got already aborted by brokers/transactional-coordinator if this happens
             } catch (final KafkaException error) {
                 throw new StreamsException(
-                    formatException("Producer encounter unexpected error trying to abort a transaction"),
+                    formatException("Error encounter trying to abort a transaction"),
                     error
                 );
             }
@@ -212,15 +215,18 @@ public class StreamsProducer {
         }
     }
 
-    public List<PartitionInfo> partitionsFor(final String topic) throws TimeoutException {
+    List<PartitionInfo> partitionsFor(final String topic) throws TimeoutException {
         return producer.partitionsFor(topic);
     }
 
-    public void flush() {
+    void flush() {
         producer.flush();
     }
 
-    // for testing only
+    boolean eosEnabled() {
+        return eosEnabled;
+    }
+
     Producer<byte[], byte[]> kafkaProducer() {
         return producer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -147,19 +147,27 @@ public interface Task {
     /**
      * Prepare to close a task that we still own and prepare it for committing
      * Throws an exception if this couldn't be done.
+     * Must be idempotent.
      *
      * @throws StreamsException fatal error, should close the thread
      */
     Map<TopicPartition, Long> prepareCloseClean();
 
+    /**
+     * Must be idempotent.
+     */
     void closeClean(final Map<TopicPartition, Long> checkpoint);
 
     /**
      * Prepare to close a task that we may not own. Discard any uncommitted progress and close the task.
      * Never throws an exception, but just makes all attempts to release resources while closing.
+     * Must be idempotent.
      */
     void prepareCloseDirty();
 
+    /**
+     * Must be idempotent.
+     */
     void closeDirty();
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -73,7 +74,6 @@ public interface Task {
         RESTORING(2, 3, 4),    // 1
         RUNNING(3, 4),         // 2
         SUSPENDED(1, 4),       // 3
-        CLOSING(4, 5),         // 4, we allow CLOSING to transit to itself to make close idempotent
         CLOSED(0);             // 5, we allow CLOSED to transit to CREATED to handle corrupted tasks
 
         private final Set<Integer> validTransitions = new HashSet<>();
@@ -125,35 +125,41 @@ public interface Task {
     boolean commitNeeded();
 
     /**
-     * @throws TaskMigratedException all the task has been migrated
      * @throws StreamsException fatal error, should close the thread
      */
-    void commit();
+    void prepareCommit();
+
+    void postCommit();
 
     /**
      * @throws TaskMigratedException all the task has been migrated
      * @throws StreamsException fatal error, should close the thread
      */
+    void prepareSuspend();
+
     void suspend();
-
     /**
+     *
      * @throws StreamsException fatal error, should close the thread
      */
     void resume();
 
     /**
-     * Close a task that we still own. Commit all progress and close the task gracefully.
+     * Prepare to close a task that we still own and prepare it for committing
      * Throws an exception if this couldn't be done.
      *
-     * @throws TaskMigratedException all the task has been migrated
      * @throws StreamsException fatal error, should close the thread
      */
-    void closeClean();
+    Map<TopicPartition, Long> prepareCloseClean();
+
+    void closeClean(final Map<TopicPartition, Long> checkpoint);
 
     /**
-     * Close a task that we may not own. Discard any uncommitted progress and close the task.
+     * Prepare to close a task that we may not own. Discard any uncommitted progress and close the task.
      * Never throws an exception, but just makes all attempts to release resources while closing.
      */
+    void prepareCloseDirty();
+
     void closeDirty();
 
     /**
@@ -182,6 +188,10 @@ public interface Task {
         return Collections.emptyMap();
     }
 
+    default Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
+        return Collections.emptyMap();
+    }
+
     default boolean process(final long wallClockTime) {
         return false;
     }
@@ -197,4 +207,5 @@ public interface Task {
     default boolean maybePunctuateSystemTime() {
         return false;
     }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -74,7 +74,7 @@ public interface Task {
         RESTORING(2, 3, 4),    // 1
         RUNNING(3, 4),         // 2
         SUSPENDED(1, 4),       // 3
-        CLOSED(0);             // 5, we allow CLOSED to transit to CREATED to handle corrupted tasks
+        CLOSED(0);             // 4, we allow CLOSED to transit to CREATED to handle corrupted tasks
 
         private final Set<Integer> validTransitions = new HashSet<>();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -204,8 +204,9 @@ public class TaskManager {
 
                 try {
                     checkpointPerTask.put(task, task.prepareCloseClean());
-                    if (task.state() != CREATED) {
-                        consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                    final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+                    if (!committableOffsets.isEmpty()) {
+                        consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                     }
                 } catch (final RuntimeException e) {
                     final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
@@ -377,8 +378,9 @@ public class TaskManager {
         for (final Task task : tasks.values()) {
             if (remainingPartitions.containsAll(task.inputPartitions())) {
                 task.prepareSuspend();
-                if (task.state() != CREATED) {
-                    consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+                if (!committableOffsets.isEmpty()) {
+                    consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                 }
             }
             remainingPartitions.removeAll(task.inputPartitions());
@@ -565,8 +567,9 @@ public class TaskManager {
             if (clean) {
                 try {
                     checkpointPerTask.put(task, task.prepareCloseClean());
-                    if (task.state() != CREATED) {
-                        consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                    final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+                    if (!committableOffsets.isEmpty()) {
+                        consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                     }
                 } catch (final TaskMigratedException e) {
                     // just ignore the exception as it doesn't matter during shutdown

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -21,7 +21,9 @@ import java.util.Collections;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -71,6 +73,7 @@ public class TaskManager {
     private final InternalTopologyBuilder builder;
     private final Admin adminClient;
     private final StateDirectory stateDirectory;
+    private final boolean eosEnabled;
 
     private final Map<TaskId, Task> tasks = new TreeMap<>();
     // materializing this relationship because the lookup is on the hot path
@@ -93,7 +96,8 @@ public class TaskManager {
                 final StandbyTaskCreator standbyTaskCreator,
                 final InternalTopologyBuilder builder,
                 final Admin adminClient,
-                final StateDirectory stateDirectory) {
+                final StateDirectory stateDirectory,
+                final boolean eosEnabled) {
         this.changelogReader = changelogReader;
         this.processId = processId;
         this.logPrefix = logPrefix;
@@ -103,6 +107,7 @@ public class TaskManager {
         this.builder = builder;
         this.adminClient = adminClient;
         this.stateDirectory = stateDirectory;
+        this.eosEnabled = eosEnabled;
 
         final LogContext logContext = new LogContext(logPrefix);
         log = logContext.logger(getClass());
@@ -154,6 +159,7 @@ public class TaskManager {
             final Collection<TopicPartition> corruptedPartitions = entry.getValue();
             task.markChangelogAsCorrupted(corruptedPartitions);
 
+            task.prepareCloseDirty();
             task.closeDirty();
             task.revive();
         }
@@ -179,6 +185,11 @@ public class TaskManager {
 
         // first rectify all existing tasks
         final LinkedHashMap<TaskId, RuntimeException> taskCloseExceptions = new LinkedHashMap<>();
+
+        final Map<Task, Map<TopicPartition, Long>> checkpointPerTask = new HashMap<>();
+        final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
+        final Set<Task> dirtyTasks = new HashSet<>();
+
         final Iterator<Task> iterator = tasks.values().iterator();
         while (iterator.hasNext()) {
             final Task task = iterator.next();
@@ -192,28 +203,47 @@ public class TaskManager {
                 cleanupTask(task);
 
                 try {
-                    task.closeClean();
+                    checkpointPerTask.put(task, task.prepareCloseClean());
+                    if (task.state() != CREATED) {
+                        consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                    }
                 } catch (final RuntimeException e) {
                     final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
                     log.error(uncleanMessage, e);
                     taskCloseExceptions.put(task.id(), e);
                     // We've already recorded the exception (which is the point of clean).
                     // Now, we should go ahead and complete the close because a half-closed task is no good to anyone.
-                    task.closeDirty();
-                } finally {
-                    if (task.isActive()) {
-                        try {
-                            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(task.id());
-                        } catch (final RuntimeException e) {
-                            final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
-                            log.error(uncleanMessage, e);
-                            taskCloseExceptions.putIfAbsent(task.id(), e);
-                        }
-                    }
+                    task.prepareCloseDirty();
+                    dirtyTasks.add(task);
                 }
 
                 iterator.remove();
             }
+        }
+
+        if (!consumedOffsetsAndMetadataPerTask.isEmpty()) {
+            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+        }
+
+        for (final Map.Entry<Task, Map<TopicPartition, Long>> taskAndCheckpoint : checkpointPerTask.entrySet()) {
+            final Task task = taskAndCheckpoint.getKey();
+            try {
+                task.closeClean(checkpointPerTask.get(task));
+            } catch (final RuntimeException e) {
+                final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
+                log.error(uncleanMessage, e);
+                taskCloseExceptions.put(task.id(), e);
+                // We've already recorded the exception (which is the point of clean).
+                // Now, we should go ahead and complete the close because a half-closed task is no good to anyone.
+                task.closeDirty();
+            } finally {
+                cleanUpTaskProducer(task, taskCloseExceptions);
+            }
+        }
+
+        for (final Task task : dirtyTasks) {
+            task.closeDirty();
+            cleanUpTaskProducer(task, taskCloseExceptions);
         }
 
         if (!taskCloseExceptions.isEmpty()) {
@@ -255,6 +285,19 @@ public class TaskManager {
         );
 
         changelogReader.transitToRestoreActive();
+    }
+
+    private void cleanUpTaskProducer(final Task task,
+                                     final Map<TaskId, RuntimeException> taskCloseExceptions) {
+        if (task.isActive()) {
+            try {
+                activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(task.id());
+            } catch (final RuntimeException e) {
+                final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
+                log.error(uncleanMessage, e);
+                taskCloseExceptions.putIfAbsent(task.id(), e);
+            }
+        }
     }
 
     private void addNewTask(final Task task) {
@@ -330,11 +373,25 @@ public class TaskManager {
     void handleRevocation(final Collection<TopicPartition> revokedPartitions) {
         final Set<TopicPartition> remainingPartitions = new HashSet<>(revokedPartitions);
 
+        final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
         for (final Task task : tasks.values()) {
             if (remainingPartitions.containsAll(task.inputPartitions())) {
-                task.suspend();
+                task.prepareSuspend();
+                if (task.state() != CREATED) {
+                    consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                }
             }
             remainingPartitions.removeAll(task.inputPartitions());
+        }
+
+        if (!consumedOffsetsAndMetadataPerTask.isEmpty()) {
+            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+        }
+
+        for (final Task task : tasks.values()) {
+            if (consumedOffsetsAndMetadataPerTask.containsKey(task.id())) {
+                task.suspend();
+            }
         }
 
         if (!remainingPartitions.isEmpty()) {
@@ -362,6 +419,7 @@ public class TaskManager {
             // standby tasks while we rejoin.
             if (task.isActive()) {
                 cleanupTask(task);
+                task.prepareCloseDirty();
                 task.closeDirty();
                 iterator.remove();
                 try {
@@ -497,24 +555,49 @@ public class TaskManager {
 
     void shutdown(final boolean clean) {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
-        final Iterator<Task> iterator = tasks.values().iterator();
-        while (iterator.hasNext()) {
-            final Task task = iterator.next();
+
+        final Map<Task, Map<TopicPartition, Long>> checkpointPerTask = new HashMap<>();
+        final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
+
+        for (final Task task : tasks.values()) {
             cleanupTask(task);
 
             if (clean) {
                 try {
-                    task.closeClean();
+                    checkpointPerTask.put(task, task.prepareCloseClean());
+                    if (task.state() != CREATED) {
+                        consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
+                    }
                 } catch (final TaskMigratedException e) {
                     // just ignore the exception as it doesn't matter during shutdown
+                    task.prepareCloseDirty();
                     task.closeDirty();
                 } catch (final RuntimeException e) {
                     firstException.compareAndSet(null, e);
+                    task.prepareCloseDirty();
                     task.closeDirty();
                 }
             } else {
+                task.prepareCloseDirty();
                 task.closeDirty();
             }
+        }
+
+        if (clean && !consumedOffsetsAndMetadataPerTask.isEmpty()) {
+            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+        }
+
+        for (final Map.Entry<Task, Map<TopicPartition, Long>> taskAndCheckpoint : checkpointPerTask.entrySet()) {
+            final Task task = taskAndCheckpoint.getKey();
+            try {
+                task.closeClean(checkpointPerTask.get(task));
+            } catch (final RuntimeException e) {
+                firstException.compareAndSet(null, e);
+                task.closeDirty();
+            }
+        }
+
+        for (final Task task : tasks.values()) {
             if (task.isActive()) {
                 try {
                     activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(task.id());
@@ -526,8 +609,9 @@ public class TaskManager {
                     }
                 }
             }
-            iterator.remove();
         }
+
+        tasks.clear();
 
         try {
             activeTaskCreator.closeThreadProducerIfNeeded();
@@ -604,14 +688,23 @@ public class TaskManager {
         if (rebalanceInProgress) {
             return -1;
         } else {
-            int commits = 0;
+            final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
             for (final Task task : tasks.values()) {
                 if (task.commitNeeded()) {
-                    task.commit();
-                    commits++;
+                    task.prepareCommit();
+                    consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
                 }
             }
-            return commits;
+
+            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+
+            for (final Task task : tasks.values()) {
+                if (consumedOffsetsAndMetadataPerTask.containsKey(task.id())) {
+                    task.postCommit();
+                }
+            }
+
+            return consumedOffsetsAndMetadataPerTask.size();
         }
     }
 
@@ -623,14 +716,46 @@ public class TaskManager {
         if (rebalanceInProgress) {
             return -1;
         } else {
-            int commits = 0;
+            final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
             for (final Task task : activeTaskIterable()) {
                 if (task.commitRequested() && task.commitNeeded()) {
-                    task.commit();
-                    commits++;
+                    task.prepareCommit();
+                    consumedOffsetsAndMetadataPerTask.put(task.id(), task.committableOffsetsAndMetadata());
                 }
             }
-            return commits;
+
+            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+
+            for (final Task task : tasks.values()) {
+                if (consumedOffsetsAndMetadataPerTask.containsKey(task.id())) {
+                    task.postCommit();
+                }
+            }
+
+            return consumedOffsetsAndMetadataPerTask.size();
+        }
+    }
+
+    private void commitOffsetsOrTransaction(final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> offsetsPerTask) {
+        if (eosEnabled) {
+            for (final Map.Entry<TaskId, Map<TopicPartition, OffsetAndMetadata>> taskToCommit : offsetsPerTask.entrySet()) {
+                activeTaskCreator.streamsProducerForTask(taskToCommit.getKey()).commitTransaction(taskToCommit.getValue());
+            }
+        } else {
+            try {
+                final Map<TopicPartition, OffsetAndMetadata> allOffsets = offsetsPerTask.values().stream()
+                    .flatMap(e -> e.entrySet().stream()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                mainConsumer.commitSync(allOffsets);
+            } catch (final CommitFailedException error) {
+                throw new TaskMigratedException("Consumer committing offsets failed, " +
+                    "indicating the corresponding thread is no longer part of the group", error);
+            } catch (final TimeoutException error) {
+                // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
+                throw new StreamsException("Timed out while committing offsets via consumer", error);
+            } catch (final KafkaException error) {
+                throw new StreamsException("Error encountered committing offsets via consumer", error);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -203,8 +203,10 @@ public class TaskManager {
                 cleanupTask(task);
 
                 try {
-                    checkpointPerTask.put(task, task.prepareCloseClean());
+                    final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
                     final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+
+                    checkpointPerTask.put(task, checkpoint);
                     if (!committableOffsets.isEmpty()) {
                         consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                     }
@@ -566,8 +568,10 @@ public class TaskManager {
 
             if (clean) {
                 try {
-                    checkpointPerTask.put(task, task.prepareCloseClean());
+                    final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
                     final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+
+                    checkpointPerTask.put(task, checkpoint);
                     if (!committableOffsets.isEmpty()) {
                         consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -61,7 +61,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@SuppressWarnings("unchecked")
 @Category({IntegrationTest.class})
 public class MetricsIntegrationTest {
 
@@ -261,7 +260,7 @@ public class MetricsIntegrationTest {
 
         verifyStateMetric(State.CREATED);
         verifyTopologyDescriptionMetric(topology.describe().toString());
-        verifyApplicationIdMetric(APPLICATION_ID_VALUE);
+        verifyApplicationIdMetric();
 
         kafkaStreams.start();
         TestUtils.waitForCondition(
@@ -501,13 +500,13 @@ public class MetricsIntegrationTest {
         assertThat(metricsList.get(0).metricValue(), is(topologyDescription));
     }
 
-    private void verifyApplicationIdMetric(final String applicationId) {
+    private void verifyApplicationIdMetric() {
         final List<Metric> metricsList = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
             .filter(m -> m.metricName().name().equals(APPLICATION_ID) &&
                 m.metricName().group().equals(STREAM_CLIENT_NODE_METRICS))
             .collect(Collectors.toList());
         assertThat(metricsList.size(), is(1));
-        assertThat(metricsList.get(0).metricValue(), is(applicationId));
+        assertThat(metricsList.get(0).metricValue(), is(APPLICATION_ID_VALUE));
     }
 
     private void checkClientLevelMetrics() {
@@ -565,10 +564,6 @@ public class MetricsIntegrationTest {
             .collect(Collectors.toList());
         final int numberOfAddedMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 0 : 4;
         final int numberOfMetricsWithRemovedParent = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 5 : 4;
-        checkMetricByName(listMetricTask, COMMIT_LATENCY_AVG, numberOfMetricsWithRemovedParent);
-        checkMetricByName(listMetricTask, COMMIT_LATENCY_MAX, numberOfMetricsWithRemovedParent);
-        checkMetricByName(listMetricTask, COMMIT_RATE, numberOfMetricsWithRemovedParent);
-        checkMetricByName(listMetricTask, COMMIT_TOTAL, numberOfMetricsWithRemovedParent);
         checkMetricByName(listMetricTask, ENFORCED_PROCESSING_RATE, 4);
         checkMetricByName(listMetricTask, ENFORCED_PROCESSING_TOTAL, 4);
         checkMetricByName(listMetricTask, RECORD_LATENESS_AVG, 4);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.io.File;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -43,14 +44,22 @@ import org.junit.runner.RunWith;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.same;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
 public class ActiveTaskCreatorTest {
@@ -72,6 +81,122 @@ public class ActiveTaskCreatorTest {
     final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), "clientId", StreamsConfig.METRICS_LATEST);
 
     private ActiveTaskCreator activeTaskCreator;
+
+    @Test
+    public void shouldFailForNonEosOnStreamsProducerPerTask() {
+        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
+        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.AT_LEAST_ONCE);
+        expect(config.getProducerConfigs(anyString())).andReturn(Collections.emptyMap());
+        replay(config);
+
+        activeTaskCreator = new ActiveTaskCreator(
+            builder,
+            config,
+            streamsMetrics,
+            stateDirectory,
+            changeLogReader,
+            new ThreadCache(new LogContext(), 0L, streamsMetrics),
+            new MockTime(),
+            mockClientSupplier,
+            "threadId",
+            new LogContext().logger(ActiveTaskCreator.class)
+        );
+
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> activeTaskCreator.streamsProducerForTask(null)
+        );
+
+        assertThat(thrown.getMessage(), is("Producer per thread is used"));
+    }
+
+    @Test
+    public void shouldFailForUnknownTaskOnStreamsProducerPerTask() {
+        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
+        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
+        expect(config.getProducerConfigs(anyString())).andReturn(Collections.emptyMap());
+        replay(config);
+
+        activeTaskCreator = new ActiveTaskCreator(
+            builder,
+            config,
+            streamsMetrics,
+            stateDirectory,
+            changeLogReader,
+            new ThreadCache(new LogContext(), 0L, streamsMetrics),
+            new MockTime(),
+            mockClientSupplier,
+            "threadId",
+            new LogContext().logger(ActiveTaskCreator.class)
+        );
+
+        {
+            final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> activeTaskCreator.streamsProducerForTask(null)
+            );
+
+            assertThat(thrown.getMessage(), is("Unknown TaskId: null"));
+        }
+        {
+            final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> activeTaskCreator.streamsProducerForTask(new TaskId(0, 0))
+            );
+
+            assertThat(thrown.getMessage(), is("Unknown TaskId: 0_0"));
+        }
+    }
+
+    @Test
+    public void shouldReturnStreamsProducerPerTask() {
+        final TaskId task00 = new TaskId(0, 0);
+        final TaskId task01 = new TaskId(0, 1);
+        final ProcessorTopology topology = mock(ProcessorTopology.class);
+
+        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
+        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
+        expect(config.getProducerConfigs(anyString())).andReturn(new HashMap<>()).anyTimes();
+        expect(config.getLong(anyString())).andReturn(0L).anyTimes();
+        expect(config.getInt(anyString())).andReturn(0).anyTimes();
+        expect(builder.buildSubtopology(task00.topicGroupId)).andReturn(topology).anyTimes();
+        expect(stateDirectory.directoryForTask(task00)).andReturn(new File(task00.toString()));
+        expect(stateDirectory.directoryForTask(task01)).andReturn(new File(task01.toString()));
+        expect(topology.storeToChangelogTopic()).andReturn(Collections.emptyMap()).anyTimes();
+        expect(topology.source("topic")).andReturn(mock(SourceNode.class)).andReturn(mock(SourceNode.class));
+        expect(topology.globalStateStores()).andReturn(Collections.emptyList()).anyTimes();
+        replay(config, builder, stateDirectory, topology);
+
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        activeTaskCreator = new ActiveTaskCreator(
+            builder,
+            config,
+            streamsMetrics,
+            stateDirectory,
+            changeLogReader,
+            new ThreadCache(new LogContext(), 0L, streamsMetrics),
+            new MockTime(),
+            mockClientSupplier,
+            "threadId",
+            new LogContext().logger(ActiveTaskCreator.class)
+        );
+
+        assertThat(
+            activeTaskCreator.createTasks(
+                null,
+                mkMap(
+                    mkEntry(task00, Collections.singleton(new TopicPartition("topic", 0))),
+                    mkEntry(task01, Collections.singleton(new TopicPartition("topic", 1)))
+                )
+            ).stream().map(Task::id). collect(Collectors.toSet()),
+            equalTo(mkSet(task00, task01))
+        );
+
+        final StreamsProducer streamsProducer1 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 0));
+        final StreamsProducer streamsProducer2 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 1));
+
+        assertThat(streamsProducer1, not(same(streamsProducer2)));
+    }
 
     @Test
     public void shouldConstructProducerMetricsWithoutEOS() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -188,7 +188,7 @@ public class ActiveTaskCreatorTest {
                     mkEntry(task00, Collections.singleton(new TopicPartition("topic", 0))),
                     mkEntry(task01, Collections.singleton(new TopicPartition("topic", 1)))
                 )
-            ).stream().map(Task::id). collect(Collectors.toSet()),
+            ).stream().map(Task::id).collect(Collectors.toSet()),
             equalTo(mkSet(task00, task01))
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -266,9 +266,6 @@ public class StreamTaskTest {
         ctrl.replay();
 
         task = createStatefulTask(createConfig(true, "100"), true, stateManager);
-        task.transitionTo(Task.State.RESTORING);
-        task.transitionTo(Task.State.RUNNING);
-        task.transitionTo(Task.State.SUSPENDED);
         task.prepareCloseDirty();
         task.closeDirty();
         task = null;
@@ -1320,14 +1317,18 @@ public class StreamTaskTest {
     @Test
     public void shouldThrowIfCommittingOnIllegalState() {
         task = createStatelessTask(createConfig(false, "100"), StreamsConfig.METRICS_LATEST);
+        assertThrows(IllegalStateException.class, task::prepareCommit);
 
+        task.transitionTo(Task.State.CLOSED);
         assertThrows(IllegalStateException.class, task::prepareCommit);
     }
 
     @Test
     public void shouldThrowIfPostCommittingOnIllegalState() {
         task = createStatelessTask(createConfig(false, "100"), StreamsConfig.METRICS_LATEST);
+        assertThrows(IllegalStateException.class, task::postCommit);
 
+        task.transitionTo(Task.State.CLOSED);
         assertThrows(IllegalStateException.class, task::postCommit);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -207,6 +207,7 @@ public class StreamTaskTest {
     @After
     public void cleanup() throws IOException {
         if (task != null && !task.isClosed()) {
+            task.prepareCloseDirty();
             task.closeDirty();
             task = null;
         }
@@ -264,7 +265,10 @@ public class StreamTaskTest {
         ctrl.replay();
 
         task = createStatefulTask(createConfig(true, "100"), true, stateManager);
-        task.transitionTo(Task.State.CLOSING);
+        task.transitionTo(Task.State.RESTORING);
+        task.transitionTo(Task.State.RUNNING);
+        task.transitionTo(Task.State.SUSPENDED);
+        task.prepareCloseDirty();
         task.closeDirty();
         task = null;
 
@@ -381,31 +385,6 @@ public class StreamTaskTest {
 
     private void testMetrics(final String builtInMetricsVersion) {
         task = createStatelessTask(createConfig(false, "100"), builtInMetricsVersion);
-
-        assertNotNull(getMetric(
-            "commit",
-            "%s-latency-avg",
-            task.id().toString(),
-            builtInMetricsVersion
-        ));
-        assertNotNull(getMetric(
-            "commit",
-            "%s-latency-max",
-            task.id().toString(),
-            builtInMetricsVersion
-        ));
-        assertNotNull(getMetric(
-            "commit",
-            "%s-rate",
-            task.id().toString(),
-            builtInMetricsVersion
-        ));
-        assertNotNull(getMetric(
-            "commit",
-            "%s-total",
-            task.id().toString(),
-            builtInMetricsVersion
-        ));
 
         assertNotNull(getMetric(
             "enforced-processing",
@@ -714,44 +693,48 @@ public class StreamTaskTest {
         assertTrue(task.process(0L));
         assertTrue(task.commitNeeded());
 
-        task.commit();
+        task.prepareCommit();
+        assertTrue(task.commitNeeded());
+
+        task.postCommit();
         assertFalse(task.commitNeeded());
 
         assertTrue(task.maybePunctuateStreamTime());
         assertTrue(task.commitNeeded());
 
-        task.commit();
+        task.prepareCommit();
+        assertTrue(task.commitNeeded());
+
+        task.postCommit();
         assertFalse(task.commitNeeded());
 
         time.sleep(10);
         assertTrue(task.maybePunctuateSystemTime());
         assertTrue(task.commitNeeded());
 
-        task.commit();
+        task.prepareCommit();
+        assertTrue(task.commitNeeded());
+
+        task.postCommit();
         assertFalse(task.commitNeeded());
     }
 
     @Test
     public void shouldCommitNextOffsetFromQueueIfAvailable() {
-        recordCollector.commit(EasyMock.eq(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, encodeTimestamp(5L))))));
-        EasyMock.expectLastCall();
-
         task = createStatelessTask(createConfig(false, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
         task.completeRestoration();
 
         task.addRecords(partition1, Arrays.asList(getConsumerRecord(partition1, 0L), getConsumerRecord(partition1, 5L)));
         task.process(0L);
-        task.commit();
+        task.prepareCommit();
+        final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = task.committableOffsetsAndMetadata();
 
-        EasyMock.verify(recordCollector);
+        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, encodeTimestamp(5L))))));
     }
 
     @Test
     public void shouldCommitConsumerPositionIfRecordQueueIsEmpty() {
-        recordCollector.commit(EasyMock.eq(mkMap(mkEntry(partition1, new OffsetAndMetadata(3L, encodeTimestamp(0L))))));
-        EasyMock.expectLastCall();
-
         task = createStatelessTask(createConfig(false, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
         task.completeRestoration();
@@ -763,9 +746,10 @@ public class StreamTaskTest {
 
         task.addRecords(partition1, singletonList(getConsumerRecord(partition1, 0L)));
         task.process(0L);
-        task.commit();
+        task.prepareCommit();
+        final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = task.committableOffsetsAndMetadata();
 
-        EasyMock.verify(recordCollector);
+        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(3L, encodeTimestamp(0L))))));
     }
 
     @Test
@@ -1041,8 +1025,6 @@ public class StreamTaskTest {
         stateDirectory = EasyMock.createNiceMock(StateDirectory.class);
         EasyMock.expect(stateDirectory.lock(taskId)).andReturn(true);
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, 10L));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
         stateManager.checkpoint(EasyMock.eq(Collections.singletonMap(changelogPartition, 10L)));
         EasyMock.expectLastCall();
@@ -1053,6 +1035,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
 
+        task.prepareSuspend();
         task.suspend();
 
         assertEquals(Task.State.SUSPENDED, task.state());
@@ -1082,8 +1065,6 @@ public class StreamTaskTest {
         stateDirectory = EasyMock.createNiceMock(StateDirectory.class);
         EasyMock.expect(stateDirectory.lock(taskId)).andReturn(true);
         EasyMock.expect(recordCollector.offsets()).andThrow(new AssertionError("Should not try to read offsets")).anyTimes();
-        recordCollector.commit(EasyMock.anyObject());
-        EasyMock.expectLastCall().andThrow(new AssertionError("Should not try to commit")).anyTimes();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
         stateManager.checkpoint(EasyMock.eq(Collections.emptyMap()));
         EasyMock.expectLastCall();
@@ -1094,6 +1075,7 @@ public class StreamTaskTest {
 
         task.initializeIfNeeded();
 
+        task.prepareSuspend();
         task.suspend();
 
         assertEquals(Task.State.SUSPENDED, task.state());
@@ -1120,8 +1102,6 @@ public class StreamTaskTest {
         final Long offset = 543L;
 
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, offset));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         stateManager.checkpoint(EasyMock.eq(Collections.singletonMap(changelogPartition, offset)));
         EasyMock.expectLastCall();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.singleton(changelogPartition));
@@ -1133,7 +1113,8 @@ public class StreamTaskTest {
 
         task.initializeIfNeeded();
         task.completeRestoration();
-        task.commit();
+        task.prepareCommit();
+        task.postCommit();
 
         EasyMock.verify(recordCollector);
     }
@@ -1149,7 +1130,8 @@ public class StreamTaskTest {
 
         task.initializeIfNeeded();
         task.completeRestoration();
-        task.commit();
+        task.prepareCommit();
+        task.postCommit();
         final File checkpointFile = new File(
             stateDirectory.directoryForTask(taskId),
             StateManagerUtil.CHECKPOINT_FILE_NAME
@@ -1220,6 +1202,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
 
+        task.prepareCloseDirty();
         task.closeDirty();
 
         EasyMock.verify(stateManager);
@@ -1262,7 +1245,7 @@ public class StreamTaskTest {
         assertTrue(task.process(0L));
         assertTrue(task.process(0L));
 
-        task.commit();
+        task.prepareCommit();
 
         final Map<TopicPartition, Long> map = task.purgeableOffsets();
 
@@ -1292,7 +1275,14 @@ public class StreamTaskTest {
     public void shouldThrowIfCommittingOnIllegalState() {
         task = createStatelessTask(createConfig(false, "100"), StreamsConfig.METRICS_LATEST);
 
-        assertThrows(IllegalStateException.class, task::commit);
+        assertThrows(IllegalStateException.class, task::prepareCommit);
+    }
+
+    @Test
+    public void shouldThrowIfPostCommittingOnIllegalState() {
+        task = createStatelessTask(createConfig(false, "100"), StreamsConfig.METRICS_LATEST);
+
+        assertThrows(IllegalStateException.class, task::postCommit);
     }
 
     @Test
@@ -1325,7 +1315,8 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
 
-        task.closeClean();
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        task.closeClean(checkpoint);
 
         assertEquals(Task.State.CLOSED, task.state());
         assertFalse(source1.initialized);
@@ -1354,6 +1345,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
 
+        task.prepareCloseDirty();
         task.closeDirty();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -1372,14 +1364,13 @@ public class StreamTaskTest {
         EasyMock.expectLastCall();
         stateManager.checkpoint(EasyMock.eq(Collections.emptyMap()));
         EasyMock.expectLastCall();
-        recordCollector.commit(EasyMock.anyObject());
-        EasyMock.expectLastCall().andThrow(new AssertionError("Should not call this function")).anyTimes();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
         EasyMock.replay(stateManager);
 
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
 
         task.initializeIfNeeded();
+        task.prepareSuspend();
         task.suspend();
 
         assertEquals(Task.State.SUSPENDED, task.state());
@@ -1393,15 +1384,14 @@ public class StreamTaskTest {
         EasyMock.expectLastCall();
         stateManager.checkpoint(EasyMock.eq(Collections.emptyMap()));
         EasyMock.expectLastCall();
-        recordCollector.commit(EasyMock.anyObject());
-        EasyMock.expectLastCall().andThrow(new AssertionError("Should not call this function")).anyTimes();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
         EasyMock.replay(stateManager);
 
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
 
         task.initializeIfNeeded();
-        task.closeClean();
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        task.closeClean(checkpoint);
 
         assertEquals(Task.State.CLOSED, task.state());
 
@@ -1413,8 +1403,6 @@ public class StreamTaskTest {
         final long offset = 543L;
 
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, offset));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         stateManager.close();
         EasyMock.expectLastCall();
         stateManager.flush();
@@ -1428,7 +1416,8 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
         task.initializeIfNeeded();
         task.completeRestoration();
-        task.closeClean();
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        task.closeClean(checkpoint);
 
         assertEquals(Task.State.CLOSED, task.state());
 
@@ -1439,12 +1428,10 @@ public class StreamTaskTest {
     }
 
     @Test
-    public void shouldThrowOnCloseCleanError() {
+    public void shouldSwallowExceptionOnCloseCleanError() {
         final long offset = 543L;
 
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, offset));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         stateManager.checkpoint(EasyMock.eq(Collections.singletonMap(changelogPartition, offset)));
         EasyMock.expectLastCall();
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.singleton(changelogPartition)).anyTimes();
@@ -1457,9 +1444,8 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
 
-        assertThrows(ProcessorStateException.class, task::closeClean);
-
-        assertEquals(Task.State.CLOSING, task.state());
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        assertThrows(ProcessorStateException.class, () -> task.closeClean(checkpoint));
 
         final double expectedCloseTaskMetric = 0.0;
         verifyCloseTaskMetric(expectedCloseTaskMetric, streamsMetrics, metricName);
@@ -1467,6 +1453,8 @@ public class StreamTaskTest {
         EasyMock.verify(stateManager);
         EasyMock.reset(stateManager);
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.singleton(changelogPartition)).anyTimes();
+        stateManager.close();
+        EasyMock.expectLastCall();
         EasyMock.replay(stateManager);
     }
 
@@ -1475,8 +1463,6 @@ public class StreamTaskTest {
         final long offset = 543L;
 
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, offset));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         stateManager.flush();
         EasyMock.expectLastCall().andThrow(new ProcessorStateException("KABOOM!")).anyTimes();
         stateManager.checkpoint(EasyMock.anyObject());
@@ -1490,7 +1476,7 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
         task.initializeIfNeeded();
 
-        assertThrows(ProcessorStateException.class, task::closeClean);
+        assertThrows(ProcessorStateException.class, task::prepareCloseClean);
 
         assertEquals(Task.State.RESTORING, task.state());
 
@@ -1508,8 +1494,6 @@ public class StreamTaskTest {
         final long offset = 543L;
 
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.singletonMap(changelogPartition, offset));
-        recordCollector.commit(EasyMock.eq(Collections.emptyMap()));
-        EasyMock.expectLastCall();
         stateManager.flush();
         EasyMock.expectLastCall();
         stateManager.checkpoint(Collections.emptyMap());
@@ -1524,7 +1508,8 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
         task.initializeIfNeeded();
 
-        assertThrows(ProcessorStateException.class, task::closeClean);
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        assertThrows(ProcessorStateException.class, () -> task.closeClean(checkpoint));
 
         assertEquals(Task.State.RESTORING, task.state());
 
@@ -1558,10 +1543,11 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
 
-        task.closeClean();
+        final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
+        task.closeClean(checkpoint);
 
         // close call are not idempotent since we are already in closed
-        assertThrows(IllegalStateException.class, task::closeClean);
+        assertThrows(IllegalStateException.class, () -> task.closeClean(checkpoint));
         assertThrows(IllegalStateException.class, task::closeDirty);
 
         EasyMock.reset(stateManager);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1046,6 +1046,10 @@ public class StreamThreadTest {
 
         assertThat(thread.activeTasks().size(), equalTo(1));
 
+        // need to process a record to enable committing
+        addRecord(mockConsumer, 0L);
+        thread.runOnce();
+
         clientSupplier.producers.get(0).commitTransactionException = new ProducerFencedException("Producer is fenced");
         assertThrows(TaskMigratedException.class, () -> thread.rebalanceListener.onPartitionsRevoked(assignedPartitions));
         assertFalse(clientSupplier.producers.get(0).transactionCommitted());
@@ -1132,6 +1136,10 @@ public class StreamThreadTest {
         thread.runOnce();
 
         assertThat(thread.activeTasks().size(), equalTo(1));
+
+        // need to process a record to enable committing
+        addRecord(mockConsumer, 0L);
+        thread.runOnce();
 
         thread.rebalanceListener.onPartitionsRevoked(assignedPartitions);
         assertTrue(clientSupplier.producers.get(0).transactionCommitted());

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -200,10 +200,8 @@ public class KeyValueStoreTestDriver<K, V> {
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             new TaskId(0, 0),
-            consumer,
-            new StreamsProducer(producer, false, logContext, null),
+            new StreamsProducer(producer, false, null, logContext),
             new DefaultProductionExceptionHandler(),
-            false,
             new MockStreamsMetrics(new Metrics())
         ) {
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -374,10 +374,13 @@ public class StreamThreadStateStoreProviderTest {
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             taskId,
-            clientSupplier.consumer,
-            new StreamsProducer(clientSupplier.getProducer(new HashMap<>()), eosEnabled, logContext, streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)),
+            new StreamsProducer(
+                clientSupplier.getProducer(new HashMap<>()),
+                eosEnabled,
+                streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG),
+                logContext
+            ),
             streamsConfig.defaultProductionExceptionHandler(),
-            eosEnabled,
             new MockStreamsMetrics(metrics));
         return new StreamTask(
             taskId,

--- a/streams/src/test/java/org/apache/kafka/test/MockRecordCollector.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockRecordCollector.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.test;
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
@@ -35,9 +34,6 @@ public class MockRecordCollector implements RecordCollector {
 
     // remember all records that are collected so far
     private final List<ProducerRecord<Object, Object>> collected = new LinkedList<>();
-
-    // remember all commits that are submitted so far
-    private final List<Map<TopicPartition, OffsetAndMetadata>> committed = new LinkedList<>();
 
     // remember if flushed is called
     private boolean flushed = false;
@@ -80,11 +76,6 @@ public class MockRecordCollector implements RecordCollector {
     public void initialize() {}
 
     @Override
-    public void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        committed.add(offsets);
-    }
-
-    @Override
     public void flush() {
         flushed = true;
     }
@@ -99,10 +90,6 @@ public class MockRecordCollector implements RecordCollector {
 
     public List<ProducerRecord<Object, Object>> collected() {
         return unmodifiableList(collected);
-    }
-
-    public List<Map<TopicPartition, OffsetAndMetadata>> committed() {
-        return unmodifiableList(committed);
     }
 
     public boolean flushed() {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.utils.LogContext;
+
+import java.util.Map;
+
+public class TestDriverProducer extends StreamsProducer {
+
+    public TestDriverProducer(final Producer<byte[], byte[]> producer,
+                              final boolean eosEnabled,
+                              final String applicationId,
+                              final LogContext logContext) {
+        super(producer, eosEnabled, applicationId, logContext);
+    }
+
+    public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
+        super.commitTransaction(offsets);
+    }
+}


### PR DESCRIPTION
With KIP-447 we need to commit all tasks at once using eos-beta as all tasks share the same producer. Right now, each task is committed individually (by making multiple calls to `consumer.commitSync` or individual calls to `producer.commitTransaction` for the corresponding task producer).

To allow for a unified commit logic, we move the commit logic into `TaskManager`. For non-eos, we collect all offset to be committed and do a single call to `consumer.commitSync` -- for eos-alpha we still commit each transaction individually (but now triggered by the `TaskManager` to have all code in one place).

To allow for a unified commit logic, we need to split existing method on `Task` interface in pre/post parts to allow committing in between, in particular:

 - `commit()` -> `prepareCommit()` and `postCommit()`
 - `suspend()` -> `prepareSuspend()` and `suspend()` (we keep the name as it still does suspend the task)
 - `closeClean()` -> `prepareCloseClean()` and `closeClean(Map<TopicPartitions, Long> checkpoint)` (we keep the name as it still does close the task)
 - `closeDirty()` -> `prepareCloseDirty()` and `closeDirty()` (we keep the name as it still does close the task)

`prepareCloseClean()` returns checkpoint information to allow checkpointing after the `TaskManager` did the commit within `closeClean()`.

In a follow up PR, we will introduce eso-beta and commit a single transaction over all task using the shared producer.

Call for review @guozhangwang @abbccdda 