### PR TITLE
KAFKA-9767: Add logging to basic auth rest extension

### DIFF
--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/BasicAuthSecurityRestExtension.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/BasicAuthSecurityRestExtension.java
@@ -20,6 +20,8 @@ package org.apache.kafka.connect.rest.basic.auth.extension;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -57,9 +59,13 @@ import java.util.Map;
  */
 public class BasicAuthSecurityRestExtension implements ConnectRestExtension {
 
+    private static final Logger log = LoggerFactory.getLogger(BasicAuthSecurityRestExtension.class);
+
     @Override
     public void register(ConnectRestExtensionContext restPluginContext) {
+        log.trace("Registering JAAS basic auth filter");
         restPluginContext.configurable().register(JaasBasicAuthFilter.class);
+        log.trace("Finished registering JAAS basic auth filter");
     }
 
     @Override

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilter.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilter.java
@@ -20,6 +20,8 @@ package org.apache.kafka.connect.rest.basic.auth.extension;
 import java.util.regex.Pattern;
 import javax.ws.rs.HttpMethod;
 import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,24 +39,39 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 
 public class JaasBasicAuthFilter implements ContainerRequestFilter {
-    private static final String CONNECT_LOGIN_MODULE = "KafkaConnect";
-    static final String AUTHORIZATION = "Authorization";
+
+    private static final Logger log = LoggerFactory.getLogger(JaasBasicAuthFilter.class);
     private static final Pattern TASK_REQUEST_PATTERN = Pattern.compile("/?connectors/([^/]+)/tasks/?");
+    private static final String CONNECT_LOGIN_MODULE = "KafkaConnect";
+
+    static final String AUTHORIZATION = "Authorization";
+
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (isInternalTaskConfigRequest(requestContext)) {
+            log.trace("Skipping authentication for internal request");
+            return;
+        }
+
         try {
-            if (!(requestContext.getMethod().equals(HttpMethod.POST) && TASK_REQUEST_PATTERN.matcher(requestContext.getUriInfo().getPath()).matches())) {
-                LoginContext loginContext =
-                    new LoginContext(CONNECT_LOGIN_MODULE, new BasicAuthCallBackHandler(
-                        requestContext.getHeaderString(AUTHORIZATION)));
-                loginContext.login();
-            }
+            log.debug("Authenticating request");
+            LoginContext loginContext =
+                new LoginContext(CONNECT_LOGIN_MODULE, new BasicAuthCallBackHandler(
+                    requestContext.getHeaderString(AUTHORIZATION)));
+            loginContext.login();
         } catch (LoginException | ConfigException e) {
+            // Log at debug here in order to avoid polluting log files whenever someone mistypes their credentials
+            log.debug("Request failed authentication", e);
             requestContext.abortWith(
                 Response.status(Response.Status.UNAUTHORIZED)
                     .entity("User cannot access the resource.")
                     .build());
         }
+    }
+
+    private static boolean isInternalTaskConfigRequest(ContainerRequestContext requestContext) {
+        return requestContext.getMethod().equals(HttpMethod.POST)
+            && TASK_REQUEST_PATTERN.matcher(requestContext.getUriInfo().getPath()).matches();
     }
 
 
@@ -67,36 +84,61 @@ public class JaasBasicAuthFilter implements ContainerRequestFilter {
         private String password;
 
         public BasicAuthCallBackHandler(String credentials) {
-            if (credentials != null) {
-                int space = credentials.indexOf(SPACE);
-                if (space > 0) {
-                    String method = credentials.substring(0, space);
-                    if (BASIC.equalsIgnoreCase(method)) {
-                        credentials = credentials.substring(space + 1);
-                        credentials = new String(Base64.getDecoder().decode(credentials),
-                                                 StandardCharsets.UTF_8);
-                        int i = credentials.indexOf(COLON);
-                        if (i > 0) {
-                            username = credentials.substring(0, i);
-                            password = credentials.substring(i + 1);
-                        }
-                    }
-                }
+            if (credentials == null) {
+                log.trace("No credentials were provided with the request");
+                return;
             }
+
+            int space = credentials.indexOf(SPACE);
+            if (space <= 0) {
+                log.trace("Request credentials were malformed; no space present in value for authorization header");
+                return;
+            }
+
+            String method = credentials.substring(0, space);
+            if (!BASIC.equalsIgnoreCase(method)) {
+                log.trace("Request credentials did not use basic authentication; ignoring");
+                return;
+            }
+
+            credentials = credentials.substring(space + 1);
+            credentials = new String(Base64.getDecoder().decode(credentials),
+                                     StandardCharsets.UTF_8);
+            int i = credentials.indexOf(COLON);
+            if (i <= 0) {
+                log.trace("Request credentials were malformed; no colon present between username and password");
+                return;
+            }
+
+            username = credentials.substring(0, i);
+            password = credentials.substring(i + 1);
         }
 
         @Override
         public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+            Callback unsupportedCallback = null;
             for (Callback callback : callbacks) {
                 if (callback instanceof NameCallback) {
                     ((NameCallback) callback).setName(username);
                 } else if (callback instanceof PasswordCallback) {
                     ((PasswordCallback) callback).setPassword(password.toCharArray());
                 } else {
-                    throw new UnsupportedCallbackException(callback, "Supports only NameCallback "
-                                                                     + "and PasswordCallback");
+                    // Log at WARN level here as this indicates incompatibility between the Connect basic auth
+                    // extension and the JAAS login module that the user has configured and it is likely that the
+                    // worker will need to be reconfigured and restarted
+                    log.warn(
+                        "Asked to handle unsupported callback '{}' of type {}; request authentication will fail",
+                        callback,
+                        callback.getClass()
+                    );
+                    if (unsupportedCallback == null)
+                        unsupportedCallback = callback;
                 }
             }
+            if (unsupportedCallback != null)
+                throw new UnsupportedCallbackException(
+                    unsupportedCallback,
+                    "Supports only NameCallback and PasswordCallback");
         }
     }
 }

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilter.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilter.java
@@ -97,7 +97,7 @@ public class JaasBasicAuthFilter implements ContainerRequestFilter {
 
             String method = credentials.substring(0, space);
             if (!BASIC.equalsIgnoreCase(method)) {
-                log.trace("Request credentials did not use basic authentication; ignoring");
+                log.trace("Request credentials used {} authentication, but only {} supported; ignoring", BASIC, method);
                 return;
             }
 

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
@@ -62,17 +62,27 @@ public class PropertyFileLoginModule implements LoginModule {
         if (fileName == null || fileName.trim().isEmpty()) {
             throw new ConfigException("Property Credentials file must be specified");
         }
+
         if (!credentialPropertiesMap.containsKey(fileName)) {
+            log.trace("Opening credential properties file '{}'", fileName);
             Properties credentialProperties = new Properties();
             try {
                 try (InputStream inputStream = Files.newInputStream(Paths.get(fileName))) {
+                    log.trace("Parsing credential properties file '{}'", fileName);
                     credentialProperties.load(inputStream);
                 }
                 credentialPropertiesMap.putIfAbsent(fileName, credentialProperties);
+                if (credentialProperties.isEmpty())
+                    log.warn("Credential properties file '{}' is empty; all requests will be permitted",
+                        fileName);
             } catch (IOException e) {
                 log.error("Error loading credentials file ", e);
                 throw new ConfigException("Error loading Property Credentials file");
             }
+        } else {
+            log.trace(
+                "Credential properties file '{}' has already been opened and parsed; will read from cached, in-memory store",
+                fileName);
         }
     }
 
@@ -80,8 +90,10 @@ public class PropertyFileLoginModule implements LoginModule {
     public boolean login() throws LoginException {
         Callback[] callbacks = configureCallbacks();
         try {
+            log.trace("Authenticating user; invoking JAAS login callbacks");
             callbackHandler.handle(callbacks);
         } catch (Exception e) {
+            log.trace("Authentication failed while invoking JAAS login callbacks");
             throw new LoginException(e.getMessage());
         }
 
@@ -89,8 +101,24 @@ public class PropertyFileLoginModule implements LoginModule {
         char[] passwordChars = ((PasswordCallback) callbacks[1]).getPassword();
         String password = passwordChars != null ? new String(passwordChars) : null;
         Properties credentialProperties = credentialPropertiesMap.get(fileName);
-        authenticated = credentialProperties.isEmpty() ||
-                        (password != null && password.equals(credentialProperties.get(username)));
+
+        if (credentialProperties.isEmpty()) {
+            log.trace("Not validating credentials for user '{}' as credential properties file '{}' is empty",
+                username,
+                fileName);
+            authenticated = true;
+        } else if (password != null && password.equals(credentialProperties.get(username))) {
+            log.trace("Credentials provided for user '{}' match those present in the credential properties file '{}'",
+                username,
+                fileName);
+            authenticated = true;
+        } else {
+            log.trace("Credentials provided for user '{}' do not match those present in the credential properties file '{}'",
+                username,
+                fileName);
+            authenticated = false;
+        }
+
         return authenticated;
     }
 
@@ -110,7 +138,6 @@ public class PropertyFileLoginModule implements LoginModule {
     }
 
     private Callback[] configureCallbacks() {
-
         Callback[] callbacks = new Callback[2];
         callbacks[0] = new NameCallback("Enter user name");
         callbacks[1] = new PasswordCallback("Enter password", false);

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
@@ -93,7 +93,7 @@ public class PropertyFileLoginModule implements LoginModule {
             log.trace("Authenticating user; invoking JAAS login callbacks");
             callbackHandler.handle(callbacks);
         } catch (Exception e) {
-            log.warn("Authentication failed while invoking JAAS login callbacks");
+            log.warn("Authentication failed while invoking JAAS login callbacks", e);
             throw new LoginException(e.getMessage());
         }
 
@@ -107,11 +107,19 @@ public class PropertyFileLoginModule implements LoginModule {
                 username,
                 fileName);
             authenticated = true;
+        } else if (username == null) {
+            log.trace("No credentials were provided or the provided credentials were malformed");
+            authenticated = false;
         } else if (password != null && password.equals(credentialProperties.get(username))) {
             log.trace("Credentials provided for user '{}' match those present in the credential properties file '{}'",
                 username,
                 fileName);
             authenticated = true;
+        } else if (!credentialProperties.containsKey(username)) {
+            log.trace("User '{}' is not present in the credential properties file '{}'",
+                username,
+                fileName);
+            authenticated = false;
         } else {
             log.trace("Credentials provided for user '{}' do not match those present in the credential properties file '{}'",
                 username,

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
@@ -93,7 +93,7 @@ public class PropertyFileLoginModule implements LoginModule {
             log.trace("Authenticating user; invoking JAAS login callbacks");
             callbackHandler.handle(callbacks);
         } catch (Exception e) {
-            log.trace("Authentication failed while invoking JAAS login callbacks");
+            log.warn("Authentication failed while invoking JAAS login callbacks");
             throw new LoginException(e.getMessage());
         }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9767)

The changes here are strictly targeted towards improving logging for the basic auth rest extension. However, in several sections, some refactoring is also performed in order to reduce nesting especially with the `else` halves of `if`/`else` statements.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
