### PR TITLE
KAFKA-9441: Cleanup Streams metrics for removed task commit latency metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -42,8 +42,6 @@ public class TaskMetrics {
     private static final String COMMIT_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + COMMIT_DESCRIPTION;
     private static final String COMMIT_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + COMMIT_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
-    private static final String COMMIT_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION + COMMIT_DESCRIPTION;
-    private static final String COMMIT_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION + COMMIT_DESCRIPTION;
 
     private static final String PUNCTUATE = "punctuate";
     private static final String PUNCTUATE_DESCRIPTION = "calls to punctuate";
@@ -119,14 +117,12 @@ public class TaskMetrics {
                                       final String taskId,
                                       final StreamsMetricsImpl streamsMetrics,
                                       final Sensor... parentSensor) {
-        return invocationRateAndCountAndAvgAndMaxLatencySensor(
+        return invocationRateAndCountSensor(
             threadId,
             taskId,
             COMMIT,
             COMMIT_RATE_DESCRIPTION,
             COMMIT_TOTAL_DESCRIPTION,
-            COMMIT_AVG_LATENCY_DESCRIPTION,
-            COMMIT_MAX_LATENCY_DESCRIPTION,
             Sensor.RecordingLevel.DEBUG,
             streamsMetrics,
             parentSensor

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -41,7 +41,6 @@ public class ThreadMetrics {
     private ThreadMetrics() {}
 
     private static final String COMMIT = "commit";
-    private static final String COMMIT_LATENCY = COMMIT + LATENCY_SUFFIX;
     private static final String POLL = "poll";
     private static final String PROCESS = "process";
     private static final String PUNCTUATE = "punctuate";
@@ -82,10 +81,6 @@ public class ThreadMetrics {
         "calls to commit over all tasks assigned to one stream thread";
     private static final String COMMIT_OVER_TASKS_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + COMMIT_OVER_TASKS_DESCRIPTION;
     private static final String COMMIT_OVER_TASKS_RATE_DESCRIPTION = RATE_DESCRIPTION + COMMIT_OVER_TASKS_DESCRIPTION;
-    private static final String COMMIT_OVER_TASKS_AVG_LATENCY_DESCRIPTION =
-        "The average commit latency over all tasks assigned to one stream thread";
-    private static final String COMMIT_OVER_TASKS_MAX_LATENCY_DESCRIPTION =
-        "The maximum commit latency over all tasks assigned to one stream thread";
     private static final String PROCESS_RATIO_DESCRIPTION =
         "The fraction of time the thread spent on processing active tasks.";
     private static final String PUNCTUATE_RATIO_DESCRIPTION =
@@ -212,14 +207,6 @@ public class ThreadMetrics {
         final Sensor commitOverTasksSensor =
             streamsMetrics.threadLevelSensor(threadId, COMMIT, Sensor.RecordingLevel.DEBUG);
         final Map<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, ROLLUP_VALUE);
-        addAvgAndMaxToSensor(
-            commitOverTasksSensor,
-            TASK_LEVEL_GROUP,
-            tagMap,
-            COMMIT_LATENCY,
-            COMMIT_OVER_TASKS_AVG_LATENCY_DESCRIPTION,
-            COMMIT_OVER_TASKS_MAX_LATENCY_DESCRIPTION
-        );
         addInvocationRateAndCountToSensor(
             commitOverTasksSensor,
             TASK_LEVEL_GROUP,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/metrics/TaskMetricsTest.java
@@ -143,11 +143,8 @@ public class TaskMetricsTest {
     @Test
     public void shouldGetCommitSensor() {
         final String operation = "commit";
-        final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
         final String totalDescription = "The total number of calls to commit";
         final String rateDescription = "The average number of calls to commit per second";
-        final String avgLatencyDescription = "The average latency of calls to commit";
-        final String maxLatencyDescription = "The maximum latency of calls to commit";
         expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, TASK_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
@@ -157,14 +154,6 @@ public class TaskMetricsTest {
             operation,
             rateDescription,
             totalDescription
-        );
-        StreamsMetricsImpl.addAvgAndMaxToSensor(
-            expectedSensor,
-            TASK_LEVEL_GROUP,
-            tagMap,
-            operationLatency,
-            avgLatencyDescription,
-            maxLatencyDescription
         );
         replay(StreamsMetricsImpl.class, streamsMetrics);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -453,8 +453,6 @@ public class StreamTaskTest {
 
     private void testMetricsForBuiltInMetricsVersion0100To24() {
         final String builtInMetricsVersion = StreamsConfig.METRICS_0100_TO_24;
-        assertNotNull(getMetric("commit", "%s-latency-avg", "all", builtInMetricsVersion));
-        assertNotNull(getMetric("commit", "%s-latency-max", "all", builtInMetricsVersion));
         assertNotNull(getMetric("commit", "%s-rate", "all", builtInMetricsVersion));
 
         assertNull(getMetric("process", "%s-latency-avg", task.id().toString(), builtInMetricsVersion));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -373,10 +373,6 @@ public class StreamThreadTest {
             mkMap(mkEntry("task-id", "all"), mkEntry(getThreadTagKey(builtInMetricsVersion), thread.getName()));
         if (builtInMetricsVersion.equals(StreamsConfig.METRICS_0100_TO_24)) {
             assertNotNull(metrics.metrics().get(metrics.metricName(
-                "commit-latency-avg", taskGroupName, descriptionIsNotVerified, taskTags)));
-            assertNotNull(metrics.metrics().get(metrics.metricName(
-                "commit-latency-max", taskGroupName, descriptionIsNotVerified, taskTags)));
-            assertNotNull(metrics.metrics().get(metrics.metricName(
                 "commit-rate", taskGroupName, descriptionIsNotVerified, taskTags)));
         } else {
             assertNull(metrics.metrics().get(metrics.metricName(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.hamcrest.CoreMatchers.is;
@@ -298,41 +297,4 @@ public class ThreadMetricsTest {
         assertThat(sensor, is(expectedSensor));
     }
 
-    @Test
-    public void shouldGetCommitOverTasksSensor() {
-        final String operation = "commit";
-        final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
-        final String totalDescription =
-            "The total number of calls to commit over all tasks assigned to one stream thread";
-        final String rateDescription =
-            "The average per-second number of calls to commit over all tasks assigned to one stream thread";
-        final String avgLatencyDescription =
-            "The average commit latency over all tasks assigned to one stream thread";
-        final String maxLatencyDescription =
-            "The maximum commit latency over all tasks assigned to one stream thread";
-        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
-        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, ROLLUP_VALUE)).andReturn(tagMap);
-        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
-            expectedSensor,
-            TASK_LEVEL_GROUP,
-            tagMap,
-            operation,
-            rateDescription,
-            totalDescription
-        );
-        StreamsMetricsImpl.addAvgAndMaxToSensor(
-            expectedSensor,
-            TASK_LEVEL_GROUP,
-            tagMap,
-            operationLatency,
-            avgLatencyDescription,
-            maxLatencyDescription
-        );
-        replay(StreamsMetricsImpl.class, streamsMetrics);
-
-        final Sensor sensor = ThreadMetrics.commitOverTasksSensor(THREAD_ID, streamsMetrics);
-
-        verify(StreamsMetricsImpl.class, streamsMetrics);
-        assertThat(sensor, is(expectedSensor));
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.hamcrest.CoreMatchers.is;
@@ -297,4 +298,28 @@ public class ThreadMetricsTest {
         assertThat(sensor, is(expectedSensor));
     }
 
+    @Test
+    public void shouldGetCommitOverTasksSensor() {
+        final String operation = "commit";
+        final String totalDescription =
+            "The total number of calls to commit over all tasks assigned to one stream thread";
+        final String rateDescription =
+            "The average per-second number of calls to commit over all tasks assigned to one stream thread";
+        expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
+        expect(streamsMetrics.taskLevelTagMap(THREAD_ID, ROLLUP_VALUE)).andReturn(tagMap);
+        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
+            expectedSensor,
+            TASK_LEVEL_GROUP,
+            tagMap,
+            operation,
+            rateDescription,
+            totalDescription
+        );
+        replay(StreamsMetricsImpl.class, streamsMetrics);
+
+        final Sensor sensor = ThreadMetrics.commitOverTasksSensor(THREAD_ID, streamsMetrics);
+
+        verify(StreamsMetricsImpl.class, streamsMetrics);
+        assertThat(sensor, is(expectedSensor));
+    }
 }


### PR DESCRIPTION
Follow up to #8218 (KIP-447) that remove usage of task commit latency sensor. However, the underlying metrics were still registered, even if unused. This PR does the follow up cleanup to remove the metrics entirely.

The thread level commit metrics are no rollups but tracked individually and thus are not affected.

Call for review @cadonna @abbccdda @guozhangwang 