### PR TITLE
KAFKA-9709: add a confirm when kafka-server-stop.sh find multiple kafka instances to kill

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -28,5 +28,14 @@ if [ -z "$PIDS" ]; then
   echo "No kafka server to stop"
   exit 1
 else
+  count=$(echo $PIDS |wc -w)
+  if [ $count -gt 1 ]; then
+    echo "find $count kafka instances (" $PIDS ") are you sure to kill them all?"
+    read -p "(yes/no) " choice
+    if [ "Xyes" != "X$choice" ]; then
+      echo "stop canceled"
+      exit 1
+    fi
+  fi
   kill -s $SIGNAL $PIDS
 fi


### PR DESCRIPTION
add a confirm when kafka-server-stop.sh find multiple kafka instances, avoid mistakenly kill all instance of this machine.