### PR TITLE
KAFKA-9451: Enable producer per thread for Streams EOS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -50,7 +50,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.apache.kafka.common.IsolationLevel.READ_COMMITTED;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
@@ -287,8 +286,8 @@ public class StreamsConfig extends AbstractConfig {
      * Config value for parameter {@link #PROCESSING_GUARANTEE_CONFIG "processing.guarantee"} for exactly-once processing guarantees.
      * <p>
      * Enabling exactly-once processing semantics requires broker version 0.11.0 or higher.
-     * If you enable this feature, Kafka Streams will use a producer per task
-     * (instead a producer per thread as for the {@link #AT_LEAST_ONCE} case).
+     * If you enable this feature Kafka Streams will use more resources (like broker connections)
+     * compared to the {@link #AT_LEAST_ONCE} case.
      *
      * @see #EXACTLY_ONCE_BETA
      */
@@ -299,8 +298,8 @@ public class StreamsConfig extends AbstractConfig {
      * Config value for parameter {@link #PROCESSING_GUARANTEE_CONFIG "processing.guarantee"} for exactly-once processing guarantees.
      * <p>
      * Enabling exactly-once (beta) requires broker version 2.5 or higher.
-     * In contrast to {@link #EXACTLY_ONCE} Kafka Streams uses a producer per thread model,
-     * similar to the {@link #AT_LEAST_ONCE} case.
+     * If you enable this feature Kafka Streams will use less resources (like broker connections)
+     * compare to the {@link #EXACTLY_ONCE} case.
      */
     @SuppressWarnings("WeakerAccess")
     public static final String EXACTLY_ONCE_BETA = "exactly_once_beta";
@@ -1026,7 +1025,7 @@ public class StreamsConfig extends AbstractConfig {
         // Streams will be used instead.
 
         final String nonConfigurableConfigMessage = "Unexpected user-specified %s config: %s found. %sUser setting (%s) will be ignored and the Streams default setting (%s) will be used ";
-        final String eosMessage =  PROCESSING_GUARANTEE_CONFIG + " is set to " + getString(PROCESSING_GUARANTEE_CONFIG) + ". Hence, ";
+        final String eosMessage = PROCESSING_GUARANTEE_CONFIG + " is set to " + getString(PROCESSING_GUARANTEE_CONFIG) + ". Hence, ";
 
         for (final String config: nonConfigurableConfigs) {
             if (clientProvidedProps.containsKey(config)) {
@@ -1256,9 +1255,6 @@ public class StreamsConfig extends AbstractConfig {
 
         // generate producer configs from original properties and overridden maps
         final Map<String, Object> props = new HashMap<>(eosEnabled ? PRODUCER_EOS_OVERRIDES : PRODUCER_DEFAULT_OVERRIDES);
-        if (StreamThread.eosBetaEnabled(this)) {
-            props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, getString(StreamsConfig.APPLICATION_ID_CONFIG) + "-" + UUID.randomUUID());
-        }
         props.putAll(getClientCustomProps());
         props.putAll(clientProvidedProps);
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -278,18 +278,6 @@ public class StreamsConfig extends AbstractConfig {
     public static final String UPGRADE_FROM_23 = "2.3";
 
     /**
-     * Config value for parameter {@link #UPGRADE_FROM_CONFIG "upgrade.from"} for upgrading an application from version {@code 2.4.x}.
-     */
-    @SuppressWarnings("WeakerAccess")
-    public static final String UPGRADE_FROM_24 = "2.4";
-
-    /**
-     * Config value for parameter {@link #UPGRADE_FROM_CONFIG "upgrade.from"} for upgrading an application from version {@code 2.5.x}.
-     */
-    @SuppressWarnings("WeakerAccess")
-    public static final String UPGRADE_FROM_25 = "2.5";
-
-    /**
      * Config value for parameter {@link #PROCESSING_GUARANTEE_CONFIG "processing.guarantee"} for at-least-once processing guarantees.
      */
     @SuppressWarnings("WeakerAccess")
@@ -310,7 +298,7 @@ public class StreamsConfig extends AbstractConfig {
     /**
      * Config value for parameter {@link #PROCESSING_GUARANTEE_CONFIG "processing.guarantee"} for exactly-once processing guarantees.
      * <p>
-     * Enabling exactly-once (beta) requires broker version 2.4 or higher.
+     * Enabling exactly-once (beta) requires broker version 2.5 or higher.
      * In contrast to {@link #EXACTLY_ONCE} Kafka Streams uses a producer per thread model,
      * similar to the {@link #AT_LEAST_ONCE} case.
      */
@@ -482,7 +470,7 @@ public class StreamsConfig extends AbstractConfig {
     public static final String PROCESSING_GUARANTEE_CONFIG = "processing.guarantee";
     private static final String PROCESSING_GUARANTEE_DOC = "The processing guarantee that should be used. " +
         "Possible values are <code>" + AT_LEAST_ONCE + "</code> (default), <code>" + EXACTLY_ONCE + "</code>, " +
-        "and <code>" + EXACTLY_ONCE_BETA + "</code> (requires brokers version 2.4 or higher). " +
+        "and <code>" + EXACTLY_ONCE_BETA + "</code> (requires brokers version 2.5 or higher). " +
         "Note that exactly-once processing requires a cluster of at least three brokers by default what is the " +
         "recommended setting for production; for development you can change this, by adjusting broker setting " +
         "<code>transaction.state.log.replication.factor</code> and <code>transaction.state.log.min.isr</code>.";
@@ -548,13 +536,11 @@ public class StreamsConfig extends AbstractConfig {
     public static final String UPGRADE_FROM_CONFIG = "upgrade.from";
     private static final String UPGRADE_FROM_DOC = "Allows upgrading in a backward compatible way. " +
         "This is needed when upgrading from [0.10.0, 1.1] to 2.0+, or when upgrading from [2.0, 2.3] to 2.4+. " +
-        "When upgrading from [0.11, 2.5] to a newer version it is only required to specify this config if you want to " +
-        "switch from <code>" + EXACTLY_ONCE + "</code> to <code>" + EXACTLY_ONCE_BETA + "</code>. Default is `null`. " +
+        "When upgrading from 2.4 to a newer version it is not required to specify this config. Default is `null`. " +
         "Accepted values are \"" + UPGRADE_FROM_0100 + "\", \"" + UPGRADE_FROM_0101 + "\", \"" +
         UPGRADE_FROM_0102 + "\", \"" + UPGRADE_FROM_0110 + "\", \"" + UPGRADE_FROM_10 + "\", \"" +
         UPGRADE_FROM_11 + "\", \"" + UPGRADE_FROM_20 + "\", \"" + UPGRADE_FROM_21 + "\", \"" +
-        UPGRADE_FROM_22 + "\", \"" + UPGRADE_FROM_23 + "\", \"" + UPGRADE_FROM_24 + "\", \"" +
-        UPGRADE_FROM_25 + "\" (for upgrading from the corresponding old version).";
+        UPGRADE_FROM_22 + "\", \"" + UPGRADE_FROM_23 + "\" (for upgrading from the corresponding old version).";
 
     /** {@code windowstore.changelog.additional.retention.ms} */
     @SuppressWarnings("WeakerAccess")
@@ -837,9 +823,7 @@ public class StreamsConfig extends AbstractConfig {
                        UPGRADE_FROM_20,
                        UPGRADE_FROM_21,
                        UPGRADE_FROM_22,
-                       UPGRADE_FROM_23,
-                       UPGRADE_FROM_24,
-                       UPGRADE_FROM_25),
+                       UPGRADE_FROM_23),
                     Importance.LOW,
                     UPGRADE_FROM_DOC)
             .define(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG,
@@ -1272,7 +1256,7 @@ public class StreamsConfig extends AbstractConfig {
 
         // generate producer configs from original properties and overridden maps
         final Map<String, Object> props = new HashMap<>(eosEnabled ? PRODUCER_EOS_OVERRIDES : PRODUCER_DEFAULT_OVERRIDES);
-        if (StreamThread.eosBetaEnabled(this) && !StreamThread.eosUpgradeModeEnabled(this)) {
+        if (StreamThread.eosBetaEnabled(this)) {
             props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, getString(StreamsConfig.APPLICATION_ID_CONFIG) + "-" + UUID.randomUUID());
         }
         props.putAll(getClientCustomProps());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -110,9 +110,9 @@ class ActiveTaskCreator {
             if (StreamThread.eosBetaEnabled(config)) {
                 final String threadIdPrefix = String.format("stream-thread [%s] ", Thread.currentThread().getName());
                 final LogContext logContext = new LogContext(threadIdPrefix);
-                 eosBetaStreamsProducer = new StreamsProducer(threadProducer, true, logContext);
+                eosBetaStreamsProducer = new StreamsProducer(threadProducer, true, logContext);
             } else {
-                 eosBetaStreamsProducer = null;
+                eosBetaStreamsProducer = null;
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -93,9 +93,7 @@ class ActiveTaskCreator {
         createTaskSensor = ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
         applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
 
-        if (StreamThread.eosAlphaEnabled(config) ||
-            (StreamThread.eosBetaEnabled(config) && StreamThread.eosUpgradeModeEnabled(config))) {
-
+        if (StreamThread.eosAlphaEnabled(config)) {
             threadProducer = null;
             eosBetaStreamsProducer = null;
             taskProducers = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
-
 class StandbyTaskCreator {
     private final InternalTopologyBuilder builder;
     private final StreamsConfig config;
@@ -74,7 +72,7 @@ class StandbyTaskCreator {
                 final ProcessorStateManager stateManager = new ProcessorStateManager(
                     taskId,
                     Task.TaskType.STANDBY,
-                    EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)),
+                    StreamThread.eosEnabled(config),
                     logContext,
                     stateDirectory,
                     storeChangelogReader,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -120,7 +120,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
         this.time = time;
         this.recordCollector = recordCollector;
-        eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        eosEnabled = StreamThread.eosEnabled(config);
 
         final String threadId = Thread.currentThread().getName();
         closeTaskSensor = ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
@@ -561,7 +561,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * @return true if this method processes a record, false if it does not process a record.
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("unchecked")
     public boolean process(final long wallClockTime) {
         if (!isProcessable(wallClockTime)) {
             return false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -311,9 +311,19 @@ public class StreamThread extends Thread {
 
         final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
 
+        final ProcessingMode processingMode;
+        if (StreamThread.eosAlphaEnabled(config)) {
+            processingMode = StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA;
+        } else if (StreamThread.eosBetaEnabled(config)) {
+            processingMode = StreamThread.ProcessingMode.EXACTLY_ONCE_BETA;
+        } else {
+            processingMode = StreamThread.ProcessingMode.AT_LEAST_ONCE;
+        }
+
         final ActiveTaskCreator activeTaskCreator = new ActiveTaskCreator(
             builder,
             config,
+            processingMode,
             streamsMetrics,
             stateDirectory,
             changelogReader,
@@ -343,7 +353,7 @@ public class StreamThread extends Thread {
             builder,
             adminClient,
             stateDirectory,
-            config
+            processingMode
         );
 
         log.info("Creating consumer client");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -321,6 +321,7 @@ public class StreamThread extends Thread {
             time,
             clientSupplier,
             threadId,
+            processId,
             log
         );
         final StandbyTaskCreator standbyTaskCreator = new StandbyTaskCreator(
@@ -380,6 +381,20 @@ public class StreamThread extends Thread {
         );
 
         return streamThread.updateThreadMetadata(getSharedAdminClientId(clientId));
+    }
+
+    enum ProcessingMode {
+        AT_LEAST_ONCE("AT_LEAST_ONCE"),
+
+        EXACTLY_ONCE_ALPHA("EXACTLY_ONCE_ALPHA"),
+
+        EXACTLY_ONCE_BETA("EXACTLY_ONCE_BETA");
+
+        public final String name;
+
+        ProcessingMode(final String name) {
+            this.name = name;
+        }
     }
 
     static boolean eosAlphaEnabled(final StreamsConfig config) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -394,21 +394,6 @@ public class StreamThread extends Thread {
         return eosAlphaEnabled(config) || eosBetaEnabled(config);
     }
 
-    public static boolean eosUpgradeModeEnabled(final StreamsConfig config) {
-        final Set<String> eosAlphaVersions = new HashSet<>();
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_25);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_24);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_23);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_22);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_21);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_20);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_11);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_10);
-        eosAlphaVersions.add(StreamsConfig.UPGRADE_FROM_0110);
-
-        return eosBetaEnabled(config) && eosAlphaVersions.contains(config.getString(StreamsConfig.UPGRADE_FROM_CONFIG));
-    }
-
     public StreamThread(final Time time,
                         final StreamsConfig config,
                         final Admin adminClient,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -166,7 +167,7 @@ public class StreamsProducer {
             producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata);
             producer.commitTransaction();
             transactionInFlight = false;
-        } catch (final ProducerFencedException error) {
+        } catch (final ProducerFencedException | CommitFailedException error) {
             throw new TaskMigratedException(
                 formatException("Producer got fenced trying to commit a transaction"),
                 error

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -51,7 +52,6 @@ public class StreamsProducer {
     private final String logPrefix;
 
     private final Producer<byte[], byte[]> producer;
-    private final String applicationId;
     private final boolean eosEnabled;
 
     private boolean transactionInFlight = false;
@@ -59,14 +59,9 @@ public class StreamsProducer {
 
     public StreamsProducer(final Producer<byte[], byte[]> producer,
                            final boolean eosEnabled,
-                           final String applicationId,
                            final LogContext logContext) {
         this.producer = Objects.requireNonNull(producer, "producer cannot be null");
         this.eosEnabled = eosEnabled;
-        this.applicationId = applicationId;
-        if (eosEnabled && applicationId == null) {
-            throw new IllegalArgumentException("applicationId cannot be null if EOS is enabled");
-        }
 
         log = Objects.requireNonNull(logContext, "logContext cannot be null").logger(getClass());
         logPrefix = logContext.logPrefix().trim();
@@ -161,13 +156,29 @@ public class StreamsProducer {
      * @throws IllegalStateException if EOS is disabled
      * @throws TaskMigratedException
      */
-    void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
+    void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                           final String applicationId) throws ProducerFencedException {
+        commitTransaction(offsets, applicationId, null);
+    }
+
+    void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                           final ConsumerGroupMetadata consumerGroupMetadata) throws ProducerFencedException {
+        commitTransaction(offsets, null, consumerGroupMetadata);
+    }
+
+    private void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                   final String applicationId,
+                                   final ConsumerGroupMetadata consumerGroupMetadata) throws ProducerFencedException {
         if (!eosEnabled) {
             throw new IllegalStateException(formatException("EOS is disabled"));
         }
         maybeBeginTransaction();
         try {
-            producer.sendOffsetsToTransaction(offsets, applicationId);
+            if (applicationId != null) {
+                producer.sendOffsetsToTransaction(offsets, applicationId);
+            } else {
+                producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata);
+            }
             producer.commitTransaction();
             transactionInFlight = false;
         } catch (final ProducerFencedException error) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -157,28 +157,13 @@ public class StreamsProducer {
      * @throws TaskMigratedException
      */
     void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
-                           final String applicationId) throws ProducerFencedException {
-        commitTransaction(offsets, applicationId, null);
-    }
-
-    void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
                            final ConsumerGroupMetadata consumerGroupMetadata) throws ProducerFencedException {
-        commitTransaction(offsets, null, consumerGroupMetadata);
-    }
-
-    private void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
-                                   final String applicationId,
-                                   final ConsumerGroupMetadata consumerGroupMetadata) throws ProducerFencedException {
         if (!eosEnabled) {
             throw new IllegalStateException(formatException("EOS is disabled"));
         }
         maybeBeginTransaction();
         try {
-            if (applicationId != null) {
-                producer.sendOffsetsToTransaction(offsets, applicationId);
-            } else {
-                producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata);
-            }
+            producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata);
             producer.commitTransaction();
             transactionInFlight = false;
         } catch (final ProducerFencedException error) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -224,6 +224,7 @@ public class KafkaStreamsTest {
             anyString()
         )).andReturn("admin").anyTimes();
 
+        EasyMock.expect(StreamThread.eosEnabled(anyObject(StreamsConfig.class))).andReturn(false).anyTimes();
         EasyMock.expect(streamThreadOne.getId()).andReturn(0L).anyTimes();
         EasyMock.expect(streamThreadTwo.getId()).andReturn(1L).anyTimes();
         prepareStreamThread(streamThreadOne, true);

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -46,7 +46,6 @@ import java.util.Properties;
 
 import static org.apache.kafka.common.IsolationLevel.READ_COMMITTED;
 import static org.apache.kafka.common.IsolationLevel.READ_UNCOMMITTED;
-import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_BETA;
 import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION;
@@ -633,44 +632,6 @@ public class StreamsConfigTest {
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
         assertThat((String) producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), startsWith(applicationId + "-"));
-    }
-
-    @Test
-    public void shouldSetTransactionalIdIfEosBetaEnabledWhileUpgradingFromPreEosVersion() {
-        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_BETA);
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            props.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            final StreamsConfig streamsConfig = new StreamsConfig(props);
-
-            final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
-
-            assertThat((String) producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), startsWith(applicationId + "-"));
-        }
-    }
-
-    @Test
-    public void shouldNotSetTransactionalIdIfEosBetaEnabledWhenUpgradingFromEosAlphaVersion() {
-        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_BETA);
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            props.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
-
-            assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
-        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -486,6 +487,7 @@ public class ActiveTaskCreatorTest {
             new MockTime(),
             mockClientSupplier,
             "threadId",
+            UUID.randomUUID(),
             new LogContext().logger(ActiveTaskCreator.class)
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -18,10 +18,6 @@ package org.apache.kafka.streams.processor.internals;
 
 import java.io.File;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
@@ -31,7 +27,9 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.test.MockClientSupplier;
@@ -44,21 +42,20 @@ import org.junit.runner.RunWith;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.same;
+import static org.easymock.EasyMock.reset;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 @RunWith(EasyMockRunner.class)
@@ -67,40 +64,70 @@ public class ActiveTaskCreatorTest {
     @Mock(type = MockType.NICE)
     private InternalTopologyBuilder builder;
     @Mock(type = MockType.NICE)
-    private StreamsConfig config;
-    @Mock(type = MockType.NICE)
     private StateDirectory stateDirectory;
     @Mock(type = MockType.NICE)
     private ChangelogReader changeLogReader;
-    @Mock(type = MockType.NICE)
-    private Consumer<byte[], byte[]> consumer;
-    @Mock(type = MockType.NICE)
-    private Admin adminClient;
 
     private final MockClientSupplier mockClientSupplier = new MockClientSupplier();
     final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), "clientId", StreamsConfig.METRICS_LATEST);
+    final Map<String, Object> properties = mkMap(
+        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")
+    );
 
     private ActiveTaskCreator activeTaskCreator;
 
-    @Test
-    public void shouldFailForNonEosOnStreamsProducerPerTask() {
-        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
-        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.AT_LEAST_ONCE);
-        expect(config.getProducerConfigs(anyString())).andReturn(Collections.emptyMap());
-        replay(config);
 
-        activeTaskCreator = new ActiveTaskCreator(
-            builder,
-            config,
-            streamsMetrics,
-            stateDirectory,
-            changeLogReader,
-            new ThreadCache(new LogContext(), 0L, streamsMetrics),
-            new MockTime(),
-            mockClientSupplier,
-            "threadId",
-            new LogContext().logger(ActiveTaskCreator.class)
-        );
+
+    // non-EOS test
+
+    // functional test
+
+    @Test
+    public void shouldCreateThreadProducerIfEosDisabled() {
+        createTasks();
+
+        assertThat(mockClientSupplier.producers.size(), is(1));
+    }
+
+    @Test
+    public void shouldConstructProducerMetricsWithEosDisabled() {
+        shouldConstructThreadProducerMetric();
+    }
+
+    @Test
+    public void shouldConstructClientIdWithEosDisabled() {
+        createTasks();
+
+        final Set<String> clientIds = activeTaskCreator.producerClientIds();
+
+        assertThat(clientIds, is(Collections.singleton("threadId-producer")));
+    }
+
+    @Test
+    public void shouldCloseThreadProducerIfEosDisabled() {
+        createTasks();
+
+        activeTaskCreator.closeThreadProducerIfNeeded();
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+    }
+
+    @Test
+    public void shouldNoOpCloseTaskProducerIfEosDisabled() {
+        createTasks();
+
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
+    }
+
+    // error handling
+
+    @Test
+    public void shouldFailOnStreamsProducerPerTaskIfEosDisabled() {
+        createTasks();
 
         final IllegalStateException thrown = assertThrows(
             IllegalStateException.class,
@@ -111,24 +138,110 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldFailForUnknownTaskOnStreamsProducerPerTask() {
-        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
-        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
-        expect(config.getProducerConfigs(anyString())).andReturn(Collections.emptyMap());
-        replay(config);
+    public void shouldFailOnGetThreadProducerIfEosDisabled() {
+        createTasks();
 
-        activeTaskCreator = new ActiveTaskCreator(
-            builder,
-            config,
-            streamsMetrics,
-            stateDirectory,
-            changeLogReader,
-            new ThreadCache(new LogContext(), 0L, streamsMetrics),
-            new MockTime(),
-            mockClientSupplier,
-            "threadId",
-            new LogContext().logger(ActiveTaskCreator.class)
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            activeTaskCreator::threadProducer
         );
+
+        assertThat(thrown.getMessage(), is("Exactly-once beta is not enabled."));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnErrorCloseThreadProducerIfEosDisabled() {
+        createTasks();
+        mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            activeTaskCreator::closeThreadProducerIfNeeded
+        );
+
+        assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
+        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+    }
+
+
+
+    // eos-alpha test
+
+    // functional test
+
+    @Test
+    public void shouldCreateProducerPerTaskIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        assertThat(mockClientSupplier.producers.size(), is(2));
+    }
+
+    @Test
+    public void shouldReturnStreamsProducerPerTaskIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+
+        shouldReturnStreamsProducerPerTask();
+    }
+
+    @Test
+    public void shouldConstructProducerMetricsWithEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+
+        shouldConstructProducerMetricsPerTask();
+    }
+
+    @Test
+    public void shouldConstructClientIdWithEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        final Set<String> clientIds = activeTaskCreator.producerClientIds();
+
+        assertThat(clientIds, is(mkSet("threadId-0_0-producer", "threadId-0_1-producer")));
+    }
+
+    @Test
+    public void shouldNoOpCloseThreadProducerIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        activeTaskCreator.closeThreadProducerIfNeeded();
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
+        assertThat(mockClientSupplier.producers.get(1).closed(), is(false));
+    }
+
+    @Test
+    public void shouldCloseTaskProducersIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
+        // should no-op unknown task
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 2));
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+        assertThat(mockClientSupplier.producers.get(1).closed(), is(true));
+
+        // should not throw because producer should be removed
+        mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+    }
+
+    // error handling
+
+    @Test
+    public void shouldFailForUnknownTaskOnStreamsProducerPerTaskIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
 
         {
             final IllegalStateException thrown = assertThrows(
@@ -141,36 +254,613 @@ public class ActiveTaskCreatorTest {
         {
             final IllegalStateException thrown = assertThrows(
                 IllegalStateException.class,
-                () -> activeTaskCreator.streamsProducerForTask(new TaskId(0, 0))
+                () -> activeTaskCreator.streamsProducerForTask(new TaskId(0, 2))
             );
 
-            assertThat(thrown.getMessage(), is("Unknown TaskId: 0_0"));
+            assertThat(thrown.getMessage(), is("Unknown TaskId: 0_2"));
         }
     }
 
     @Test
-    public void shouldReturnStreamsProducerPerTask() {
+    public void shouldFailOnGetThreadProducerIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            activeTaskCreator::threadProducer
+        );
+
+        assertThat(thrown.getMessage(), is("Exactly-once beta is not enabled."));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnErrorCloseTaskProducerIfEosAlphaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+        mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            () -> activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0))
+        );
+
+        assertThat(thrown.getMessage(), is("[0_0] task producer encounter error trying to close."));
+        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+
+        // should not throw again because producer should be removed
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+    }
+
+
+
+    // eos-beta test
+
+    // functional test
+
+    @Test
+    public void shouldCreateThreadProducerIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        assertThat(mockClientSupplier.producers.size(), is(1));
+    }
+
+    @Test
+    public void shouldCreateThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            assertThat(mockClientSupplier.producers.size(), is(1));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldCreateProducerPerTaskIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            assertThat(mockClientSupplier.producers.size(), is(2));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldReturnThreadProducerIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        final StreamsProducer threadProducer = activeTaskCreator.threadProducer();
+
+        assertThat(mockClientSupplier.producers.size(), is(1));
+        assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
+    }
+
+    @Test
+    public void shouldReturnThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            final StreamsProducer threadProducer = activeTaskCreator.threadProducer();
+
+            assertThat(mockClientSupplier.producers.size(), is(1));
+            assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldReturnStreamsProducerPerTaskIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+
+            shouldReturnStreamsProducerPerTask();
+        }
+    }
+
+    @Test
+    public void shouldConstructProducerMetricsWithEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        shouldConstructThreadProducerMetric();
+    }
+
+    @Test
+    public void shouldConstructProducerMetricsWithEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+
+            shouldConstructThreadProducerMetric();
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldConstructProducerMetricsWithEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+
+            shouldConstructProducerMetricsPerTask();
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldConstructClientIdWithEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        final Set<String> clientIds = activeTaskCreator.producerClientIds();
+
+        assertThat(clientIds, is(Collections.singleton("threadId-producer")));
+    }
+
+    @Test
+    public void shouldConstructClientIdWithEosBetaEnabledAndUpgradingFromPreEosVerion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            final Set<String> clientIds = activeTaskCreator.producerClientIds();
+
+            assertThat(clientIds, is(Collections.singleton("threadId-producer")));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldConstructClientIdWithEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            final Set<String> clientIds = activeTaskCreator.producerClientIds();
+
+            assertThat(clientIds, is(mkSet("threadId-0_0-producer", "threadId-0_1-producer")));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldCloseThreadProducerIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+
+        activeTaskCreator.closeThreadProducerIfNeeded();
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+    }
+
+    @Test
+    public void shouldCloseThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            activeTaskCreator.closeThreadProducerIfNeeded();
+
+            assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldNoOpCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            activeTaskCreator.closeThreadProducerIfNeeded();
+
+            assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
+            assertThat(mockClientSupplier.producers.get(1).closed(), is(false));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldNoOpCloseTaskProducerIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
+
+        assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
+    }
+
+    @Test
+    public void shouldNoOpCloseTaskProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
+
+            assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
+            // should no-op unknown task
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 2));
+
+            assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+            assertThat(mockClientSupplier.producers.get(1).closed(), is(true));
+
+            // should not throw because producer should be removed
+            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    // error handling
+
+    @Test
+    public void shouldFailOnStreamsProducerPerTaskIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> activeTaskCreator.streamsProducerForTask(null)
+        );
+
+        assertThat(thrown.getMessage(), is("Producer per thread is used"));
+    }
+
+    @Test
+    public void shouldFailOnStreamsProducerPerTaskIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> activeTaskCreator.streamsProducerForTask(null)
+            );
+
+            assertThat(thrown.getMessage(), is("Producer per thread is used"));
+        }
+    }
+
+    @Test
+    public void shouldFailOnGetThreadProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+
+            final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                activeTaskCreator::threadProducer
+            );
+
+            assertThat(thrown.getMessage(), is("Exactly-once beta is not enabled."));
+        }
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnErrorCloseThreadProducerIfEosBetaEnabled() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+        createTasks();
+        mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+
+        final StreamsException thrown = assertThrows(
+            StreamsException.class,
+            activeTaskCreator::closeThreadProducerIfNeeded
+        );
+
+        assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
+        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnErrorCloseThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0100,
+            StreamsConfig.UPGRADE_FROM_0101,
+            StreamsConfig.UPGRADE_FROM_0102)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+
+            final StreamsException thrown = assertThrows(
+                StreamsException.class,
+                activeTaskCreator::closeThreadProducerIfNeeded
+            );
+
+            assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
+            assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnErrorCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        for (final String upgradeFrom : mkSet(
+            StreamsConfig.UPGRADE_FROM_0110,
+            StreamsConfig.UPGRADE_FROM_10,
+            StreamsConfig.UPGRADE_FROM_11,
+            StreamsConfig.UPGRADE_FROM_20,
+            StreamsConfig.UPGRADE_FROM_21,
+            StreamsConfig.UPGRADE_FROM_22,
+            StreamsConfig.UPGRADE_FROM_23,
+            StreamsConfig.UPGRADE_FROM_24,
+            StreamsConfig.UPGRADE_FROM_25)) {
+
+            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
+            createTasks();
+            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
+
+            final StreamsException thrown = assertThrows(
+                StreamsException.class,
+                () -> activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0))
+            );
+
+            assertThat(thrown.getMessage(), is("[0_0] task producer encounter error trying to close."));
+            assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+
+            // should not throw again because producer should be removed
+            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
+
+            mockClientSupplier.producers.clear();
+        }
+    }
+
+    private void shouldReturnStreamsProducerPerTask() {
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        final StreamsProducer streamsProducer1 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 0));
+        final StreamsProducer streamsProducer2 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 1));
+
+        assertThat(streamsProducer1, not(is(streamsProducer2)));
+    }
+
+    private void shouldConstructProducerMetricsPerTask() {
+        mockClientSupplier.setApplicationIdForProducer("appId");
+
+        createTasks();
+
+        final MetricName testMetricName1 = new MetricName("test_metric_1", "", "", new HashMap<>());
+        final Metric testMetric1 = new KafkaMetric(
+            new Object(),
+            testMetricName1,
+            (Measurable) (config, now) -> 0,
+            null,
+            new MockTime());
+        mockClientSupplier.producers.get(0).setMockMetrics(testMetricName1, testMetric1);
+        final MetricName testMetricName2 = new MetricName("test_metric_2", "", "", new HashMap<>());
+        final Metric testMetric2 = new KafkaMetric(
+            new Object(),
+            testMetricName2,
+            (Measurable) (config, now) -> 0,
+            null,
+            new MockTime());
+        mockClientSupplier.producers.get(0).setMockMetrics(testMetricName2, testMetric2);
+
+        final Map<MetricName, Metric> producerMetrics = activeTaskCreator.producerMetrics();
+
+        assertThat(producerMetrics, is(mkMap(mkEntry(testMetricName1, testMetric1), mkEntry(testMetricName2, testMetric2))));
+    }
+
+    private void shouldConstructThreadProducerMetric() {
+        createTasks();
+
+        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
+        final Metric testMetric = new KafkaMetric(
+            new Object(),
+            testMetricName,
+            (Measurable) (config, now) -> 0,
+            null,
+            new MockTime());
+        mockClientSupplier.producers.get(0).setMockMetrics(testMetricName, testMetric);
+        assertThat(mockClientSupplier.producers.size(), is(1));
+
+        final Map<MetricName, Metric> producerMetrics = activeTaskCreator.producerMetrics();
+
+        assertThat(producerMetrics.size(), is(1));
+        assertThat(producerMetrics.get(testMetricName), is(testMetric));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void createTasks() {
         final TaskId task00 = new TaskId(0, 0);
         final TaskId task01 = new TaskId(0, 1);
+
         final ProcessorTopology topology = mock(ProcessorTopology.class);
+        final SourceNode sourceNode = mock(SourceNode.class);
 
-        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
-        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
-        expect(config.getProducerConfigs(anyString())).andReturn(new HashMap<>()).anyTimes();
-        expect(config.getLong(anyString())).andReturn(0L).anyTimes();
-        expect(config.getInt(anyString())).andReturn(0).anyTimes();
-        expect(builder.buildSubtopology(task00.topicGroupId)).andReturn(topology).anyTimes();
-        expect(stateDirectory.directoryForTask(task00)).andReturn(new File(task00.toString()));
-        expect(stateDirectory.directoryForTask(task01)).andReturn(new File(task01.toString()));
+        reset(builder, stateDirectory);
+        expect(builder.buildSubtopology(0)).andReturn(topology).anyTimes();
+        expect(stateDirectory.directoryForTask(task00)).andReturn(mock(File.class));
+        expect(stateDirectory.checkpointFileFor(task00)).andReturn(mock(File.class));
+        expect(stateDirectory.directoryForTask(task01)).andReturn(mock(File.class));
+        expect(stateDirectory.checkpointFileFor(task01)).andReturn(mock(File.class));
         expect(topology.storeToChangelogTopic()).andReturn(Collections.emptyMap()).anyTimes();
-        expect(topology.source("topic")).andReturn(mock(SourceNode.class)).andReturn(mock(SourceNode.class));
+        expect(topology.source("topic")).andReturn(sourceNode).anyTimes();
+        expect(sourceNode.getTimestampExtractor()).andReturn(mock(TimestampExtractor.class)).anyTimes();
         expect(topology.globalStateStores()).andReturn(Collections.emptyList()).anyTimes();
-        replay(config, builder, stateDirectory, topology);
+        replay(builder, stateDirectory, topology, sourceNode);
 
-        mockClientSupplier.setApplicationIdForProducer("appId");
         activeTaskCreator = new ActiveTaskCreator(
             builder,
-            config,
+            new StreamsConfig(properties),
             streamsMetrics,
             stateDirectory,
             changeLogReader,
@@ -191,92 +881,5 @@ public class ActiveTaskCreatorTest {
             ).stream().map(Task::id).collect(Collectors.toSet()),
             equalTo(mkSet(task00, task01))
         );
-
-        final StreamsProducer streamsProducer1 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 0));
-        final StreamsProducer streamsProducer2 = activeTaskCreator.streamsProducerForTask(new TaskId(0, 1));
-
-        assertThat(streamsProducer1, not(same(streamsProducer2)));
-    }
-
-    @Test
-    public void shouldConstructProducerMetricsWithoutEOS() {
-        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
-        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.AT_LEAST_ONCE);
-        expect(config.getProducerConfigs(anyString())).andReturn(Collections.emptyMap());
-        replay(config);
-
-        activeTaskCreator = new ActiveTaskCreator(
-            builder,
-            config,
-            streamsMetrics,
-            stateDirectory,
-            changeLogReader,
-            new ThreadCache(new LogContext(), 0L, streamsMetrics),
-            new MockTime(),
-            mockClientSupplier,
-            "threadId",
-            new LogContext().logger(ActiveTaskCreator.class)
-        );
-
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
-        final Metric testMetric = new KafkaMetric(
-            new Object(),
-            testMetricName,
-            (Measurable) (config, now) -> 0,
-            null,
-            new MockTime());
-
-        mockClientSupplier.producers.get(0).setMockMetrics(testMetricName, testMetric);
-        final Map<MetricName, Metric> producerMetrics = activeTaskCreator.producerMetrics();
-        assertEquals(testMetricName, producerMetrics.get(testMetricName).metricName());
-    }
-
-    @Test
-    public void shouldConstructProducerMetricsWithEOS() {
-        final TaskId taskId = new TaskId(0, 0);
-        final ProcessorTopology topology = mock(ProcessorTopology.class);
-
-        expect(config.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
-        expect(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
-        expect(config.getLong(anyString())).andReturn(0L);
-        expect(config.getInt(anyString())).andReturn(0);
-        expect(config.getProducerConfigs(anyString())).andReturn(new HashMap<>());
-        expect(builder.buildSubtopology(taskId.topicGroupId)).andReturn(topology);
-        expect(stateDirectory.directoryForTask(taskId)).andReturn(new File(taskId.toString()));
-        expect(topology.storeToChangelogTopic()).andReturn(Collections.emptyMap());
-        expect(topology.source("topic")).andReturn(mock(SourceNode.class));
-        expect(topology.globalStateStores()).andReturn(Collections.emptyList());
-        replay(config, builder, stateDirectory, topology);
-
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        activeTaskCreator = new ActiveTaskCreator(
-            builder,
-            config,
-            streamsMetrics,
-            stateDirectory,
-            changeLogReader,
-            new ThreadCache(new LogContext(), 0L, streamsMetrics),
-            new MockTime(),
-            mockClientSupplier,
-            "threadId",
-            new LogContext().logger(ActiveTaskCreator.class)
-        );
-
-        activeTaskCreator.createTasks(
-            new MockConsumer<>(OffsetResetStrategy.NONE),
-            mkMap(mkEntry(new TaskId(0, 0), Collections.singleton(new TopicPartition("topic", 0)))));
-
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
-        final Metric testMetric = new KafkaMetric(
-            new Object(),
-            testMetricName,
-            (Measurable) (config, now) -> 0,
-            null,
-            new MockTime());
-
-        mockClientSupplier.producers.get(0).setMockMetrics(testMetricName, testMetric);
-        final Map<MetricName, Metric> producerMetrics = activeTaskCreator.producerMetrics();
-        assertEquals(testMetricName, producerMetrics.get(testMetricName).metricName());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -311,48 +311,6 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldCreateThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            assertThat(mockClientSupplier.producers.size(), is(1));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldCreateProducerPerTaskIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            assertThat(mockClientSupplier.producers.size(), is(2));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
     public void shouldReturnThreadProducerIfEosBetaEnabled() {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
         mockClientSupplier.setApplicationIdForProducer("appId");
@@ -366,92 +324,11 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldReturnThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            final StreamsProducer threadProducer = activeTaskCreator.threadProducer();
-
-            assertThat(mockClientSupplier.producers.size(), is(1));
-            assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldReturnStreamsProducerPerTaskIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-
-            shouldReturnStreamsProducerPerTask();
-        }
-    }
-
-    @Test
     public void shouldConstructProducerMetricsWithEosBetaEnabled() {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
         mockClientSupplier.setApplicationIdForProducer("appId");
 
         shouldConstructThreadProducerMetric();
-    }
-
-    @Test
-    public void shouldConstructProducerMetricsWithEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-
-            shouldConstructThreadProducerMetric();
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldConstructProducerMetricsWithEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-
-            shouldConstructProducerMetricsPerTask();
-            mockClientSupplier.producers.clear();
-        }
     }
 
     @Test
