### PR TITLE
MINOR: allow retries for unitTest and integrationTest runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,10 @@ subprojects {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
 
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
+    }
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
@@ -343,6 +347,11 @@ subprojects {
       useJUnit {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }
+    }
+
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
     }
   }
 


### PR DESCRIPTION
We will currently retry if you run gradle test, but not unitTest or integrationTest, which are used directly in Jenkins. This means that we have not been achieving the expected retry behavior.