### PR TITLE
Minor: fix flaky StateDirectoryTest.shouldOnlyListNonEmptyTaskDirecto…

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -315,12 +316,12 @@ public class StateDirectoryTest {
         final File storeDir = new File(taskDir1, "store");
         assertTrue(storeDir.mkdir());
 
-        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.listAllTaskDirectories()));
+        assertEquals(new HashSet<>(Arrays.asList(taskDir1, taskDir2)), new HashSet<>(Arrays.asList(directory.listAllTaskDirectories())));
         assertEquals(Collections.singletonList(taskDir1), Arrays.asList(directory.listNonEmptyTaskDirectories()));
 
         directory.cleanRemovedTasks(0L);
 
-        assertEquals(Arrays.asList(taskDir1, taskDir2), Arrays.asList(directory.listAllTaskDirectories()));
+        assertEquals(new HashSet<>(Arrays.asList(taskDir1, taskDir2)), new HashSet<>(Arrays.asList(directory.listAllTaskDirectories())));
         assertEquals(Collections.emptyList(), Arrays.asList(directory.listNonEmptyTaskDirectories()));
     }
 


### PR DESCRIPTION
```File.listFiles``` does not guarantee any order so the comparison of two list may fail.

related to #8267

```
java.lang.AssertionError: expected:<[/tmp/kafka-k0Nn0/applicationId/0_0, /tmp/kafka-k0Nn0/applicationId/0_1]> but was:<[/tmp/kafka-k0Nn0/applicationId/0_1, /tmp/kafka-k0Nn0/applicationId/0_0]>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.kafka.streams.processor.internals.StateDirectoryTest.shouldOnlyListNonEmptyTaskDirectories(StateDirectoryTest.java:318)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
