### PR TITLE
HOTFIX: fix flaky StateDirectoryTest.shouldReturnEmptyArrayIfListFile…

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -316,7 +316,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldReturnEmptyArrayIfListFilesReturnsNull() {
+    public void shouldReturnEmptyArrayIfListFilesReturnsNull() throws IOException {
         stateDir = new File(TestUtils.IO_TMP_DIR, "kafka-" + TestUtils.randomString(5));
         directory = new StateDirectory(
             new StreamsConfig(new Properties() {
@@ -329,9 +329,12 @@ public class StateDirectoryTest {
             time, true);
         appDir = new File(stateDir, applicationId);
 
-        assertTrue(stateDir.renameTo(new File(TestUtils.IO_TMP_DIR, "state-renamed")));
-
-        assertTrue(Arrays.asList(directory.listAllTaskDirectories()).isEmpty());
+        // make sure the File#listFiles returns null and StateDirectory#listAllTaskDirectories is able to handle null
+        Utils.delete(appDir);
+        assertTrue(appDir.createNewFile());
+        assertTrue(appDir.exists());
+        assertNull(appDir.listFiles());
+        assertEquals(0, directory.listAllTaskDirectories().length);
     }
 
     @Test


### PR DESCRIPTION
```StateDirectoryTest.shouldReturnEmptyArrayIfListFilesReturnsNull``` always moves the stage dir to /tmp/state-renamed so it always fails if there is already a folder (for example, the stuff leaved by previous test)

We should just delete the folder to make stage dir disappear

related to #8304

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