@@ -466,52 +343,6 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldConstructClientIdWithEosBetaEnabledAndUpgradingFromPreEosVerion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            final Set<String> clientIds = activeTaskCreator.producerClientIds();
-
-            assertThat(clientIds, is(Collections.singleton("threadId-producer")));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldConstructClientIdWithEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            final Set<String> clientIds = activeTaskCreator.producerClientIds();
-
-            assertThat(clientIds, is(mkSet("threadId-0_0-producer", "threadId-0_1-producer")));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
     public void shouldCloseThreadProducerIfEosBetaEnabled() {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
         mockClientSupplier.setApplicationIdForProducer("appId");
@@ -520,53 +351,6 @@ public class ActiveTaskCreatorTest {
         activeTaskCreator.closeThreadProducerIfNeeded();
 
         assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
-    }
-
-    @Test
-    public void shouldCloseThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            activeTaskCreator.closeThreadProducerIfNeeded();
-
-            assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldNoOpCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            activeTaskCreator.closeThreadProducerIfNeeded();
-
-            assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
-            assertThat(mockClientSupplier.producers.get(1).closed(), is(false));
-            mockClientSupplier.producers.clear();
-        }
     }
 
     @Test
@@ -580,62 +364,6 @@ public class ActiveTaskCreatorTest {
         activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
 
         assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
-    }
-
-    @Test
-    public void shouldNoOpCloseTaskProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
-
-            assertThat(mockClientSupplier.producers.get(0).closed(), is(false));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 1));
-            // should no-op unknown task
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 2));
-
-            assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
-            assertThat(mockClientSupplier.producers.get(1).closed(), is(true));
-
-            // should not throw because producer should be removed
-            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
-
-            mockClientSupplier.producers.clear();
-        }
     }
 
     // error handling
