### PR TITLE
KAFKA-9656: Return COORDINATOR_NOT_AVAILABLE for older producer clients

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -677,9 +677,7 @@ class GroupCoordinator(val brokerId: Int,
                              offsetMetadata: immutable.Map[TopicPartition, OffsetAndMetadata],
                              responseCallback: immutable.Map[TopicPartition, Errors] => Unit): Unit = {
     validateGroupStatus(groupId, ApiKeys.TXN_OFFSET_COMMIT) match {
-      case Some(error) => {
-        responseCallback(offsetMetadata.map { case (k, _) => k -> error })
-      }
+      case Some(error) => responseCallback(offsetMetadata.map { case (k, _) => k -> error })
       case None =>
         val group = groupManager.getGroup(groupId).getOrElse {
           groupManager.addGroup(new GroupMetadata(groupId, Empty, time))

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -677,7 +677,9 @@ class GroupCoordinator(val brokerId: Int,
                              offsetMetadata: immutable.Map[TopicPartition, OffsetAndMetadata],
                              responseCallback: immutable.Map[TopicPartition, Errors] => Unit): Unit = {
     validateGroupStatus(groupId, ApiKeys.TXN_OFFSET_COMMIT) match {
-      case Some(error) => responseCallback(offsetMetadata.map { case (k, _) => k -> error })
+      case Some(error) => {
+        responseCallback(offsetMetadata.map { case (k, _) => k -> error })
+      }
       case None =>
         val group = groupManager.getGroup(groupId).getOrElse {
           groupManager.addGroup(new GroupMetadata(groupId, Empty, time))

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2211,8 +2211,11 @@ class KafkaApis(val requestChannel: RequestChannel,
             }
           }
 
-        // For KAFKA-9656, we need to replace COORDINATOR_LOAD_IN_PROGRESS with COORDINATOR_NOT_AVAILABLE
-        // for older producer client which could potentially fail due to a later bug fix in KAFKA-7296.
+        // We need to replace COORDINATOR_LOAD_IN_PROGRESS with COORDINATOR_NOT_AVAILABLE
+        // for older producer client from 0.11 to prior 2.0, which could potentially crash due
+        // to unexpected loading error. This bug is fixed later by KAFKA-7296 in version 2.0.
+        // Clients using txn commit protocol >= 2 (version 2.3 and on onwards)
+        // are guaranteed to have the fix to check for the loading error.
         if (txnOffsetCommitRequest.version < 2) {
           combinedCommitStatus.foreach { case (topicPartition, error) =>
             if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2213,9 +2213,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
         // We need to replace COORDINATOR_LOAD_IN_PROGRESS with COORDINATOR_NOT_AVAILABLE
         // for older producer client from 0.11 to prior 2.0, which could potentially crash due
-        // to unexpected loading error. This bug is fixed later by KAFKA-7296 in version 2.0.
-        // Clients using txn commit protocol >= 2 (version 2.3 and on onwards)
-        // are guaranteed to have the fix to check for the loading error.
+        // to unexpected loading error. This bug is fixed later by KAFKA-7296. Clients using
+        // txn commit protocol >= 2 (version 2.3 and onwards) are guaranteed to have
+        // the fix to check for the loading error.
         if (txnOffsetCommitRequest.version < 2) {
           combinedCommitStatus.foreach { case (topicPartition, error) =>
             if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS) {


### PR DESCRIPTION
Txn commit has a bug for lower versions where it would treat `COORDINATOR_LOAD_IN_PROGRESS` as fatal. This PR fixes the handling of older client to return 
`COORDINATOR_NOT_AVAILABLE` so that it won't crash upon doing txn commit. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
