### PR TITLE
KAFKA-9659: Add more log4j when updating static member mappings

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -123,7 +123,7 @@ private[group] case object Empty extends GroupState {
 }
 
 
-private object GroupMetadata {
+private object GroupMetadata extends Logging {
 
   def loadGroup(groupId: String,
                 initialState: GroupState,
@@ -143,6 +143,8 @@ private object GroupMetadata {
     members.foreach(member => {
       group.add(member, null)
       if (member.isStaticMember) {
+        info(s"Static member $member.groupInstanceId of group $groupId loaded " +
+          s"with member id ${member.memberId} at generation ${group.generationId}.")
         group.addStaticMember(member.groupInstanceId, member.memberId)
       }
     })


### PR DESCRIPTION
We could update the mappings when:

1) known static member joins with empty member.id: we will generate a new member.id and put into the mapping, and if there's already an old member id it will be replaced.

2) unknown static member joins with empty member.id: we will generation a new member.id and blindly put into the mapping.

3) new leader loading __consumer_offsets and read consumer group generation messages.

I suspect that there's a bug on broker side such that upon leader migration, the new leader did not load all the way up to the latest entry and hence in 3) above we mistakenly bootstrap the coordinator's cache with an old generation's mapping.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
