### PR TITLE
KAFKA-9742: Fix StandbyTaskEOSIntegrationTest End offset

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -120,7 +120,7 @@ public class StandbyTaskEOSIntegrationTest {
             new StreamsConfig(props), new MockTime(), true);
 
         new OffsetCheckpoint(new File(stateDirectory.directoryForTask(taskId), ".checkpoint"))
-            .write(Collections.singletonMap(new TopicPartition("unknown-topic", 0), 5L));
+            .write(Collections.singletonMap(new TopicPartition("unknown-topic", 0), 0L));
 
         assertTrue(new File(stateDirectory.directoryForTask(taskId),
             "rocksdb/KSTREAM-AGGREGATE-STATE-STORE-0000000001").mkdirs());


### PR DESCRIPTION
The `StandbyTaskEOSIntegrationTest` was broken due to the incorrect offset setting in the checkpoint file enforced by https://github.com/apache/kafka/commit/6cf27c9c771900baf43cc47f9b010dbf7a86fa22. The fix is to set the offset to a legitimate value even if the topic doesn't exist.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
