### PR TITLE
KAFKA-6647: Do note delete the lock file while holding the lock

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -734,16 +734,25 @@ public final class Utils {
     }
 
     /**
-     * Recursively delete the given file/directory and any subfiles (if any exist);
-     * if there are specified subfiles to keep, then maitain those files as well as the parent file
+     * Recursively delete the given file/directory and any subfiles (if any exist)
      *
      * @param rootFile The root file at which to begin deleting
-     * @param filesToKeep The subfiles to keep
      */
-    public static void delete(final File rootFile, final String... filesToKeep) throws IOException {
+    public static void delete(final File rootFile) throws IOException {
+        delete(rootFile, Collections.emptyList());
+    }
+
+    /**
+     * Recursively delete the subfiles (if any exist) of the passed in root file that are not included
+     * in the list to keep
+     *
+     * @param rootFile The root file at which to begin deleting
+     * @param filesToKeep The subfiles to keep (note that if a subfile is to be kept, so are all its parent
+     *                    files in its pat)h; if empty we would also delete the root file
+     */
+    public static void delete(final File rootFile, final List<File> filesToKeep) throws IOException {
         if (rootFile == null)
             return;
-        final List<String> files = Arrays.asList(filesToKeep);
         Files.walkFileTree(rootFile.toPath(), new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFileFailed(Path path, IOException exc) throws IOException {
@@ -755,7 +764,7 @@ public final class Utils {
 
             @Override
             public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-                if (!files.contains(path.toFile().getName())) {
+                if (!filesToKeep.contains(path.toFile())) {
                     Files.delete(path);
                 }
                 return FileVisitResult.CONTINUE;
@@ -769,7 +778,7 @@ public final class Utils {
                 }
 
                 // only delete the parent directory if there's nothing to keep
-                if (files.isEmpty())
+                if (filesToKeep.isEmpty())
                     Files.delete(path);
 
                 return FileVisitResult.CONTINUE;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -777,9 +777,14 @@ public final class Utils {
                     throw exc;
                 }
 
-                // only delete the parent directory if there's nothing to keep
-                if (filesToKeep.isEmpty())
+                if (rootFile.toPath().equals(path)) {
+                    // only delete the parent directory if there's nothing to keep
+                    if (filesToKeep.isEmpty()) {
+                        Files.delete(path);
+                    }
+                } else if (!filesToKeep.contains(path.toFile())) {
                     Files.delete(path);
+                }
 
                 return FileVisitResult.CONTINUE;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -716,11 +716,11 @@ public class KafkaStreams implements AutoCloseable {
         }
         final ProcessorTopology globalTaskTopology = internalTopologyBuilder.buildGlobalStateTopology();
         final long cacheSizePerThread = totalCacheSize / (threads.length + (globalTaskTopology == null ? 0 : 1));
-        final boolean createStateDirectory = taskTopology.hasPersistentLocalStore() ||
+        final boolean hasPersistentStores = taskTopology.hasPersistentLocalStore() ||
                 (globalTaskTopology != null && globalTaskTopology.hasPersistentGlobalStore());
 
         try {
-            stateDirectory = new StateDirectory(config, time, createStateDirectory);
+            stateDirectory = new StateDirectory(config, time, hasPersistentStores);
         } catch (final ProcessorStateException fatal) {
             throw new StreamsException(fatal);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -33,6 +33,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
@@ -318,12 +319,12 @@ public class StateDirectory {
                             log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
                                 logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
 
-                            Utils.delete(taskDir, LOCK_FILE_NAME);
+                            Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         } else if (manualUserCall) {
                             log.info("{} Deleting state directory {} for task {} as user calling cleanup.",
                                 logPrefix(), dirName, id);
 
-                            Utils.delete(taskDir, LOCK_FILE_NAME);
+                            Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         }
                     }
                 } catch (final OverlappingFileLockException | IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -318,12 +318,12 @@ public class StateDirectory {
                             log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
                                 logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
 
-                            Utils.delete(taskDir);
+                            Utils.delete(taskDir, LOCK_FILE_NAME);
                         } else if (manualUserCall) {
                             log.info("{} Deleting state directory {} for task {} as user calling cleanup.",
                                 logPrefix(), dirName, id);
 
-                            Utils.delete(taskDir);
+                            Utils.delete(taskDir, LOCK_FILE_NAME);
                         }
                     }
                 } catch (final OverlappingFileLockException | IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -127,7 +127,7 @@ public class TaskManager {
     void handleRebalanceStart(final Set<String> subscribedTopics) {
         builder.addSubscribedTopicsFromMetadata(subscribedTopics, logPrefix);
 
-        tryToLockAllTaskDirectories();
+        tryToLockAllNonEmptyTaskDirectories();
 
         rebalanceInProgress = true;
     }
@@ -379,7 +379,7 @@ public class TaskManager {
 
     /**
      * Compute the offset total summed across all stores in a task. Includes offset sum for any tasks we own the
-     * lock for, which includes assigned and unassigned tasks we locked in {@link #tryToLockAllTaskDirectories()}
+     * lock for, which includes assigned and unassigned tasks we locked in {@link #tryToLockAllNonEmptyTaskDirectories()}
      *
      * @return Map from task id to its total offset summed across all state stores
      */
@@ -410,12 +410,12 @@ public class TaskManager {
     }
 
     /**
-     * Makes a weak attempt to lock all task directories in the state dir. We are responsible for computing and
+     * Makes a weak attempt to lock all non-empty task directories in the state dir. We are responsible for computing and
      * reporting the offset sum for any unassigned tasks we obtain the lock for in the upcoming rebalance. Tasks
      * that we locked but didn't own will be released at the end of the rebalance (unless of course we were
      * assigned the task as a result of the rebalance). This method should be idempotent.
      */
-    private void tryToLockAllTaskDirectories() {
+    private void tryToLockAllNonEmptyTaskDirectories() {
         for (final File dir : stateDirectory.listNonEmptyTaskDirectories()) {
             try {
                 final TaskId id = TaskId.parse(dir.getName());
@@ -438,7 +438,7 @@ public class TaskManager {
 
     /**
      * We must release the lock for any unassigned tasks that we temporarily locked in preparation for a
-     * rebalance in {@link #tryToLockAllTaskDirectories()}.
+     * rebalance in {@link #tryToLockAllNonEmptyTaskDirectories()}.
      */
     private void releaseLockedUnassignedTaskDirectories() {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -395,7 +395,7 @@ public class TaskManager {
 
         final Set<TaskId> locallyStoredTasks = new HashSet<>();
 
-        final File[] stateDirs = stateDirectory.listTaskDirectories();
+        final File[] stateDirs = stateDirectory.listNonEmptyTaskDirectories();
         if (stateDirs != null) {
             for (final File dir : stateDirs) {
                 try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -258,7 +258,7 @@ public class StateDirectoryTest {
             directory.lock(task0);
             directory.lock(task1);
 
-            List<File> files = Arrays.asList(Objects.requireNonNull(directory.lisAllTaskDirectories()));
+            List<File> files = Arrays.asList(Objects.requireNonNull(directory.listAllTaskDirectories()));
             assertEquals(3, files.size());
 
 
@@ -268,7 +268,7 @@ public class StateDirectoryTest {
             time.sleep(5000);
             directory.cleanRemovedTasks(0);
 
-            files = Arrays.asList(Objects.requireNonNull(directory.lisAllTaskDirectories()));
+            files = Arrays.asList(Objects.requireNonNull(directory.listAllTaskDirectories()));
             assertEquals(3, files.size());
 
             files = Arrays.asList(Objects.requireNonNull(directory.listNonEmptyTaskDirectories()));
@@ -289,13 +289,13 @@ public class StateDirectoryTest {
         final int cleanupDelayMs = 60000;
         directory.cleanRemovedTasks(cleanupDelayMs);
         assertTrue(dir.exists());
-        assertEquals(1, directory.lisAllTaskDirectories().length);
+        assertEquals(1, directory.listAllTaskDirectories().length);
         assertEquals(1, directory.listNonEmptyTaskDirectories().length);
 
         time.sleep(cleanupDelayMs + 1000);
         directory.cleanRemovedTasks(cleanupDelayMs);
         assertTrue(dir.exists());
-        assertEquals(1, directory.lisAllTaskDirectories().length);
+        assertEquals(1, directory.listAllTaskDirectories().length);
         assertEquals(0, directory.listNonEmptyTaskDirectories().length);
     }
 
@@ -307,7 +307,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldNotListNonEmptyTaskDirectories() {
+    public void shouldOnlyListNonEmptyTaskDirectories() {
         TestUtils.tempDirectory(stateDir.toPath(), "foo");
         final File taskDir1 = directory.directoryForTask(new TaskId(0, 0));
         final File taskDir2 = directory.directoryForTask(new TaskId(0, 1));
@@ -315,12 +315,12 @@ public class StateDirectoryTest {
         final File storeDir = new File(taskDir1, "store");
         assertTrue(storeDir.mkdir());
 
-        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.lisAllTaskDirectories()));
+        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.listAllTaskDirectories()));
         assertEquals(Collections.singletonList(taskDir1), Arrays.asList(directory.listNonEmptyTaskDirectories()));
 
         directory.cleanRemovedTasks(0L);
 
-        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.lisAllTaskDirectories()));
+        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.listAllTaskDirectories()));
         assertEquals(Collections.emptyList(), Arrays.asList(directory.listNonEmptyTaskDirectories()));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -261,6 +261,9 @@ public class StateDirectoryTest {
             directory.cleanRemovedTasks(0);
 
             files = Arrays.asList(Objects.requireNonNull(appDir.listFiles()));
+            assertEquals(3, files.size());
+
+            files = Arrays.asList(Objects.requireNonNull(directory.listNonEmptyTaskDirectories()));
             assertEquals(2, files.size());
             assertTrue(files.contains(new File(appDir, task0.toString())));
             assertTrue(files.contains(new File(appDir, task1.toString())));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -258,8 +258,9 @@ public class StateDirectoryTest {
             directory.lock(task0);
             directory.lock(task1);
 
-            List<File> files = Arrays.asList(Objects.requireNonNull(appDir.listFiles()));
+            List<File> files = Arrays.asList(Objects.requireNonNull(directory.lisAllTaskDirectories()));
             assertEquals(3, files.size());
+
 
             files = Arrays.asList(Objects.requireNonNull(directory.listNonEmptyTaskDirectories()));
             assertEquals(3, files.size());
@@ -267,7 +268,7 @@ public class StateDirectoryTest {
             time.sleep(5000);
             directory.cleanRemovedTasks(0);
 
-            files = Arrays.asList(Objects.requireNonNull(appDir.listFiles()));
+            files = Arrays.asList(Objects.requireNonNull(directory.lisAllTaskDirectories()));
             assertEquals(3, files.size());
 
             files = Arrays.asList(Objects.requireNonNull(directory.listNonEmptyTaskDirectories()));
@@ -288,11 +289,13 @@ public class StateDirectoryTest {
         final int cleanupDelayMs = 60000;
         directory.cleanRemovedTasks(cleanupDelayMs);
         assertTrue(dir.exists());
+        assertEquals(1, directory.lisAllTaskDirectories().length);
         assertEquals(1, directory.listNonEmptyTaskDirectories().length);
 
         time.sleep(cleanupDelayMs + 1000);
         directory.cleanRemovedTasks(cleanupDelayMs);
         assertTrue(dir.exists());
+        assertEquals(1, directory.lisAllTaskDirectories().length);
         assertEquals(0, directory.listNonEmptyTaskDirectories().length);
     }
 
@@ -312,13 +315,13 @@ public class StateDirectoryTest {
         final File storeDir = new File(taskDir1, "store");
         assertTrue(storeDir.mkdir());
 
-        List<File> dirs = Arrays.asList(directory.listNonEmptyTaskDirectories());
-        assertEquals(Collections.singletonList(taskDir1), dirs);
+        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.lisAllTaskDirectories()));
+        assertEquals(Collections.singletonList(taskDir1), Arrays.asList(directory.listNonEmptyTaskDirectories()));
 
         directory.cleanRemovedTasks(0L);
 
-        dirs = Arrays.asList(directory.listNonEmptyTaskDirectories());
-        assertEquals(Collections.emptyList(), dirs);
+        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.lisAllTaskDirectories()));
+        assertEquals(Collections.emptyList(), Arrays.asList(directory.listNonEmptyTaskDirectories()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -290,15 +290,21 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldListAllTaskDirectories() {
+    public void shouldNotListNonEmptyTaskDirectories() {
         TestUtils.tempDirectory(stateDir.toPath(), "foo");
         final File taskDir1 = directory.directoryForTask(new TaskId(0, 0));
         final File taskDir2 = directory.directoryForTask(new TaskId(0, 1));
 
-        final List<File> dirs = Arrays.asList(directory.listTaskDirectories());
-        assertEquals(2, dirs.size());
-        assertTrue(dirs.contains(taskDir1));
-        assertTrue(dirs.contains(taskDir2));
+        final File storeDir = new File(taskDir1, "store");
+        assertTrue(storeDir.mkdir());
+
+        List<File> dirs = Arrays.asList(directory.listNonEmptyTaskDirectories());
+        assertEquals(Collections.singletonList(taskDir1), dirs);
+
+        directory.cleanRemovedTasks(0L);
+
+        dirs = Arrays.asList(directory.listNonEmptyTaskDirectories());
+        assertEquals(Collections.emptyList(), dirs);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -168,7 +168,7 @@ public class TaskManagerTest {
         assertThat((new File(taskFolders[1], StateManagerUtil.CHECKPOINT_FILE_NAME)).createNewFile(), is(true));
         assertThat((new File(taskFolders[3], StateManagerUtil.CHECKPOINT_FILE_NAME)).createNewFile(), is(true));
 
-        expect(stateDirectory.listTaskDirectories()).andReturn(taskFolders).once();
+        expect(stateDirectory.listNonEmptyTaskDirectories()).andReturn(taskFolders).once();
 
         replay(activeTaskCreator, stateDirectory);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -168,7 +168,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldNotLockAnythingIfStateDirIsEmpty() {
-        expect(stateDirectory.listAllTaskDirectories()).andReturn(new File[0]).once();
+        expect(stateDirectory.listNonEmptyTaskDirectories()).andReturn(new File[0]).once();
 
         replay(stateDirectory);
         taskManager.handleRebalanceStart(singleton("topic"));
@@ -999,7 +999,7 @@ public class TaskManagerTest {
         expect(consumer.assignment()).andReturn(assignment);
         consumer.pause(assignment);
         expectLastCall();
-        expect(stateDirectory.listAllTaskDirectories()).andReturn(new File[0]);
+        expect(stateDirectory.listNonEmptyTaskDirectories()).andReturn(new File[0]);
         replay(consumer, stateDirectory);
         assertThat(taskManager.isRebalanceInProgress(), is(false));
         taskManager.handleRebalanceStart(emptySet());
@@ -1665,7 +1665,7 @@ public class TaskManagerTest {
         for (int i = 0; i < names.length; ++i) {
             taskFolders[i] = testFolder.newFolder(names[i]);
         }
-        expect(stateDirectory.listAllTaskDirectories()).andReturn(taskFolders).once();
+        expect(stateDirectory.listNonEmptyTaskDirectories()).andReturn(taskFolders).once();
     }
 
     private void writeCheckpointFile(final TaskId task, final Map<TopicPartition, Long> offsets) throws IOException {


### PR DESCRIPTION
1. Inside StateDirectory#cleanRemovedTasks, skip deleting the lock file (and hence the parent directory) until releasing the lock. And after the lock is released only go ahead and delete the parent directory if `manualUserCall == true`. That is, this is triggered from `KafkaStreams#cleanUp` and users are responsible to make sure that Streams instance is not started and hence there are no other threads trying to grab that lock.

2. As a result, during scheduled cleanup the corresponding task.dir would not be empty but be left with only the lock file, so effectively we still achieve the goal of releasing disk spaces. For callers of `listTaskDirectories` like KIP-441 (cc @ableegoldman to take a look) I've introduced a new `listNonEmptyTaskDirectories` which excludes such dummy task.dirs with only the lock file left.

3. Also fixed KAFKA-8999 along the way to expose the exception while traversing the directory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
