### PR TITLE
KAFKA-9651: Fix ArithmeticException (÷ by 0) in Partitioner impls

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.clients.producer.internals;
 
-import java.util.List;
-import java.util.Map;
-
 import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.common.Cluster;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.utils.Utils;
+
+import java.util.Map;
 
 /**
  * The default partitioning strategy:
@@ -50,11 +48,29 @@ public class DefaultPartitioner implements Partitioner {
      * @param cluster The current cluster metadata
      */
     public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+        return partition(topic, key, keyBytes, value, valueBytes, cluster, 0);
+    }
+
+    /**
+     * Compute the partition for the given record.
+     *
+     * @param topic The topic name
+     * @param numPartitions The number of partitions of the given {@code topic}, or 0 to obtain this from
+     *                      the given {@code cluster}
+     * @param key The key to partition on (or null if no key)
+     * @param keyBytes serialized key to partition on (or null if no key)
+     * @param value The value to partition on or null
+     * @param valueBytes serialized value to partition on or null
+     * @param cluster The current cluster metadata
+     */
+    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster,
+                         int numPartitions) {
         if (keyBytes == null) {
             return stickyPartitionCache.partition(topic, cluster);
-        } 
-        List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
-        int numPartitions = partitions.size();
+        }
+        if (numPartitions <= 0) {
+            numPartitions = cluster.partitionsForTopic(topic).size();
+        }
         // hash the keyBytes to choose a partition
         return Utils.toPositive(Utils.murmur2(keyBytes)) % numPartitions;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
@@ -48,15 +48,14 @@ public class DefaultPartitioner implements Partitioner {
      * @param cluster The current cluster metadata
      */
     public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
-        return partition(topic, key, keyBytes, value, valueBytes, cluster, 0);
+        return partition(topic, key, keyBytes, value, valueBytes, cluster, cluster.partitionsForTopic(topic).size());
     }
 
     /**
      * Compute the partition for the given record.
      *
      * @param topic The topic name
-     * @param numPartitions The number of partitions of the given {@code topic}, or 0 to obtain this from
-     *                      the given {@code cluster}
+     * @param numPartitions The number of partitions of the given {@code topic}
      * @param key The key to partition on (or null if no key)
      * @param keyBytes serialized key to partition on (or null if no key)
      * @param value The value to partition on or null
@@ -67,9 +66,6 @@ public class DefaultPartitioner implements Partitioner {
                          int numPartitions) {
         if (keyBytes == null) {
             return stickyPartitionCache.partition(topic, cluster);
-        }
-        if (numPartitions <= 0) {
-            numPartitions = cluster.partitionsForTopic(topic).size();
         }
         // hash the keyBytes to choose a partition
         return Utils.toPositive(Utils.murmur2(keyBytes)) % numPartitions;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -36,6 +36,6 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
     @Override
     public Integer partition(final String topic, final K key, final V value, final int numPartitions) {
         final byte[] keyBytes = keySerializer.serialize(topic, key);
-        return defaultPartitioner.partition(topic, key, keyBytes, value, null, cluster);
+        return defaultPartitioner.partition(topic, key, keyBytes, value, null, cluster, numPartitions);
     }
 }


### PR DESCRIPTION
This PR fixes KAKFA-9651 by throwing UnknownTopicOrPartitionException instead of ArithmeticException. 