### PR TITLE
KAFKA-9688: kafka-topic.sh should show KIP-455 adding and removing replicas

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -147,8 +147,8 @@ object TopicCommand extends Logging {
       print("\tReplicas: " + info.replicas.asScala.map(_.id).mkString(","))
       print("\tIsr: " + info.isr.asScala.map(_.id).mkString(","))
       if (reassignment.nonEmpty) {
-        print("\tAdding Replicas: " + reassignment.get.addingReplicas())
-        print("\tRemoving Replicas: " + reassignment.get.removingReplicas())
+        print("\tAdding Replicas: " + reassignment.get.addingReplicas().asScala.mkString(","))
+        print("\tRemoving Replicas: " + reassignment.get.removingReplicas().asScala.mkString(","))
       }
       print(if (markedForDeletion) "\tMarkedForDeletion: true" else "")
       println()

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -146,6 +146,10 @@ object TopicCommand extends Logging {
       print("\tLeader: " + (if (hasLeader) info.leader.id else "none"))
       print("\tReplicas: " + info.replicas.asScala.map(_.id).mkString(","))
       print("\tIsr: " + info.isr.asScala.map(_.id).mkString(","))
+      if (reassignment.nonEmpty) {
+        print("\tAdding Replicas: " + reassignment.get.addingReplicas())
+        print("\tRemoving Replicas: " + reassignment.get.removingReplicas())
+      }
       print(if (markedForDeletion) "\tMarkedForDeletion: true" else "")
       println()
     }


### PR DESCRIPTION
*More detailed description of your change,

Print AR and RR info in describe topic command, if the current reassignment exists.


*Summary of testing strategy (including rationale)
1. Commented out step B2 to B8 in KafkaController::onPartitionReassignment so the adding replica and removing replica won’t be set to the empty set in memory.  
2. Recompile kafka src
3. Create a reassign json file with content below:
{"partitions":
             [{"topic": "my-replicated-topic",
               "partition": 0,
               "replicas": [1,2] }],
  "version":1
}
4. Ran the following scripts:
$ bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 3 --partitions 1 --topic my-replicated-topic
$ bin/kafka-topics.sh --describe --bootstrap-server localhost:9092 --topic my-replicated-topic
Topic: my-replicated-topic	PartitionCount: 1	ReplicationFactor: 3	Configs: segment.bytes=1073741824
	Topic: my-replicated-topic	Partition: 0	Leader: 2	Replicas: 2,1,0	Isr: 2,1,0
$ bin/kafka-reassign-partitions.sh --reassignment-json-file bin/reassign.json --execute --zookeeper localhost:2181
$ bin/kafka-topics.sh --describe --bootstrap-server localhost:9092 --topic my-replicated-topic
Topic: my-replicated-topic	Partition: 0	Leader: 2	Replicas: 2,1,0	Isr: 2,1,0	Adding Replicas: 	Removing Replicas: 0
5. Similarly, also tested no reassignment changes won’t throw a null ptr exception. (edited) 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