@@ -656,56 +384,6 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldFailOnStreamsProducerPerTaskIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            final IllegalStateException thrown = assertThrows(
-                IllegalStateException.class,
-                () -> activeTaskCreator.streamsProducerForTask(null)
-            );
-
-            assertThat(thrown.getMessage(), is("Producer per thread is used"));
-        }
-    }
-
-    @Test
-    public void shouldFailOnGetThreadProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-
-            final IllegalStateException thrown = assertThrows(
-                IllegalStateException.class,
-                activeTaskCreator::threadProducer
-            );
-
-            assertThat(thrown.getMessage(), is("Exactly-once beta is not enabled."));
-        }
-    }
-
-    @Test
     public void shouldThrowStreamsExceptionOnErrorCloseThreadProducerIfEosBetaEnabled() {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
         mockClientSupplier.setApplicationIdForProducer("appId");
@@ -719,66 +397,6 @@ public class ActiveTaskCreatorTest {
 
         assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
         assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionOnErrorCloseThreadProducerIfEosBetaEnabledAndUpgradingFromPreEosVersion() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0100,
-            StreamsConfig.UPGRADE_FROM_0101,
-            StreamsConfig.UPGRADE_FROM_0102)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
-
-            final StreamsException thrown = assertThrows(
-                StreamsException.class,
-                activeTaskCreator::closeThreadProducerIfNeeded
-            );
-
-            assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
-            assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
-            mockClientSupplier.producers.clear();
-        }
-    }
-
-    @Test
-    public void shouldThrowStreamsExceptionOnErrorCloseTaskProducerIfEosBetaEnabledAndUpgradingFromEosAlpha() {
-        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_BETA);
-        mockClientSupplier.setApplicationIdForProducer("appId");
-
-        for (final String upgradeFrom : mkSet(
-            StreamsConfig.UPGRADE_FROM_0110,
-            StreamsConfig.UPGRADE_FROM_10,
-            StreamsConfig.UPGRADE_FROM_11,
-            StreamsConfig.UPGRADE_FROM_20,
-            StreamsConfig.UPGRADE_FROM_21,
-            StreamsConfig.UPGRADE_FROM_22,
-            StreamsConfig.UPGRADE_FROM_23,
-            StreamsConfig.UPGRADE_FROM_24,
-            StreamsConfig.UPGRADE_FROM_25)) {
-
-            properties.put(StreamsConfig.UPGRADE_FROM_CONFIG, upgradeFrom);
-            createTasks();
-            mockClientSupplier.producers.get(0).closeException = new RuntimeException("KABOOM!");
-
-            final StreamsException thrown = assertThrows(
-                StreamsException.class,
-                () -> activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0))
-            );
-
-            assertThat(thrown.getMessage(), is("[0_0] task producer encounter error trying to close."));
-            assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
-
-            // should not throw again because producer should be removed
-            activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(new TaskId(0, 0));
-
-            mockClientSupplier.producers.clear();
-        }
     }
 
     private void shouldReturnStreamsProducerPerTask() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -101,7 +101,7 @@ public class RecordCollectorTest {
 
     private final MockProducer<byte[], byte[]> mockProducer = new MockProducer<>(
         cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
-    private final StreamsProducer streamsProducer = new StreamsProducer(mockProducer, false, null, logContext);
+    private final StreamsProducer streamsProducer = new StreamsProducer(mockProducer, false, logContext);
 
     private RecordCollectorImpl collector;
 
@@ -420,7 +420,6 @@ public class RecordCollectorTest {
                     }
                 },
                 true,
-                "appId",
                 logContext
             ),
             productionExceptionHandler,
