### PR TITLE
KAFKA-9758: Doc changes for KIP-523 and KIP-527

### DIFF
--- a/docs/streams/developer-guide/datatypes.html
+++ b/docs/streams/developer-guide/datatypes.html
@@ -145,7 +145,7 @@
             <td><code class="docutils literal"><span class="pre">Serdes.UUID()</span></code></td>
           </tr>
           </tr>
-          <tr class="row-even"><td>Void</td>
+          <tr class="row-odd"><td>Void</td>
               <td><code class="docutils literal"><span class="pre">Serdes.Void()</span></code></td>
           </tr>
           </tbody>

--- a/docs/streams/developer-guide/datatypes.html
+++ b/docs/streams/developer-guide/datatypes.html
@@ -144,6 +144,10 @@
           <tr class="row-even"><td>UUID</td>
             <td><code class="docutils literal"><span class="pre">Serdes.UUID()</span></code></td>
           </tr>
+          </tr>
+          <tr class="row-even"><td>Void</td>
+              <td><code class="docutils literal"><span class="pre">Serdes.Void()</span></code></td>
+          </tr>
           </tbody>
         </table>
         <div class="admonition tip">

--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -835,20 +835,6 @@
                     </tr>
                     <tr class="row-odd"><td><p class="first"><strong>Table to Stream</strong></p>
                         <ul class="last simple">
