### PR TITLE
KAFKA-9216: Enforce internal config topic settings for Connect workers during startup

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -265,6 +265,13 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         // Before startup, callbacks are *not* invoked. You can grab a snapshot after starting -- just take care that
         // updates can continue to occur in the background
         configLog.start();
+
+        int partitionCount = configLog.getPartitionCount();
+        if (partitionCount > 1) {
+            throw new ConfigException("KafkaConfigBackingStore must have exactly 1 partition but found " + partitionCount + ", check topic set by " +
+                DistributedConfig.CONFIG_TOPIC_CONFIG);
+        }
+
         started = true;
         log.info("Started KafkaConfigBackingStore");
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -266,10 +266,13 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         // updates can continue to occur in the background
         configLog.start();
 
-        int partitionCount = configLog.getPartitionCount();
+        int partitionCount = configLog.partitionCount();
         if (partitionCount > 1) {
-            throw new ConfigException("KafkaConfigBackingStore must have exactly 1 partition but found " + partitionCount + ", check topic set by " +
-                DistributedConfig.CONFIG_TOPIC_CONFIG);
+            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
+                    + "to have a single partition in order to guarantee consistency of "
+                    + "connector configurations, but found %d partitions.",
+                    topic, DistributedConfig.CONFIG_TOPIC_CONFIG, partitionCount);
+            throw new ConfigException(msg);
         }
 
         started = true;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -74,6 +74,7 @@ public class KafkaBasedLog<K, V> {
 
     private Time time;
     private final String topic;
+    private int partitionCount;
     private final Map<String, Object> producerConfigs;
     private final Map<String, Object> consumerConfigs;
     private final Callback<ConsumerRecord<K, V>> consumedCallback;
@@ -145,6 +146,7 @@ public class KafkaBasedLog<K, V> {
 
         for (PartitionInfo partition : partitionInfos)
             partitions.add(new TopicPartition(partition.topic(), partition.partition()));
+        partitionCount = partitions.size();
         consumer.assign(partitions);
 
         // Always consume from the beginning of all partitions. Necessary to ensure that we don't use committed offsets
@@ -238,6 +240,9 @@ public class KafkaBasedLog<K, V> {
         producer.send(new ProducerRecord<>(topic, key, value), callback);
     }
 
+    public int getPartitionCount() {
+        return partitionCount;
+    }
 
     private Producer<K, V> createProducer() {
         // Always require producer acks to all to ensure durable writes

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -240,7 +240,7 @@ public class KafkaBasedLog<K, V> {
         producer.send(new ProducerRecord<>(topic, key, value), callback);
     }
 
-    public int getPartitionCount() {
+    public int partitionCount() {
         return partitionCount;
     }
 


### PR DESCRIPTION
Currently, if Kafka Connect will create its config backing topic with a fire and forget approach.
This is fine unless someone has manually created that topic already with the wrong partition count.

In such a case Kafka Connect "may" run for some time.
Especially if it's in standalone mode and once switched to distributed mode it will almost certainly fail.

To counter this I've added a check when the KafkaConfigBackingStore is starting.
This check will throw a ConfigException if there is more than one partition in the backing store.

This exception is then caught upstream and logged by either:
- class: DistributedHerder, method: run
- class: ConnectStandalone, method: main

After a review I don't believe it impacts any other upstream code.

Finally, to supper this new functionality I've added a public method to KafkaBasedLog which returns the partition count and a variable to store this.

And, I've created a unit test in KafkaConfigBackingStoreTest to verify the behaviour.
