### PR TITLE
MINOR: Don't process sasl.kerberos.principal.to.local.rules on client-side

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -140,7 +140,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
             }
 
             Class<? extends Login> defaultLoginClass = defaultLoginClass();
-            if (jaasContexts.containsKey(SaslConfigs.GSSAPI_MECHANISM)) {
+            if (mode == Mode.SERVER && jaasContexts.containsKey(SaslConfigs.GSSAPI_MECHANISM)) {
                 String defaultRealm;
                 try {
                     defaultRealm = defaultKerberosRealm();


### PR DESCRIPTION
`sasl.kerberos.principal.to.local.rules` is a broker-side config that is not used on clients. We should ignore this for client-side channel builders.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
