### PR TITLE
KAFKA-9707: Fix InsertField.Key should apply to keys of tombstone records

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -127,17 +127,13 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
 
     @Override
     public R apply(R record) {
-        if (isTombstoneRecord(record)) {
+        if (operatingValue(record) == null) {
             return record;
         } else if (operatingSchema(record) == null) {
             return applySchemaless(record);
         } else {
             return applyWithSchema(record);
         }
-    }
-
-    private boolean isTombstoneRecord(R record) {
-        return operatingValue(record) == null;
     }
 
     private R applySchemaless(R record) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -137,7 +137,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
     }
 
     private boolean isTombstoneRecord(R record) {
-        return record.value() == null;
+        return operatingValue(record) == null;
     }
 
     private R applySchemaless(R record) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -156,7 +156,7 @@ public class InsertFieldTest {
     }
 
     @Test
-    public void insertkeyFieldsIntoTombstoneEvent() {
+    public void insertKeyFieldsIntoTombstoneEvent() {
         final Map<String, Object> props = new HashMap<>();
         props.put("topic.field", "topic_field!");
         props.put("partition.field", "partition_field");
@@ -177,5 +177,25 @@ public class InsertFieldTest {
         assertEquals(null, ((Map<?, ?>) transformedRecord.key()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map<?, ?>) transformedRecord.key()).get("instance_id"));
         assertEquals(null, transformedRecord.value());
+    }
+
+    @Test
+    public void insertIntoNullKeyLeavesKeyUnchanged() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put("topic.field", "topic_field!");
+        props.put("partition.field", "partition_field");
+        props.put("timestamp.field", "timestamp_field?");
+        props.put("static.field", "instance_id");
+        props.put("static.value", "my-instance-id");
+
+        xformKey.configure(props);
+
+        final SourceRecord record = new SourceRecord(null, null, "test", 0,
+          null, null, null, Collections.singletonMap("magic", 42L));
+
+        final SourceRecord transformedRecord = xformKey.apply(record);
+
+        assertEquals(null, transformedRecord.key());
+        assertEquals(42L, ((Map<?, ?>) transformedRecord.value()).get("magic"));
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -180,7 +180,7 @@ public class InsertFieldTest {
     }
 
     @Test
-    public void insertIntoNullKeyLeavesKeyUnchanged() {
+    public void insertIntoNullKeyLeavesRecordUnchanged() {
         final Map<String, Object> props = new HashMap<>();
         props.put("topic.field", "topic_field!");
         props.put("partition.field", "partition_field");
@@ -195,7 +195,6 @@ public class InsertFieldTest {
 
         final SourceRecord transformedRecord = xformKey.apply(record);
 
-        assertEquals(null, transformedRecord.key());
-        assertEquals(42L, ((Map<?, ?>) transformedRecord.value()).get("magic"));
+        assertEquals(record, transformedRecord);
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -33,17 +33,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 public class InsertFieldTest {
-    private InsertField<SourceRecord> xform = new InsertField.Value<>();
+    private InsertField<SourceRecord> xformKey = new InsertField.Key<>();
+    private InsertField<SourceRecord> xformValue = new InsertField.Value<>();
 
     @After
     public void teardown() {
-        xform.close();
+        xformValue.close();
     }
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
-        xform.configure(Collections.singletonMap("topic.field", "topic_field"));
-        xform.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
+        xformValue.configure(Collections.singletonMap("topic.field", "topic_field"));
+        xformValue.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
     }
 
     @Test
@@ -55,13 +56,13 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        xform.configure(props);
+        xformValue.configure(props);
 
         final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic", Schema.OPTIONAL_INT64_SCHEMA).build();
         final Struct simpleStruct = new Struct(simpleStructSchema).put("magic", 42L);
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0, simpleStructSchema, simpleStruct);
-        final SourceRecord transformedRecord = xform.apply(record);
+        final SourceRecord transformedRecord = xformValue.apply(record);
 
         assertEquals(simpleStructSchema.name(), transformedRecord.valueSchema().name());
         assertEquals(simpleStructSchema.version(), transformedRecord.valueSchema().version());
@@ -83,7 +84,7 @@ public class InsertFieldTest {
         assertEquals("my-instance-id", ((Struct) transformedRecord.value()).getString("instance_id"));
 
         // Exercise caching
-        final SourceRecord transformedRecord2 = xform.apply(
+        final SourceRecord transformedRecord2 = xformValue.apply(
                 new SourceRecord(null, null, "test", 1, simpleStructSchema, new Struct(simpleStructSchema)));
         assertSame(transformedRecord.valueSchema(), transformedRecord2.valueSchema());
     }
@@ -97,12 +98,12 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        xform.configure(props);
+        xformValue.configure(props);
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0,
                 null, Collections.singletonMap("magic", 42L));
 
-        final SourceRecord transformedRecord = xform.apply(record);
+        final SourceRecord transformedRecord = xformValue.apply(record);
 
         assertEquals(42L, ((Map<?, ?>) transformedRecord.value()).get("magic"));
         assertEquals("test", ((Map<?, ?>) transformedRecord.value()).get("topic_field"));
@@ -121,12 +122,12 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        xform.configure(props);
+        xformValue.configure(props);
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0,
                 null, null);
 
-        final SourceRecord transformedRecord = xform.apply(record);
+        final SourceRecord transformedRecord = xformValue.apply(record);
 
         assertEquals(null, transformedRecord.value());
         assertEquals(null, transformedRecord.valueSchema());
@@ -141,16 +142,39 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        xform.configure(props);
+        xformValue.configure(props);
 
         final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic", Schema.OPTIONAL_INT64_SCHEMA).build();
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0,
                 simpleStructSchema, null);
 
-        final SourceRecord transformedRecord = xform.apply(record);
+        final SourceRecord transformedRecord = xformValue.apply(record);
 
         assertEquals(null, transformedRecord.value());
         assertEquals(simpleStructSchema, transformedRecord.valueSchema());
+    }
+
+    @Test
+    public void insertkeyFieldsIntoTombstoneEvent() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put("topic.field", "topic_field!");
+        props.put("partition.field", "partition_field");
+        props.put("timestamp.field", "timestamp_field?");
+        props.put("static.field", "instance_id");
+        props.put("static.value", "my-instance-id");
+
+        xformKey.configure(props);
+
+        final SourceRecord record = new SourceRecord(null, null, "test", 0,
+            null, Collections.singletonMap("magic", 42L), null, null);
+
+        final SourceRecord transformedRecord = xformKey.apply(record);
+
+        assertEquals(42L, ((Map<?, ?>) transformedRecord.key()).get("magic"));
+        assertEquals("test", ((Map<?, ?>) transformedRecord.key()).get("topic_field"));
+        assertEquals(0, ((Map<?, ?>) transformedRecord.key()).get("partition_field"));
+        assertEquals(null, ((Map<?, ?>) transformedRecord.key()).get("timestamp_field"));
+        assertEquals("my-instance-id", ((Map<?, ?>) transformedRecord.key()).get("instance_id"));
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -176,5 +176,6 @@ public class InsertFieldTest {
         assertEquals(0, ((Map<?, ?>) transformedRecord.key()).get("partition_field"));
         assertEquals(null, ((Map<?, ?>) transformedRecord.key()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map<?, ?>) transformedRecord.key()).get("instance_id"));
+        assertEquals(null, transformedRecord.value());
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -195,6 +195,6 @@ public class InsertFieldTest {
 
         final SourceRecord transformedRecord = xformKey.apply(record);
 
-        assertEquals(record, transformedRecord);
+        assertSame(record, transformedRecord);
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -191,7 +191,7 @@ public class InsertFieldTest {
         xformKey.configure(props);
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0,
-          null, null, null, Collections.singletonMap("magic", 42L));
+            null, null, null, Collections.singletonMap("magic", 42L));
 
         final SourceRecord transformedRecord = xformKey.apply(record);
 


### PR DESCRIPTION
* Fix typo that hardcoded .value() instead of abstract operatingValue
* Add test for Key transform that was previously not tested

Signed-off-by: Greg Harris <gregh@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
