### PR TITLE
HOTFIX: faile to compile HighwatermarkCheckpointBench by scala 2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1540,7 +1540,6 @@ project(':jmh-benchmarks') {
     compile project(':core')
     compile project(':clients')
     compile project(':streams')
-    compile project(':core')
     compile project(':clients').sourceSets.test.output
     compile project(':core').sourceSets.test.output
     compile libs.jmhCore

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/HighwatermarkCheckpointBench.java
@@ -59,7 +59,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import scala.jdk.CollectionConverters;
+import scala.collection.JavaConverters;
 
 
 @Warmup(iterations = 5)
@@ -100,9 +100,8 @@ public class HighwatermarkCheckpointBench {
         this.metrics = new Metrics();
         this.time = new MockTime();
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());
-        final List<File> files =
-            CollectionConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
-        this.logManager = TestUtils.createLogManager(CollectionConverters.asScalaBuffer(files),
+        final List<File> files = JavaConverters.asJavaCollection(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
+        this.logManager = TestUtils.createLogManager(JavaConverters.iterableAsScalaIterableConverter(files).asScala().toSeq(),
                 LogConfig.apply(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
                         Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
@@ -160,7 +159,7 @@ public class HighwatermarkCheckpointBench {
         this.metrics.close();
         this.scheduler.shutdown();
         this.quotaManagers.shutdown();
-        for (File dir : CollectionConverters.asJavaCollection(logManager.liveLogDirs())) {
+        for (File dir : JavaConverters.asJavaCollection(logManager.liveLogDirs())) {
             Utils.delete(dir);
         }
     }


### PR DESCRIPTION
The source compatibility offered by ```scala-collection-compat``` is based on scala implicit conversions. It means the "explicit" reference in java code ```HighwatermarkCheckpointBench``` can't join the party (```scala.jdk.CollectionConverters``` is linked to scala 2.13 code and the symbol used by ```HighwatermarkCheckpointBench``` is gone)

It seems to me we should have a collection of helper methods to offer the conversion like ```scala-collection-compat``` and it servers for jmh java code only.

This PR replaces ```scala.jdk.CollectionConverters``` by ```scala.collection.JavaConverters``` since ```scala.collection.JavaConverters``` methods required by ```HighwatermarkCheckpointBench``` exists on both scala 2.12 and scala 2.13.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
