### PR TITLE
KAFKA-9778: Add validateConnector functionality to the EmbeddedConnectCluster

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -126,15 +125,15 @@ public class ExampleConnectIntegrationTest {
         connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
 
         // validate the intended connector configuration, a config that errors
-        ConfigInfos configInfosError = connect.validateConnectorConfig(SINK_CONNECTOR_CLASS_NAME, props);
-        assertEquals(1, configInfosError.errorCount());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(SINK_CONNECTOR_CLASS_NAME, props, 1,
+            "Validating connector configuration produced an unexpected number or errors.");
 
         // add missing configuration to make the config valid
         props.put("name", CONNECTOR_NAME);
 
         // validate the intended connector configuration, a valid config
-        ConfigInfos configInfosValid = connect.validateConnectorConfig(SINK_CONNECTOR_CLASS_NAME, props);
-        assertEquals(0, configInfosValid.errorCount());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(SINK_CONNECTOR_CLASS_NAME, props, 0,
+            "Validating connector configuration produced an unexpected number or errors.");
 
         // start a sink connector
         connect.configureConnector(CONNECTOR_NAME, props);
@@ -187,15 +186,15 @@ public class ExampleConnectIntegrationTest {
         connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
 
         // validate the intended connector configuration, a config that errors
-        ConfigInfos configInfosError = connect.validateConnectorConfig(SOURCE_CONNECTOR_CLASS_NAME, props);
-        assertEquals(1, configInfosError.errorCount());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(SOURCE_CONNECTOR_CLASS_NAME, props, 1,
+            "Validating connector configuration produced an unexpected number or errors.");
 
         // add missing configuration to make the config valid
         props.put("name", CONNECTOR_NAME);
 
         // validate the intended connector configuration, a valid config
-        ConfigInfos configInfosValid = connect.validateConnectorConfig(SOURCE_CONNECTOR_CLASS_NAME, props);
-        assertEquals(0, configInfosValid.errorCount());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(SOURCE_CONNECTOR_CLASS_NAME, props, 0,
+            "Validating connector configuration produced an unexpected number or errors.");
 
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -125,10 +125,14 @@ public class ExampleConnectIntegrationTest {
         // expect all records to be consumed by the connector
         connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
 
-        // validate the intended connector configuration
+        // validate the intended connector configuration, a config that errors
         ConfigInfos configInfosError = connect.validateConnectorConfig(SINK_CONNECTOR_CLASS_NAME, props);
         assertEquals(1, configInfosError.errorCount());
+
+        // add missing configuration to make the config valid
         props.put("name", CONNECTOR_NAME);
+
+        // validate the intended connector configuration, a valid config
         ConfigInfos configInfosValid = connect.validateConnectorConfig(SINK_CONNECTOR_CLASS_NAME, props);
         assertEquals(0, configInfosValid.errorCount());
 
@@ -182,10 +186,14 @@ public class ExampleConnectIntegrationTest {
         // expect all records to be produced by the connector
         connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
 
-        // validate the intended connector configuration
+        // validate the intended connector configuration, a config that errors
         ConfigInfos configInfosError = connect.validateConnectorConfig(SOURCE_CONNECTOR_CLASS_NAME, props);
         assertEquals(1, configInfosError.errorCount());
+
+        // add missing configuration to make the config valid
         props.put("name", CONNECTOR_NAME);
+
+        // validate the intended connector configuration, a valid config
         ConfigInfos configInfosValid = connect.validateConnectorConfig(SOURCE_CONNECTOR_CLASS_NAME, props);
         assertEquals(0, configInfosValid.errorCount());
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -299,7 +299,7 @@ public class EmbeddedConnectCluster {
         try{
             configInfos = new ObjectMapper().readValue(response, ConfigInfos.class);
         } catch (IOException e) {
-            throw new ConnectException("Could not deserialize connector configuration");
+            throw new ConnectException("Unable deserialize response into a ConfigInfos object");
         }
         return configInfos;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -16,12 +16,10 @@
  */
 package org.apache.kafka.connect.util.clusters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.runtime.Connect;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -296,7 +294,7 @@ public class EmbeddedConnectCluster {
         String url = endpointForResource(String.format("connector-plugins/%s/config/validate", connClassName));
         String response = putConnectorConfig(url, connConfig);
         ConfigInfos configInfos;
-        try{
+        try {
             configInfos = new ObjectMapper().readValue(response, ConfigInfos.class);
         } catch (IOException e) {
             throw new ConnectException("Unable deserialize response into a ConfigInfos object");


### PR DESCRIPTION
A validate endpoint should be added to enables the integration testing of validation functionalities, including validation success and assertion of specific error messages. 

This PR adds a method `validateConnectorConfig` to the `EmbeddedConnectCluster` that pings the `/config/validate` endpoint with the given configurations. [More about the endpoint here.](https://kafka.apache.org/documentation/#connect_rest)

With this addition, the validations for the connector can be tested in a similar way integration tests currently use the `configureConnector` method, for ex: `connect.configureConnector(CONNECTOR_NAME, props);`. The validation call would look like: `ConfigInfos validateResponse = connect.validateConnectorConfig(CONNECTOR_CLASS_NAME, props);`. 
