### PR TITLE
KAFKA-9770: Close underlying state store also when flush throws

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -402,11 +402,13 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         final String key = storeSensorPrefix(threadId, taskId, storeName);
         synchronized (storeLevelSensors) {
             final String fullSensorName = key + SENSOR_NAME_DELIMITER + sensorName;
-            return Optional.ofNullable(metrics.getSensor(fullSensorName))
-                .orElseGet(() -> {
-                    storeLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
-                    return metrics.sensor(fullSensorName, recordingLevel, parents);
-                });
+            final Sensor sensor = metrics.getSensor(fullSensorName);
+            if (sensor == null) {
+                storeLevelSensors.computeIfAbsent(key, ignored -> new LinkedList<>()).push(fullSensorName);
+                return metrics.sensor(fullSensorName, recordingLevel, parents);
+            } else {
+                return sensor;
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -297,7 +297,7 @@ public class CachingKeyValueStore
                 () -> cache.close(cacheName),
                 wrapped()::close
             );
-            if (suppressed != null && !suppressed.isEmpty()) {
+            if (!suppressed.isEmpty()) {
                 throwSuppressed("Caught an exception while closing caching key value store for store " + name(),
                                 suppressed);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -27,12 +27,15 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.kafka.streams.state.internals.ExceptionUtils.executeAll;
+import static org.apache.kafka.streams.state.internals.ExceptionUtils.throwSuppressed;
 
 public class CachingKeyValueStore
     extends WrappedStateStore<KeyValueStore<Bytes, byte[]>, byte[], byte[]>
@@ -120,6 +123,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         lock.writeLock().lock();
         try {
+            validateStoreOpen();
             // for null bytes, we still put it into cache indicating tombstones
             putInternal(key, value);
         } finally {
@@ -149,6 +153,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         lock.writeLock().lock();
         try {
+            validateStoreOpen();
             final byte[] v = getInternal(key);
             if (v == null) {
                 putInternal(key, value);
@@ -164,6 +169,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         lock.writeLock().lock();
         try {
+            validateStoreOpen();
             for (final KeyValue<Bytes, byte[]> entry : entries) {
                 Objects.requireNonNull(entry.key, "key cannot be null");
                 put(entry.key, entry.value);
@@ -179,6 +185,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         lock.writeLock().lock();
         try {
+            validateStoreOpen();
             return deleteInternal(key);
         } finally {
             lock.writeLock().unlock();
@@ -203,6 +210,7 @@ public class CachingKeyValueStore
         }
         theLock.lock();
         try {
+            validateStoreOpen();
             return getInternal(key);
         } finally {
             theLock.unlock();
@@ -260,6 +268,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         lock.readLock().lock();
         try {
+            validateStoreOpen();
             return wrapped().approximateNumEntries();
         } finally {
             lock.readLock().unlock();
@@ -268,10 +277,12 @@ public class CachingKeyValueStore
 
     @Override
     public void flush() {
+        validateStoreOpen();
         lock.writeLock().lock();
         try {
+            validateStoreOpen();
             cache.flush(cacheName);
-            super.flush();
+            wrapped().flush();
         } finally {
             lock.writeLock().unlock();
         }
@@ -279,17 +290,19 @@ public class CachingKeyValueStore
 
     @Override
     public void close() {
-        final List<RuntimeException> suppressed = new ArrayList<>();
-        captureException(this::flush, suppressed);
-        captureException(() -> cache.close(cacheName), suppressed);
-        captureException(super::close, suppressed);
-        if (!suppressed.isEmpty()) {
-            final RuntimeException toThrow =
-                new RuntimeException("Caught an exception while closing caching key value store for store " + name());
-            for (final RuntimeException e : suppressed) {
-                toThrow.addSuppressed(e);
+        lock.writeLock().lock();
+        try {
+            final LinkedList<RuntimeException> suppressed = executeAll(
+                () -> cache.flush(cacheName),
+                () -> cache.close(cacheName),
+                wrapped()::close
+            );
+            if (suppressed != null && !suppressed.isEmpty()) {
+                throwSuppressed("Caught an exception while closing caching key value store for store " + name(),
+                                suppressed);
             }
-            throw toThrow;
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -232,9 +232,15 @@ class CachingSessionStore
     }
 
     public void close() {
-        flush();
-        cache.close(cacheName);
-        super.close();
+        try {
+            flush();
+        } finally {
+            try {
+                super.close();
+            } finally {
+                cache.close(cacheName);
+            }
+        }
     }
 
     private class CacheIteratorWrapper implements PeekingKeyValueIterator<Bytes, LRUCacheEntry> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -242,7 +242,7 @@ class CachingSessionStore
             () -> cache.close(cacheName),
             wrapped()::close
         );
-        if (!suppressed.isEmpty()) {
+        if (suppressed != null && !suppressed.isEmpty()) {
             throwSuppressed("Caught an exception while closing caching session store for store " + name(),
                             suppressed);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -242,7 +242,7 @@ class CachingSessionStore
             () -> cache.close(cacheName),
             wrapped()::close
         );
-        if (suppressed != null && !suppressed.isEmpty()) {
+        if (!suppressed.isEmpty()) {
             throwSuppressed("Caught an exception while closing caching session store for store " + name(),
                             suppressed);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -304,7 +304,7 @@ class CachingWindowStore
             () -> cache.close(name),
             wrapped()::close
         );
-        if (suppressed != null && !suppressed.isEmpty()) {
+        if (!suppressed.isEmpty()) {
             throwSuppressed("Caught an exception while closing caching window store for store " + name(),
                             suppressed);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -294,9 +294,15 @@ class CachingWindowStore
 
     @Override
     public void close() {
-        flush();
-        cache.close(name);
-        wrapped().close();
+        try {
+            flush();
+        } finally {
+            try {
+                wrapped().close();
+            } finally {
+                cache.close(name);
+            }
+        }
     }
 
     private class CacheIteratorWrapper implements PeekingKeyValueIterator<Bytes, LRUCacheEntry> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ExceptionUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ExceptionUtils.java
@@ -22,14 +22,11 @@ final class ExceptionUtils {
     private ExceptionUtils() {}
 
     static LinkedList<RuntimeException> executeAll(final Runnable... actions) {
-        LinkedList<RuntimeException> suppressed = null;
+        final LinkedList<RuntimeException> suppressed = new LinkedList<>();
         for (final Runnable action : actions) {
             try {
                 action.run();
             } catch (final RuntimeException exception) {
-                if (suppressed == null) {
-                    suppressed = new LinkedList<>();
-                }
                 suppressed.add(exception);
             }
         }
@@ -37,7 +34,7 @@ final class ExceptionUtils {
     }
 
     static void throwSuppressed(final String message, final LinkedList<RuntimeException> suppressed) {
-        if (suppressed != null && !suppressed.isEmpty()) {
+        if (!suppressed.isEmpty()) {
             final RuntimeException firstCause = suppressed.pollFirst();
             final RuntimeException toThrow = new RuntimeException(message, firstCause);
             for (final RuntimeException e : suppressed) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ExceptionUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ExceptionUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.LinkedList;
+
+final class ExceptionUtils {
+    private ExceptionUtils() {}
+
+    static LinkedList<RuntimeException> executeAll(final Runnable... actions) {
+        LinkedList<RuntimeException> suppressed = null;
+        for (final Runnable action : actions) {
+            try {
+                action.run();
+            } catch (final RuntimeException exception) {
+                if (suppressed == null) {
+                    suppressed = new LinkedList<>();
+                }
+                suppressed.add(exception);
+            }
+        }
+        return suppressed;
+    }
+
+    static void throwSuppressed(final String message, final LinkedList<RuntimeException> suppressed) {
+        if (suppressed != null && !suppressed.isEmpty()) {
+            final RuntimeException firstCause = suppressed.pollFirst();
+            final RuntimeException toThrow = new RuntimeException(message, firstCause);
+            for (final RuntimeException e : suppressed) {
+                toThrow.addSuppressed(e);
+            }
+            throw toThrow;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -199,8 +199,11 @@ public class MeteredKeyValueStore<K, V>
 
     @Override
     public void close() {
-        super.close();
-        streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        try {
+            wrapped().close();
+        } finally {
+            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        }
     }
 
     private V outerValue(final byte[] value) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -228,8 +228,11 @@ public class MeteredSessionStore<K, V>
 
     @Override
     public void close() {
-        super.close();
-        streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        try {
+            wrapped().close();
+        } finally {
+            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        }
     }
 
     private Bytes keyBytes(final K key) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -202,8 +202,11 @@ public class MeteredWindowStore<K, V>
 
     @Override
     public void close() {
-        super.close();
-        streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        try {
+            wrapped().close();
+        } finally {
+            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+        }
     }
 
     private Bytes keyBytes(final K key) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -21,6 +21,8 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 
+import java.util.List;
+
 /**
  * A storage engine wrapper for utilities like logging, caching, and metering.
  */
@@ -91,5 +93,13 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
 
     public S wrapped() {
         return wrapped;
+    }
+
+    protected static void captureException(final Runnable action, final List<RuntimeException> suppressed) {
+        try {
+            action.run();
+        } catch (final RuntimeException exception) {
+            suppressed.add(exception);
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -21,8 +21,6 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
 
-import java.util.List;
-
 /**
  * A storage engine wrapper for utilities like logging, caching, and metering.
  */
@@ -93,13 +91,5 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
 
     public S wrapped() {
         return wrapped;
-    }
-
-    protected static void captureException(final Runnable action, final List<RuntimeException> suppressed) {
-        try {
-            action.run();
-        } catch (final RuntimeException exception) {
-            suppressed.add(exception);
-        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -33,9 +33,12 @@ import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
+import org.easymock.EasyMock;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -67,27 +70,30 @@ public class CachingSessionStoreTest {
     private static final int MAX_CACHE_SIZE_BYTES = 600;
     private static final Long DEFAULT_TIMESTAMP = 10L;
     private static final long SEGMENT_INTERVAL = 100L;
+    private static final String TOPIC = "topic";
+    private static final String CACHE_NAMESPACE = "0_0-store-name";
+
     private final Bytes keyA = Bytes.wrap("a".getBytes());
     private final Bytes keyAA = Bytes.wrap("aa".getBytes());
     private final Bytes keyB = Bytes.wrap("b".getBytes());
 
+    private SessionStore<org.apache.kafka.common.utils.Bytes, byte[]> sessionStore =
+        new InMemorySessionStore("store-name", Long.MAX_VALUE, "metric-scope");
+    private InternalMockProcessorContext context;
     private CachingSessionStore cachingStore;
     private ThreadCache cache;
 
-    public CachingSessionStoreTest() {
-        final SessionKeySchema schema = new SessionKeySchema();
-        final RocksDBSegmentedBytesStore root =
-            new RocksDBSegmentedBytesStore("test", "metrics-scope", 0L, SEGMENT_INTERVAL, schema);
-        final RocksDBSessionStore sessionStore = new RocksDBSessionStore(root);
+    @Before
+    public void before() {
         cachingStore = new CachingSessionStore(sessionStore, SEGMENT_INTERVAL);
         cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
         final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
-        context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, "topic", null));
+        context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, TOPIC, null));
         cachingStore.init(context, cachingStore);
     }
 
     @After
-    public void close() {
+    public void after() {
         cachingStore.close();
     }
 
@@ -121,6 +127,72 @@ public class CachingSessionStoreTest {
         verifyWindowedKeyValue(all.next(), new Windowed<>(keyAA, new SessionWindow(0, 0)), "1");
         verifyWindowedKeyValue(all.next(), new Windowed<>(keyB, new SessionWindow(0, 0)), "1");
         assertFalse(all.hasNext());
+    }
+
+    @Test
+    public void shouldCloseWrappedStoreAfterErrorDuringCacheFlush() {
+        setUpCloseTests();
+        cache.flush(CACHE_NAMESPACE);
+        EasyMock.expectLastCall().andThrow(new NullPointerException("Simulating an error on flush"));
+        EasyMock.replay(cache);
+        EasyMock.reset(sessionStore);
+        sessionStore.close();
+        EasyMock.replay(sessionStore);
+
+        try {
+            cachingStore.close();
+        } catch (final NullPointerException npe) {
+            EasyMock.verify(sessionStore);
+        }
+    }
+
+    @Test
+    public void shouldCloseWrappedStoreAfterErrorDuringCacheClose() {
+        setUpCloseTests();
+        cache.flush(CACHE_NAMESPACE);
+        cache.close(CACHE_NAMESPACE);
+        EasyMock.expectLastCall().andThrow(new NullPointerException("Simulating an error on close"));
+        EasyMock.replay(cache);
+        EasyMock.reset(sessionStore);
+        sessionStore.close();
+        EasyMock.replay(sessionStore);
+
+        try {
+            cachingStore.close();
+        } catch (final NullPointerException npe) {
+            EasyMock.verify(sessionStore);
+        }
+    }
+
+    @Test
+    public void shouldCloseCacheAfterErrorDuringStateStoreClose() {
+        setUpCloseTests();
+        EasyMock.reset(cache);
+        cache.flush(CACHE_NAMESPACE);
+        cache.close(CACHE_NAMESPACE);
+        EasyMock.replay(cache);
+        EasyMock.reset(sessionStore);
+        sessionStore.close();
+        EasyMock.expectLastCall().andThrow(new NullPointerException("Simulating an error on close"));
+        EasyMock.replay(sessionStore);
+
+        try {
+            cachingStore.close();
+        } catch (final NullPointerException npe) {
+            EasyMock.verify(cache);
+        }
+    }
+
+    private void setUpCloseTests() {
+        sessionStore = EasyMock.createNiceMock(SessionStore.class);
+        EasyMock.expect(sessionStore.name()).andStubReturn("store-name");
+        EasyMock.expect(sessionStore.isOpen()).andStubReturn(true);
+        EasyMock.replay(sessionStore);
+        cachingStore = new CachingSessionStore(sessionStore, SEGMENT_INTERVAL);
+        cache = EasyMock.niceMock(ThreadCache.class);
+        context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
+        context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, null));
+        cachingStore.init(context, cachingStore);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -49,7 +49,9 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -64,8 +66,11 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -339,8 +344,40 @@ public class MeteredSessionStoreTest {
         assertFalse(metered.setFlushListener(null, false));
     }
 
+    @Test
+    public void shouldRemoveMetricsOnClose() {
+        inner.close();
+        expectLastCall();
+        init(); // replays "inner"
+
+        // There's always a "count" metric registered
+        assertThat(storeMetrics(), not(empty()));
+        metered.close();
+        assertThat(storeMetrics(), empty());
+        verify(inner);
+    }
+
+    @Test
+    public void shouldRemoveMetricsEvenIfWrappedStoreThrowsOnClose() {
+        inner.close();
+        expectLastCall().andThrow(new RuntimeException("Oops!"));
+        init(); // replays "inner"
+
+        assertThat(storeMetrics(), not(empty()));
+        assertThrows(RuntimeException.class, metered::close);
+        assertThat(storeMetrics(), empty());
+        verify(inner);
+    }
+
     private KafkaMetric metric(final String name) {
         return this.metrics.metric(new MetricName(name, storeLevelGroup, "", this.tags));
     }
 
+    private List<MetricName> storeMetrics() {
+        return metrics.metrics()
+                      .keySet()
+                      .stream()
+                      .filter(name -> name.group().equals(storeLevelGroup) && name.tags().equals(tags))
+                      .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
When a caching state store is closed it calls its flush() method.
If flush() throws an exception the underlying state store is not closed.

This commit ensures that state stores underlying a caching state store
are closed even when flush() throws.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
