### PR TITLE
KAFKA-6145: Pt 2.5 Compute overall task lag per client

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -12,7 +12,7 @@
     <suppress checks="CyclomaticComplexity|BooleanExpressionComplexity"
               files="(SchemaGenerator|MessageDataGenerator|FieldSpec).java"/>
     <suppress checks="NPathComplexity"
-              files="(MessageDataGenerator|FieldSpec).java"/>
+              files="(MessageDataGenerator|FieldSpec|AssignorConfiguration).java"/>
     <suppress checks="JavaNCSS"
               files="(ApiMessageType).java|MessageDataGenerator.java"/>
     <suppress checks="MethodLength"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1119,7 +1119,7 @@ public interface Admin extends AutoCloseable {
      * @param topicPartitionOffsets The mapping from partition to the OffsetSpec to look up.
      * @return The ListOffsetsResult.
      */
-    default ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
+    default ListOffsetsResult  listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
         return listOffsets(topicPartitionOffsets, new ListOffsetsOptions());
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1119,7 +1119,7 @@ public interface Admin extends AutoCloseable {
      * @param topicPartitionOffsets The mapping from partition to the OffsetSpec to look up.
      * @return The ListOffsetsResult.
      */
-    default ListOffsetsResult  listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
+    default ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
         return listOffsets(topicPartitionOffsets, new ListOffsetsOptions());
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.common.utils;
 
-import static java.util.Arrays.asList;
-
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.kafka.common.KafkaException;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.utils;
 
+import static java.util.Arrays.asList;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.apache.kafka.common.KafkaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -660,7 +664,7 @@ public final class Utils {
         return existingBuffer;
     }
 
-    /*
+    /**
      * Creates a set
      * @param elems the elements
      * @param <T> the type of element
@@ -669,6 +673,20 @@ public final class Utils {
     @SafeVarargs
     public static <T> Set<T> mkSet(T... elems) {
         Set<T> result = new HashSet<>((int) (elems.length / 0.75) + 1);
+        for (T elem : elems)
+            result.add(elem);
+        return result;
+    }
+
+    /**
+     * Creates a sorted set
+     * @param elems the elements
+     * @param <T> the type of element, must be comparable
+     * @return SortedSet
+     */
+    @SafeVarargs
+    public static <T extends Comparable<T>> SortedSet<T> mkSortedSet(T... elems) {
+        SortedSet<T> result = new TreeSet<>();
         for (T elem : elems)
             result.add(elem);
         return result;

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams;
 import java.util.LinkedList;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
@@ -27,6 +28,7 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
@@ -1217,7 +1219,7 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         log.debug("Current changelog positions: {}", allChangelogPositions);
-        final Map<TopicPartition, ListOffsetsResultInfo> allEndOffsets = fetchEndOffsets(allPartitions, adminClient);
+        final Map<TopicPartition, ListOffsetsResultInfo> allEndOffsets = fetchEndOffsetsWithoutTimeout(allPartitions, adminClient);
         log.debug("Current end offsets :{}", allEndOffsets);
 
         for (final Map.Entry<TopicPartition, ListOffsetsResultInfo> entry : allEndOffsets.entrySet()) {
@@ -1237,14 +1239,27 @@ public class KafkaStreams implements AutoCloseable {
         return Collections.unmodifiableMap(localStorePartitionLags);
     }
 
+    static Map<TopicPartition, ListOffsetsResultInfo> fetchEndOffsetsWithoutTimeout(final Collection<TopicPartition> partitions,
+                                                                                    final Admin adminClient) {
+        return fetchEndOffsets(partitions, adminClient, null);
+    }
+
     public static Map<TopicPartition, ListOffsetsResultInfo> fetchEndOffsets(final Collection<TopicPartition> partitions,
-                                                                             final Admin adminClient) {
+                                                                             final Admin adminClient,
+                                                                             final Duration timeout) {
+        final Map<TopicPartition, ListOffsetsResultInfo> endOffsets;
         try {
-            return adminClient.listOffsets(
-                partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()))
-            ).all().get();
-        } catch (final RuntimeException | InterruptedException | ExecutionException e) {
+            final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> future =  adminClient.listOffsets(
+                partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest())))
+                                                                                        .all();
+            if (timeout == null) {
+                endOffsets = future.get();
+            } else {
+                endOffsets = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            }
+        } catch (final TimeoutException | RuntimeException | InterruptedException | ExecutionException e) {
             throw new StreamsException("Unable to obtain end offsets from kafka", e);
         }
+        return endOffsets;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -17,6 +17,10 @@
 package org.apache.kafka.streams.processor.internals;
 
 import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.common.Cluster;
@@ -30,6 +34,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
@@ -60,6 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static java.util.UUID.randomUUID;
+import static org.apache.kafka.streams.KafkaStreams.fetchEndOffsets;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.EARLIEST_PROBEABLE_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
@@ -124,9 +130,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             state.addOwnedPartitions(ownedPartitions, consumerMemberId);
         }
 
-        void addPreviousTasks(final SubscriptionInfo info) {
-            state.addPreviousActiveTasks(info.prevTasks());
-            state.addPreviousStandbyTasks(info.standbyTasks());
+        void addPreviousTasksAndOffsetSums(final Map<TaskId, Long> taskOffsetSums) {
+            state.addPreviousTasksAndOffsetSums(taskOffsetSums);
         }
 
         @Override
@@ -203,6 +208,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     protected int usedSubscriptionMetadataVersion = LATEST_SUPPORTED_VERSION;
 
+    private Admin adminClient;
     private InternalTopicManager internalTopicManager;
     private CopartitionedTopicsEnforcer copartitionedTopicsEnforcer;
     private RebalanceProtocol rebalanceProtocol;
@@ -228,6 +234,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         assignmentConfigs = assignorConfiguration.getAssignmentConfigs();
         partitionGrouper = assignorConfiguration.getPartitionGrouper();
         userEndPoint = assignorConfiguration.getUserEndPoint();
+        adminClient = assignorConfiguration.getAdminClient();
         internalTopicManager = assignorConfiguration.getInternalTopicManager();
         copartitionedTopicsEnforcer = assignorConfiguration.getCopartitionedTopicsEnforcer();
         rebalanceProtocol = assignorConfiguration.rebalanceProtocol();
@@ -350,7 +357,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             // add the consumer and any info in its subscription to the client
             clientMetadata.addConsumer(consumerId, subscription.ownedPartitions());
             allOwnedPartitions.addAll(subscription.ownedPartitions());
-            clientMetadata.addPreviousTasks(info);
+            clientMetadata.addPreviousTasksAndOffsetSums(info.taskOffsetSums());
         }
 
         final boolean versionProbing =
