### PR TITLE
MINOR: Add method to Herder to control logging of connector configs during validation

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -300,6 +300,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public ConfigInfos validateConnectorConfig(Map<String, String> connectorProps) {
+        return validateConnectorConfig(connectorProps, true);
+    }
+
+    @Override
+    public ConfigInfos validateConnectorConfig(Map<String, String> connectorProps, boolean doLog) {
         if (worker.configTransformer() != null) {
             connectorProps = worker.configTransformer().transform(connectorProps);
         }
@@ -354,7 +359,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             configValues.addAll(config.configValues());
             ConfigInfos configInfos =  generateResult(connType, configKeys, configValues, new ArrayList<>(allGroups));
 
-            AbstractConfig connectorConfig = new AbstractConfig(new ConfigDef(), connectorProps);
+            AbstractConfig connectorConfig = new AbstractConfig(new ConfigDef(), connectorProps, doLog);
             String connName = connectorProps.get(ConnectorConfig.NAME_CONFIG);
             ConfigInfos producerConfigInfos = null;
             ConfigInfos consumerConfigInfos = null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -181,6 +181,16 @@ public interface Herder {
     ConfigInfos validateConnectorConfig(Map<String, String> connectorConfig);
 
     /**
+     * Validate the provided connector config values against the configuration definition.
+     * @param connectorConfig the provided connector config values
+     * @param doLog set it to true to log all connectorConfig with INFO level. false to log nothing.
+     *              Noted: there are many endpoints requiring this method but not all configs are worth being logged.
+     */
+    default ConfigInfos validateConnectorConfig(Map<String, String> connectorConfig, boolean doLog) {
+        return validateConnectorConfig(connectorConfig);
+    }
+
+    /**
      * Restart the task with the given id.
      * @param id id of the task
      * @param cb callback to invoke upon completion

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -183,8 +183,8 @@ public interface Herder {
     /**
      * Validate the provided connector config values against the configuration definition.
      * @param connectorConfig the provided connector config values
-     * @param doLog set it to true to log all connectorConfig with INFO level. false to log nothing.
-     *              Noted: there are many endpoints requiring this method but not all configs are worth being logged.
+     * @param doLog if true log all the connector configurations at INFO level; if false, no connector configurations are logged.
+     *              Note that logging of configuration is not necessary in every endpoint that uses this method.
      */
     default ConfigInfos validateConnectorConfig(Map<String, String> connectorConfig, boolean doLog) {
         return validateConnectorConfig(connectorConfig);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -78,7 +78,7 @@ public class ConnectorPluginsResource {
             );
         }
 
-        // the validated configs don't need to be logger.
+        // the validated configs don't need to be logged
         return herder.validateConnectorConfig(connectorConfig, false);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -78,7 +78,8 @@ public class ConnectorPluginsResource {
             );
         }
 
-        return herder.validateConnectorConfig(connectorConfig);
+        // the validated configs don't need to be logger.
+        return herder.validateConnectorConfig(connectorConfig, false);
     }
 
     @GET

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -198,7 +198,7 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithSingleErrorDueToMissingConnectorClassname() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(partialProps));
+        herder.validateConnectorConfig(EasyMock.eq(partialProps), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -243,7 +243,7 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithSimpleName() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props));
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -284,7 +284,7 @@ public class ConnectorPluginsResourceTest {
 
     @Test
     public void testValidateConfigWithAlias() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props));
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -325,7 +325,7 @@ public class ConnectorPluginsResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void testValidateConfigWithNonExistentName() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props));
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
@@ -362,7 +362,7 @@ public class ConnectorPluginsResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void testValidateConfigWithNonExistentAlias() throws Throwable {
-        herder.validateConnectorConfig(EasyMock.eq(props));
+        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.anyBoolean());
 
         PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();


### PR DESCRIPTION
Connector validation API is useful in validating connector configs before starting connector. And our application counts on it to generate friendly feedback to users. However, Connector validation API always log all configs when handling validation request since it creates AbstractConfig to check the overridable configs (introduced by #6624) and AbstractConfig, by default, logs all configs. In our case, the worker logs are filled with the following messages when there are a log of validation requests.
```
INFO AbstractConfig values:
xxx
xxx
xxx
```
It seems to me the response of Connector validation API is good enough. By contrast, the logs are a bit noisy and useless.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