@@ -461,7 +460,6 @@ public class RecordCollectorTest {
                     }
                 },
                 false,
-                null,
                 logContext
             ),
             productionExceptionHandler,
@@ -501,7 +499,6 @@ public class RecordCollectorTest {
                     }
                 },
                 false,
-                null,
                 logContext
             ),
             new AlwaysContinueProductionExceptionHandler(),
@@ -542,7 +539,6 @@ public class RecordCollectorTest {
                     }
                 },
                 false,
-                null,
                 logContext
             ),
             new AlwaysContinueProductionExceptionHandler(),
@@ -581,7 +577,6 @@ public class RecordCollectorTest {
                     }
                 },
                 true,
-                "appId",
                 logContext
             ),
             productionExceptionHandler,
@@ -605,7 +600,6 @@ public class RecordCollectorTest {
                     }
                 },
                 false,
-                null,
                 logContext
             ),
             productionExceptionHandler,
@@ -625,7 +619,7 @@ public class RecordCollectorTest {
         final RecordCollector collector = new RecordCollectorImpl(
             logContext,
             taskId,
-            new StreamsProducer(mockProducer, true, "appId", logContext),
+            new StreamsProducer(mockProducer, true, logContext),
             productionExceptionHandler,
             streamsMetrics
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -73,12 +74,12 @@ public class StreamsProducerTest {
     private final MockProducer<byte[], byte[]> nonEosMockProducer = new MockProducer<>(
         cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
     private final StreamsProducer nonEosStreamsProducer =
-        new StreamsProducer(nonEosMockProducer, false, null, logContext);
+        new StreamsProducer(nonEosMockProducer, false, logContext);
 
     private final MockProducer<byte[], byte[]> eosMockProducer = new MockProducer<>(
         cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer);
     private final StreamsProducer eosStreamsProducer =
-        new StreamsProducer(eosMockProducer, true, "appId", logContext);
+        new StreamsProducer(eosMockProducer, true, logContext);
 
     private final ProducerRecord<byte[], byte[]> record =
         new ProducerRecord<>(topic, 0, 0L, new byte[0], new byte[0], new RecordHeaders());
@@ -103,7 +104,7 @@ public class StreamsProducerTest {
         replay(producer);
 
         final StreamsProducer streamsProducer =
-            new StreamsProducer(producer, false, null, logContext);
+            new StreamsProducer(producer, false, logContext);
 
         final List<PartitionInfo> partitionInfo = streamsProducer.partitionsFor(topic);
 
@@ -120,7 +121,7 @@ public class StreamsProducerTest {
         replay(producer);
 
         final StreamsProducer streamsProducer =
-            new StreamsProducer(producer, false, null, logContext);
+            new StreamsProducer(producer, false, logContext);
 
         streamsProducer.flush();
 
@@ -134,7 +135,7 @@ public class StreamsProducerTest {
         {
             final NullPointerException thrown = assertThrows(
                 NullPointerException.class,
-                () -> new StreamsProducer(null, false, "appId", logContext)
+                () -> new StreamsProducer(null, false, logContext)
             );
 
             assertThat(thrown.getMessage(), is("producer cannot be null"));
@@ -143,7 +144,7 @@ public class StreamsProducerTest {
         {
             final NullPointerException thrown = assertThrows(
                 NullPointerException.class,
-                () -> new StreamsProducer(null, true, "appId", logContext)
+                () -> new StreamsProducer(null, true, logContext)
             );
 
             assertThat(thrown.getMessage(), is("producer cannot be null"));
@@ -154,7 +155,7 @@ public class StreamsProducerTest {
     public void shouldFailIfLogContextIsNull() {
         final NullPointerException thrown = assertThrows(
             NullPointerException.class,
-            () -> new StreamsProducer(nonEosMockProducer, false, "appId", null)
+            () -> new StreamsProducer(nonEosMockProducer, false, null)
         );
 
         assertThat(thrown.getMessage(), is("logContext cannot be null"));
@@ -224,7 +225,7 @@ public class StreamsProducerTest {
     public void shouldFailOnCommitIfEosDisabled() {
         final IllegalStateException thrown = assertThrows(
             IllegalStateException.class,
-            () -> nonEosStreamsProducer.commitTransaction(null)
+            () -> nonEosStreamsProducer.commitTransaction(null, "appId")
         );
 
         assertThat(thrown.getMessage(), is("EOS is disabled [test]"));
@@ -285,17 +286,17 @@ public class StreamsProducerTest {
         replay(producer);
 
         final StreamsProducer streamsProducer =
-            new StreamsProducer(producer, true, "appId", logContext);
+            new StreamsProducer(producer, true, logContext);
         streamsProducer.initTransaction();
 
-        streamsProducer.commitTransaction(offsetsAndMetadata);
+        streamsProducer.commitTransaction(offsetsAndMetadata, "appId");
 
         verify(producer);
     }
 
     @Test
     public void shouldSendOffsetToTxOnEosCommit() {
-        eosStreamsProducer.commitTransaction(offsetsAndMetadata);
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId");
         assertThat(eosMockProducer.sentOffsets(), is(true));
     }
 
@@ -304,7 +305,7 @@ public class StreamsProducerTest {
         eosStreamsProducer.send(record, null);
         assertThat(eosMockProducer.transactionInFlight(), is(true));
 
-        eosStreamsProducer.commitTransaction(offsetsAndMetadata);
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId");
 
         assertThat(eosMockProducer.transactionInFlight(), is(false));
         assertThat(eosMockProducer.uncommittedRecords().isEmpty(), is(true));
@@ -313,6 +314,58 @@ public class StreamsProducerTest {
         assertThat(eosMockProducer.history().get(0), is(record));
         assertThat(eosMockProducer.consumerGroupOffsetsHistory().size(), is(1));
         assertThat(eosMockProducer.consumerGroupOffsetsHistory().get(0).get("appId"), is(offsetsAndMetadata));
+    }
+
+    @Test
+    public void shouldCommitTxWithApplicationIdOnEosAlphaCommit() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.initTransactions();
+        expectLastCall();
+        producer.beginTransaction();
+        expectLastCall();
+        expect(producer.send(record, null)).andReturn(null);
+        producer.sendOffsetsToTransaction(null, "appId");
+        expectLastCall();
+        producer.commitTransaction();
+        expectLastCall();
+        replay(producer);
+
+        final StreamsProducer streamsProducer =
+            new StreamsProducer(producer, true, logContext);
+        streamsProducer.initTransaction();
+        // call `send()` to start a transaction
+        streamsProducer.send(record, null);
+
+        streamsProducer.commitTransaction(null, "appId");
+
+        verify(producer);
+    }
+
+    @Test
+    public void shouldCommitTxWithConsumerGroupMetadataOnEosBetaCommit() {
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+
+        producer.initTransactions();
+        expectLastCall();
+        producer.beginTransaction();
+        expectLastCall();
+        expect(producer.send(record, null)).andReturn(null);
+        producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata("appId"));
+        expectLastCall();
+        producer.commitTransaction();
+        expectLastCall();
+        replay(producer);
+
+        final StreamsProducer streamsProducer =
+            new StreamsProducer(producer, true, logContext);
+        streamsProducer.initTransaction();
+        // call `send()` to start a transaction
+        streamsProducer.send(record, null);
+
+        streamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"));
+
+        verify(producer);
     }
 
     @Test
@@ -341,7 +394,7 @@ public class StreamsProducerTest {
         replay(producer);
 
         final StreamsProducer streamsProducer =
-            new StreamsProducer(producer, true, "appId", logContext);
+            new StreamsProducer(producer, true, logContext);
         streamsProducer.initTransaction();
 
         streamsProducer.abortTransaction();
@@ -352,21 +405,11 @@ public class StreamsProducerTest {
     // error handling tests
 
     @Test
-    public void shouldFailIfApplicationIdIsNullOnEos() {
-        final IllegalArgumentException thrown = assertThrows(
-            IllegalArgumentException.class,
-            () -> new StreamsProducer(eosMockProducer, true, null, logContext)
-        );
-
-        assertThat(thrown.getMessage(), is("applicationId cannot be null if EOS is enabled"));
-    }
-
-    @Test
     public void shouldThrowTimeoutExceptionOnEosInitTxTimeout() {
         // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new TimeoutException("KABOOM!");
         final StreamsProducer streamsProducer =
-            new StreamsProducer(nonEosMockProducer, true, "appId", logContext);
+            new StreamsProducer(nonEosMockProducer, true, logContext);
 
         final TimeoutException thrown = assertThrows(
             TimeoutException.class,
@@ -381,7 +424,7 @@ public class StreamsProducerTest {
         // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new KafkaException("KABOOM!");
         final StreamsProducer streamsProducer =
-            new StreamsProducer(nonEosMockProducer, true, "appId", logContext);
+            new StreamsProducer(nonEosMockProducer, true, logContext);
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
@@ -397,7 +440,7 @@ public class StreamsProducerTest {
         // use `mockProducer` instead of `eosMockProducer` to avoid double Tx-Init
         nonEosMockProducer.initTransactionException = new RuntimeException("KABOOM!");
         final StreamsProducer streamsProducer =
-            new StreamsProducer(nonEosMockProducer, true, "appId", logContext);
+            new StreamsProducer(nonEosMockProducer, true, logContext);
 
         final RuntimeException thrown = assertThrows(
             RuntimeException.class,
@@ -499,7 +542,7 @@ public class StreamsProducerTest {
             TaskMigratedException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null)
+            () -> eosStreamsProducer.commitTransaction(null, "appId")
         );
 
         assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
@@ -518,7 +561,7 @@ public class StreamsProducerTest {
             StreamsException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null)
+            () -> eosStreamsProducer.commitTransaction(null, "appId")
         );
 
         assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
@@ -536,7 +579,7 @@ public class StreamsProducerTest {
             RuntimeException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null)
+            () -> eosStreamsProducer.commitTransaction(null, "appId")
         );
 
         assertThat(thrown.getMessage(), is("KABOOM!"));
@@ -549,7 +592,7 @@ public class StreamsProducerTest {
 
         final TaskMigratedException thrown = assertThrows(
             TaskMigratedException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -568,7 +611,7 @@ public class StreamsProducerTest {
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -582,7 +625,7 @@ public class StreamsProducerTest {
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -599,7 +642,7 @@ public class StreamsProducerTest {
 
         final RuntimeException thrown = assertThrows(
             RuntimeException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata)
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -618,7 +661,7 @@ public class StreamsProducerTest {
         replay(producer);
 
         final StreamsProducer streamsProducer =
-            new StreamsProducer(producer, true, "appId", logContext);
+            new StreamsProducer(producer, true, logContext);
         streamsProducer.initTransaction();
         // call `send()` to start a transaction
         streamsProducer.send(record, null);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -225,7 +225,7 @@ public class StreamsProducerTest {
     public void shouldFailOnCommitIfEosDisabled() {
         final IllegalStateException thrown = assertThrows(
             IllegalStateException.class,
-            () -> nonEosStreamsProducer.commitTransaction(null, "appId")
+            () -> nonEosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(thrown.getMessage(), is("EOS is disabled [test]"));
@@ -280,7 +280,7 @@ public class StreamsProducerTest {
 
         producer.initTransactions();
         producer.beginTransaction();
-        producer.sendOffsetsToTransaction(offsetsAndMetadata, "appId");
+        producer.sendOffsetsToTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
         producer.commitTransaction();
         expectLastCall();
         replay(producer);
@@ -289,14 +289,14 @@ public class StreamsProducerTest {
             new StreamsProducer(producer, true, logContext);
         streamsProducer.initTransaction();
 
-        streamsProducer.commitTransaction(offsetsAndMetadata, "appId");
+        streamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
 
         verify(producer);
     }
 
     @Test
     public void shouldSendOffsetToTxOnEosCommit() {
-        eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId");
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
         assertThat(eosMockProducer.sentOffsets(), is(true));
     }
 
@@ -305,7 +305,7 @@ public class StreamsProducerTest {
         eosStreamsProducer.send(record, null);
         assertThat(eosMockProducer.transactionInFlight(), is(true));
 
-        eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId");
+        eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
 
         assertThat(eosMockProducer.transactionInFlight(), is(false));
         assertThat(eosMockProducer.uncommittedRecords().isEmpty(), is(true));
@@ -325,7 +325,7 @@ public class StreamsProducerTest {
         producer.beginTransaction();
         expectLastCall();
         expect(producer.send(record, null)).andReturn(null);
-        producer.sendOffsetsToTransaction(null, "appId");
+        producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata("appId"));
         expectLastCall();
         producer.commitTransaction();
         expectLastCall();
@@ -337,7 +337,7 @@ public class StreamsProducerTest {
         // call `send()` to start a transaction
         streamsProducer.send(record, null);
 
-        streamsProducer.commitTransaction(null, "appId");
+        streamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"));
 
         verify(producer);
     }
@@ -542,7 +542,7 @@ public class StreamsProducerTest {
             TaskMigratedException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null, "appId")
+            () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
@@ -561,7 +561,7 @@ public class StreamsProducerTest {
             StreamsException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null, "appId")
+            () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
@@ -579,7 +579,7 @@ public class StreamsProducerTest {
             RuntimeException.class,
             // we pass in `null` to verify that `sendOffsetsToTransaction()` fails instead of `commitTransaction()`
             // `sendOffsetsToTransaction()` would throw an NPE on `null` offsets
-            () -> eosStreamsProducer.commitTransaction(null, "appId")
+            () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(thrown.getMessage(), is("KABOOM!"));
@@ -592,7 +592,7 @@ public class StreamsProducerTest {
 
         final TaskMigratedException thrown = assertThrows(
             TaskMigratedException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -611,7 +611,7 @@ public class StreamsProducerTest {
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -625,7 +625,7 @@ public class StreamsProducerTest {
 
         final StreamsException thrown = assertThrows(
             StreamsException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));
@@ -642,7 +642,7 @@ public class StreamsProducerTest {
 
         final RuntimeException thrown = assertThrows(
             RuntimeException.class,
-            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, "appId")
+            () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
         assertThat(eosMockProducer.sentOffsets(), is(true));

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -200,7 +200,7 @@ public class KeyValueStoreTestDriver<K, V> {
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             new TaskId(0, 0),
-            new StreamsProducer(producer, false, null, logContext),
+            new StreamsProducer(producer, false, logContext),
             new DefaultProductionExceptionHandler(),
             new MockStreamsMetrics(new Metrics())
         ) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -377,7 +377,6 @@ public class StreamThreadStateStoreProviderTest {
             new StreamsProducer(
                 clientSupplier.getProducer(new HashMap<>()),
                 eosEnabled,
-                streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG),
                 logContext
             ),
             streamsConfig.defaultProductionExceptionHandler(),

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -317,7 +317,6 @@ public class TopologyTestDriver implements Closeable {
         testDriverProducer = new TestDriverProducer(
             producer,
             eosEnabled,
-            streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG),
             logContext
         );
 
@@ -589,7 +588,7 @@ public class TopologyTestDriver implements Closeable {
 
     private void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         if (eosEnabled) {
-            testDriverProducer.commitTransaction(offsets);
+            testDriverProducer.commitTransaction(offsets, "dummy-app-id");
         } else {
             consumer.commitSync(offsets);
         }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -588,7 +589,7 @@ public class TopologyTestDriver implements Closeable {
 
     private void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         if (eosEnabled) {
-            testDriverProducer.commitTransaction(offsets, "dummy-app-id");
+            testDriverProducer.commitTransaction(offsets, new ConsumerGroupMetadata("dummy-app-id"));
         } else {
             consumer.commitSync(offsets);
         }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
@@ -28,12 +29,13 @@ public class TestDriverProducer extends StreamsProducer {
 
     public TestDriverProducer(final Producer<byte[], byte[]> producer,
                               final boolean eosEnabled,
-                              final String applicationId,
                               final LogContext logContext) {
-        super(producer, eosEnabled, applicationId, logContext);
+        super(producer, eosEnabled, logContext);
     }
 
-    public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets) throws ProducerFencedException {
-        super.commitTransaction(offsets);
+    @Override
+    public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                  final String applicationId) throws ProducerFencedException {
+        super.commitTransaction(offsets, applicationId);
     }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
@@ -34,7 +35,7 @@ public class TestDriverProducer extends StreamsProducer {
 
     @Override
     public void commitTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
-                                  final String applicationId) throws ProducerFencedException {
-        super.commitTransaction(offsets, applicationId);
+                                  final ConsumerGroupMetadata consumerGroupMetadata) throws ProducerFencedException {
+        super.commitTransaction(offsets, consumerGroupMetadata);
     }
 }


### PR DESCRIPTION
Enabled producer per thread via KIP-447.

- add configs to enable EOS-beta and for a safe upgrade from older versions
- for eos-beta, create a single shared producer and `StreamsProducer` over all tasks
- when committing, commit all tasks

Call for review @abbccdda @guozhangwang 