### PR TITLE
MINOR: Allow topics with `null` leader on MockAdminClient.createTopic.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -169,8 +169,10 @@ public class MockAdminClient extends AdminClient {
             }
         }
         ArrayList<String> logDirs = new ArrayList<>();
-        for (int i = 0; i < partitions.size(); i++) {
-            logDirs.add(brokerLogDirs.get(partitions.get(i).leader().id()).get(0));
+        for (TopicPartitionInfo partition : partitions) {
+            if (partition.leader() != null) {
+                logDirs.add(brokerLogDirs.get(partition.leader().id()).get(0));
+            }
         }
         allTopics.put(name, new TopicMetadata(internal, partitions, logDirs, configs));
     }


### PR DESCRIPTION
Behaviour was accidentally changed recently on https://github.com/apache/kafka/pull/8244 to not allow the creation of topics with `null` leader. https://github.com/confluentinc/kafka-rest relies on this to test defensive behaviour against AdminClient returning a topic with `null` leader.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
