### PR TITLE
KAFKA-9674: corruption should also cleanup producer and recreate

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -132,11 +132,7 @@ class ActiveTaskCreator {
             );
 
             if (threadProducer == null) {
-                final String taskProducerClientId = getTaskProducerClientId(threadId, taskId);
-                final Map<String, Object> producerConfigs = config.getProducerConfigs(taskProducerClientId);
-                producerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, applicationId + "-" + taskId);
-                log.info("Creating producer client for task {}", taskId);
-                taskProducers.put(taskId, clientSupplier.getProducer(producerConfigs));
+                createTaskProducer(taskId);
             }
 
             final RecordCollector recordCollector = new RecordCollectorImpl(
@@ -170,6 +166,14 @@ class ActiveTaskCreator {
             createTaskSensor.record();
         }
         return createdTasks;
+    }
+
+    void createTaskProducer(final TaskId taskId) {
+        final String taskProducerClientId = getTaskProducerClientId(threadId, taskId);
+        final Map<String, Object> producerConfigs = config.getProducerConfigs(taskProducerClientId);
+        producerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, applicationId + "-" + taskId);
+        log.info("Creating producer client for task {}", taskId);
+        taskProducers.put(taskId, clientSupplier.getProducer(producerConfigs));
     }
 
     void closeThreadProducerIfNeeded() {


### PR DESCRIPTION
The task producer cleanup doesn't involve handling of task corruption. Adding recreation of task producer to avoid reusing a fatal state producer in next cycle.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
