### PR TITLE
KAFKA-6145: add new assignment configs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -297,6 +297,11 @@ public class StreamsConfig extends AbstractConfig {
      */
     public static final String METRICS_LATEST = "latest";
 
+    /** {@code acceptable.recovery.lag} */
+    public static final String ACCEPTABLE_RECOVERY_LAG_CONFIG = "acceptable.recovery.lag";
+    private static final String ACCEPTABLE_RECOVERY_LAG_DOC = "The maximum acceptable lag (number of offsets to catch up) for a client to be considered caught-up for an active task." +
+                                                                  "Should correspond to a recovery time of well under a minute for a given workload. Must be at least 0.";
+
     /** {@code application.id} */
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_ID_CONFIG = "application.id";
@@ -306,6 +311,10 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_SERVER_CONFIG = "application.server";
     private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to a user-defined endpoint that can be used for state store discovery and interactive queries on this KafkaStreams instance.";
+
+    /** {@code balance.factor} */
+    public static final String BALANCE_FACTOR_CONFIG = "balance.factor";
+    private static final String BALANCE_FACTOR_DOC = "Maximum difference in the number of active tasks assigned to the stream thread with the most tasks and the stream thread with the least in a steady-state assignment. Must be at least 1.";
 
     /** {@code bootstrap.servers} */
     @SuppressWarnings("WeakerAccess")
@@ -392,6 +401,12 @@ public class StreamsConfig extends AbstractConfig {
     public static final String DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG = "default.timestamp.extractor";
     private static final String DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_DOC = "Default timestamp extractor class that implements the <code>org.apache.kafka.streams.processor.TimestampExtractor</code> interface.";
 
+    /** {@code max.warmup.replicas} */
+    public static final String MAX_WARMUP_REPLICAS_CONFIG = "max.warmup.replicas";
+    private static final String MAX_WARMUP_REPLICAS_DOC = "The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once for the purpose of keeping " +
+                                                              " the task available on one instance while it is warming up on another instance it has been reassigned to. Used to throttle how much extra broker " +
+                                                              " traffic and cluster state can be used for high availability. Must be at least 1.";
+
     /** {@code metadata.max.age.ms} */
     @SuppressWarnings("WeakerAccess")
     public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
@@ -426,6 +441,11 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public static final String POLL_MS_CONFIG = "poll.ms";
     private static final String POLL_MS_DOC = "The amount of time in milliseconds to block waiting for input.";
+
+    /** {@code probing.rebalance.interval.ms} */
+    public static final String PROBING_REBALANCE_INTERVAL_MS_CONFIG = "probing.rebalance.interval.ms";
+    private static final String PROBING_REBALANCE_INTERVAL_MS_DOC = "The maximum time to wait before triggering a rebalance to probe for warmup replicas that have finished warming up and are ready to become active. Probing rebalances " +
+                                                                        "will continue to be triggered until the assignment is balanced according to the " + BALANCE_FACTOR_CONFIG + ". Must be at least 1 minute.";
 
     /** {@code processing.guarantee} */
     @SuppressWarnings("WeakerAccess")
@@ -544,6 +564,12 @@ public class StreamsConfig extends AbstractConfig {
 
             // MEDIUM
 
+            .define(ACCEPTABLE_RECOVERY_LAG_CONFIG,
+                    Type.LONG,
+                    10_000L,
+                    atLeast(0),
+                    Importance.MEDIUM,
+                    ACCEPTABLE_RECOVERY_LAG_DOC)
             .define(CACHE_MAX_BYTES_BUFFERING_CONFIG,
                     Type.LONG,
                     10 * 1024 * 1024L,
@@ -595,6 +621,12 @@ public class StreamsConfig extends AbstractConfig {
                     0L,
                     Importance.MEDIUM,
                     MAX_TASK_IDLE_MS_DOC)
+            .define(MAX_WARMUP_REPLICAS_CONFIG,
+                    Type.INT,
+                    2,
+                    atLeast(1),
+                    Importance.MEDIUM,
+                    MAX_WARMUP_REPLICAS_DOC)
             .define(PROCESSING_GUARANTEE_CONFIG,
                     Type.STRING,
                     AT_LEAST_ONCE,
@@ -620,6 +652,12 @@ public class StreamsConfig extends AbstractConfig {
                     "",
                     Importance.LOW,
                     APPLICATION_SERVER_DOC)
+            .define(BALANCE_FACTOR_CONFIG,
+                    Type.INT,
+                    1,
+                    atLeast(1),
+                    Importance.LOW,
+                    BALANCE_FACTOR_DOC)
             .define(BUFFERED_RECORDS_PER_PARTITION_CONFIG,
                     Type.INT,
                     1000,
@@ -684,6 +722,12 @@ public class StreamsConfig extends AbstractConfig {
                     100L,
                     Importance.LOW,
                     POLL_MS_DOC)
+            .define(PROBING_REBALANCE_INTERVAL_MS_CONFIG,
+                    Type.LONG,
+                    10 * 60 * 1000L,
+                    atLeast(60 * 1000L),
+                    Importance.LOW,
+                    PROBING_REBALANCE_INTERVAL_MS_DOC)
             .define(RECEIVE_BUFFER_CONFIG,
                     Type.INT,
                     32 * 1024,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.common.Cluster;
@@ -32,6 +33,7 @@ import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ClientState;
 import org.apache.kafka.streams.processor.internals.assignment.CopartitionedTopicsEnforcer;
@@ -153,6 +155,53 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
     }
 
+    public static class RankedClient<ID extends Comparable<? super ID>> implements Comparable<RankedClient<ID>> {
+
+        private final ID clientId;
+        private final long rank;
+
+        public RankedClient(final ID clientId, final long rank) {
+            this.clientId = clientId;
+            this.rank = rank;
+        }
+
+        public ID clientId() {
+            return clientId;
+        }
+
+        public long rank() {
+            return rank;
+        }
+
+        @Override
+        public int compareTo(final RankedClient<ID> clientIdAndLag) {
+            if (rank < clientIdAndLag.rank) {
+                return -1;
+            } else if (rank > clientIdAndLag.rank) {
+                return 1;
+            } else {
+                return clientId.compareTo(clientIdAndLag.clientId);
+            }
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final RankedClient other = (RankedClient) o;
+            return clientId == other.clientId() && rank == other.rank();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clientId, rank);
+        }
+    }
+
     // keep track of any future consumers in a "dummy" Client since we can't decipher their subscription
     private static final UUID FUTURE_ID = randomUUID();
 
@@ -160,7 +209,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition);
 
     private String userEndPoint;
-    private int numStandbyReplicas;
+    private AssignmentConfigs assignmentConfigs;
 
     private TaskManager taskManager;
     private StreamsMetadataState streamsMetadataState;
@@ -192,7 +241,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         taskManager = assignorConfiguration.getTaskManager();
         streamsMetadataState = assignorConfiguration.getStreamsMetadataState();
         assignmentErrorCode = assignorConfiguration.getAssignmentErrorCode(configs);
-        numStandbyReplicas = assignorConfiguration.getNumStandbyReplicas();
+        assignmentConfigs = assignorConfiguration.getAssignmentConfigs();
         partitionGrouper = assignorConfiguration.getPartitionGrouper();
         userEndPoint = assignorConfiguration.getUserEndPoint();
         internalTopicManager = assignorConfiguration.getInternalTopicManager();
@@ -716,12 +765,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         }
 
         log.debug("Assigning tasks {} to clients {} with number of replicas {}",
-            partitionsForTask.keySet(), states, numStandbyReplicas);
+            partitionsForTask.keySet(), states, assignmentConfigs.numStandbyReplicas);
 
         // assign tasks to clients
         final StickyTaskAssignor<UUID> taskAssignor =
             new StickyTaskAssignor<>(states, partitionsForTask.keySet(), standbyTaskIds);
-        taskAssignor.assign(numStandbyReplicas);
+        taskAssignor.assign(assignmentConfigs.numStandbyReplicas);
 
         log.info("Assigned tasks to clients as {}{}.", Utils.NL, states.entrySet().stream()
                                                                      .map(Map.Entry::toString).collect(Collectors.joining(Utils.NL)));
@@ -1411,6 +1460,26 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     protected void handleRebalanceStart(final Set<String> topics) {
         taskManager.handleRebalanceStart(topics);
+    }
+
+    long acceptableRecoveryLag() {
+        return assignmentConfigs.acceptableRecoveryLag;
+    }
+
+    int balanceFactor() {
+        return assignmentConfigs.balanceFactor;
+    }
+
+    int maxWarmupReplicas() {
+        return assignmentConfigs.maxWarmupReplicas;
+    }
+
+    int numStandbyReplicas() {
+        return assignmentConfigs.numStandbyReplicas;
+    }
+
+    long probingRebalanceIntervalMs() {
+        return assignmentConfigs.probingRebalanceIntervalMs;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -39,7 +39,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.StreamsAss
 public final class AssignorConfiguration {
     private final String logPrefix;
     private final Logger log;
-    private final Integer numStandbyReplicas;
+    private final AssignmentConfigs assignmentConfigs;
     @SuppressWarnings("deprecation")
     private final org.apache.kafka.streams.processor.PartitionGrouper partitionGrouper;
     private final String userEndPoint;
@@ -58,7 +58,7 @@ public final class AssignorConfiguration {
         final LogContext logContext = new LogContext(logPrefix);
         log = logContext.logger(getClass());
 
-        numStandbyReplicas = streamsConfig.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
+        assignmentConfigs = new AssignmentConfigs(streamsConfig);
 
         partitionGrouper = streamsConfig.getConfiguredInstance(
             StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG,
@@ -241,10 +241,6 @@ public final class AssignorConfiguration {
         return priorVersion;
     }
 
-    public int getNumStandbyReplicas() {
-        return numStandbyReplicas;
-    }
-
     @SuppressWarnings("deprecation")
     public org.apache.kafka.streams.processor.PartitionGrouper getPartitionGrouper() {
         return partitionGrouper;
@@ -260,5 +256,25 @@ public final class AssignorConfiguration {
 
     public CopartitionedTopicsEnforcer getCopartitionedTopicsEnforcer() {
         return copartitionedTopicsEnforcer;
+    }
+
+    public AssignmentConfigs getAssignmentConfigs() {
+        return assignmentConfigs;
+    }
+
+    public static class AssignmentConfigs {
+        public final long acceptableRecoveryLag;
+        public final int balanceFactor;
+        public final int maxWarmupReplicas;
+        public final int numStandbyReplicas;
+        public final long probingRebalanceIntervalMs;
+
+        AssignmentConfigs(final StreamsConfig configs) {
+            acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);
+            balanceFactor = configs.getInt(StreamsConfig.BALANCE_FACTOR_CONFIG);
+            maxWarmupReplicas = configs.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG);
+            numStandbyReplicas = configs.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
+            probingRebalanceIntervalMs = configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -720,6 +720,66 @@ public class StreamsConfigTest {
             hasItem("Configuration parameter `" + StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG + "` is deprecated and will be removed in 3.0.0 release."));
     }
 
+    @Test
+    public void shouldSetDefaultAcceptableRecoveryLag() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertThat(config.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG), is(10000L));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionIfAcceptableRecoveryLagIsOutsideBounds() {
+        props.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, -1L);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+    }
+
+    @Test
+    public void shouldSetDefaultBalanceFactor() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertThat(config.getInt(StreamsConfig.BALANCE_FACTOR_CONFIG), is(1));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionIfBalanceFactorIsOutsideBounds() {
+        props.put(StreamsConfig.BALANCE_FACTOR_CONFIG, 0);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+    }
+
+    @Test
+    public void shouldSetDefaultNumStandbyReplicas() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertThat(config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG), is(0));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionIfNumStandbyReplicasIsOutsideBounds() {
+        props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, -1L);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+    }
+
+    @Test
+    public void shouldSetDefaultMaxWarmupReplicas() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertThat(config.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG), is(2));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionIfMaxWarmupReplicasIsOutsideBounds() {
+        props.put(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, 0L);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+    }
+
+    @Test
+    public void shouldSetDefaultProbingRebalanceInterval() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertThat(config.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG), is(10 * 60 * 1000L));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionIfProbingRebalanceIntervalIsOutsideBounds() {
+        props.put(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, (60 * 1000L) - 1);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+    }
+
     static class MisconfiguredSerde implements Serde {
         @Override
         public void configure(final Map configs, final boolean isKey) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1733,6 +1733,26 @@ public class StreamsPartitionAssignorTest {
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions));
     }
 
