### PR TITLE
MINOR: Include partition directory for logging generated from Log

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -224,7 +224,7 @@ class Log(@volatile var dir: File,
 
   import kafka.log.Log._
 
-  this.logIdent = s"[Log partition=$topicPartition, dir=${dir.getParent}] "
+  this.logIdent = s"[Log partition=$topicPartition, dir=$dir] "
 
   /* A lock that guards all modifications to the log */
   private val lock = new Object


### PR DESCRIPTION
Logging from the Log layer could be confusing at times, when we have quick topic recreations, as we include the parent log directory in log messages. This PR changes this so that we include the partition directory instead.