### PR TITLE
KAFKA-9225: Bump rocksdb 5.18.3 to 5.18.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ versions += [
   owaspDepCheckPlugin: "5.2.4",
   powermock: "2.0.5",
   reflections: "0.9.12",
-  rocksDB: "5.18.3",
+  rocksDB: "5.18.4",
   scalaCollectionCompat: "2.1.3",
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.0",


### PR DESCRIPTION
Bump rocksdb 5.18.3 to 5.18.4 that supports all platforms.
Issues about this version are https://github.com/facebook/rocksdb/pull/6497
and https://github.com/facebook/rocksdb/issues/6188

Change-Id: I3febec8e36550edcb7f88839cc1e2b2a54984564
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
