### PR TITLE
KAFKA-9771: Port patch for inter-worker Connect SSL from Jetty 9.4.25

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import javax.net.ssl.X509ExtendedKeyManager;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -20,8 +20,10 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
+import javax.net.ssl.X509ExtendedKeyManager;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +66,20 @@ public class SSLUtils {
     public static SslContextFactory createClientSideSslContextFactory(WorkerConfig config) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
 
-        final SslContextFactory.Client ssl = new SslContextFactory.Client();
+        // Override this method in order to avoid running into
+        // https://github.com/eclipse/jetty.project/issues/4385, which would otherwise cause this to
+        // break when the keystore contains multiple certificates.
+        // The override here matches the bug fix in Jetty for that issue:
+        // https://github.com/eclipse/jetty.project/pull/4404/files#diff-58640db0f8f2cd84b7e653d1c1540913R2188-R2193
+        // TODO: Remove this override when the version of Jetty for the framework is bumped to
+        //       9.4.25 or later
+        final SslContextFactory.Client ssl = new SslContextFactory.Client() {
+            @Override
+            @SuppressWarnings("deprecation")
+            protected X509ExtendedKeyManager newSniX509ExtendedKeyManager(X509ExtendedKeyManager keyManager) {
+                return keyManager;
+            }
+        };
 
         configureSslContextFactoryKeyStore(ssl, sslConfigValues);
         configureSslContextFactoryTrustStore(ssl, sslConfigValues);


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9771)

For reasons outlined in the ticket, we can't upgrade to a version of Jetty with the bug fixed, or downgrade to one prior to the introduction of the bug. Luckily, the actual fix is pretty straightforward and can be ported over to Connect for use until it's possible to upgrade to a version of Jetty with that bug fixed: https://github.com/eclipse/jetty.project/pull/4404/files#diff-58640db0f8f2cd84b7e653d1c1540913R2188-R2193

The changes here have been verified locally; currently investigating how they can best be tested via unit/integration/system tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
