### PR TITLE
MINOR: Use Exit.exit instead of System.exit in MM2

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -278,7 +278,7 @@ public class MirrorMaker {
             ns = parser.parseArgs(args);
         } catch (ArgumentParserException e) {
             parser.handleError(e);
-            System.exit(-1);
+            Exit.exit(-1);
             return;
         }
         File configFile = (File) ns.get("config");


### PR DESCRIPTION
Exit.exit needs to be used in code instead of System.exit. 

Particularly in integration tests using System.exit is disrupting because it exits the jvm process and does not only fail test correctly. Integration tests override procedures in Exit to protect against such cases. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
