### PR TITLE
Set "-Ywarn-unused" compiler flags when using 2.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -463,7 +463,13 @@ subprojects {
     if (versions.baseScala == '2.12') {
       scalaCompileOptions.additionalParameters += [
         "-Xlint:by-name-right-associative",
-        "-Xlint:unsound-match"
+        "-Xlint:unsound-match",
+        "-Ywarn-unused:implicits",
+        "-Ywarn-unused:imports",
+        "-Ywarn-unused:locals",
+        "-Ywarn-unused:params",
+        "-Ywarn-unused:patvars",
+        "-Ywarn-unused:privates"
       ]
     }
 


### PR DESCRIPTION
Currently, when compiling using Scala 2.12, we do not get any unused warnings in the build stdout. The `-Xlint:unused` flag was added for Scala 2.13.

This change keeps the `-Xlint:unused` flag but also adds a set of `-Ywarn-unused` compiler flags to include unused warnings when compiling with Scala 2.12.

Example output from either setting `scala.version` to 2.12.10 (the default) or 2.13.1

```
/kafka/core/src/main/scala/kafka/cluster/Partition.scala:303: parameter value replicaId in method createLog is never used
  private[cluster] def createLog(replicaId: Int, isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints): Log = {
                                 ^
/kafka/core/src/main/scala/kafka/cluster/Partition.scala:481: parameter value controllerId in method makeLeader is never used
  def makeLeader(controllerId: Int,
                 ^
/kafka/core/src/main/scala/kafka/cluster/Partition.scala:483: parameter value correlationId in method makeLeader is never used
                 correlationId: Int,
                 ^
/kafka/core/src/main/scala/kafka/cluster/Partition.scala:552: parameter value controllerId in method makeFollower is never used
  def makeFollower(controllerId: Int,
                   ^
/kafka/core/src/main/scala/kafka/cluster/Partition.scala:554: parameter value correlationId in method makeFollower is never used
                   correlationId: Int,
                   ^
``` 

References:
* http://tpolecat.github.io/2017/04/25/scalac-flags.html
* https://github.com/fthomas/refined/pull/280/files
* https://docs.scala-lang.org/overviews/compiler-options/index.html