### PR TITLE
KAFKA-9712: Catch and handle exception thrown by reflections scanner

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -346,7 +346,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         } catch (ReflectionsException e) {
             log.debug("Reflection scanner could not find any classes for URLs {}",
                 reflections.getConfiguration().getUrls());
-            return result;
+            return Collections.emptyList();
         }
 
         for (Class<? extends T> plugin : plugins) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -340,7 +340,6 @@ public class DelegatingClassLoader extends URLClassLoader {
             Class<T> klass,
             ClassLoader loader
     ) throws InstantiationException, IllegalAccessException {
-        Collection<PluginDesc<T>> result = new ArrayList<>();
         Set<Class<? extends T>> plugins;
         try {
              plugins = reflections.getSubTypesOf(klass);
@@ -349,7 +348,8 @@ public class DelegatingClassLoader extends URLClassLoader {
                 reflections.getConfiguration().getUrls());
             return Collections.emptyList();
         }
-
+        
+        Collection<PluginDesc<T>> result = new ArrayList<>();
         for (Class<? extends T> plugin : plugins) {
             if (PluginUtils.isConcrete(plugin)) {
                 result.add(new PluginDesc<>(plugin, versionFor(plugin), loader));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -342,13 +342,13 @@ public class DelegatingClassLoader extends URLClassLoader {
     ) throws InstantiationException, IllegalAccessException {
         Set<Class<? extends T>> plugins;
         try {
-             plugins = reflections.getSubTypesOf(klass);
+            plugins = reflections.getSubTypesOf(klass);
         } catch (ReflectionsException e) {
             log.debug("Reflections scanner could not find any classes for URLs: " +
-                reflections.getConfiguration().getUrls(), e);
+                    reflections.getConfiguration().getUrls(), e);
             return Collections.emptyList();
         }
-        
+
         Collection<PluginDesc<T>> result = new ArrayList<>();
         for (Class<? extends T> plugin : plugins) {
             if (PluginUtils.isConcrete(plugin)) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -344,8 +344,8 @@ public class DelegatingClassLoader extends URLClassLoader {
         try {
              plugins = reflections.getSubTypesOf(klass);
         } catch (ReflectionsException e) {
-            log.debug("Reflections scanner could not find any classes for URLs {}",
-                reflections.getConfiguration().getUrls());
+            log.debug("Reflections scanner could not find any classes for URLs: " +
+                reflections.getConfiguration().getUrls(), e);
             return Collections.emptyList();
         }
         

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -339,9 +339,16 @@ public class DelegatingClassLoader extends URLClassLoader {
             Class<T> klass,
             ClassLoader loader
     ) throws InstantiationException, IllegalAccessException {
-        Set<Class<? extends T>> plugins = reflections.getSubTypesOf(klass);
-
         Collection<PluginDesc<T>> result = new ArrayList<>();
+        Set<Class<? extends T>> plugins;
+        try {
+             plugins = reflections.getSubTypesOf(klass);
+        } catch (ReflectionsException e) {
+            log.debug("Reflection scanner could not find any classes for URLs {}",
+                reflections.getConfiguration().getUrls());
+            return result;
+        }
+
         for (Class<? extends T> plugin : plugins) {
             if (PluginUtils.isConcrete(plugin)) {
                 result.add(new PluginDesc<>(plugin, versionFor(plugin), loader));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -47,6 +47,7 @@ import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -344,7 +345,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         try {
              plugins = reflections.getSubTypesOf(klass);
         } catch (ReflectionsException e) {
-            log.debug("Reflection scanner could not find any classes for URLs {}",
+            log.debug("Reflections scanner could not find any classes for URLs {}",
                 reflections.getConfiguration().getUrls());
             return Collections.emptyList();
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -17,14 +17,21 @@
 
 package org.apache.kafka.connect.runtime.isolation;
 
-import java.util.Collections;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.assertNotNull;
+import java.util.Collections;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class DelegatingClassLoaderTest {
+
+    @Rule
+    public TemporaryFolder pluginPath = new TemporaryFolder();
+
 
     @Test
     public void testWhiteListedManifestResources() {
@@ -60,5 +67,24 @@ public class DelegatingClassLoaderTest {
             assertNotNull(classLoader.loadClass(pluginClassName));
             assertNotNull(classLoader.pluginClassLoader(pluginClassName));
         }
+    }
+
+    @Test
+    public void testLoadingInvalidUberJar() throws Exception {
+        pluginPath.newFile("test.jar");
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginPath.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
+    }
+
+    @Test
+    public void testLoadingPluginDirContainsInvalidJarsOnly() throws Exception {
+        pluginPath.newFolder("my-plugin");
+        pluginPath.newFile("my-plugin/test.jar");
+
+        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+            Collections.singletonList(pluginPath.getRoot().getAbsolutePath()));
+        classLoader.initLoaders();
     }
 }


### PR DESCRIPTION
This commit works around a bug in v0.9.12 in upstream `reflections` library by catching and handling the exception thrown.

The reflections issue is tracked by:
https://github.com/ronmamo/reflections/issues/273

New unit tests were introduced to test the behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
