### PR TITLE
MINOR: Update Scala to 2.12.11

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.12.10
+  SCALA_VERSION=2.12.11
   if [[ -f "$base_dir/gradle.properties" ]]; then
     SCALA_VERSION=`grep "^scalaVersion=" "$base_dir/gradle.properties" | cut -d= -f 2`
   fi

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.12.10
+  set SCALA_VERSION=2.12.11
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.6.0-SNAPSHOT
-scalaVersion=2.12.10
+scalaVersion=2.12.11
 task=build
 org.gradle.jvmargs=-Xmx1024m -Xss2m

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,7 @@ ext {
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.10'
+def defaultScala212Version = '2.12.11'
 def defaultScala213Version = '2.13.1'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -149,6 +149,12 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- offsets is a lazy val and it confuses spotBugs with its locking scheme -->
+        <Class name="kafka.server.checkpoints.LazyOffsetCheckpointMap"/>
+        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+    </Match>
+
+    <Match>
         <!-- Uncallable anonymous methods are left behind after inlining by scalac 2.12, fixed in 2.13 -->
         <Source name="LogManager.scala"/>
         <Package name="kafka.log"/>


### PR DESCRIPTION
Highlights:
* Performance improvements in the ollections
library: algorithmic improvements and
changes to avoid unnecessary allocations.
* Performance improvements in the compiler.
* ASM was upgraded to 7.3.1, allowing the
optimizer to run on JDK 13+.

Full release notes: https://github.com/scala/scala/releases/tag/v2.12.11

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