-                            <li>KStream &rarr; KTable</li>
-                        </ul>
-                    </td>
-                        <td><p class="first">Convert an event stream into a table, or say a changelog stream.
-                            (<a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/kstream/KStream.html#toTable--">details</a>)</p>
-                            <div class="last highlight-java"><div class="highlight"><pre><span></span><span class="n">KStream</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">stream</span> <span class="o">=</span> <span class="o">...;</span>
-
-<span class="n">KTable</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">table</span> <span class="o">=</span> <span class="n">stream</span><span class="o">.</span><span class="na">toTable</span><span class="o">();</span>
-</pre></div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr class="row-even"><td><p class="first"><strong>Stream to Table</strong></p>
-                        <ul class="last simple">
                             <li>KTable &rarr; KStream</li>
                         </ul>
                     </td>
@@ -859,6 +845,20 @@
 <span class="c1">// Also, a variant of `toStream` exists that allows you</span>
 <span class="c1">// to select a new key for the resulting stream.</span>
 <span class="n">KStream</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">stream</span> <span class="o">=</span> <span class="n">table</span><span class="o">.</span><span class="na">toStream</span><span class="o">();</span>
+</pre></div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr class="row-even"><td><p class="first"><strong>Stream to Table</strong></p>
+                        <ul class="last simple">
+                            <li>KStream &rarr; KTable</li>
+                        </ul>
+                    </td>
+                        <td><p class="first">Convert an event stream into a table, or say a changelog stream.
+                            (<a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/kstream/KStream.html#toTable--">details</a>)</p>
+                            <div class="last highlight-java"><div class="highlight"><pre><span></span><span class="n">KStream</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">stream</span> <span class="o">=</span> <span class="o">...;</span>
+
+<span class="n">KTable</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">table</span> <span class="o">=</span> <span class="n">stream</span><span class="o">.</span><span class="na">toTable</span><span class="o">();</span>
 </pre></div>
                             </div>
                         </td>

--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -835,6 +835,20 @@
                     </tr>
                     <tr class="row-odd"><td><p class="first"><strong>Table to Stream</strong></p>
                         <ul class="last simple">
+                            <li>KStream &rarr; KTable</li>
+                        </ul>
+                    </td>
+                        <td><p class="first">Convert an event stream into a table, or say a changelog stream.
+                            (<a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/kstream/KStream.html#toTable--">details</a>)</p>
+                            <div class="last highlight-java"><div class="highlight"><pre><span></span><span class="n">KStream</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">stream</span> <span class="o">=</span> <span class="o">...;</span>
+
+<span class="n">KTable</span><span class="o">&lt;</span><span class="kt">byte</span><span class="o">[],</span> <span class="n">String</span><span class="o">&gt;</span> <span class="n">table</span> <span class="o">=</span> <span class="n">stream</span><span class="o">.</span><span class="na">toTable</span><span class="o">();</span>
+</pre></div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr class="row-even"><td><p class="first"><strong>Stream to Table</strong></p>
+                        <ul class="last simple">
                             <li>KTable &rarr; KStream</li>
                         </ul>
                     </td>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -81,16 +81,17 @@
     </p>
     <p>
         We added a new <code>KStream.toTable()</code> API to translate an input event stream into a changelog stream as per
-        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-523%3A+Add+KStream%23toTable+to+the+Streams+DSL">KIP-523</a>
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-523%3A+Add+KStream%23toTable+to+the+Streams+DSL">KIP-523</a>.
     </p>
     <p>
         We added a new Serde type <code>Void</code> in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-527%3A+Add+VoidSerde+to+Serdes">KIP-527</a> to represent
-        null keys from input topic.
+        null keys or null values from input topic.
     </p>
     <p>
         As of 2.5.0 Kafka we deprecated <code>UsePreviousTimeOnInvalidTimestamp</code> and replaced it with <code>UsePartitionTimeOnInvalidTimeStamp</code> as per
         <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
     </p>
+
     <h3><a id="streams_api_changes_240" href="#streams_api_changes_240">Streams API changes in 2.4.0</a></h3>
     <p>     
          As of 2.4.0 Kafka Streams offers a KTable-KTable foreign-key join (as per <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-213+Support+non-key+joining+in+KTable">KIP-213</a>). 

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -83,7 +83,10 @@
         As of 2.5.0 Kafka we deprecated <code>UsePreviousTimeOnInvalidTimestamp</code> and replaced it with <code>UsePartitionTimeOnInvalidTimeStamp</code> as per
         <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
     </p>
-
+    <p>
+        We added a new Serde type <code>Void</code> in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-527%3A+Add+VoidSerde+to+Serdes">KIP-527</a> to represent
+        null keys from input topic.
+    </p>
     <h3><a id="streams_api_changes_240" href="#streams_api_changes_240">Streams API changes in 2.4.0</a></h3>
     <p>     
          As of 2.4.0 Kafka Streams offers a KTable-KTable foreign-key join (as per <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-213+Support+non-key+joining+in+KTable">KIP-213</a>). 

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -80,12 +80,16 @@
         We refer to the <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">developer guide</a> for more details.
     </p>
     <p>
-        As of 2.5.0 Kafka we deprecated <code>UsePreviousTimeOnInvalidTimestamp</code> and replaced it with <code>UsePartitionTimeOnInvalidTimeStamp</code> as per
-        <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
+        We added a new <code>KStream.toTable()</code> API to translate an input event stream into a changelog stream as per
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-523%3A+Add+KStream%23toTable+to+the+Streams+DSL">KIP-523</a>
     </p>
     <p>
         We added a new Serde type <code>Void</code> in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-527%3A+Add+VoidSerde+to+Serdes">KIP-527</a> to represent
         null keys from input topic.
+    </p>
+    <p>
+        As of 2.5.0 Kafka we deprecated <code>UsePreviousTimeOnInvalidTimestamp</code> and replaced it with <code>UsePartitionTimeOnInvalidTimeStamp</code> as per
+        <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=130028807">KIP-530</a>
     </p>
     <h3><a id="streams_api_changes_240" href="#streams_api_changes_240">Streams API changes in 2.4.0</a></h3>
     <p>     


### PR DESCRIPTION
As title, this PR adds doc changes for two mentioned KIPs in 2.5.

Visualized changes:
![image](https://user-images.githubusercontent.com/5845561/77491649-9ad39d80-6dfb-11ea-8273-1b6d03fb6dd5.png)
![image](https://user-images.githubusercontent.com/5845561/77491695-b8a10280-6dfb-11ea-93ff-1011c707c83e.png)
![image](https://user-images.githubusercontent.com/5845561/77491724-cf475980-6dfb-11ea-8ccb-21804f60fc5d.png)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
