### PR TITLE
KAFKA-9763: Correct InsertField to not skip keys of tombstone records

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -127,17 +127,13 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
 
     @Override
     public R apply(R record) {
-        if (isTombstoneRecord(record)) {
+        if (operatingValue(record) == null) {
             return record;
         } else if (operatingSchema(record) == null) {
             return applySchemaless(record);
         } else {
             return applyWithSchema(record);
         }
-    }
-
-    private boolean isTombstoneRecord(R record) {
-        return record.value() == null;
     }
 
     private R applySchemaless(R record) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -153,4 +153,50 @@ public class InsertFieldTest {
         assertEquals(null, transformedRecord.value());
         assertEquals(simpleStructSchema, transformedRecord.valueSchema());
     }
+
+    @Test
+    public void insertConfiguredFieldsIntoNullKeyWithoutKeySchemaReturnsSameRecord() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put("topic.field", "topic_field!");
+        props.put("partition.field", "partition_field");
+        props.put("timestamp.field", "timestamp_field?");
+        props.put("static.field", "instance_id");
+        props.put("static.value", "my-instance-id");
+
+        xform = new InsertField.Key<>();
+        xform.configure(props);
+
+        final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic", Schema.OPTIONAL_INT64_SCHEMA).build();
+        final Struct simpleStruct = new Struct(simpleStructSchema).put("magic", 42L);
+
+        final SourceRecord record = new SourceRecord(null, null, "test", 0,
+                null, null, simpleStructSchema, simpleStruct);
+
+        final SourceRecord transformedRecord = xform.apply(record);
+
+        assertSame(record, transformedRecord);
+    }
+
+    @Test
+    public void insertConfiguredFieldsIntoNullKeyWithKeySchemaReturnsSameRecord() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put("topic.field", "topic_field!");
+        props.put("partition.field", "partition_field");
+        props.put("timestamp.field", "timestamp_field?");
+        props.put("static.field", "instance_id");
+        props.put("static.value", "my-instance-id");
+
+        xform = new InsertField.Key<>();
+        xform.configure(props);
+
+        final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic", Schema.OPTIONAL_INT64_SCHEMA).build();
+        final Struct simpleStruct = new Struct(simpleStructSchema).put("magic", 42L);
+
+        final SourceRecord record = new SourceRecord(null, null, "test", 0,
+                Schema.STRING_SCHEMA, null, simpleStructSchema, simpleStruct);
+
+        final SourceRecord transformedRecord = xform.apply(record);
+
+        assertSame(record, transformedRecord);
+    }
 }


### PR DESCRIPTION
The fix for [KAFKA-8523](https://issues.apache.org/jira/browse/KAFKA-8523) attempted to skip (immediately returns) tombstone records when InsertField$Value is used. However, it also inadvertently also skips tombstone records when InsertField$Key is used, despite the possibility that the tombstone record’s key is non null.

This commit corrects the behavior so that the InsertField$Value continues to skip tombstone records, but InsertField$Key only skips when the record’s *key* is null.

Added two unit tests, and verified that these tests fail without the proposed fix and pass with the proposed fix. The other unit tests were added with [KAFKA-8523](https://issues.apache.org/jira/browse/KAFKA-8523) continue to pass.

This should be backported all the way back to the 1.0 branch, since that's how far back [KAFKA-8523](https://issues.apache.org/jira/browse/KAFKA-8523) was backported.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
