### PR TITLE
KAFKA-9756: Process more than one record of one task at a time

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -95,7 +95,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Sensor enforcedProcessingSensor;
     private final InternalProcessorContext processorContext;
 
-    private long idleStartTime;
+    private long idleStartTimeMs;
     private boolean commitNeeded = false;
     private boolean commitRequested = false;
 
@@ -205,7 +205,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             initializeMetadata();
             initializeTopology();
             processorContext.initialize();
-            idleStartTime = RecordQueue.UNKNOWN;
+            idleStartTimeMs = RecordQueue.UNKNOWN;
             transitionTo(State.RUNNING);
 
             log.info("Restored and ready to run");
@@ -534,14 +534,14 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
 
         if (partitionGroup.allPartitionsBuffered()) {
-            idleStartTime = RecordQueue.UNKNOWN;
+            idleStartTimeMs = RecordQueue.UNKNOWN;
             return true;
         } else if (partitionGroup.numBuffered() > 0) {
-            if (idleStartTime == RecordQueue.UNKNOWN) {
-                idleStartTime = wallClockTime;
+            if (idleStartTimeMs == RecordQueue.UNKNOWN) {
+                idleStartTimeMs = wallClockTime;
             }
 
-            if (wallClockTime - idleStartTime >= maxTaskIdleMs) {
+            if (wallClockTime - idleStartTimeMs >= maxTaskIdleMs) {
                 enforcedProcessingSensor.record();
                 return true;
             } else {
@@ -550,7 +550,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         } else {
             // there's no data in any of the topics; we should reset the enforced
             // processing timer
-            idleStartTime = RecordQueue.UNKNOWN;
+            idleStartTimeMs = RecordQueue.UNKNOWN;
             return false;
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -643,7 +643,7 @@ public class StreamThread extends Thread {
         // if there's no active restoring or standby updating it would not try to fetch any data
         changelogReader.restore();
 
-        final long restoreLatency = advanceNowAndComputeLatency();
+        advanceNowAndComputeLatency();
 
         long totalCommitLatency = 0L;
         long totalProcessLatency = 0L;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -585,7 +585,8 @@ public class StreamThread extends Thread {
     // Visible for testing
     void runOnce() {
         final ConsumerRecords<byte[], byte[]> records;
-        now = time.milliseconds();
+        final long startMs = time.milliseconds();
+        now = startMs;
 
         if (state == State.PARTITIONS_ASSIGNED) {
             // try to fetch some records with zero poll millis
@@ -659,6 +660,8 @@ public class StreamThread extends Thread {
              */
             do {
                 final int processed = taskManager.process(numIterations, now);
+                final long processLatency = advanceNowAndComputeLatency();
+                totalProcessLatency += processLatency;
                 if (processed > 0) {
                     // It makes no difference to the outcome of these metrics when we record "0",
                     // so we can just avoid the method call when we didn't process anything.
@@ -667,29 +670,26 @@ public class StreamThread extends Thread {
                     // This metric is scaled to represent the _average_ processing time of _each_
                     // task. Note, it's hard to interpret this as defined, but we would need a KIP
                     // to change it to simply report the overall time spent processing all tasks.
-                    final long processLatency = advanceNowAndComputeLatency();
                     processLatencySensor.record(processLatency / (double) processed, now);
-                    totalProcessLatency += processLatency;
                 }
 
                 final int punctuated = taskManager.punctuate();
+                final long punctuateLatency = advanceNowAndComputeLatency();
+                totalPunctuateLatency += punctuateLatency;
                 if (punctuated > 0) {
-                    final long punctuateLatency = advanceNowAndComputeLatency();
                     punctuateSensor.record(punctuateLatency / (double) punctuated, now);
-                    totalPunctuateLatency += punctuateLatency;
                 }
 
                 final int committed = maybeCommit();
+                final long commitLatency = advanceNowAndComputeLatency();
+                totalCommitLatency += commitLatency;
                 if (committed > 0) {
-                    final long commitLatency = advanceNowAndComputeLatency();
                     commitSensor.record(commitLatency / (double) committed, now);
 
                     if (log.isDebugEnabled()) {
                         log.debug("Committed all active tasks {} and standby tasks {} in {}ms",
                             taskManager.activeTaskIds(), taskManager.standbyTaskIds(), commitLatency);
                     }
-
-                    totalCommitLatency += commitLatency;
                 }
 
                 if (processed == 0) {
@@ -706,7 +706,8 @@ public class StreamThread extends Thread {
             } while (true);
         }
 
-        final long runOnceLatency = pollLatency + restoreLatency + totalCommitLatency + totalProcessLatency + totalPunctuateLatency;
+        now = time.milliseconds();
+        final long runOnceLatency = now - startMs;
         processRatioSensor.record((double) totalProcessLatency / runOnceLatency);
         punctuateRatioSensor.record((double) totalPunctuateLatency / runOnceLatency);
         pollRatioSensor.record((double) pollLatency / runOnceLatency);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -811,13 +811,15 @@ public class TaskManager {
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
     int process(final int maxNumRecords, final long now) {
-        int processed = 0;
+        int totalProcessed = 0;
 
         for (final Task task : activeTaskIterable()) {
             try {
+                int processed = 0;
                 while (processed < maxNumRecords && task.process(now)) {
                     processed++;
                 }
+                totalProcessed += processed;
             } catch (final TaskMigratedException e) {
                 log.info("Failed to process stream task {} since it got migrated to another thread already. " +
                              "Will trigger a new rebalance and close all tasks as zombies together.", task.id());
@@ -828,7 +830,7 @@ public class TaskManager {
             }
         }
 
-        return processed;
+        return totalProcessed;
     }
 
     /**
@@ -854,6 +856,7 @@ public class TaskManager {
                 throw e;
             }
         }
+
         return punctuated;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -810,12 +810,12 @@ public class TaskManager {
     /**
      * @throws TaskMigratedException if the task producer got fenced (EOS only)
      */
-    int process(final long now) {
+    int process(final int maxNumRecords, final long now) {
         int processed = 0;
 
         for (final Task task : activeTaskIterable()) {
             try {
-                if (task.process(now)) {
+                while (processed < maxNumRecords && task.process(now)) {
                     processed++;
                 }
             } catch (final TaskMigratedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -807,6 +807,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
+    public static void maybeMeasureLatency(final double elapsedNs, final Sensor sensor) {
+        if (sensor.shouldRecord() && sensor.hasMetrics()) {
+            sensor.record(elapsedNs);
+        }
+    }
+
     public static <T> T maybeMeasureLatency(final Supplier<T> actionToMeasure,
                                             final Time time,
                                             final Sensor sensor) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -807,12 +807,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public static void maybeMeasureLatency(final double elapsedNs, final Sensor sensor) {
-        if (sensor.shouldRecord() && sensor.hasMetrics()) {
-            sensor.record(elapsedNs);
-        }
-    }
-
     public static <T> T maybeMeasureLatency(final Supplier<T> actionToMeasure,
                                             final Time time,
                                             final Sensor sensor) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -87,13 +87,13 @@ public class ThreadMetrics {
     private static final String COMMIT_OVER_TASKS_MAX_LATENCY_DESCRIPTION =
         "The maximum commit latency over all tasks assigned to one stream thread";
     private static final String PROCESS_RATIO_DESCRIPTION =
-        "The fraction of time stream thread is spending on processing active tasks.";
+        "The fraction of time the thread spent on processing active tasks.";
     private static final String PUNCTUATE_RATIO_DESCRIPTION =
-        "The fraction of time stream thread is spending on punctuating active tasks.";
+        "The fraction of time the thread spent on punctuating active tasks.";
     private static final String POLL_RATIO_DESCRIPTION =
-        "The fraction of time stream thread is spending on polling records from consumer.";
+        "The fraction of time the thread spent on polling records from consumer.";
     private static final String COMMIT_RATIO_DESCRIPTION =
-        "The fraction of time stream thread is spending on committing all tasks.";
+        "The fraction of time the thread spent on committing all tasks.";
 
     public static Sensor createTaskSensor(final String threadId,
                                           final StreamsMetricsImpl streamsMetrics) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -16,8 +16,10 @@
  */
 package org.apache.kafka.streams.processor.internals.metrics;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
@@ -25,6 +27,7 @@ import java.util.Map;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATIO_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_LEVEL_GROUP;
@@ -83,6 +86,14 @@ public class ThreadMetrics {
         "The average commit latency over all tasks assigned to one stream thread";
     private static final String COMMIT_OVER_TASKS_MAX_LATENCY_DESCRIPTION =
         "The maximum commit latency over all tasks assigned to one stream thread";
+    private static final String PROCESS_RATIO_DESCRIPTION =
+        "The fraction of time stream thread is spending on processing active tasks.";
+    private static final String PUNCTUATE_RATIO_DESCRIPTION =
+        "The fraction of time stream thread is spending on punctuating active tasks.";
+    private static final String POLL_RATIO_DESCRIPTION =
+        "The fraction of time stream thread is spending on polling records from consumer.";
+    private static final String COMMIT_RATIO_DESCRIPTION =
+        "The fraction of time stream thread is spending on committing all tasks.";
 
     public static Sensor createTaskSensor(final String threadId,
                                           final StreamsMetricsImpl streamsMetrics) {
@@ -218,6 +229,70 @@ public class ThreadMetrics {
             COMMIT_OVER_TASKS_TOTAL_DESCRIPTION
         );
         return commitOverTasksSensor;
+    }
+
+    public static Sensor processRatioSensor(final String threadId,
+                                            final StreamsMetricsImpl streamsMetrics) {
+        final Sensor sensor =
+            streamsMetrics.threadLevelSensor(threadId, PROCESS + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        sensor.add(
+            new MetricName(
+                PROCESS + RATIO_SUFFIX,
+                threadLevelGroup(streamsMetrics),
+                PROCESS_RATIO_DESCRIPTION,
+                tagMap),
+            new Value()
+        );
+        return sensor;
+    }
+
+    public static Sensor punctuateRatioSensor(final String threadId,
+                                              final StreamsMetricsImpl streamsMetrics) {
+        final Sensor sensor =
+            streamsMetrics.threadLevelSensor(threadId, PUNCTUATE + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        sensor.add(
+            new MetricName(
+                PUNCTUATE + RATIO_SUFFIX,
+                threadLevelGroup(streamsMetrics),
+                PUNCTUATE_RATIO_DESCRIPTION,
+                tagMap),
+            new Value()
+        );
+        return sensor;
+    }
+
+    public static Sensor pollRatioSensor(final String threadId,
+                                         final StreamsMetricsImpl streamsMetrics) {
+        final Sensor sensor =
+            streamsMetrics.threadLevelSensor(threadId, POLL + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        sensor.add(
+            new MetricName(
+                POLL + RATIO_SUFFIX,
+                threadLevelGroup(streamsMetrics),
+                POLL_RATIO_DESCRIPTION,
+                tagMap),
+            new Value()
+        );
+        return sensor;
+    }
+
+    public static Sensor commitRatioSensor(final String threadId,
+                                           final StreamsMetricsImpl streamsMetrics) {
+        final Sensor sensor =
+            streamsMetrics.threadLevelSensor(threadId, COMMIT + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        sensor.add(
+            new MetricName(
+                COMMIT + RATIO_SUFFIX,
+                threadLevelGroup(streamsMetrics),
+                COMMIT_RATIO_DESCRIPTION,
+                tagMap),
+            new Value()
+        );
+        return sensor;
     }
 
     private static Sensor invocationRateAndCountSensor(final String threadId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -234,7 +234,7 @@ public class ThreadMetrics {
     public static Sensor processRatioSensor(final String threadId,
                                             final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
-            streamsMetrics.threadLevelSensor(threadId, PROCESS + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+            streamsMetrics.threadLevelSensor(threadId, PROCESS + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         sensor.add(
             new MetricName(
@@ -250,7 +250,7 @@ public class ThreadMetrics {
     public static Sensor punctuateRatioSensor(final String threadId,
                                               final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
-            streamsMetrics.threadLevelSensor(threadId, PUNCTUATE + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+            streamsMetrics.threadLevelSensor(threadId, PUNCTUATE + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         sensor.add(
             new MetricName(
@@ -266,7 +266,7 @@ public class ThreadMetrics {
     public static Sensor pollRatioSensor(final String threadId,
                                          final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
-            streamsMetrics.threadLevelSensor(threadId, POLL + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+            streamsMetrics.threadLevelSensor(threadId, POLL + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         sensor.add(
             new MetricName(
@@ -282,7 +282,7 @@ public class ThreadMetrics {
     public static Sensor commitRatioSensor(final String threadId,
                                            final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
-            streamsMetrics.threadLevelSensor(threadId, COMMIT + RATIO_SUFFIX, Sensor.RecordingLevel.DEBUG);
+            streamsMetrics.threadLevelSensor(threadId, COMMIT + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         sensor.add(
             new MetricName(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -483,10 +483,7 @@ public class StreamThreadTest {
         final TaskId task1 = new TaskId(0, t1p1.partition());
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
-        thread.taskManager().handleAssignment(
-            Collections.singletonMap(task1, assignedPartitions),
-            emptyMap()
-        );
+        thread.taskManager().handleAssignment(Collections.singletonMap(task1, assignedPartitions), emptyMap());
 
         final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer;
         mockConsumer.assign(Collections.singleton(t1p1));
@@ -511,18 +508,25 @@ public class StreamThreadTest {
         thread.runOnce();
         assertThat(thread.currentNumIterations(), equalTo(2));
 
-        // system time based punctutation halves to 1
+        // system time based punctutation without processing any record, iteration stays as 2
         mockTime.sleep(11L);
+
+        thread.runOnce();
+        assertThat(thread.currentNumIterations(), equalTo(2));
+
+        // system time based punctutation after processing a record, half iteration to 1
+        mockTime.sleep(11L);
+        addRecord(mockConsumer, ++offset, 5L);
 
         thread.runOnce();
         assertThat(thread.currentNumIterations(), equalTo(1));
 
-        // processed two records, bumping up iterations to 2
+        // processed two records, bumping up iterations to 3 (1 + 2)
         addRecord(mockConsumer, ++offset, 5L);
         addRecord(mockConsumer, ++offset, 6L);
         thread.runOnce();
 
-        assertThat(thread.currentNumIterations(), equalTo(2));
+        assertThat(thread.currentNumIterations(), equalTo(3));
 
         // stream time based punctutation halves to 1
         addRecord(mockConsumer, ++offset, 11L);
@@ -542,15 +546,29 @@ public class StreamThreadTest {
         addRecord(mockConsumer, ++offset, 15L);
         thread.runOnce();
 
-        // user requested commit should not impact on iteration adjustment
+        // user requested commit should half iteration to 1
+        assertThat(thread.currentNumIterations(), equalTo(1));
+
+        // processed three records, bumping up iterations to 3 (1 + 2)
+        addRecord(mockConsumer, ++offset, 15L);
+        addRecord(mockConsumer, ++offset, 16L);
+        addRecord(mockConsumer, ++offset, 17L);
+        thread.runOnce();
+
         assertThat(thread.currentNumIterations(), equalTo(3));
 
-        // time based commit, halves iterations to 3 / 2 = 1
+        // time based commit without processing, should keep the iteration as 3
         mockTime.sleep(90L);
         thread.runOnce();
 
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertThat(thread.currentNumIterations(), equalTo(3));
 
+        // time based commit without processing, should half the iteration to 1
+        mockTime.sleep(90L);
+        addRecord(mockConsumer, ++offset, 18L);
+        thread.runOnce();
+
+        assertThat(thread.currentNumIterations(), equalTo(1));
     }
 
     @Test
@@ -1373,8 +1391,7 @@ public class StreamThreadTest {
             }
 
             @Override
-            public void process(final Object key,
-                                final Object value) {}
+            public void process(final Object key, final Object value) {}
 
             @Override
             public void close() {}


### PR DESCRIPTION
1. Within a single while loop, process the tasks in AAABBBCCC instead of ABCABCABC. This also helps the follow-up PR to time the per-task processing ratio to record less time, hence less overhead.

2. Add thread-level process / punctuate / poll / commit ratio metrics.

3. Fixed a few issues discovered (inline commented).

I am adding metrics test coverage for 2) above in another PR, which added more sensor / metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
