### PR TITLE
KAFKA-9700:Fix negative estimatedCompressionRatio issue

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionRatioEstimator.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionRatioEstimator.java
@@ -46,7 +46,7 @@ public class CompressionRatioEstimator {
             if (observedRatio > currentEstimation)
                 compressionRatioForTopic[type.id] = Math.max(currentEstimation + COMPRESSION_RATIO_DETERIORATE_STEP, observedRatio);
             else if (observedRatio < currentEstimation) {
-                compressionRatioForTopic[type.id] = currentEstimation - COMPRESSION_RATIO_IMPROVING_STEP;
+                compressionRatioForTopic[type.id] = Math.max(currentEstimation - COMPRESSION_RATIO_IMPROVING_STEP, observedRatio);
             }
         }
         return compressionRatioForTopic[type.id];

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
@@ -25,7 +25,6 @@ public class CompressionRatioEstimatorTest {
 
     @Test
     public void testUpdateEstimation() {
-        String topic = "tp";
         class EstimationsObservedRatios {
             float currentEstimation;
             float observedRatio;
@@ -40,11 +39,12 @@ public class CompressionRatioEstimatorTest {
         // 0.005. There are four cases,and updatedCompressionRatio shouldn't smaller than observedRatio in all of cases.
         // Refer to non test code for more details.
         List<EstimationsObservedRatios> estimationsObservedRatios = Arrays.asList(
-                new EstimationsObservedRatios(0.8f, 0.84f),
-                new EstimationsObservedRatios(0.6f, 0.7f),
-                new EstimationsObservedRatios(0.6f, 0.4f),
-                new EstimationsObservedRatios(0.004f, 0.001f));
-            for (EstimationsObservedRatios estimationsObservedRatio : estimationsObservedRatios) {
+            new EstimationsObservedRatios(0.8f, 0.84f),
+            new EstimationsObservedRatios(0.6f, 0.7f),
+            new EstimationsObservedRatios(0.6f, 0.4f),
+            new EstimationsObservedRatios(0.004f, 0.001f));
+        for (EstimationsObservedRatios estimationsObservedRatio : estimationsObservedRatios) {
+            String topic = "tp";
             CompressionRatioEstimator.setEstimation(topic, CompressionType.ZSTD, estimationsObservedRatio.currentEstimation);
             float updatedCompressionRatio = CompressionRatioEstimator.updateEstimation(topic, CompressionType.ZSTD, estimationsObservedRatio.observedRatio);
             assertTrue(updatedCompressionRatio >= estimationsObservedRatio.observedRatio);

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
@@ -18,9 +18,11 @@ package org.apache.kafka.common.record;
 
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class CompressionRatioEstimatorTest {
+
     @Test
     public void testUpdateEstimation() {
         String topic = "tp";
@@ -37,17 +39,15 @@ public class CompressionRatioEstimatorTest {
         // COMPRESSION_RATIO_DETERIORATE_STEP 0.05, otherwise currentEstimation minus COMPRESSION_RATIO_IMPROVING_STEP
         // 0.005. There are four cases,and updatedCompressionRatio shouldn't smaller than observedRatio in all of cases.
         // Refer to non test code for more details.
-        ArrayList<EstimationsObservedRatios> estimationsObservedRatios = new ArrayList<EstimationsObservedRatios>();
-        estimationsObservedRatios.add(new EstimationsObservedRatios(0.8f, 0.84f));
-        estimationsObservedRatios.add(new EstimationsObservedRatios(0.6f, 0.7f));
-        estimationsObservedRatios.add(new EstimationsObservedRatios(0.6f, 0.4f));
-        estimationsObservedRatios.add(new EstimationsObservedRatios(0.004f, 0.001f));
-        float updatedCompressionRatio;
-        for(EstimationsObservedRatios estimationsObservedRatio:estimationsObservedRatios)
-        {
+        List<EstimationsObservedRatios> estimationsObservedRatios = Arrays.asList(
+                new EstimationsObservedRatios(0.8f, 0.84f),
+                new EstimationsObservedRatios(0.6f, 0.7f),
+                new EstimationsObservedRatios(0.6f, 0.4f),
+                new EstimationsObservedRatios(0.004f, 0.001f));
+            for (EstimationsObservedRatios estimationsObservedRatio : estimationsObservedRatios) {
             CompressionRatioEstimator.setEstimation(topic, CompressionType.ZSTD, estimationsObservedRatio.currentEstimation);
-            updatedCompressionRatio = CompressionRatioEstimator.updateEstimation(topic, CompressionType.ZSTD, estimationsObservedRatio.observedRatio);
-            assertTrue(updatedCompressionRatio < estimationsObservedRatio.observedRatio);
+            float updatedCompressionRatio = CompressionRatioEstimator.updateEstimation(topic, CompressionType.ZSTD, estimationsObservedRatio.observedRatio);
+            assertTrue(updatedCompressionRatio >= estimationsObservedRatio.observedRatio);
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class CompressionRatioEstimatorTest {
+    @Test
+    public void testUpdateEstimation() {
+        String topic = "tp";
+        class EstimationsObservedRatios {
+            float currentEstimation;
+            float observedRatio;
+            float expected;
+            EstimationsObservedRatios(float currentEstimation, float observedRatio, float expected) {
+                this.currentEstimation = currentEstimation;
+                this.observedRatio = observedRatio;
+                this.expected = expected;
+            }
+        }
+
+        // Method updateEstimation is to update compressionRatioForTopic according to observedRatio and currentEstimation.
+        // If currentEstimation is smaller than observedRatio, update compressionRatioForTopic to
+        // Math.max(currentEstimation + COMPRESSION_RATIO_DETERIORATE_STEP, observedRatio)
+        // If currentEstimation is larger than observedRatio, update compressionRatioForTopic to
+        // Math.max(currentEstimation - COMPRESSION_RATIO_IMPROVING_STEP, observedRatio).
+        // COMPRESSION_RATIO_DETERIORATE_STEP is 0.05f. COMPRESSION_RATIO_IMPROVING_STEP is 0.005f.
+        // There are four cases:
+        // 1. currentEstimation < observedRatio && (currentEstimation + COMPRESSION_RATIO_DETERIORATE_STEP) < observedRatio
+        // 2. currentEstimation < observedRatio && (currentEstimation + COMPRESSION_RATIO_DETERIORATE_STEP) > observedRatio
+        // 3. currentEstimation > observedRatio && (currentEstimation - COMPRESSION_RATIO_IMPROVING_STEP) > observedRatio
+        // 4. currentEstimation > observedRatio && (currentEstimation - COMPRESSION_RATIO_IMPROVING_STEP) < observedRatio
+        // In all cases, updatedCompressionRatio shouldn't smaller than observedRatio
+        EstimationsObservedRatios[] currentEstimationsObservedRatios = new EstimationsObservedRatios[] {
+            new EstimationsObservedRatios(0.8f, 0.84f, 0.84f),
+            new EstimationsObservedRatios(0.6f, 0.7f, 0.7f),
+            new EstimationsObservedRatios(0.6f, 0.4f, 0.4f),
+            new EstimationsObservedRatios(0.004f, 0.001f, 0.001f)
+        };
+
+        float updatedCompressionRatio;
+        for (int i = 0; i < currentEstimationsObservedRatios.length; i++) {
+            CompressionRatioEstimator.setEstimation(topic, CompressionType.ZSTD, currentEstimationsObservedRatios[i].currentEstimation);
+            updatedCompressionRatio = CompressionRatioEstimator.updateEstimation(topic, CompressionType.ZSTD, currentEstimationsObservedRatios[i].observedRatio);
+            assertTrue(updatedCompressionRatio >= currentEstimationsObservedRatios[i].expected);
+        }
+    }
+}


### PR DESCRIPTION
There are cases that currentEstimation is smaller than
COMPRESSION_RATIO_IMPROVING_STEP and it will get negative
estimatedCompressionRatio,which leads to misjudgment
about if there is no room and MESSAGE_TOO_LARGE might occur.

Change-Id: I0932a2a6ca669f673ab5d862d3fe7b2bb6d96ff6
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
