### PR TITLE
MINOR: double -Xss setting from 2m to 4m in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -469,7 +469,7 @@ subprojects {
 
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = '1g'
-      jvmArgs = ['-Xss2m']
+      jvmArgs = ['-Xss4m']
     }
   }
 


### PR DESCRIPTION
I have seen an increased incidence in StackOverflowError(s) when compiling scala. This change doubles the max stack size to 4m.

```
> Task :core:compileScala FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':core:compileScala'.
> java.lang.StackOverflowError (no error message)
```