### PR TITLE
KAFKA-9742: Fix broken StandbyTaskEOSIntegrationTest

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -825,7 +825,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             }
 
             if (fetchEndOffsetsSuccessful) {
-                state.computeTaskLags(allTaskEndOffsetSums);
+                state.computeTaskLags(uuid, allTaskEndOffsetSums);
             }
             clientStates.put(uuid, state);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -98,7 +98,7 @@ public class StandbyTaskEOSIntegrationTest {
             waitForCondition(() -> streamInstanceOne.state().equals(KafkaStreams.State.RUNNING),
                              "Stream instance one should be up and running by now");
             waitForCondition(() -> streamInstanceTwo.state().equals(KafkaStreams.State.RUNNING),
-                             "Stream instance one should be up and running by now");
+                             "Stream instance two should be up and running by now");
 
             streamInstanceOne.close(Duration.ZERO);
             streamInstanceTwo.close(Duration.ZERO);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -82,29 +82,27 @@ public class StandbyTaskEOSIntegrationTest {
 
         final CountDownLatch instanceLatch = new CountDownLatch(1);
 
-        final String stateDirPathOne = stateDirPath + "/" + appId + "-1/";
-        final KafkaStreams streamInstanceOne =
-            buildStreamWithDirtyStateDir(appId, stateDirPathOne, instanceLatch);
+        try (
+            final KafkaStreams streamInstanceOne = buildStreamWithDirtyStateDir(appId, stateDirPath + "/" + appId + "-1/", instanceLatch);
+            final KafkaStreams streamInstanceTwo = buildStreamWithDirtyStateDir(appId, stateDirPath + "/" + appId + "-2/", instanceLatch);
+        ) {
 
-        final String stateDirPathTwo = stateDirPath + "/" + appId + "-2/";
-        final KafkaStreams streamInstanceTwo =
-            buildStreamWithDirtyStateDir(appId, stateDirPathTwo, instanceLatch);
 
-        streamInstanceOne.start();
+            streamInstanceOne.start();
 
-        streamInstanceTwo.start();
+            streamInstanceTwo.start();
 
-        // Wait for the record to be processed
-        assertTrue(instanceLatch.await(15, TimeUnit.SECONDS));
+            // Wait for the record to be processed
+            assertTrue(instanceLatch.await(15, TimeUnit.SECONDS));
 
-        waitForCondition(() -> streamInstanceOne.state().equals(KafkaStreams.State.RUNNING),
-            "Stream instance one should be up and running by now");
-        waitForCondition(() -> streamInstanceTwo.state().equals(KafkaStreams.State.RUNNING),
-            "Stream instance one should be up and running by now");
+            waitForCondition(() -> streamInstanceOne.state().equals(KafkaStreams.State.RUNNING),
+                             "Stream instance one should be up and running by now");
+            waitForCondition(() -> streamInstanceTwo.state().equals(KafkaStreams.State.RUNNING),
+                             "Stream instance one should be up and running by now");
 
-        streamInstanceOne.close(Duration.ofSeconds(30));
-        streamInstanceTwo.close(Duration.ofSeconds(30));
-
+            streamInstanceOne.close(Duration.ZERO);
+            streamInstanceTwo.close(Duration.ZERO);
+        }
     }
 
     private KafkaStreams buildStreamWithDirtyStateDir(final String appId,
@@ -123,14 +121,14 @@ public class StandbyTaskEOSIntegrationTest {
             .write(Collections.singletonMap(new TopicPartition("unknown-topic", 0), 5L));
 
         assertTrue(new File(stateDirectory.directoryForTask(taskId),
-            "rocksdb/KSTREAM-AGGREGATE-STATE-STORE-0000000001").mkdirs());
+                            "rocksdb/KSTREAM-AGGREGATE-STATE-STORE-0000000001").mkdirs());
 
         builder.stream(inputTopic,
-            Consumed.with(Serdes.Integer(), Serdes.Integer()))
-            .groupByKey()
-            .count()
-            .toStream()
-            .peek((key, value) -> recordProcessLatch.countDown());
+                       Consumed.with(Serdes.Integer(), Serdes.Integer()))
+               .groupByKey()
+               .count()
+               .toStream()
+               .peek((key, value) -> recordProcessLatch.countDown());
 
         return new KafkaStreams(builder.build(), props);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -199,7 +199,7 @@ public class ClientStateTest {
             mkEntry(taskId02, 100L)
         );
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
 
         assertThat(client.lagFor(taskId01), equalTo(500L));
         assertThat(client.lagFor(taskId02), equalTo(0L));
@@ -210,7 +210,7 @@ public class ClientStateTest {
         final Map<TaskId, Long> taskOffsetSums = Collections.emptyMap();
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(taskId01), equalTo(500L));
     }
 
@@ -219,7 +219,7 @@ public class ClientStateTest {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, Task.LATEST_OFFSET);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(taskId01), equalTo(Task.LATEST_OFFSET));
     }
 
@@ -228,7 +228,7 @@ public class ClientStateTest {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, UNKNOWN_OFFSET_SUM);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(taskId01), equalTo(UNKNOWN_OFFSET_SUM));
     }
 
@@ -237,7 +237,7 @@ public class ClientStateTest {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 5L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 1L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(taskId01), equalTo(1L));
     }
 
@@ -245,8 +245,8 @@ public class ClientStateTest {
     public void shouldThrowIllegalStateExceptionIfTaskLagsMapIsNotEmpty() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 5L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 1L);
-        client.computeTaskLags(taskOffsetSums);
-        assertThrows(IllegalStateException.class, () -> client.computeTaskLags(allTaskEndOffsetSums));
+        client.computeTaskLags(null, taskOffsetSums);
+        assertThrows(IllegalStateException.class, () -> client.computeTaskLags(null, allTaskEndOffsetSums));
     }
 
     @Test
@@ -254,7 +254,7 @@ public class ClientStateTest {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 0L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 500L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        client.computeTaskLags(allTaskEndOffsetSums);
+        client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThrows(IllegalStateException.class, () -> client.lagFor(taskId02));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -233,11 +233,12 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldThrowIllegalStateExceptionIfOffsetSumIsGreaterThanEndOffsetSum() {
+    public void shouldReturnEndOffsetSumIfOffsetSumIsGreaterThanEndOffsetSum() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(taskId01, 5L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(taskId01, 1L);
         client.addPreviousTasksAndOffsetSums(taskOffsetSums);
-        assertThrows(IllegalStateException.class, () -> client.computeTaskLags(allTaskEndOffsetSums));
+        client.computeTaskLags(allTaskEndOffsetSums);
+        assertThat(client.lagFor(taskId01), equalTo(1L));
     }
 
     @Test


### PR DESCRIPTION
Relax the requirement that tasks' reported offsetSum is less than the endOffsetSum for those
tasks. This was surfaced by a test for corrupted tasks, but it can happen with real corrupted
tasks. Rather than throw an exception on the leader, we now de-prioritize the corrupted task.
Ideally, that instance will not get assigned the task and the stateDirCleaner will make 
the problem "go away". If it does get assigned the task, then it will detect the corruption and
delete the task directory before recovering the entire changelog. Thus, the estimate we provide
accurately reflects the amount of lag such a corrupted task would have to recover (the whole log).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
