### PR TITLE
MINOR: clean up required setup for StreamsPartitionAssignorTest

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1393,12 +1393,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     // following functions are for test only
-    void setRebalanceProtocol(final RebalanceProtocol rebalanceProtocol) {
-        this.rebalanceProtocol = rebalanceProtocol;
-    }
-
     void setInternalTopicManager(final InternalTopicManager internalTopicManager) {
         this.internalTopicManager = internalTopicManager;
+    }
+
+    RebalanceProtocol rebalanceProtocol() {
+        return rebalanceProtocol;
     }
 
     protected String userEndPoint() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -225,29 +225,6 @@ public class StreamsPartitionAssignorTest {
         streamsMetadataState = EasyMock.createNiceMock(StreamsMetadataState.class);
     }
 
-    private static SubscriptionInfo getInfo(final UUID processId,
-                                            final Map<TaskId, Long> taskOffsetSums,
-                                            final String userEndPoint) {
-        return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, taskOffsetSums);
-    }
-
-    private static SubscriptionInfo getInfo(final int version,
-                                            final UUID processId,
-                                            final Set<TaskId> prevTasks,
-                                            final Set<TaskId> standbyTasks,
-                                            final String userEndPoint) {
-        return new SubscriptionInfo(
-            version, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks));
-    }
-
-    private static SubscriptionInfo getInfo(final UUID processId,
-                                            final Set<TaskId> prevTasks,
-                                            final Set<TaskId> standbyTasks) {
-        return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, USER_END_POINT, getTaskOffsetSums(prevTasks, standbyTasks));
-    }
-
     @Test
     public void shouldUseEagerRebalancingProtocol() {
         createDefaultMockTaskManager();
@@ -1941,6 +1918,29 @@ public class StreamsPartitionAssignorTest {
 
             assertThat(thisTaskList, equalTo(otherTaskList));
         }
+    }
+
+    private static SubscriptionInfo getInfo(final UUID processId,
+                                            final Map<TaskId, Long> taskOffsetSums,
+                                            final String userEndPoint) {
+        return new SubscriptionInfo(
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, taskOffsetSums);
+    }
+
+    private static SubscriptionInfo getInfo(final int version,
+                                            final UUID processId,
+                                            final Set<TaskId> prevTasks,
+                                            final Set<TaskId> standbyTasks,
+                                            final String userEndPoint) {
+        return new SubscriptionInfo(
+            version, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks));
+    }
+
+    private static SubscriptionInfo getInfo(final UUID processId,
+                                            final Set<TaskId> prevTasks,
+                                            final Set<TaskId> standbyTasks) {
+        return new SubscriptionInfo(
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, USER_END_POINT, getTaskOffsetSums(prevTasks, standbyTasks));
     }
 
     static Map<TaskId, Long> getTaskOffsetSums(final Set<TaskId> activeTasks, final Set<TaskId> standbyTasks) {


### PR DESCRIPTION
No logical or behavioral changes, just a bit of cleanup in this class before we have to write and fix a lot of these tests for KIP-441:

- Moved creation of `streamsMetadata` mock to `setUp` (in exactly one test it will be overwritten with a strict mock)
- Tried to clean up the use of helper methods for configuring the assignor