### PR TITLE
KAFKA-9458: Kafka broker crashes in windows platform

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -519,7 +519,7 @@ class Log(@volatile var dir: File,
     var minCleanedFileOffset = Long.MaxValue
 
     for (segDir <- dir.listFiles if segDir.isDirectory) {
-      val baseOffset = dir.getName.toLong
+      val baseOffset = segDir.getName.toLong
       if (!LogSegment.canReadSegment(dir, baseOffset))
         throw new IOException(s"Could not read file $segDir")
       val segmentStatus = LogSegment.getStatus(segDir)
@@ -545,7 +545,7 @@ class Log(@volatile var dir: File,
     // KAFKA-6264: Delete all .swap files whose base offset is greater than the minimum .cleaned segment offset. Such .swap
     // files could be part of an incomplete split operation that could not complete. See Log#splitOverflowedSegment
     // for more details about the split operation.
-    val (invalidSwapFiles, validSwapDirs) = swapFiles.partition(file => offsetFromFile(file) >= minCleanedFileOffset)
+    val (invalidSwapFiles, validSwapDirs) = swapFiles.partition(segDir => segDir.getName.toLong >= minCleanedFileOffset)
     invalidSwapFiles.foreach { segDir =>
       debug(s"Deleting invalid swap file ${segDir.getAbsoluteFile} minCleanedFileOffset: $minCleanedFileOffset")
       LogSegment.deleteIfExists(segDir)

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2191,7 +2191,7 @@ class Log(@volatile var dir: File,
           LogSegment.deleteIfExists(dir)
           deletedSegments.remove(segDir)
         }catch{
-          case e: Throwable => (s"Unable to delete segment  ${topicPartition.toString} : $segDir, Reason : ${e.getMessage}")
+          case e: Throwable => warn(s"Unable to delete segment  ${topicPartition.toString} : $segDir, Reason : ${e.getMessage}")
         }
       })
     }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2188,10 +2188,11 @@ class Log(@volatile var dir: File,
       deletedSegments.keySet().forEach( segDir =>{
         info(s"Deleting segment ${topicPartition.toString} : $segDir")
         try {
-          LogSegment.deleteIfExists(dir)
+          LogSegment.deleteIfExists(segDir)
           deletedSegments.remove(segDir)
         }catch{
-          case e: Throwable => warn(s"Unable to delete segment  ${topicPartition.toString} : $segDir, Reason : ${e.getMessage}")
+          case e: Throwable => warn(s"Unable to delete segment  ${topicPartition.toString} : $segDir, " +
+            s"Reason : ${if(e.getCause != null) e.getCause.getMessage else e.getMessage}")
         }
       })
     }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -433,8 +433,7 @@ object LogCleaner {
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
     val segment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      initFileSize = log.initFileSize, preallocate = log.config.preallocate, randomDigits = true)
-    LogSegment.changeStatus(log.dir, baseOffset, SegmentStatus.CLEANED)
+      initFileSize = log.initFileSize, preallocate = log.config.preallocate, randomDigits = true, segmentStatus = SegmentStatus.CLEANED)
     segment
   }
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -432,9 +432,11 @@ object LogCleaner {
   }
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
-    LogSegment.deleteIfExists(log.dir, baseOffset, fileSuffix = Log.CleanedFileSuffix)
-    LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      fileSuffix = Log.CleanedFileSuffix, initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+    LogSegment.deleteIfExists(log.dir, baseOffset)
+    val segment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
+      initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+    LogSegment.changeStatus(log.dir, baseOffset, SegmentStatus.CLEANED)
+    segment
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -432,9 +432,8 @@ object LogCleaner {
   }
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
-    LogSegment.deleteIfExists(log.dir, baseOffset)
     val segment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      initFileSize = log.initFileSize, preallocate = log.config.preallocate)
