### PR TITLE
[WIP] KAFKA-7983: supporting replication.throttled.replicas in dynamic broker configuration

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -72,7 +72,9 @@ object ConfigCommand extends Config {
   val BrokerConfigsUpdatableUsingZooKeeperWhileBrokerRunning = Set(
     DynamicConfig.Broker.LeaderReplicationThrottledRateProp,
     DynamicConfig.Broker.FollowerReplicationThrottledRateProp,
-    DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp)
+    DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp,
+    DynamicConfig.Broker.LeaderReplicationThrottledProp,
+    DynamicConfig.Broker.FollowerReplicationThrottledProp)
 
   def main(args: Array[String]): Unit = {
     try {

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -138,7 +138,9 @@ object ReassignPartitionsCommand extends Logging {
         // bitwise OR as we don't want to short-circuit
         if (configs.remove(DynamicConfig.Broker.LeaderReplicationThrottledRateProp) != null
           | configs.remove(DynamicConfig.Broker.FollowerReplicationThrottledRateProp) != null
-          | configs.remove(DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp) != null){
+          | configs.remove(DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp) != null
+          | configs.remove(DynamicConfig.Broker.LeaderReplicationThrottledProp) != null
+          | configs.remove(DynamicConfig.Broker.FollowerReplicationThrottledProp) != null){
           adminZkClient.changeBrokerConfig(Seq(brokerId), configs)
           changed = true
         }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -201,6 +201,18 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
       quotaManagers.follower.updateQuota(upperBound(getOrDefault(FollowerReplicationThrottledRateProp)))
       quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(ReplicaAlterLogDirsIoMaxBytesPerSecondProp)))
     }
+
+    def updateBrokerThrottle(prop: String, quotaManager: ReplicationQuotaManager): Unit = {
+      if (properties.containsKey(prop) && properties.getProperty(prop).equals("true")) {
+        debug(s"Removing $prop on broker ${brokerConfig.brokerId}")
+        quotaManager.markBrokerThrottled()
+      } else {
+        quotaManager.removeBrokerThrottle()
+        debug(s"Removing $prop on broker ${brokerConfig.brokerId}")
+      }
+    }
+    updateBrokerThrottle(DynamicConfig.Broker.LeaderReplicationThrottledProp, quotaManagers.leader)
+    updateBrokerThrottle(DynamicConfig.Broker.FollowerReplicationThrottledProp, quotaManagers.follower)
   }
 }
 

--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -39,6 +39,8 @@ object DynamicConfig {
     val LeaderReplicationThrottledRateProp = "leader.replication.throttled.rate"
     val FollowerReplicationThrottledRateProp = "follower.replication.throttled.rate"
     val ReplicaAlterLogDirsIoMaxBytesPerSecondProp = "replica.alter.log.dirs.io.max.bytes.per.second"
+    val LeaderReplicationThrottledProp = "leader.replication.throttled"
+    val FollowerReplicationThrottledProp = "follower.replication.throttled"
 
     //Defaults
     val DefaultReplicationThrottledRate = ReplicationQuotaManagerConfig.QuotaBytesPerSecondDefault
@@ -52,6 +54,8 @@ object DynamicConfig {
       s"limit be kept above 1MB/s for accurate behaviour."
     val ReplicaAlterLogDirsIoMaxBytesPerSecondDoc = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
       s"This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour."
+    val LeaderReplicationThrottledPropDoc = "A boolean representing if we should throttle all leaders on replication traffic. This property can be only set dynamically. "
+    val FollowerReplicationThrottledPropDoc = "A boolean representing if we should throttle all followers on replication traffic. This property can be only set dynamically. "
 
     //Definitions
     private val brokerConfigDef = new ConfigDef()
@@ -59,6 +63,9 @@ object DynamicConfig {
       .define(LeaderReplicationThrottledRateProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, LeaderReplicationThrottledRateDoc)
       .define(FollowerReplicationThrottledRateProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, FollowerReplicationThrottledRateDoc)
       .define(ReplicaAlterLogDirsIoMaxBytesPerSecondProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, ReplicaAlterLogDirsIoMaxBytesPerSecondDoc)
+      .define(LeaderReplicationThrottledProp, BOOLEAN, false, MEDIUM, LeaderReplicationThrottledPropDoc)
+      .define(FollowerReplicationThrottledProp, BOOLEAN, false, MEDIUM, FollowerReplicationThrottledPropDoc)
+
     DynamicBrokerConfig.addDynamicConfigs(brokerConfigDef)
     val nonDynamicProps = KafkaConfig.configNames.toSet -- brokerConfigDef.names.asScala
 

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotaManagerTest.scala
@@ -37,6 +37,15 @@ class ReplicationQuotaManagerTest {
   }
 
   @Test
+  def shouldBrokerLevelThrottleAffectAllTopicPartition(): Unit = {
+    val quota = new ReplicationQuotaManager(ReplicationQuotaManagerConfig(), metrics, QuotaType.Fetch, time)
+    quota.markBrokerThrottled()
+    assertTrue(quota.isThrottled(tp1(1)))
+    assertTrue(quota.isThrottled(tp1(2)))
+    assertTrue(quota.isThrottled(tp1(3)))
+  }
+
+  @Test
   def shouldThrottleOnlyDefinedReplicas(): Unit = {
     val quota = new ReplicationQuotaManager(ReplicationQuotaManagerConfig(), metrics, QuotaType.Fetch, time)
     quota.markThrottled("topic1", Seq(1, 2, 3))


### PR DESCRIPTION
**More detailed description of your change**

> In KIP-226, we added the support to change broker defaults dynamically. However, it didn't support changing leader.replication.throttled.replicas and follower.replication.throttled.replicas. These 2 configs were introduced in KIP-73 and controls the set of topic partitions on which replication throttling will be engaged. One useful case is to be able to set a default value for both configs to * to allow throttling to be engaged for all topic partitions. Currently, the static default value for both configs are ignored for replication throttling, it would be useful to fix that as well.

> leader.replication.throttled.replicas and follower.replication.throttled.replicas are dynamically set through ReplicationQuotaManager.markThrottled() at the topic level. However, these two properties don't exist at the broker level config and BrokerConfigHandler doesn't call ReplicationQuotaManager.markThrottled(). So, currently, we can't set leader.replication.throttled.replicas and follower.replication.throttled.replicas at the broker level either statically or dynamically.

In this patch, we introduced two new dynamic broker configs, both of them are type of boolean:

"leader.replication.throttled" (default: false)

"follower.replication.throttled" (default: false)

If "leader.replication.throttled" is set to "true", all leader brokers will be throttled. Similarly, if "follower.replication.throttled" is set to "true", all follower brokers will be throttled. The throttle mechanism is introduced in KIP-73. 

To implement the broker level throttle, I added a new class variable to ReplicationQuotaManager. The BrokerConfigHandler will call updateBrokerThrottle() and update this class variable upon receiving the config change notification from ZooKeeper. ReplicationQuotaManager::isThrottled()

**Summary of testing strategy (including rationale)**

Unit Tests:
Added ReplicationQuotaManagerTest::shouldBrokerLevelThrottleAffectAllTopicPartition() to test if all topic partitions will be throttled when the broker is throttled.

I'm currently working on adding more unit tests.

Integration tests:
Start Kafka and ZooKeeper using localhost, try if the alter config command can successfully change the newly added dynamic configs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
