### PR TITLE
MINOR: optimize integration test shutdown

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -123,15 +123,7 @@ public class KafkaEmbedded {
         return effectiveConfig.getProperty("zookeeper.connect", DEFAULT_ZK_CONNECT);
     }
 
-    /**
-     * Stop the broker.
-     */
     @SuppressWarnings("WeakerAccess")
-    public void stop() {
-        stopAsync();
-        awaitStoppedAndPurge();
-    }
-
     public void awaitStoppedAndPurge() {
         kafka.awaitShutdown();
         log.debug("Removing log dir at {} ...", logDir);
@@ -145,6 +137,7 @@ public class KafkaEmbedded {
             brokerList(), zookeeperConnect());
     }
 
+    @SuppressWarnings("WeakerAccess")
     public void stopAsync() {
         log.debug("Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
             brokerList(), zookeeperConnect());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -124,6 +124,13 @@ public class KafkaEmbedded {
     }
 
     @SuppressWarnings("WeakerAccess")
+    public void stopAsync() {
+        log.debug("Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
+                  brokerList(), zookeeperConnect());
+        kafka.shutdown();
+    }
+
+    @SuppressWarnings("WeakerAccess")
     public void awaitStoppedAndPurge() {
         kafka.awaitShutdown();
         log.debug("Removing log dir at {} ...", logDir);
@@ -135,13 +142,6 @@ public class KafkaEmbedded {
         tmpFolder.delete();
         log.debug("Shutdown of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
             brokerList(), zookeeperConnect());
-    }
-
-    @SuppressWarnings("WeakerAccess")
-    public void stopAsync() {
-        log.debug("Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
-            brokerList(), zookeeperConnect());
-        kafka.shutdown();
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -128,9 +128,11 @@ public class KafkaEmbedded {
      */
     @SuppressWarnings("WeakerAccess")
     public void stop() {
-        log.debug("Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
-            brokerList(), zookeeperConnect());
-        kafka.shutdown();
+        stopAsync();
+        awaitStoppedAndPurge();
+    }
+
+    public void awaitStoppedAndPurge() {
         kafka.awaitShutdown();
         log.debug("Removing log dir at {} ...", logDir);
         try {
@@ -141,6 +143,12 @@ public class KafkaEmbedded {
         tmpFolder.delete();
         log.debug("Shutdown of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
             brokerList(), zookeeperConnect());
+    }
+
+    public void stopAsync() {
+        log.debug("Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
+            brokerList(), zookeeperConnect());
+        kafka.shutdown();
     }
 
     /**


### PR DESCRIPTION
* delete topics before tearing down multi-node clusters to avoid leader elections during shutdown
* tear down all nodes concurrently instead of sequentially

Right now on the current trunk, when I run `./gradlew clean :streams:test`, I get something like:
```
BUILD SUCCESSFUL in 12m 32s
```
Running the same command with this PR, I get:
```
BUILD SUCCESSFUL in 11m 23s
```

Not huge, but it helps. A side benefit is that we avoid filling the integration test logs with hundreds/thousands of lines of log messages during shutdown related to all the leader elections for all the topics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