+      initFileSize = log.initFileSize, preallocate = log.config.preallocate, randomDigits = true)
     LogSegment.changeStatus(log.dir, baseOffset, SegmentStatus.CLEANED)
     segment
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -433,6 +433,10 @@ object LogCleaner {
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
     val segDir = LogSegment.getSegmentDir(log.dir, baseOffset, randomDigits = true)
+    val tobeRemoved = LogSegment.getCleanedSegmentFiles(log.dir, baseOffset)
+    if(tobeRemoved != null){
+      tobeRemoved.foreach( segDir => log.deleteSegment(segDir, asyncDelete = true))
+    }
     val segment = LogSegment.open(segDir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
       initFileSize = log.initFileSize, preallocate = log.config.preallocate, segmentStatus = SegmentStatus.CLEANED)
     segment

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -432,8 +432,9 @@ object LogCleaner {
   }
 
   def createNewCleanedSegment(log: Log, baseOffset: Long): LogSegment = {
-    val segment = LogSegment.open(log.dir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
-      initFileSize = log.initFileSize, preallocate = log.config.preallocate, randomDigits = true, segmentStatus = SegmentStatus.CLEANED)
+    val segDir = LogSegment.getSegmentDir(log.dir, baseOffset, randomDigits = true)
+    val segment = LogSegment.open(segDir, baseOffset, log.config, Time.SYSTEM, fileAlreadyExists = false,
+      initFileSize = log.initFileSize, preallocate = log.config.preallocate, segmentStatus = SegmentStatus.CLEANED)
     segment
   }
 

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -686,13 +686,13 @@ object LogSegment {
 
   private val random = scala.util.Random
   def open(dir: File, baseOffset: Long, config: LogConfig, time: Time, fileAlreadyExists: Boolean = false,
-           initFileSize: Int = 0, preallocate: Boolean = false, randomDigits: Boolean = false): LogSegment = {
+           initFileSize: Int = 0, preallocate: Boolean = false, randomDigits: Boolean = false, segmentStatus: SegmentStatus = SegmentStatus.HOT): LogSegment = {
     val maxIndexSize = config.maxIndexSize
     val segDir = new File(dir, if(randomDigits) baseOffset+"-"+random.nextInt(1000) else String.valueOf(baseOffset))
     val statusFile = new File(segDir, SegmentFile.STATUS.getName)
     if(!fileAlreadyExists){
       segDir.mkdirs()
-      SegmentStatusHandler.setStatus(statusFile, SegmentStatus.HOT)
+      SegmentStatusHandler.setStatus(statusFile, segmentStatus)
     }
     new LogSegment(
       FileRecords.open(new File(segDir, SegmentFile.LOG.getName), fileAlreadyExists, initFileSize, preallocate),

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -717,6 +717,10 @@ object LogSegment {
     new File(segDir, SegmentFile.SNAPSHOT.getName).exists()
   }
 
+  def getSnapshotFile(segDir: File): File = {
+    new File(segDir, SegmentFile.SNAPSHOT.getName)
+  }
+
   def getProducerSnapshotFile(dir: File, baseOffset: Long): File = {
     val segDir = new File(dir, String.valueOf(baseOffset))
     new File(segDir, SegmentFile.SNAPSHOT.getName)

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -726,9 +726,9 @@ object LogSegment {
     if(segDir.exists()){
       val files = segDir.listFiles()
       if(files != null){
-        files.foreach( file => Files.delete(file.toPath))
+        files.foreach( file => Files.deleteIfExists(file.toPath))
       }
-      Files.delete(segDir.toPath)
+      Files.deleteIfExists(segDir.toPath)
     }
   }
 

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -712,7 +712,7 @@ object LogSegment {
   def getCleanedSegmentFiles(logDir: File, offset: Long): Array[File] = {
     val fNameDir = String.valueOf(offset)
     val fNameDyn = fNameDir+"-"
-    logDir.listFiles( (segDir: File, name: String) => (name.startsWith(fNameDyn) || name.equals(fNameDir)) && getStatus(segDir) == SegmentStatus.CLEANED)
+    logDir.listFiles( file => (file.getName.startsWith(fNameDyn) || file.getName.equals(fNameDir)) && getStatus(file) == SegmentStatus.CLEANED)
   }
 
   def getSegmentDir(logDir: File, baseOffset: Long, randomDigits: Boolean = false): File = {

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -445,7 +445,7 @@ object ProducerStateManager {
   private[log] def listSnapshotFiles(dir: File): Seq[File] = {
     if (dir.exists && dir.isDirectory) {
       Option(dir.listFiles).map { files =>
-        files.filter(f => f.isDirectory && hasSnapshot(f)).toSeq
+        files.filter(f => f.isDirectory && hasSnapshot(f)).map( dir => LogSegment.getSnapshotFile(dir)).toSeq
       }.getOrElse(Seq.empty)
     } else Seq.empty
   }
@@ -454,7 +454,7 @@ object ProducerStateManager {
   private[log] def deleteSnapshotsBefore(dir: File, offset: Long): Unit = deleteSnapshotFiles(dir, _ < offset)
 
   private def deleteSnapshotFiles(dir: File, predicate: Long => Boolean = _ => true): Unit = {
-    listSnapshotFiles(dir).filter(file => predicate(offsetFromFile(file))).foreach { file =>
+    listSnapshotFiles(dir).filter(file => predicate(file.getParentFile.getName.toLong)).foreach { file =>
       Files.deleteIfExists(file.toPath)
     }
   }
@@ -548,7 +548,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
             info(s"Loading producer state from snapshot file '$file'")
             val loadedProducers = readSnapshot(file).filter { producerEntry => !isProducerExpired(currentTime, producerEntry) }
             loadedProducers.foreach(loadProducerEntry)
-            lastSnapOffset = offsetFromFile(file)
+            lastSnapOffset = offsetFromSnapshotFile(file)
             lastMapOffset = lastSnapOffset
             return
           } catch {
@@ -656,6 +656,10 @@ class ProducerStateManager(val topicPartition: TopicPartition,
     // If not a new offset, then it is not worth taking another snapshot
     if (lastMapOffset > lastSnapOffset) {
       val snapshotFile = LogSegment.getProducerSnapshotFile(logDir, lastMapOffset)
+      val parentDir = snapshotFile.getParentFile
+      if(!parentDir.exists()){
+        parentDir.mkdirs()
+      }
       info(s"Writing producer snapshot at offset $lastMapOffset")
       writeSnapshot(snapshotFile, producers)
 
@@ -667,12 +671,12 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   /**
    * Get the last offset (exclusive) of the latest snapshot file.
    */
-  def latestSnapshotOffset: Option[Long] = latestSnapshotFile.map(file => offsetFromFile(file))
+  def latestSnapshotOffset: Option[Long] = latestSnapshotFile.map(file => offsetFromSnapshotFile(file))
 
   /**
    * Get the last offset (exclusive) of the oldest snapshot file.
    */
-  def oldestSnapshotOffset: Option[Long] = oldestSnapshotFile.map(file => offsetFromFile(file))
+  def oldestSnapshotOffset: Option[Long] = oldestSnapshotFile.map(file => offsetFromSnapshotFile(file))
 
   /**
    * When we remove the head of the log due to retention, we need to remove snapshots older than
@@ -740,7 +744,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   private def oldestSnapshotFile: Option[File] = {
     val files = listSnapshotFiles
     if (files.nonEmpty)
-      Some(files.minBy(offsetFromFile))
+      Some(files.minBy(offsetFromSnapshotFile))
     else
       None
   }
@@ -748,11 +752,15 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   private def latestSnapshotFile: Option[File] = {
     val files = listSnapshotFiles
     if (files.nonEmpty)
-      Some(files.maxBy(offsetFromFile))
+      Some(files.maxBy(offsetFromSnapshotFile))
     else
       None
   }
 
   private def listSnapshotFiles: Seq[File] = ProducerStateManager.listSnapshotFiles(logDir)
+
+  def offsetFromSnapshotFile(file: File): Long = {
+    file.getParentFile.getName.toLong
+  }
 
 }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -759,7 +759,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   private def listSnapshotFiles: Seq[File] = ProducerStateManager.listSnapshotFiles(logDir)
 
   def offsetFromSnapshotFile(file: File): Long = {
-    LogSegment.getSegmentOffset(file.getParentFile)
+    LogSegment.getSnapshotOffset(file)
   }
 
 }

--- a/core/src/main/scala/kafka/log/SegmentFile.java
+++ b/core/src/main/scala/kafka/log/SegmentFile.java
@@ -1,0 +1,18 @@
+package kafka.log;
+
+import java.util.Objects;
+
+public enum SegmentFile {
+
+    LOG("log"), OFFSET_INDEX("index"), TIME_INDEX("timeindex"),
+    TXN_INDEX("txnindex"), SNAPSHOT("snapshot"), STATUS("status");
+
+    private final String name;
+    SegmentFile(String name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/core/src/main/scala/kafka/log/SegmentFile.java
+++ b/core/src/main/scala/kafka/log/SegmentFile.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public enum SegmentFile {
 
     LOG("log"), OFFSET_INDEX("index"), TIME_INDEX("timeindex"),
-    TXN_INDEX("txnindex"), SNAPSHOT("snapshot"), STATUS("status");
+    TXN_INDEX("txnindex"), STATUS("status");
 
     private final String name;
     SegmentFile(String name) {

--- a/core/src/main/scala/kafka/log/SegmentStatus.java
+++ b/core/src/main/scala/kafka/log/SegmentStatus.java
@@ -1,7 +1,7 @@
 package kafka.log;
 
 public enum SegmentStatus {
-    HOT(1), DELETED(2), CLEANED(3), SWAPPED(4), UNKNOWN(5);
+    HOT(1), DELETED(2), CLEANED(3), SWAP(4), UNKNOWN(5);
 
     private final int status;
     SegmentStatus(int status) {
@@ -21,7 +21,7 @@ public enum SegmentStatus {
             case 3:
                 return CLEANED;
             case 4:
-                return SWAPPED;
+                return SWAP;
             case 5:
                 return UNKNOWN;
             default:

--- a/core/src/main/scala/kafka/log/SegmentStatus.java
+++ b/core/src/main/scala/kafka/log/SegmentStatus.java
@@ -1,0 +1,31 @@
+package kafka.log;
+
+public enum SegmentStatus {
+    HOT(1), DELETED(2), CLEANED(3), SWAPPED(4), UNKNOWN(5);
+
+    private final int status;
+    SegmentStatus(int status) {
+        this.status = status;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public static SegmentStatus getStatus(int id){
+        switch (id){
+            case 1:
+                return HOT;
+            case 2:
+                return DELETED;
+            case 3:
+                return CLEANED;
+            case 4:
+                return SWAPPED;
+            case 5:
+                return UNKNOWN;
+            default:
+                throw new RuntimeException("Invalid file status : "+id);
+        }
+    }
+}

--- a/core/src/main/scala/kafka/log/SegmentStatusHandler.java
+++ b/core/src/main/scala/kafka/log/SegmentStatusHandler.java
@@ -8,8 +8,12 @@ import java.nio.file.Files;
 public class SegmentStatusHandler {
 
     public static SegmentStatus getStatus(File file) throws IOException {
-        final byte[] data = Files.readAllBytes(file.toPath());
-        return SegmentStatus.getStatus(ByteBuffer.wrap(data).getInt());
+        if(!file.exists()) {
+            return SegmentStatus.UNKNOWN;
+        }else{
+            final byte[] data = Files.readAllBytes(file.toPath());
+            return SegmentStatus.getStatus(ByteBuffer.wrap(data).getInt());
+        }
     }
 
     public static void setStatus(File file, SegmentStatus status) throws IOException {

--- a/core/src/main/scala/kafka/log/SegmentStatusHandler.java
+++ b/core/src/main/scala/kafka/log/SegmentStatusHandler.java
@@ -1,0 +1,19 @@
+package kafka.log;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+
+public class SegmentStatusHandler {
+
+    public static SegmentStatus getStatus(File file) throws IOException {
+        final byte[] data = Files.readAllBytes(file.toPath());
+        return SegmentStatus.getStatus(ByteBuffer.wrap(data).getInt());
+    }
+
+    public static void setStatus(File file, SegmentStatus status) throws IOException {
+        Files.write(file.toPath(), ByteBuffer.allocate(Integer.BYTES).putInt(status.getStatus()).array());
+    }
+
+}

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -727,7 +727,7 @@ class LogTest {
 
         override def addSegment(segment: LogSegment): LogSegment = {
           val wrapper = new LogSegment(segment.log, segment.lazyOffsetIndex, segment.lazyTimeIndex, segment.txnIndex, segment.baseOffset,
-            segment.indexIntervalBytes, segment.rollJitterMs, mockTime) {
+            segment.indexIntervalBytes, segment.rollJitterMs, mockTime, null) {
 
             override def read(startOffset: Long, maxSize: Int, maxPosition: Long, minOneMessage: Boolean): FetchDataInfo = {
               segmentsWithReads += this


### PR DESCRIPTION
Reason: I found that in LogSegment, files are being renamed as per the status flag(deleted, cleaned, swap). In windows renaming or deleting an opened file is not allowed.

Existing behavior (LogSegment Management):
While deleting a segment or creating a clean segment, we are trying to change the status of the segment. Segment status is maintained by the file suffix. 

Possible solutions:
1. Close the existing files before renaming or deleting
2. Maintain a separate status file to store the status of the segment.

I've implemented the second solution and it's successfully running on my windows environment. Please review the changes and let me know your comments. 
