### PR TITLE
KAFKA-9741: Update ConsumerGroupMetadata before calling onPartitionsRevoked()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -344,6 +344,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (assignor == null)
             throw new IllegalStateException("Coordinator selected invalid assignment protocol: " + assignmentStrategy);
 
+        // Give the assignor a chance to update internal state based on the received assignment
+        groupMetadata = new ConsumerGroupMetadata(rebalanceConfig.groupId, generation, memberId, rebalanceConfig.groupInstanceId);
+
         Set<TopicPartition> ownedPartitions = new HashSet<>(subscriptions.assignedPartitions());
 
         Assignment assignment = ConsumerProtocol.deserializeAssignment(assignmentBuffer);
@@ -394,9 +397,6 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         // The leader may have assigned partitions which match our subscription pattern, but which
         // were not explicitly requested, so we update the joined subscription here.
         maybeUpdateJoinedSubscription(assignedPartitions);
-
-        // Give the assignor a chance to update internal state based on the received assignment
-        groupMetadata = new ConsumerGroupMetadata(rebalanceConfig.groupId, generation, memberId, rebalanceConfig.groupInstanceId);
 
         // Catch any exception here to make sure we could complete the user callback.
         try {


### PR DESCRIPTION
If partitions are revoked, an application may want to commit the current offsets.

Using transactions, committing offsets would be done via the producer passing in the current `ConsumerGroupMetadata`. If the metadata is not updates before the callback, the call to `commitTransaction(...)` fails as and old generationId would be used.

Call for review @ableegoldman @abbccdda @guozhangwang @hachikuji 

\cc @mumrah (not sure if this is a blocker for 2.5 or not)