@@ -363,7 +370,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // parse the topology to determine the repartition source topics,
         // making sure they are created with the number of partitions as
         // the maximum of the depending sub-topologies source topics' number of partitions
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = taskManager.builder().topicGroups();
+        final Map<Integer, TopicsInfo> topicGroups = taskManager.builder().topicGroups();
 
         final Map<TopicPartition, PartitionInfo> allRepartitionTopicPartitions;
         try {
@@ -385,7 +392,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         final Set<String> allSourceTopics = new HashSet<>();
         final Map<Integer, Set<String>> sourceTopicsByGroup = new HashMap<>();
-        for (final Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> entry : topicGroups.entrySet()) {
+        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
             allSourceTopics.addAll(entry.getValue().sourceTopics);
             sourceTopicsByGroup.put(entry.getKey(), entry.getValue().sourceTopics);
         }
@@ -482,10 +489,10 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * @return a map of repartition topics and their metadata
      * @throws TaskAssignmentException if there is incomplete source topic metadata due to missing source topic(s)
      */
-    private Map<String, InternalTopicConfig> computeRepartitionTopicMetadata(final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups,
+    private Map<String, InternalTopicConfig> computeRepartitionTopicMetadata(final Map<Integer, TopicsInfo> topicGroups,
                                                                              final Cluster metadata) throws TaskAssignmentException {
         final Map<String, InternalTopicConfig> repartitionTopicMetadata = new HashMap<>();
-        for (final InternalTopologyBuilder.TopicsInfo topicsInfo : topicGroups.values()) {
+        for (final TopicsInfo topicsInfo : topicGroups.values()) {
             for (final String topic : topicsInfo.sourceTopics) {
                 if (!topicsInfo.repartitionSourceTopics.keySet().contains(topic) &&
                         !metadata.topics().contains(topic)) {
@@ -507,7 +514,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      *
      * @return map from repartition topic to its partition info
      */
-    private Map<TopicPartition, PartitionInfo> prepareRepartitionTopics(final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups,
+    private Map<TopicPartition, PartitionInfo> prepareRepartitionTopics(final Map<Integer, TopicsInfo> topicGroups,
                                                                            final Cluster metadata) {
         final Map<String, InternalTopicConfig> repartitionTopicMetadata = computeRepartitionTopicMetadata(topicGroups, metadata);
 
@@ -543,13 +550,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * Computes the number of partitions and sets it for each repartition topic in repartitionTopicMetadata
      */
     private void setRepartitionTopicMetadataNumberOfPartitions(final Map<String, InternalTopicConfig> repartitionTopicMetadata,
-                                                               final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups,
+                                                               final Map<Integer, TopicsInfo> topicGroups,
                                                                final Cluster metadata) {
         boolean numPartitionsNeeded;
         do {
             numPartitionsNeeded = false;
 
-            for (final InternalTopologyBuilder.TopicsInfo topicsInfo : topicGroups.values()) {
+            for (final TopicsInfo topicsInfo : topicGroups.values()) {
                 for (final String topicName : topicsInfo.repartitionSourceTopics.keySet()) {
                     final Optional<Integer> maybeNumPartitions = repartitionTopicMetadata.get(topicName)
                                                                      .numberOfPartitions();
@@ -557,7 +564,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
                     if (!maybeNumPartitions.isPresent()) {
                         // try set the number of partitions for this repartition topic if it is not set yet
-                        for (final InternalTopologyBuilder.TopicsInfo otherTopicsInfo : topicGroups.values()) {
+                        for (final TopicsInfo otherTopicsInfo : topicGroups.values()) {
                             final Set<String> otherSinkTopics = otherTopicsInfo.sinkTopics;
 
                             if (otherSinkTopics.contains(topicName)) {
@@ -670,17 +677,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     /**
      * Resolve changelog topic metadata and create them if necessary.
      *
-     * @return set of standby task ids (any task that is stateful and has logging enabled)
+     * @return mapping of stateful tasks to their set of changelog topics
      */
-    private Set<TaskId> prepareChangelogTopics(final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups,
-                                               final Map<Integer, Set<TaskId>> tasksForTopicGroup) {
-        final Set<TaskId> standbyTaskIds = new HashSet<>();
+    private Map<TaskId, Set<TopicPartition>> prepareChangelogTopics(final Map<Integer, TopicsInfo> topicGroups,
+                                                                    final Map<Integer, Set<TaskId>> tasksForTopicGroup) {
+        final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask = new HashMap<>();
 
         // add tasks to state change log topic subscribers
         final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
-        for (final Map.Entry<Integer, InternalTopologyBuilder.TopicsInfo> entry : topicGroups.entrySet()) {
+        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
             final int topicGroupId = entry.getKey();
-            final InternalTopologyBuilder.TopicsInfo topicsInfo = entry.getValue();
+            final TopicsInfo topicsInfo = entry.getValue();
 
             final Set<TaskId> topicGroupTasks = tasksForTopicGroup.get(topicGroupId);
             if (topicGroupTasks == null) {
@@ -690,7 +697,15 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 continue;
             }
 
-            standbyTaskIds.addAll(topicGroupTasks);
+            for (final TaskId task : topicGroupTasks) {
+                changelogsByStatefulTask.put(
+                    task,
+                    topicsInfo.stateChangelogTopics
+                        .keySet()
+                        .stream()
+                        .map(topic -> new TopicPartition(topic, task.partition))
+                        .collect(Collectors.toSet()));
+            }
 
             for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
                  // the expected number of partitions is the max value of TaskId.partition + 1
@@ -707,33 +722,88 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         prepareTopic(changelogTopicMetadata);
         log.debug("Created state changelog topics {} from the parsed topology.", changelogTopicMetadata.values());
-        return standbyTaskIds;
+        return changelogsByStatefulTask;
     }
 
     /**
-     * Assigns a set of tasks to each client (Streams instance) using the sticky assignor
+     * Assigns a set of tasks to each client (Streams instance) using the sticky assignor to prioritize clients
+     * based on the previous state and overall lag.
      */
     private void assignTasksToClients(final Set<String> allSourceTopics,
                                       final Map<TaskId, Set<TopicPartition>> partitionsForTask,
-                                      final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups,
+                                      final Map<Integer, TopicsInfo> topicGroups,
                                       final Map<UUID, ClientMetadata> clientMetadataMap,
                                       final Cluster fullMetadata) {
         final Map<TopicPartition, TaskId> taskForPartition = new HashMap<>();
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = new HashMap<>();
         populateTasksForMaps(taskForPartition, tasksForTopicGroup, allSourceTopics, partitionsForTask, fullMetadata);
 
-        final Set<TaskId> standbyTaskIds = prepareChangelogTopics(topicGroups, tasksForTopicGroup);
+        final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask =
+            prepareChangelogTopics(topicGroups, tasksForTopicGroup);
 
-        final Map<UUID, ClientState> states = new HashMap<>();
+        final Map<UUID, ClientState> clientStates = new HashMap<>();
+        final boolean lagComputationSuccessful =
+            populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogsByStatefulTask);
+
+        final Map<TaskId, SortedSet<RankedClient<UUID>>> statefulTasksToRankedCandidates =
+            buildClientRankingsByTask(changelogsByStatefulTask.keySet(), clientStates, assignmentConfigs.acceptableRecoveryLag);
+
+        // assign tasks to clients
+        if (lagComputationSuccessful) {
+            log.debug("Assigning tasks {} to clients {} with number of replicas {}",
+                partitionsForTask.keySet(), clientStates, assignmentConfigs.numStandbyReplicas);
+            final StickyTaskAssignor<UUID> taskAssignor =
+                new StickyTaskAssignor<>(clientStates, partitionsForTask.keySet(), statefulTasksToRankedCandidates.keySet());
+            taskAssignor.assign(assignmentConfigs.numStandbyReplicas);
+        } else {
+            log.debug("Failed to fetch end offsets and compute task lags, will return tasks to previous owners then retry");
+            // give tasks back to previous owners (based on prevActiveTasks and prevStandbyTasks), distribute any "unowned" tasks
+            //TODO-soph
+        }
+
+        log.info("Assigned tasks to clients as {}{}.",
+            Utils.NL, clientStates.entrySet().stream().map(Map.Entry::toString).collect(Collectors.joining(Utils.NL)));
+    }
+
+    /**
+     * Builds a map from client to state, and readies each ClientState for assignment by adding any missing prev tasks
+     * and computing the per-task overall lag based on the fetched end offsets for each changelog.
+     *
+     * @param clientStates a map from each client to its state, including offset lags. Populated by this method.
+     * @param clientMetadataMap a map from each client to its full metadata
+     * @param taskForPartition map from topic partition to its corresponding task
+     * @param changelogsByStatefulTask map from each stateful task to its set of changelog topic partitions
+     *
+     * @return whether we were able to successfully fetch the changelog end offsets and compute each client's lag
+     */
+    private boolean populateClientStatesMap(final Map<UUID, ClientState> clientStates,
+                                            final Map<UUID, ClientMetadata> clientMetadataMap,
+                                            final Map<TopicPartition, TaskId> taskForPartition,
+                                            final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask) {
+        boolean fetchEndOffsetsSuccessful;
+        Map<TaskId, Long> allTaskEndOffsetSums;
+        try {
+            final Collection<TopicPartition> allChangelogPartitions = changelogsByStatefulTask.values().stream()
+                                                                          .flatMap(Collection::stream)
+                                                                          .collect(Collectors.toList());
+            final Map<TopicPartition, ListOffsetsResultInfo> endOffsets = fetchEndOffsets(allChangelogPartitions, adminClient);
+            allTaskEndOffsetSums = computeEndOffsetSumsByTask(endOffsets, changelogsByStatefulTask);
+
+            fetchEndOffsetsSuccessful = true;
+        } catch(final StreamsException e) {
+            allTaskEndOffsetSums = null;
+            fetchEndOffsetsSuccessful = false;
+        }
+
         for (final Map.Entry<UUID, ClientMetadata> entry : clientMetadataMap.entrySet()) {
             final UUID uuid = entry.getKey();
             final ClientState state = entry.getValue().state;
-            states.put(uuid, state);
 
-            // there are two cases where we need to construct the prevTasks from the ownedPartitions:
-            // 1) COOPERATIVE clients on version 2.4-2.5 do not encode active tasks and rely on ownedPartitions instead
+            // there are three cases where we need to construct some or all of the prevTasks from the ownedPartitions:
+            // 1) COOPERATIVE clients on version 2.4-2.5 do not encode active tasks at all and rely on ownedPartitions
             // 2) future client during version probing, when we can't decode the future subscription info's prev tasks
-            if (!state.ownedPartitions().isEmpty() && (uuid == FUTURE_ID || state.prevActiveTasks().isEmpty())) {
+            // 3) stateless tasks are not encoded in the task lags, and must be figured out from the ownedPartitions
+            if (!state.ownedPartitions().isEmpty()) {
                 final Set<TaskId> previousActiveTasks = new HashSet<>();
                 for (final Map.Entry<TopicPartition, String> partitionEntry : state.ownedPartitions().entrySet()) {
                     final TopicPartition tp = partitionEntry.getKey();
@@ -746,18 +816,69 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 }
                 state.addPreviousActiveTasks(previousActiveTasks);
             }
+
+            if (fetchEndOffsetsSuccessful) {
+                state.computeTaskLags(allTaskEndOffsetSums);
+            }
+            clientStates.put(uuid, state);
         }
+        return fetchEndOffsetsSuccessful;
+    }
 
-        log.debug("Assigning tasks {} to clients {} with number of replicas {}",
-            partitionsForTask.keySet(), states, assignmentConfigs.numStandbyReplicas);
+    /**
+     * @param endOffsets the listOffsets result from the adminClient, or null if the request failed
+     * @param changelogsByStatefulTask map from stateful task to its set of changelog topic partitions
+     *
+     * @return Map from stateful task to its total end offset summed across all changelog partitions
+     */
+    private Map<TaskId, Long> computeEndOffsetSumsByTask(final Map<TopicPartition, ListOffsetsResultInfo> endOffsets,
+                                                         final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask) {
+        final Map<TaskId, Long> taskEndOffsetSums = new HashMap<>();
+        for (final Map.Entry<TaskId, Set<TopicPartition>> taskEntry : changelogsByStatefulTask.entrySet()) {
+            final TaskId task = taskEntry.getKey();
+            final Set<TopicPartition> changelogs = taskEntry.getValue();
 
-        // assign tasks to clients
-        final StickyTaskAssignor<UUID> taskAssignor =
-            new StickyTaskAssignor<>(states, partitionsForTask.keySet(), standbyTaskIds);
-        taskAssignor.assign(assignmentConfigs.numStandbyReplicas);
+            taskEndOffsetSums.put(task, 0L);
+            for (final TopicPartition changelog : changelogs) {
+                final ListOffsetsResultInfo offsetResult = endOffsets.get(changelog);
+                if (offsetResult == null) {
+                    log.debug("Fetched end offsets did not contain the changelog {} of task {}", changelog, task);
+                    throw new IllegalStateException("Could not get end offset for " + changelog);
+                }
+                taskEndOffsetSums
+                    .computeIfPresent(task, (id, curOffsetSum) -> curOffsetSum + offsetResult.offset());
+            }
+        }
+        return taskEndOffsetSums;
+    }
 
-        log.info("Assigned tasks to clients as {}{}.", Utils.NL, states.entrySet().stream()
-                                                                     .map(Map.Entry::toString).collect(Collectors.joining(Utils.NL)));
+    /**
+     * @return Sorted set of all client candidates for each stateful task, ranked by their overall lag
+     */
+    static Map<TaskId, SortedSet<RankedClient<UUID>>> buildClientRankingsByTask(final Set<TaskId> statefulTasks,
+                                                                                final Map<UUID, ClientState> states,
+                                                                                final long acceptableRecoveryLag) {
+        final Map<TaskId, SortedSet<RankedClient<UUID>>> statefulTasksToRankedCandidates = new TreeMap<>();
+
+        for (final TaskId task : statefulTasks) {
+            final SortedSet<RankedClient<UUID>> rankedClientCandidates = new TreeSet<>();
+            statefulTasksToRankedCandidates.put(task, rankedClientCandidates);
+
+            for (final Map.Entry<UUID, ClientState> clientEntry : states.entrySet()) {
+                final UUID clientId = clientEntry.getKey();
+                final long taskLag = clientEntry.getValue().lagFor(task);
+                final long clientRank;
+                if (taskLag == Task.LATEST_OFFSET) {
+                    clientRank = Task.LATEST_OFFSET;
+                } else if (taskLag <= acceptableRecoveryLag) {
+                    clientRank = 0;
+                } else {
+                    clientRank = taskLag;
+                }
+                rankedClientCandidates.add(new RankedClient<>(clientId, clientRank));
+            }
+        }
+        return statefulTasksToRankedCandidates;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1606,23 +1606,23 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         taskManager.handleRebalanceStart(topics);
     }
 
-    Long acceptableRecoveryLag() {
+    long acceptableRecoveryLag() {
         return assignmentConfigs.acceptableRecoveryLag;
     }
 
-    Integer balanceFactor() {
+    int balanceFactor() {
         return assignmentConfigs.balanceFactor;
     }
 
-    Integer maxWarmupReplicas() {
+    int maxWarmupReplicas() {
         return assignmentConfigs.maxWarmupReplicas;
     }
 
-    Integer numStandbyReplicas() {
+    int numStandbyReplicas() {
         return assignmentConfigs.numStandbyReplicas;
     }
 
-    Long probingRebalanceIntervalMs() {
+    long probingRebalanceIntervalMs() {
         return assignmentConfigs.probingRebalanceIntervalMs;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -269,11 +269,11 @@ public final class AssignorConfiguration {
     }
 
     public static class AssignmentConfigs {
-        public final long acceptableRecoveryLag;
-        public final int balanceFactor;
-        public final int maxWarmupReplicas;
-        public final int numStandbyReplicas;
-        public final long probingRebalanceIntervalMs;
+        public final Long acceptableRecoveryLag;
+        public final Integer balanceFactor;
+        public final Integer maxWarmupReplicas;
+        public final Integer numStandbyReplicas;
+        public final Long probingRebalanceIntervalMs;
 
         AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.RebalanceProtocol;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
@@ -46,6 +47,7 @@ public final class AssignorConfiguration {
     private final TaskManager taskManager;
     private final StreamsMetadataState streamsMetadataState;
     private final Admin adminClient;
+    private final int adminClientTimeout;
     private final InternalTopicManager internalTopicManager;
     private final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer;
     private final StreamsConfig streamsConfig;
@@ -149,6 +151,7 @@ public final class AssignorConfiguration {
             internalTopicManager = new InternalTopicManager(adminClient, streamsConfig);
         }
 
+        adminClientTimeout = streamsConfig.getInt(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG);
 
         copartitionedTopicsEnforcer = new CopartitionedTopicsEnforcer(logPrefix);
     }
@@ -254,6 +257,10 @@ public final class AssignorConfiguration {
 
     public Admin getAdminClient() {
         return adminClient;
+    }
+
+    public int getAdminClientTimeout() {
+        return adminClientTimeout;
     }
 
     public InternalTopicManager getInternalTopicManager() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -276,11 +276,11 @@ public final class AssignorConfiguration {
     }
 
     public static class AssignmentConfigs {
-        public final Long acceptableRecoveryLag;
-        public final Integer balanceFactor;
-        public final Integer maxWarmupReplicas;
-        public final Integer numStandbyReplicas;
-        public final Long probingRebalanceIntervalMs;
+        public final long acceptableRecoveryLag;
+        public final int balanceFactor;
+        public final int maxWarmupReplicas;
+        public final int numStandbyReplicas;
+        public final long probingRebalanceIntervalMs;
 
         AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -45,6 +45,7 @@ public final class AssignorConfiguration {
     private final String userEndPoint;
     private final TaskManager taskManager;
     private final StreamsMetadataState streamsMetadataState;
+    private final Admin adminClient;
     private final InternalTopicManager internalTopicManager;
     private final CopartitionedTopicsEnforcer copartitionedTopicsEnforcer;
     private final StreamsConfig streamsConfig;
@@ -144,7 +145,8 @@ public final class AssignorConfiguration {
                 throw fatalException;
             }
 
-            internalTopicManager = new InternalTopicManager((Admin) o, streamsConfig);
+            adminClient = (Admin) o;
+            internalTopicManager = new InternalTopicManager(adminClient, streamsConfig);
         }
 
 
@@ -248,6 +250,10 @@ public final class AssignorConfiguration {
 
     public String getUserEndPoint() {
         return userEndPoint;
+    }
+
+    public Admin getAdminClient() {
+        return adminClient;
     }
 
     public InternalTopicManager getInternalTopicManager() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -169,6 +169,9 @@ public class ClientState {
         this.taskOffsetSums.putAll(taskOffsetSums);
     }
 
+    /**
+     * Compute the lag for each stateful task, including tasks this client did not previously have.
+     */
     public void computeTaskLags(final Map<TaskId, Long> allTaskEndOffsetSums) {
         if (!taskLagTotals.isEmpty()) {
             throw new IllegalStateException("Already computed task lags for this client.");
@@ -179,15 +182,15 @@ public class ClientState {
             final Long endOffsetSum = taskEntry.getValue();
             final Long offsetSum = taskOffsetSums.getOrDefault(task, 0L);
 
-            if (endOffsetSum == UNKNOWN_OFFSET_SUM) {
-
-            } else if (endOffsetSum < offsetSum) {
+            if (endOffsetSum < offsetSum) {
                 throw new IllegalStateException("Task " + task + " had endOffsetSum=" + endOffsetSum +
                                                     " smaller than offsetSum=" + offsetSum);
             }
 
             if (offsetSum == Task.LATEST_OFFSET) {
                 taskLagTotals.put(task, Task.LATEST_OFFSET);
+            } else if (offsetSum == UNKNOWN_OFFSET_SUM) {
+                taskLagTotals.put(task, UNKNOWN_OFFSET_SUM);
             } else {
                 taskLagTotals.put(task, endOffsetSum - offsetSum);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -95,14 +95,24 @@ public class ClientState {
             capacity);
     }
 
-    public void assign(final TaskId taskId, final boolean active) {
-        if (active) {
-            activeTasks.add(taskId);
-        } else {
-            standbyTasks.add(taskId);
-        }
+    void assignActive(final TaskId task) {
+        activeTasks.add(task);
+        assignedTasks.add(task);
+    }
 
-        assignedTasks.add(taskId);
+    void assignStandby(final TaskId task) {
+        standbyTasks.add(task);
+        assignedTasks.add(task);
+    }
+
+    public void assignActiveTasks(final Collection<TaskId> tasks) {
+        activeTasks.addAll(tasks);
+        assignedTasks.addAll(tasks);
+    }
+
+    void assignStandbyTasks(final Collection<TaskId> tasks) {
+        standbyTasks.addAll(tasks);
+        assignedTasks.addAll(tasks);
     }
 
     public Set<TaskId> activeTasks() {
@@ -113,7 +123,7 @@ public class ClientState {
         return standbyTasks;
     }
 
-    public Set<TaskId> prevActiveTasks() {
+    Set<TaskId> prevActiveTasks() {
         return prevActiveTasks;
     }
 
@@ -142,6 +152,7 @@ public class ClientState {
     public void addPreviousActiveTasks(final Set<TaskId> prevTasks) {
         prevActiveTasks.addAll(prevTasks);
         prevAssignedTasks.addAll(prevTasks);
+        prevStandbyTasks.removeAll(prevTasks);
     }
 
     void addPreviousStandbyTasks(final Set<TaskId> standbyTasks) {
@@ -219,22 +230,16 @@ public class ClientState {
         assignedTasks.remove(task);
     }
 
-    @Override
-    public String toString() {
-        return "[activeTasks: (" + activeTasks +
-                ") standbyTasks: (" + standbyTasks +
-                ") assignedTasks: (" + assignedTasks +
-                ") prevActiveTasks: (" + prevActiveTasks +
-                ") prevStandbyTasks: (" + prevStandbyTasks +
-                ") prevAssignedTasks: (" + prevAssignedTasks +
-                ") prevOwnedPartitionsByConsumerId: (" + ownedPartitions.keySet() +
-                ") changelogOffsetTotalsByTask: (" + taskOffsetSums.entrySet() +
-                ") capacity: " + capacity +
-                "]";
-    }
-
     boolean reachedCapacity() {
         return assignedTasks.size() >= capacity;
+    }
+
+    int capacity() {
+        return capacity;
+    }
+
+    boolean hasUnfulfilledQuota(final int tasksPerThread) {
+        return activeTasks.size() < capacity * tasksPerThread;
     }
 
     boolean hasMoreAvailableCapacityThan(final ClientState other) {
@@ -262,6 +267,20 @@ public class ClientState {
         return assignedTasks.contains(taskId);
     }
 
+    @Override
+    public String toString() {
+        return "[activeTasks: (" + activeTasks +
+                   ") standbyTasks: (" + standbyTasks +
+                   ") assignedTasks: (" + assignedTasks +
+                   ") prevActiveTasks: (" + prevActiveTasks +
+                   ") prevStandbyTasks: (" + prevStandbyTasks +
+                   ") prevAssignedTasks: (" + prevAssignedTasks +
+                   ") prevOwnedPartitionsByConsumerId: (" + ownedPartitions.keySet() +
+                   ") changelogOffsetTotalsByTask: (" + taskOffsetSums.entrySet() +
+                   ") capacity: " + capacity +
+                   "]";
+    }
+
     // Visible for testing
     Set<TaskId> assignedTasks() {
         return assignedTasks;
@@ -271,16 +290,4 @@ public class ClientState {
         return prevAssignedTasks;
     }
 
-    int capacity() {
-        return capacity;
-    }
-
-    boolean hasUnfulfilledQuota(final int tasksPerThread) {
-        return activeTasks.size() < capacity * tasksPerThread;
-    }
-
-    // the following methods are used for testing only
-    public void assignActiveTasks(final Collection<TaskId> tasks) {
-        activeTasks.addAll(tasks);
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -46,7 +46,7 @@ public class SubscriptionInfo {
 
     static final int UNKNOWN = -1;
     static final int MIN_VERSION_OFFSET_SUM_SUBSCRIPTION = 7;
-    static final long UNKNOWN_OFFSET_SUM = -3L;
+    public static final long UNKNOWN_OFFSET_SUM = -3L;
 
     private final SubscriptionInfoData data;
     private Set<TaskId> prevTasksCache = null;
@@ -198,7 +198,7 @@ public class SubscriptionInfo {
         return standbyTasksCache;
     }
 
-    Map<TaskId, Long> taskOffsetSums() {
+    public Map<TaskId, Long> taskOffsetSums() {
         if (taskOffsetSumsCache == null) {
             taskOffsetSumsCache = new HashMap<>();
             if (data.version() >= MIN_VERSION_OFFSET_SUM_SUBSCRIPTION) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignor.java
@@ -16,6 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
-public interface TaskAssignor<C, T extends Comparable<T>> {
+public interface TaskAssignor<C> {
     void assign(int numStandbyReplicas);
 }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -16,13 +16,16 @@
  */
 package org.apache.kafka.streams;
 
+import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -33,6 +36,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.AbstractProcessor;
@@ -83,16 +87,20 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.streams.KafkaStreams.fetchEndOffsets;
 import static org.easymock.EasyMock.anyInt;
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -881,6 +889,45 @@ public class KafkaStreamsTest {
         final String globalStoreName = testName.getMethodName() + "-globalStore";
         final Topology topology = getStatefulTopology(inputTopic, outputTopic, globalTopicName, storeName, globalStoreName, true);
         startStreamsAndCheckDirExists(topology, true);
+    }
+
+    @Test
+    public void fetchEndOffsetsShouldRethrowRuntimeExceptionAsStreamsException() {
+        final Admin adminClient = EasyMock.createMock(AdminClient.class);
+        EasyMock.expect(adminClient.listOffsets(EasyMock.anyObject())).andThrow(new RuntimeException());
+        replay(adminClient);
+        assertThrows(StreamsException.class, () -> fetchEndOffsets(emptyList(), adminClient));
+        verify(adminClient);
+    }
+
+    @Test
+    public void fetchEndOffsetsShouldRethrowInterruptedExceptionAsStreamsException() throws InterruptedException, ExecutionException {
+        final Admin adminClient = EasyMock.createMock(AdminClient.class);
+        final ListOffsetsResult result = EasyMock.createNiceMock(ListOffsetsResult.class);
+        final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = EasyMock.createMock(KafkaFuture.class);
+
+        EasyMock.expect(adminClient.listOffsets(EasyMock.anyObject())).andStubReturn(result);
+        EasyMock.expect(result.all()).andStubReturn(allFuture);
+        EasyMock.expect(allFuture.get()).andThrow(new InterruptedException());
+        replay(adminClient, result, allFuture);
+
+        assertThrows(StreamsException.class, () -> fetchEndOffsets(emptyList(), adminClient));
+        verify(adminClient);
+    }
+
+    @Test
+    public void fetchEndOffsetsShouldRethrowExecutionExceptionAsStreamsException() throws InterruptedException, ExecutionException {
+        final Admin adminClient = EasyMock.createMock(AdminClient.class);
+        final ListOffsetsResult result = EasyMock.createNiceMock(ListOffsetsResult.class);
+        final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> allFuture = EasyMock.createMock(KafkaFuture.class);
+
+        EasyMock.expect(adminClient.listOffsets(EasyMock.anyObject())).andStubReturn(result);
+        EasyMock.expect(result.all()).andStubReturn(allFuture);
+        EasyMock.expect(allFuture.get()).andThrow(new ExecutionException(new RuntimeException()));
+        replay(adminClient, result, allFuture);
+
+        assertThrows(StreamsException.class, () -> fetchEndOffsets(emptyList(), adminClient));
+        verify(adminClient);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -79,7 +79,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
@@ -211,24 +210,26 @@ public class StreamsPartitionAssignorTest {
         return configurationMap;
     }
 
-    private void configureDefault() {
+    private MockInternalTopicManager configureDefault() {
         createDefaultMockTaskManager();
-        configureDefaultPartitionAssignor();
+        return configureDefaultPartitionAssignor();
     }
 
     // Make sure to complete setting up any mocks (such as TaskManager or AdminClient) before configuring the assignor
-    private void configureDefaultPartitionAssignor() {
-        configurePartitionAssignorWith(emptyMap());
+    private MockInternalTopicManager configureDefaultPartitionAssignor() {
+        return configurePartitionAssignorWith(emptyMap());
     }
 
     // Make sure to complete setting up any mocks (such as TaskManager or AdminClient) before configuring the assignor
-    private void configurePartitionAssignorWith(final Map<String, Object> props) {
+    private MockInternalTopicManager configurePartitionAssignorWith(final Map<String, Object> props) {
         final Map<String, Object> configMap = configProps();
         configMap.putAll(props);
 
         streamsConfig = new StreamsConfig(configMap);
         partitionAssignor.configure(configMap);
         EasyMock.replay(taskManager, adminClient);
+
+        return overwriteInternalTopicManagerWithMock();
     }
 
     private void createDefaultMockTaskManager() {
@@ -251,8 +252,8 @@ public class StreamsPartitionAssignorTest {
         builder.buildTopology();
     }
 
-    // If you don't care about settings the end offsets for each specific topic partition, the helper method
-    // getTopicPartitionOffsetMap is useful for building this input map based on the topics and number of partitions
+    // If you don't care about setting the end offsets for each specific topic partition, the helper method
+    // getTopicPartitionOffsetMap is useful for building this input map for all partitions
     private void createMockAdminClient(final Map<TopicPartition, Long> changelogEndOffsets) {
         adminClient = EasyMock.createMock(AdminClient.class);
 
@@ -532,7 +533,6 @@ public class StreamsPartitionAssignorTest {
 
         createMockTaskManager(prevTasks10, standbyTasks10);
         configureDefaultPartitionAssignor();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -619,7 +619,6 @@ public class StreamsPartitionAssignorTest {
         final TaskId taskIdB3 = new TaskId(1, 3);
 
         configureDefault();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -669,7 +668,6 @@ public class StreamsPartitionAssignorTest {
             singletonList(3))
         );
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG, SingleGroupPartitionGrouperStub.class));
-        overwriteInternalTopicManagerWithMock();
 
         // will throw exception if it fails
         subscriptions.put("consumer10",
@@ -758,7 +756,6 @@ public class StreamsPartitionAssignorTest {
         
         createMockTaskManager(prevTasks10, emptyTasks);
         configureDefaultPartitionAssignor();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -823,7 +820,6 @@ public class StreamsPartitionAssignorTest {
             asList(3, 3, 3))
         );
         configureDefault();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
                           new Subscription(topics, defaultSubscriptionInfo.encode()));
@@ -890,7 +886,6 @@ public class StreamsPartitionAssignorTest {
 
         createMockTaskManager(mkSet(task0_0), emptySet());
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1));
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
             new Subscription(
@@ -921,7 +916,6 @@ public class StreamsPartitionAssignorTest {
 
         createMockTaskManager(mkSet(task0_0), emptySet());
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1));
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
             new Subscription(
@@ -970,7 +964,6 @@ public class StreamsPartitionAssignorTest {
             singletonList(3))
         );
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1));
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -1087,8 +1080,7 @@ public class StreamsPartitionAssignorTest {
         final List<String> topics = asList("topic1", APPLICATION_ID + "-topicX");
         final Set<TaskId> allTasks = mkSet(task0_0, task0_1, task0_2);
 
-        configureDefault();
-        final MockInternalTopicManager internalTopicManager = overwriteInternalTopicManagerWithMock();
+        final MockInternalTopicManager internalTopicManager = configureDefault();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -1116,8 +1108,7 @@ public class StreamsPartitionAssignorTest {
         final List<String> topics = asList("topic1", APPLICATION_ID + "-topicX", APPLICATION_ID + "-topicZ");
         final Set<TaskId> allTasks = mkSet(task0_0, task0_1, task0_2);
 
-        configureDefault();
-        final MockInternalTopicManager internalTopicManager = overwriteInternalTopicManagerWithMock();
+        final MockInternalTopicManager internalTopicManager = configureDefault();
 
         subscriptions.put("consumer10",
                           new Subscription(
@@ -1164,8 +1155,7 @@ public class StreamsPartitionAssignorTest {
             asList(4, 4))
         );
 
-        configureDefault();
-        final MockInternalTopicManager mockInternalTopicManager = overwriteInternalTopicManagerWithMock();
+        final MockInternalTopicManager mockInternalTopicManager = configureDefault();
 
         subscriptions.put(client,
                           new Subscription(
@@ -1233,7 +1223,6 @@ public class StreamsPartitionAssignorTest {
 
         createDefaultMockTaskManager();
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.APPLICATION_SERVER_CONFIG, USER_END_POINT));
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer1",
                           new Subscription(
@@ -1309,8 +1298,7 @@ public class StreamsPartitionAssignorTest {
 
         builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
 
-        configureDefault();
-        final MockInternalTopicManager mockInternalTopicManager = overwriteInternalTopicManagerWithMock();
+        final MockInternalTopicManager mockInternalTopicManager = configureDefault();
 
         subscriptions.put(client,
                           new Subscription(
@@ -1395,7 +1383,6 @@ public class StreamsPartitionAssignorTest {
         props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, USER_END_POINT);
 
         configurePartitionAssignorWith(props);
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer1",
                           new Subscription(
@@ -1643,7 +1630,6 @@ public class StreamsPartitionAssignorTest {
         );
 
         configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1));
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer1",
                 new Subscription(
@@ -1799,8 +1785,6 @@ public class StreamsPartitionAssignorTest {
         final List<String> topics = asList("input-stream", "test-even_store-repartition", "test-even_store_2-repartition", "test-odd_store-repartition", "test-odd_store_2-repartition");
 
         configureDefault();
-
-        final MockInternalTopicManager internalTopicManager = overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
             new Subscription(
@@ -1972,7 +1956,6 @@ public class StreamsPartitionAssignorTest {
         );
 
         configureDefault();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
             new Subscription(
@@ -1995,7 +1978,6 @@ public class StreamsPartitionAssignorTest {
         );
 
         configureDefault();
-        overwriteInternalTopicManagerWithMock();
 
         subscriptions.put("consumer10",
             new Subscription(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 import java.util.SortedSet;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
@@ -47,6 +48,7 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.RankedClient;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ClientState;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
@@ -1822,6 +1824,17 @@ public class StreamsPartitionAssignorTest {
         assertThat(partitionAssignor.maxWarmupReplicas(), equalTo(33));
         assertThat(partitionAssignor.numStandbyReplicas(), equalTo(44));
         assertThat(partitionAssignor.probingRebalanceIntervalMs(), equalTo(55 * 60 * 1000L));
+    }
+
+    @Test
+    public void shouldSetAdminClientTimeout() {
+        createDefaultMockTaskManager();
+
+        final Map<String, Object> props = configProps();
+        props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 2 * 60 * 1000);
+        final AssignorConfiguration assignorConfiguration = new AssignorConfiguration(props);
+
+        assertThat(assignorConfiguration.getAdminClientTimeout(), is(2 * 60 * 1000));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -220,6 +221,15 @@ public class ClientStateTest {
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
         client.computeTaskLags(allTaskEndOffsetSums);
         assertThat(client.lagFor(taskId01), equalTo(Task.LATEST_OFFSET));
+    }
+
+    @Test
+    public void shouldReturnUnknownOffsetSumForLagOfTaskWithUnknownOffset() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, UNKNOWN_OFFSET_SUM);
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.computeTaskLags(allTaskEndOffsetSums);
+        assertThat(client.lagFor(taskId01), equalTo(UNKNOWN_OFFSET_SUM));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -49,13 +49,13 @@ public class ClientStateTest {
 
     @Test
     public void shouldHaveReachedCapacityWhenAssignedTasksGreaterThanOrEqualToCapacity() {
-        client.assign(taskId01, true);
+        client.assignActive(taskId01);
         assertTrue(client.reachedCapacity());
     }
 
     @Test
     public void shouldAddActiveTasksToBothAssignedAndActive() {
-        client.assign(taskId01, true);
+        client.assignActive(taskId01);
         assertThat(client.activeTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.assignedTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.assignedTaskCount(), equalTo(1));
@@ -63,8 +63,8 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldAddStandbyTasksToBothStandbyAndActive() {
-        client.assign(taskId01, false);
+    public void shouldAddStandbyTasksToBothStandbyAndAssigned() {
+        client.assignStandby(taskId01);
         assertThat(client.assignedTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.standbyTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.assignedTaskCount(), equalTo(1));
@@ -79,7 +79,7 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldAddPreviousStandbyTasksToPreviousAssigned() {
+    public void shouldAddPreviousStandbyTasksToPreviousAssignedAndPreviousStandby() {
         client.addPreviousStandbyTasks(Utils.mkSet(taskId01, taskId02));
         assertThat(client.prevActiveTasks().size(), equalTo(0));
         assertThat(client.previousAssignedTasks(), equalTo(Utils.mkSet(taskId01, taskId02)));
@@ -87,26 +87,26 @@ public class ClientStateTest {
 
     @Test
     public void shouldHaveAssignedTaskIfActiveTaskAssigned() {
-        client.assign(taskId01, true);
+        client.assignActive(taskId01);
         assertTrue(client.hasAssignedTask(taskId01));
     }
 
     @Test
     public void shouldHaveAssignedTaskIfStandbyTaskAssigned() {
-        client.assign(taskId01, false);
+        client.assignStandby(taskId01);
         assertTrue(client.hasAssignedTask(taskId01));
     }
 
     @Test
     public void shouldNotHaveAssignedTaskIfTaskNotAssigned() {
-        client.assign(taskId01, true);
+        client.assignActive(taskId01);
         assertFalse(client.hasAssignedTask(taskId02));
     }
 
     @Test
     public void shouldHaveMoreAvailableCapacityWhenCapacityTheSameButFewerAssignedTasks() {
         final ClientState otherClient = new ClientState(1);
-        client.assign(taskId01, true);
+        client.assignActive(taskId01);
         assertTrue(otherClient.hasMoreAvailableCapacityThan(client));
         assertFalse(client.hasMoreAvailableCapacityThan(otherClient));
     }
@@ -123,11 +123,11 @@ public class ClientStateTest {
         final ClientState otherClient = new ClientState(2);
 
         for (int i = 0; i < 7; i++) {
-            otherClient.assign(new TaskId(0, i), true);
+            otherClient.assignActive(new TaskId(0, i));
         }
 
         for (int i = 7; i < 11; i++) {
-            client.assign(new TaskId(0, i), true);
+            client.assignActive(new TaskId(0, i));
         }
 
         assertTrue(otherClient.hasMoreAvailableCapacityThan(client));
@@ -138,10 +138,10 @@ public class ClientStateTest {
         final ClientState client = new ClientState(3);
         final ClientState otherClient = new ClientState(3);
         for (int i = 0; i < 4; i++) {
-            client.assign(new TaskId(0, i), true);
-            otherClient.assign(new TaskId(0, i), true);
+            client.assignActive(new TaskId(0, i));
+            otherClient.assignActive(new TaskId(0, i));
         }
-        otherClient.assign(new TaskId(0, 5), true);
+        otherClient.assignActive(new TaskId(0, 5));
         assertTrue(client.hasMoreAvailableCapacityThan(otherClient));
     }
 
@@ -157,13 +157,13 @@ public class ClientStateTest {
 
     @Test
     public void shouldHaveUnfulfilledQuotaWhenActiveTaskSizeLessThanCapacityTimesTasksPerThread() {
-        client.assign(new TaskId(0, 1), true);
+        client.assignActive(new TaskId(0, 1));
         assertTrue(client.hasUnfulfilledQuota(2));
     }
 
     @Test
     public void shouldNotHaveUnfulfilledQuotaWhenActiveTaskSizeGreaterEqualThanCapacityTimesTasksPerThread() {
-        client.assign(new TaskId(0, 1), true);
+        client.assignActive(new TaskId(0, 1));
         assertFalse(client.hasUnfulfilledQuota(1));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -16,20 +16,30 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.Map;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.Task;
 import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ClientStateTest {
 
     private final ClientState client = new ClientState(1);
+    private final ClientState zeroCapacityClient = new ClientState(0);
+
+    private final TaskId taskId01 = new TaskId(0, 1);
+    private final TaskId taskId02 = new TaskId(0, 2);
 
     @Test
     public void shouldHaveNotReachedCapacityWhenAssignedTasksLessThanCapacity() {
@@ -38,142 +48,203 @@ public class ClientStateTest {
 
     @Test
     public void shouldHaveReachedCapacityWhenAssignedTasksGreaterThanOrEqualToCapacity() {
-        client.assign(new TaskId(0, 1), true);
+        client.assign(taskId01, true);
         assertTrue(client.reachedCapacity());
     }
 
-
     @Test
     public void shouldAddActiveTasksToBothAssignedAndActive() {
-        final TaskId tid = new TaskId(0, 1);
-
-        client.assign(tid, true);
-        assertThat(client.activeTasks(), equalTo(Collections.singleton(tid)));
-        assertThat(client.assignedTasks(), equalTo(Collections.singleton(tid)));
+        client.assign(taskId01, true);
+        assertThat(client.activeTasks(), equalTo(Collections.singleton(taskId01)));
+        assertThat(client.assignedTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.assignedTaskCount(), equalTo(1));
         assertThat(client.standbyTasks().size(), equalTo(0));
     }
 
     @Test
     public void shouldAddStandbyTasksToBothStandbyAndActive() {
-        final TaskId tid = new TaskId(0, 1);
-
-        client.assign(tid, false);
-        assertThat(client.assignedTasks(), equalTo(Collections.singleton(tid)));
-        assertThat(client.standbyTasks(), equalTo(Collections.singleton(tid)));
+        client.assign(taskId01, false);
+        assertThat(client.assignedTasks(), equalTo(Collections.singleton(taskId01)));
+        assertThat(client.standbyTasks(), equalTo(Collections.singleton(taskId01)));
         assertThat(client.assignedTaskCount(), equalTo(1));
         assertThat(client.activeTasks().size(), equalTo(0));
     }
 
     @Test
     public void shouldAddPreviousActiveTasksToPreviousAssignedAndPreviousActive() {
-        final TaskId tid1 = new TaskId(0, 1);
-        final TaskId tid2 = new TaskId(0, 2);
-
-        client.addPreviousActiveTasks(Utils.mkSet(tid1, tid2));
-        assertThat(client.prevActiveTasks(), equalTo(Utils.mkSet(tid1, tid2)));
-        assertThat(client.previousAssignedTasks(), equalTo(Utils.mkSet(tid1, tid2)));
+        client.addPreviousActiveTasks(Utils.mkSet(taskId01, taskId02));
+        assertThat(client.prevActiveTasks(), equalTo(Utils.mkSet(taskId01, taskId02)));
+        assertThat(client.previousAssignedTasks(), equalTo(Utils.mkSet(taskId01, taskId02)));
     }
 
     @Test
     public void shouldAddPreviousStandbyTasksToPreviousAssigned() {
-        final TaskId tid1 = new TaskId(0, 1);
-        final TaskId tid2 = new TaskId(0, 2);
-
-        client.addPreviousStandbyTasks(Utils.mkSet(tid1, tid2));
+        client.addPreviousStandbyTasks(Utils.mkSet(taskId01, taskId02));
         assertThat(client.prevActiveTasks().size(), equalTo(0));
-        assertThat(client.previousAssignedTasks(), equalTo(Utils.mkSet(tid1, tid2)));
+        assertThat(client.previousAssignedTasks(), equalTo(Utils.mkSet(taskId01, taskId02)));
     }
 
     @Test
     public void shouldHaveAssignedTaskIfActiveTaskAssigned() {
-        final TaskId tid = new TaskId(0, 2);
-
-        client.assign(tid, true);
-        assertTrue(client.hasAssignedTask(tid));
+        client.assign(taskId01, true);
+        assertTrue(client.hasAssignedTask(taskId01));
     }
 
     @Test
     public void shouldHaveAssignedTaskIfStandbyTaskAssigned() {
-        final TaskId tid = new TaskId(0, 2);
-
-        client.assign(tid, false);
-        assertTrue(client.hasAssignedTask(tid));
+        client.assign(taskId01, false);
+        assertTrue(client.hasAssignedTask(taskId01));
     }
 
     @Test
     public void shouldNotHaveAssignedTaskIfTaskNotAssigned() {
-
-        client.assign(new TaskId(0, 2), true);
-        assertFalse(client.hasAssignedTask(new TaskId(0, 3)));
+        client.assign(taskId01, true);
+        assertFalse(client.hasAssignedTask(taskId02));
     }
 
     @Test
     public void shouldHaveMoreAvailableCapacityWhenCapacityTheSameButFewerAssignedTasks() {
-        final ClientState c2 = new ClientState(1);
-        client.assign(new TaskId(0, 1), true);
-        assertTrue(c2.hasMoreAvailableCapacityThan(client));
-        assertFalse(client.hasMoreAvailableCapacityThan(c2));
+        final ClientState otherClient = new ClientState(1);
+        client.assign(taskId01, true);
+        assertTrue(otherClient.hasMoreAvailableCapacityThan(client));
+        assertFalse(client.hasMoreAvailableCapacityThan(otherClient));
     }
 
     @Test
     public void shouldHaveMoreAvailableCapacityWhenCapacityHigherAndSameAssignedTaskCount() {
-        final ClientState c2 = new ClientState(2);
-        assertTrue(c2.hasMoreAvailableCapacityThan(client));
-        assertFalse(client.hasMoreAvailableCapacityThan(c2));
+        final ClientState otherClient = new ClientState(2);
+        assertTrue(otherClient.hasMoreAvailableCapacityThan(client));
+        assertFalse(client.hasMoreAvailableCapacityThan(otherClient));
     }
 
     @Test
     public void shouldUseMultiplesOfCapacityToDetermineClientWithMoreAvailableCapacity() {
-        final ClientState c2 = new ClientState(2);
+        final ClientState otherClient = new ClientState(2);
 
         for (int i = 0; i < 7; i++) {
-            c2.assign(new TaskId(0, i), true);
+            otherClient.assign(new TaskId(0, i), true);
         }
 
         for (int i = 7; i < 11; i++) {
             client.assign(new TaskId(0, i), true);
         }
 
-        assertTrue(c2.hasMoreAvailableCapacityThan(client));
+        assertTrue(otherClient.hasMoreAvailableCapacityThan(client));
     }
 
     @Test
     public void shouldHaveMoreAvailableCapacityWhenCapacityIsTheSameButAssignedTasksIsLess() {
-        final ClientState c1 = new ClientState(3);
-        final ClientState c2 = new ClientState(3);
+        final ClientState client = new ClientState(3);
+        final ClientState otherClient = new ClientState(3);
         for (int i = 0; i < 4; i++) {
-            c1.assign(new TaskId(0, i), true);
-            c2.assign(new TaskId(0, i), true);
+            client.assign(new TaskId(0, i), true);
+            otherClient.assign(new TaskId(0, i), true);
         }
-        c2.assign(new TaskId(0, 5), true);
-        assertTrue(c1.hasMoreAvailableCapacityThan(c2));
+        otherClient.assign(new TaskId(0, 5), true);
+        assertTrue(client.hasMoreAvailableCapacityThan(otherClient));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowIllegalStateExceptionIfCapacityOfThisClientStateIsZero() {
-        final ClientState c1 = new ClientState(0);
-        c1.hasMoreAvailableCapacityThan(new ClientState(1));
+        assertThrows(IllegalStateException.class, () -> zeroCapacityClient.hasMoreAvailableCapacityThan(client));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowIllegalStateExceptionIfCapacityOfOtherClientStateIsZero() {
-        final ClientState c1 = new ClientState(1);
-        c1.hasMoreAvailableCapacityThan(new ClientState(0));
+        assertThrows(IllegalStateException.class, () -> client.hasMoreAvailableCapacityThan(zeroCapacityClient));
     }
 
     @Test
     public void shouldHaveUnfulfilledQuotaWhenActiveTaskSizeLessThanCapacityTimesTasksPerThread() {
-        final ClientState client = new ClientState(1);
         client.assign(new TaskId(0, 1), true);
         assertTrue(client.hasUnfulfilledQuota(2));
     }
 
     @Test
     public void shouldNotHaveUnfulfilledQuotaWhenActiveTaskSizeGreaterEqualThanCapacityTimesTasksPerThread() {
-        final ClientState client = new ClientState(1);
         client.assign(new TaskId(0, 1), true);
         assertFalse(client.hasUnfulfilledQuota(1));
+    }
+
+    @Test
+    public void shouldAddTasksWithLatestOffsetToPrevActiveTasks() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, Task.LATEST_OFFSET);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        assertThat(client.prevActiveTasks(), equalTo(Collections.singleton(taskId01)));
+        assertThat(client.previousAssignedTasks(), equalTo(Collections.singleton(taskId01)));
+        assertTrue(client.prevStandbyTasks().isEmpty());
+    }
+
+    @Test
+    public void shouldAddTasksInOffsetSumsMapToPrevStandbyTasks() {
+        final Map<TaskId, Long> taskOffsetSums = mkMap(
+            mkEntry(taskId01, 0L),
+            mkEntry(taskId02, 100L)
+        );
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        assertThat(client.prevStandbyTasks(), equalTo(mkSet(taskId01, taskId02)));
+        assertThat(client.previousAssignedTasks(), equalTo(mkSet(taskId01, taskId02)));
+        assertTrue(client.prevActiveTasks().isEmpty());
+    }
+
+    @Test
+    public void shouldComputeTaskLags() {
+        final Map<TaskId, Long> taskOffsetSums = mkMap(
+            mkEntry(taskId01, 0L),
+            mkEntry(taskId02, 100L)
+        );
+        final Map<TaskId, Long> allTaskEndOffsetSums = mkMap(
+            mkEntry(taskId01, 500L),
+            mkEntry(taskId02, 100L)
+        );
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.computeTaskLags(allTaskEndOffsetSums);
+
+        assertThat(client.lagFor(taskId01), equalTo(500L));
+        assertThat(client.lagFor(taskId02), equalTo(0L));
+    }
+
+    @Test
+    public void shouldReturnEndOffsetSumForLagOfTaskWeDidNotPreviouslyOwn() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.emptyMap();
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.computeTaskLags(allTaskEndOffsetSums);
+        assertThat(client.lagFor(taskId01), equalTo(500L));
+    }
+
+    @Test
+    public void shouldReturnLatestOffsetForLagOfPreviousActiveRunningTask() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, Task.LATEST_OFFSET);
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.computeTaskLags(allTaskEndOffsetSums);
+        assertThat(client.lagFor(taskId01), equalTo(Task.LATEST_OFFSET));
+    }
+
+    @Test
+    public void shouldThrowIllegalStateExceptionIfOffsetSumIsGreaterThanEndOffsetSum() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 5L);
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 1L);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        assertThrows(IllegalStateException.class, () -> client.computeTaskLags(allTaskEndOffsetSums));
+    }
+
+    @Test
+    public void shouldThrowIllegalStateExceptionIfTaskLagsMapIsNotEmpty() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 5L);
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 1L);
+        client.computeTaskLags(taskOffsetSums);
+        assertThrows(IllegalStateException.class, () -> client.computeTaskLags(allTaskEndOffsetSums));
+    }
+
+    @Test
+    public void shouldThrowIllegalStateExceptionOnLagForUnknownTask() {
+        final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 0L);
+        final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
+        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.computeTaskLags(allTaskEndOffsetSums);
+        assertThrows(IllegalStateException.class, () -> client.lagFor(taskId02));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -674,6 +674,19 @@ public class StickyTaskAssignorTest {
         assertThat(newClient.activeTaskCount(), equalTo(2));
     }
 
+    @Test
+    public void shouldViolateBalanceToPreserveActiveTaskStickiness() {
+        final ClientState c1 = createClientWithPreviousActiveTasks(p1, 1, task00, task01, task02);
+        final ClientState c2 = createClient(p2, 1);
+
+        final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task01, task02);
+        taskAssignor.preservePreviousTaskAssignment();
+        taskAssignor.assign(0);
+
+        assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task00, task01, task02)));
+        assertTrue(c2.activeTasks().isEmpty());
+    }
+
     private StickyTaskAssignor<Integer> createTaskAssignor(final TaskId... tasks) {
         final List<TaskId> taskIds = Arrays.asList(tasks);
         Collections.shuffle(taskIds);


### PR DESCRIPTION
Once we have encoded the offset sums per task for each client, we can compute the overall lag during `assign` by fetching the end offsets for all changelog and subtracting.

If the `listOffsets` request fails, we simply return a "completely sticky" assignment, ie all active tasks are given to previous owners regardless of balance.

Builds (but does not yet use) the `statefulTasksToRankedCandidates` map with the ranking:
    Rank -1:    active running task
    Rank 0:     standby or restoring task whose overall lag is within `acceptableRecoveryLag`
    Rank 1:      tasks whose lag is unknown (eg during version probing)
    Rank 1+:    all other tasks are ranked according to their actual total lag