### PR TITLE
KAFKA-9730 add tag "partition" to BrokerTopicMetrics so as to observe…

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1088,7 +1088,7 @@ class Log(@volatile var dir: File,
               if (batch.sizeInBytes > config.maxMessageSize) {
                 // we record the original message set size instead of the trimmed size
                 // to be consistent with pre-compression bytesRejectedRate recording
-                brokerTopicStats.topicStats(topicPartition.topic).bytesRejectedRate.mark(records.sizeInBytes)
+                brokerTopicStats. topicStats(topicPartition).bytesRejectedRate.mark(records.sizeInBytes)
                 brokerTopicStats.allTopicsStats.bytesRejectedRate.mark(records.sizeInBytes)
                 throw new RecordTooLargeException(s"Message batch size is ${batch.sizeInBytes} bytes in append to" +
                   s"partition $topicPartition which exceeds the maximum configured size of ${config.maxMessageSize}.")
@@ -1362,7 +1362,7 @@ class Log(@volatile var dir: File,
       // Check if the message sizes are valid.
       val batchSize = batch.sizeInBytes
       if (batchSize > config.maxMessageSize) {
-        brokerTopicStats.topicStats(topicPartition.topic).bytesRejectedRate.mark(records.sizeInBytes)
+        brokerTopicStats.topicStats(topicPartition).bytesRejectedRate.mark(records.sizeInBytes)
         brokerTopicStats.allTopicsStats.bytesRejectedRate.mark(records.sizeInBytes)
         throw new RecordTooLargeException(s"The record batch size in the append to $topicPartition is $batchSize bytes " +
           s"which exceeds the maximum configured value of ${config.maxMessageSize}.")

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -746,7 +746,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           unconvertedFetchResponse.sessionId)
         // record the bytes out metrics only when the response is being sent
         response.responseData.asScala.foreach { case (tp, data) =>
-          brokerTopicStats.updateBytesOut(tp.topic, fetchRequest.isFromFollower, reassigningPartitions.contains(tp), data.records.sizeInBytes)
+          brokerTopicStats.updateBytesOut(tp, fetchRequest.isFromFollower, reassigningPartitions.contains(tp), data.records.sizeInBytes)
         }
         response
       }
@@ -2915,10 +2915,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (conversionCount > 0) {
       request.header.apiKey match {
         case ApiKeys.PRODUCE =>
-          brokerTopicStats.topicStats(tp.topic).produceMessageConversionsRate.mark(conversionCount)
+          brokerTopicStats.topicStats(tp).produceMessageConversionsRate.mark(conversionCount)
           brokerTopicStats.allTopicsStats.produceMessageConversionsRate.mark(conversionCount)
         case ApiKeys.FETCH =>
-          brokerTopicStats.topicStats(tp.topic).fetchMessageConversionsRate.mark(conversionCount)
+          brokerTopicStats.topicStats(tp).fetchMessageConversionsRate.mark(conversionCount)
           brokerTopicStats.allTopicsStats.fetchMessageConversionsRate.mark(conversionCount)
         case _ =>
           throw new IllegalStateException("Message conversion info is recorded only for Produce/Fetch requests")

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -64,7 +64,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     // Don't consume messages as it may cause metrics to be re-created causing the test to fail, see KAFKA-5238
     TestUtils.generateAndProduceMessages(servers, topic, nMessages)
     assertTrue("Topic metrics don't exist", topicMetricGroups(topic).nonEmpty)
-    servers.foreach(s => assertNotNull(s.brokerTopicStats.topicStats(topic)))
+    servers.foreach(s => assertNotNull(s.brokerTopicStats.topicStats(new TopicPartition(topic, 0))))
     adminZkClient.deleteTopic(topic)
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     assertEquals("Topic metrics exists after deleteTopic", Set.empty, topicMetricGroups(topic))
@@ -126,8 +126,8 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     val topic = "test-bytes-in-out"
     val replicationBytesIn = BrokerTopicStats.ReplicationBytesInPerSec
     val replicationBytesOut = BrokerTopicStats.ReplicationBytesOutPerSec
-    val bytesIn = s"${BrokerTopicStats.BytesInPerSec},topic=$topic"
-    val bytesOut = s"${BrokerTopicStats.BytesOutPerSec},topic=$topic"
+    val bytesIn = s"${BrokerTopicStats.BytesInPerSec},topic=$topic,partition=0"
+    val bytesOut = s"${BrokerTopicStats.BytesOutPerSec},topic=$topic,partition=0"
 
     val topicConfig = new Properties
     topicConfig.setProperty(LogConfig.MinInSyncReplicasProp, "2")

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1508,17 +1508,18 @@ class ReplicaManagerTest {
     val mockTopicStats1: BrokerTopicStats = EasyMock.mock(classOf[BrokerTopicStats])
     val (rm0, rm1) = prepareDifferentReplicaManagers(EasyMock.mock(classOf[BrokerTopicStats]), mockTopicStats1)
 
-    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(topic)).andVoid.once
+    // make broker 0 the leader of partition 0 and
+    // make broker 1 the leader of partition 1
+    val tp0 = new TopicPartition(topic, 0)
+    val tp1 = new TopicPartition(topic, 1)
+    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(tp0)).andVoid.times(2)
+    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(tp1)).andVoid.once
+    EasyMock.expect(mockTopicStats1.removeOldFollowerMetrics(tp1)).andVoid.once
     EasyMock.replay(mockTopicStats1)
 
     try {
-      // make broker 0 the leader of partition 0 and
-      // make broker 1 the leader of partition 1
-      val tp0 = new TopicPartition(topic, 0)
-      val tp1 = new TopicPartition(topic, 1)
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val partition1Replicas = Seq[Integer](1, 0).asJava
-
       val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
         controllerId, 0, brokerEpoch,
         Seq(
@@ -1596,15 +1597,17 @@ class ReplicaManagerTest {
     val mockTopicStats1: BrokerTopicStats = EasyMock.mock(classOf[BrokerTopicStats])
     val (rm0, rm1) = prepareDifferentReplicaManagers(EasyMock.mock(classOf[BrokerTopicStats]), mockTopicStats1)
 
-    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(topic)).andVoid.once
-    EasyMock.expect(mockTopicStats1.removeOldFollowerMetrics(topic)).andVoid.once
+    // make broker 0 the leader of partition 0 and
+    // make broker 1 the leader of partition 1
+    val tp0 = new TopicPartition(topic, 0)
+    val tp1 = new TopicPartition(topic, 1)
+    EasyMock.expect(mockTopicStats1.removeOldFollowerMetrics(tp0)).andVoid.once
+    EasyMock.expect(mockTopicStats1.removeOldFollowerMetrics(tp1)).andVoid.once
+    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(tp0)).andVoid.once
+    EasyMock.expect(mockTopicStats1.removeOldLeaderMetrics(tp1)).andVoid.once
     EasyMock.replay(mockTopicStats1)
 
     try {
-      // make broker 0 the leader of partition 0 and
-      // make broker 1 the leader of partition 1
-      val tp0 = new TopicPartition(topic, 0)
-      val tp1 = new TopicPartition(topic, 1)
       val partition0Replicas = Seq[Integer](1, 0).asJava
       val partition1Replicas = Seq[Integer](1, 0).asJava
 

--- a/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
@@ -170,7 +170,7 @@ class SimpleFetchTest {
   @Test
   def testReadFromLog(): Unit = {
     val brokerTopicStats = new BrokerTopicStats
-    val initialTopicCount = brokerTopicStats.topicStats(topic).totalFetchRequestRate.count()
+    val initialTopicCount = brokerTopicStats.topicStats(topicPartition).totalFetchRequestRate.count()
     val initialAllTopicsCount = brokerTopicStats.allTopicsStats.totalFetchRequestRate.count()
 
     val readCommittedRecords = replicaManager.readFromLocalLog(
@@ -200,7 +200,7 @@ class SimpleFetchTest {
     assertEquals("Reading any data can return messages up to the end of the log", recordToLEO,
       new SimpleRecord(firstRecord))
 
-    assertEquals("Counts should increment after fetch", initialTopicCount+2, brokerTopicStats.topicStats(topic).totalFetchRequestRate.count())
+    assertEquals("Counts should increment after fetch", initialTopicCount+2, brokerTopicStats.topicStats(topicPartition).totalFetchRequestRate.count())
     assertEquals("Counts should increment after fetch", initialAllTopicsCount+2, brokerTopicStats.allTopicsStats.totalFetchRequestRate.count())
   }
 }


### PR DESCRIPTION
```Partitioner``` enable us to dispatch the data to the specify partition as we wish. However, we can't observe the partition metrics if they are on the same broker. The root cause is that the key of topic metrics doesn't contain "partition" so all partitions on the same broker are merged into single metrics (see attachment).

**before**
![trunk](https://user-images.githubusercontent.com/6234750/76848178-30ac7d00-687e-11ea-8d28-6b7eba17c89b.jpg)

**after**
![patch](https://user-images.githubusercontent.com/6234750/76848197-3a35e500-687e-11ea-8fa3-ee36a9d59586.jpg)

[KAFKA-9730](https://issues.apache.org/jira/browse/KAFKA-9730)

[KIP-581](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=148642648)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
