### PR TITLE
KAFKA-9743: Catch commit offset exception to eventually close dirty tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -237,10 +237,16 @@ public class TaskManager {
                 }
             }
 
-            commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
+            try {
+                commitOffsetsOrTransaction(consumedOffsetsAndMetadataPerTask);
 
-            for (final Task task : additionalTasksForCommitting) {
-                task.postCommit();
+                for (final Task task : additionalTasksForCommitting) {
+                    task.postCommit();
+                }
+            } catch (final RuntimeException e) {
+                log.error("Failed to commit tasks, closing all tasks as dirty", e);
+                dirtyTasks.addAll(checkpointPerTask.keySet());
+                checkpointPerTask.clear();
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -244,9 +244,12 @@ public class TaskManager {
                     task.postCommit();
                 }
             } catch (final RuntimeException e) {
-                log.error("Failed to commit tasks, closing all tasks as dirty", e);
+                log.error("Failed to commit tasks that are " +
+                    "prepared to close clean, will close them as dirty instead", e);
                 dirtyTasks.addAll(checkpointPerTask.keySet());
                 checkpointPerTask.clear();
+                // Just add first taskId to re-throw by the end.
+                taskCloseExceptions.put(consumedOffsetsAndMetadataPerTask.keySet().iterator().next(), e);
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1212,7 +1212,7 @@ public class TaskManagerTest {
             topologyBuilder,
             adminClient,
             stateDirectory,
-            true
+            StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA
         );
         taskManager.setMainConsumer(consumer);
 
@@ -2250,11 +2250,6 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldNotCloseTasksIfCommittingFailsDuringAssignment() {
-        shouldNotCloseTaskIfCommitFailsDuringAction(() -> taskManager.handleAssignment(Collections.emptyMap(), Collections.emptyMap()));
-    }
-
-    @Test
     public void shouldNotCloseTasksIfCommittingFailsDuringRevocation() {
         shouldNotCloseTaskIfCommitFailsDuringAction(() -> taskManager.handleRevocation(singletonList(t1p0)));
     }
@@ -2281,7 +2276,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(taskId00Assignment, Collections.emptyMap());
 
-        final RuntimeException thrown =  assertThrows(RuntimeException.class, action);
+        final RuntimeException thrown = assertThrows(RuntimeException.class, action);
 
         assertThat(thrown.getMessage(), is("KABOOM!"));
         assertThat(task00.state(), is(Task.State.CREATED));


### PR DESCRIPTION
This PR tries to close all the dirty tasks during `HandleAssignment` in case the commit call failed. The previous outcome was that all the lost tasks are not properly closed which leads to the RocksDB metric stats not cleared, and eventually blows the application away, since we have an illegal state check for re-adding an existing metrics:
```
 public void addMetricsRecorder(final RocksDBMetricsRecorder metricsRecorder) {
        final String metricsRecorderName = metricsRecorderName(metricsRecorder);
        if (metricsRecordersToTrigger.containsKey(metricsRecorderName)) {
            throw new IllegalStateException("RocksDB metrics recorder for store \"" + metricsRecorder.storeName() +
                "\" of task " + metricsRecorder.taskId().toString() + " has already been added. "
                + "This is a bug in Kafka Streams.");
        }
        metricsRecordersToTrigger.put(metricsRecorderName, metricsRecorder);
    }
```
Unit test will be added shortly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
