### PR TITLE
Kafka-9621: AdminClient listOffsets operation does not respect retries and backoff

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2840,6 +2840,221 @@ public class KafkaAdminClientTest {
         }
     }
 
+    /**
+     * Test if listOffsets can get the correct offsets for each partition after maxAllowedNumTries times of failed tries
+     * @throws Exception
+     */
+    @Test
+    public void testListOffsetsMaxAllowedNumRetriesSuccess() throws Exception {
+
+        Node node0 = new Node(0, "localhost", 8120);
+        List<PartitionInfo> pInfos = new ArrayList<>();
+        pInfos.add(new PartitionInfo("foo", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("bar", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("baz", 0, node0, new Node[]{node0}, new Node[]{node0}));
+
+        MockTime time = new MockTime();
+        String maxAllowedNumTries = "3";
+        String retryBackoff = "0";
+
+        final Cluster cluster =
+                new Cluster(
+                        "mockClusterId",
+                        Arrays.asList(node0),
+                        pInfos,
+                        Collections.<String>emptySet(),
+                        Collections.<String>emptySet(),
+                        node0);
+
+        final TopicPartition tp1 = new TopicPartition("foo", 0);
+        final TopicPartition tp2 = new TopicPartition("bar", 0);
+        final TopicPartition tp3 = new TopicPartition("baz", 0);
+
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, cluster,
+                AdminClientConfig.RETRIES_CONFIG, maxAllowedNumTries,
+                AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoff)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            for (int i = 0; i < Integer.parseInt(maxAllowedNumTries); i++) {
+                env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+                Map<TopicPartition, PartitionData> responseData = new HashMap<>();
+                responseData.put(tp1, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, -1L, 123L, Optional.of(321)));
+                responseData.put(tp2, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, -1L, 234L, Optional.of(432)));
+                responseData.put(tp3, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, 123456789L, 345L, Optional.of(543)));
+                env.kafkaClient().prepareResponse(new ListOffsetResponse(responseData));
+            }
+
+            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+            Map<TopicPartition, PartitionData> responseData = new HashMap<>();
+            responseData.put(tp1, new PartitionData(Errors.NONE, -1L, 123L, Optional.of(321)));
+            responseData.put(tp2, new PartitionData(Errors.NONE, -1L, 234L, Optional.of(432)));
+            responseData.put(tp3, new PartitionData(Errors.NONE, 123456789L, 345L, Optional.of(543)));
+            env.kafkaClient().prepareResponse(new ListOffsetResponse(responseData));
+
+            Map<TopicPartition, OffsetSpec> partitions = new HashMap<>();
+            partitions.put(tp1, OffsetSpec.latest());
+            partitions.put(tp2, OffsetSpec.earliest());
+            partitions.put(tp3, OffsetSpec.forTimestamp(System.currentTimeMillis()));
+            ListOffsetsResult result = env.adminClient().listOffsets(partitions);
+
+            Map<TopicPartition, ListOffsetsResultInfo> offsets = result.all().get();
+            assertFalse(offsets.isEmpty());
+            assertEquals(123L, offsets.get(tp1).offset());
+            assertEquals(321, offsets.get(tp1).leaderEpoch().get().intValue());
+            assertEquals(-1L, offsets.get(tp1).timestamp());
+            assertEquals(234L, offsets.get(tp2).offset());
+            assertEquals(432, offsets.get(tp2).leaderEpoch().get().intValue());
+            assertEquals(-1L, offsets.get(tp2).timestamp());
+            assertEquals(345L, offsets.get(tp3).offset());
+            assertEquals(543, offsets.get(tp3).leaderEpoch().get().intValue());
+            assertEquals(123456789L, offsets.get(tp3).timestamp());
+            assertEquals(offsets.get(tp1), result.partitionResult(tp1).get());
+            assertEquals(offsets.get(tp2), result.partitionResult(tp2).get());
+            assertEquals(offsets.get(tp3), result.partitionResult(tp3).get());
+            try {
+                result.partitionResult(new TopicPartition("unknown", 0)).get();
+                fail("should have thrown IllegalArgumentException");
+            } catch (IllegalArgumentException expected) { }
+        }
+    }
+
+    /**
+     * Test if listOffsets will timeout after maxAllowedNumTries + 1 times of failed tries
+     * @throws Exception
+     */
+    @Test
+    public void testListOffsetsMaxAllowedNumRetriesTimeOut() throws Exception {
+
+        Node node0 = new Node(0, "localhost", 8120);
+        List<PartitionInfo> pInfos = new ArrayList<>();
+        pInfos.add(new PartitionInfo("foo", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("bar", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("baz", 0, node0, new Node[]{node0}, new Node[]{node0}));
+
+        MockTime time = new MockTime();
+        String maxAllowedNumTries = "3";
+        String retryBackoff = "0";
+
+        final Cluster cluster =
+                new Cluster(
+                        "mockClusterId",
+                        Arrays.asList(node0),
+                        pInfos,
+                        Collections.<String>emptySet(),
+                        Collections.<String>emptySet(),
+                        node0);
+
+        final TopicPartition tp1 = new TopicPartition("foo", 0);
+        final TopicPartition tp2 = new TopicPartition("bar", 0);
+        final TopicPartition tp3 = new TopicPartition("baz", 0);
+
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, cluster,
+                AdminClientConfig.RETRIES_CONFIG, maxAllowedNumTries,
+                AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoff)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            for (int i = 0; i < Integer.parseInt(maxAllowedNumTries) + 1; i++) {
+                env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+                Map<TopicPartition, PartitionData> responseData = new HashMap<>();
+                responseData.put(tp1, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, -1L, 123L, Optional.of(321)));
+                responseData.put(tp2, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, -1L, 234L, Optional.of(432)));
+                responseData.put(tp3, new PartitionData(Errors.NOT_LEADER_FOR_PARTITION, 123456789L, 345L, Optional.of(543)));
+                env.kafkaClient().prepareResponse(new ListOffsetResponse(responseData));
+            }
+
+            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+
+            Map<TopicPartition, OffsetSpec> partitions = new HashMap<>();
+            partitions.put(tp1, OffsetSpec.latest());
+            partitions.put(tp2, OffsetSpec.earliest());
+            partitions.put(tp3, OffsetSpec.forTimestamp(time.milliseconds()));
+            ListOffsetsResult result = env.adminClient().listOffsets(partitions);
+            TestUtils.assertFutureError(result.all(), TimeoutException.class);
+
+        }
+    }
+
+
+    /**
+     * Test if listOffsets will respect the retry backoff
+     * @throws Exception
+     */
+    @Test
+    public void testListOffsetsRetryBackoff() throws Exception {
+
+        Node node0 = new Node(0, "localhost", 8120);
+        List<PartitionInfo> pInfos = new ArrayList<>();
+        pInfos.add(new PartitionInfo("foo", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("bar", 0, node0, new Node[]{node0}, new Node[]{node0}));
+        pInfos.add(new PartitionInfo("baz", 0, node0, new Node[]{node0}, new Node[]{node0}));
+
+        MockTime time = new MockTime();
+        int retryBackoff = 100;
+
+        AtomicLong firstAttemptTime = new AtomicLong(0);
+        AtomicLong secondAttemptTime = new AtomicLong(0);
+
+        final Cluster cluster =
+                new Cluster(
+                        "mockClusterId",
+                        Arrays.asList(node0),
+                        pInfos,
+                        Collections.<String>emptySet(),
+                        Collections.<String>emptySet(),
+                        node0);
+
+        final TopicPartition tp1 = new TopicPartition("foo", 0);
+        final TopicPartition tp2 = new TopicPartition("bar", 0);
+        final TopicPartition tp3 = new TopicPartition("baz", 0);
+
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, cluster,
+                AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, "" + retryBackoff)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+            Map<TopicPartition, PartitionData> responseData = new HashMap<>();
+            responseData.put(tp1, new PartitionData(Errors.LEADER_NOT_AVAILABLE, -1L, 123L, Optional.of(321)));
+            responseData.put(tp2, new PartitionData(Errors.LEADER_NOT_AVAILABLE, -1L, 234L, Optional.of(432)));
+            responseData.put(tp3, new PartitionData(Errors.LEADER_NOT_AVAILABLE, 123456789L, 345L, Optional.of(543)));
+            env.kafkaClient().prepareResponse(body -> {
+                firstAttemptTime.set(time.milliseconds());
+                return true;
+            }, new ListOffsetResponse(responseData));
+
+            env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
+
+            responseData = new HashMap<>();
+            responseData.put(tp1, new PartitionData(Errors.NONE, -1L, 123L, Optional.of(321)));
+            responseData.put(tp2, new PartitionData(Errors.NONE, -1L, 234L, Optional.of(432)));
+            responseData.put(tp3, new PartitionData(Errors.NONE, 123456789L, 345L, Optional.of(543)));
+            env.kafkaClient().prepareResponse(body -> {
+                secondAttemptTime.set(time.milliseconds());
+                return true;
+            }, new ListOffsetResponse(responseData));
+
+            Map<TopicPartition, OffsetSpec> partitions = new HashMap<>();
+            partitions.put(tp1, OffsetSpec.latest());
+            partitions.put(tp2, OffsetSpec.earliest());
+            partitions.put(tp3, OffsetSpec.forTimestamp(time.milliseconds()));
+            ListOffsetsResult result = env.adminClient().listOffsets(partitions);
+            final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> future = result.all();
+            TestUtils.waitForCondition(() -> env.kafkaClient().numAwaitingResponses() == 1, "Failed awaiting ListOffsets first request failure");
+            TestUtils.waitForCondition(() -> ((KafkaAdminClient) env.adminClient()).numPendingCalls() == 1, "Failed to add retry ListOffsets call on first failure");
+            time.sleep(retryBackoff);
+
+            future.get();
+
+            long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
+            assertEquals("ListOffsets retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+        }
+    }
+
+
     @Test
     public void testListOffsetsRetriableErrors() throws Exception {
 


### PR DESCRIPTION
MERGE AFTER KAFKA-9047

*More detailed description,

Similar to https://issues.apache.org/jira/browse/KAFKA-9047, currently the listOffsets operation doesn't respect the configured retries and backoff for a given call.

For example, the code path could go like so:

Make a metadata request and schedule subsequent list offsets calls

Metadata error comes back with InvalidMetadataException

Go back to 1

The problem here is that the state is not preserved across calls. We lose the information regarding how many tries the call has been tried and how far out we should schedule the call to try again. This could lead to a tight retry loop and put pressure on the brokers.

*Changes
Added an overloaded getListOffsetsCalls() to take in the failed call metadata and build call instances' retry number and backoff variables upon the existing getListOffsetsCalls(). The retry calls can then recursively have their retry numbers + 1 and backoffs + x.

*Summary of testing strategy (including rationale)

Unit tests:

Test if listOffsets can get the correct offsets for each partition after maxAllowedNumTries times of failed tries
Test if listOffsets will timeout after maxAllowedNumTries + 1 times of failed tries
Test if listOffsets will respect the retry backoff


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
