### PR TITLE
Change "matchingAclExists" method visibility modifier to protected in AclAuthorizer

### DIFF
--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -367,7 +367,7 @@ class AclAuthorizer extends Authorizer with Logging {
     }
   }
 
-  private def matchingAclExists(operation: AclOperation,
+  protected def matchingAclExists(operation: AclOperation,
                                 resource: ResourcePattern,
                                 principal: KafkaPrincipal,
                                 host: String,


### PR DESCRIPTION
Changing method visibility modifier allows to make acl matching logic overridable by children components. This is useful in situations where the ACL matching logic is more complex (with custom authorizers) and/or when KafkaPrincipal is customized.
Unfortunately KafkaPrincipal used inside "matchingAclExists" method is not built from the PrincipalBuilder but from static method SecurityUtils.parseKafkaPrincipal , this prevents the possibility to ovveride "equals" method in KafkaPrincipal and so to override the equality logic between two custom kafka principals.

