### PR TITLE
Minor: Don't swallow errors when altering log dirs in ReplicaManager

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -643,7 +643,7 @@ class ReplicaManager(val config: KafkaConfig,
                   _: LogDirNotFoundException |
                   _: ReplicaNotAvailableException |
                   _: KafkaStorageException) =>
-            error("Unable to alter log dirs for %s".format(topicPartition), e)
+            warn("Unable to alter log dirs for %s".format(topicPartition), e)
             (topicPartition, Errors.forException(e))
           case t: Throwable =>
             error("Error while changing replica dir for partition %s".format(topicPartition), t)
@@ -693,7 +693,8 @@ class ReplicaManager(val config: KafkaConfig,
         }
 
       } catch {
-        case _: KafkaStorageException =>
+        case e: KafkaStorageException =>
+          warn("Unable to describe replica dirs for %s".format(absolutePath), e)
           new DescribeLogDirsResponseData.DescribeLogDirsResult()
             .setLogDir(absolutePath)
             .setErrorCode(Errors.KAFKA_STORAGE_ERROR.code)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -643,6 +643,7 @@ class ReplicaManager(val config: KafkaConfig,
                   _: LogDirNotFoundException |
                   _: ReplicaNotAvailableException |
                   _: KafkaStorageException) =>
+            error("Unable to alter log dirs for %s".format(topicPartition), e)
             (topicPartition, Errors.forException(e))
           case t: Throwable =>
             error("Error while changing replica dir for partition %s".format(topicPartition), t)


### PR DESCRIPTION
Previously, when trying to change the log dirs for a offline replica, the reassignment tool would only give a generic error message like

> Caused by: org.apache.kafka.common.errors.KafkaStorageException: Disk error when trying to access log file on the disk.

And the broker would not have any error in its log. This was due to a few exceptions getting swallowed in `ReplicaManager#alterReplicaLogDirs`. After this change, the broker will produce error logs like:

> [2020-03-25 11:46:10,382] ERROR [ReplicaManager broker=0] Unable to alter log dirs for test-1 (kafka.server.ReplicaManager)
org.apache.kafka.common.errors.KafkaStorageException: Partition test-1 is offline