+    @Test
+    public void shouldGetAssignmentConfigs() {
+        createDefaultMockTaskManager();
+
+        final Map<String, Object> props = configProps();
+        props.put(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, 11);
+        props.put(StreamsConfig.BALANCE_FACTOR_CONFIG, 22);
+        props.put(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, 33);
+        props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 44);
+        props.put(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, 55 * 60 * 1000L);
+
+        partitionAssignor.configure(props);
+
+        assertThat(partitionAssignor.acceptableRecoveryLag(), equalTo(11L));
+        assertThat(partitionAssignor.balanceFactor(), equalTo(22));
+        assertThat(partitionAssignor.maxWarmupReplicas(), equalTo(33));
+        assertThat(partitionAssignor.numStandbyReplicas(), equalTo(44));
+        assertThat(partitionAssignor.probingRebalanceIntervalMs(), equalTo(55 * 60 * 1000L));
+    }
+
     private static ByteBuffer encodeFutureSubscription() {
         final ByteBuffer buf = ByteBuffer.allocate(4 /* used version */ + 4 /* supported version */);
         buf.putInt(LATEST_SUPPORTED_VERSION + 1);


### PR DESCRIPTION
For KIP-441 we intend to add 4 new configs:

1. assignment.acceptable.recovery.lag
2. assignment.balance.factor
3. assignment.max.extra.replicas
4. assignment.probing.rebalance.interval.ms

I think we should give them all a common prefix to make it clear they're related, but am open to better suggestions than just "assignment"