### PR TITLE
KAFKA-9775: Fix IllegalFormatConversionException in ToolsUtils

### DIFF
--- a/core/src/main/scala/kafka/utils/ToolsUtils.scala
+++ b/core/src/main/scala/kafka/utils/ToolsUtils.scala
@@ -57,11 +57,11 @@ object ToolsUtils {
     println(s"\n%-${maxLengthOfDisplayName}s   %s".format("Metric Name", "Value"))
     sortedMap.foreach {
       case (metricName, value) =>
-        val fmt = value match {
-          case _ @ (_: java.lang.Float | _: java.lang.Double) => s"%-${maxLengthOfDisplayName}s : %.3f"
-          case _ => s"%-${maxLengthOfDisplayName}s : %s"
+        val specifier = value match {
+          case _ @ (_: java.lang.Float | _: java.lang.Double) => "%.3f"
+          case _ => "%s"
         }
-        println(fmt.format(metricName, value))
+        println(s"%-${maxLengthOfDisplayName}s : $specifier".format(metricName, value))
     }
   }
 }

--- a/core/src/main/scala/kafka/utils/ToolsUtils.scala
+++ b/core/src/main/scala/kafka/utils/ToolsUtils.scala
@@ -56,8 +56,14 @@ object ToolsUtils {
     }
     println(s"\n%-${maxLengthOfDisplayName}s   %s".format("Metric Name", "Value"))
     sortedMap.foreach {
-      case (metricName, value) =>
-        println(s"%-${maxLengthOfDisplayName}s : %.3f".format(metricName, value))
+      case (metricName, value) => {
+        val fmt =
+          if (value.isInstanceOf[java.lang.Float] || value.isInstanceOf[java.lang.Double])
+            s"%-${maxLengthOfDisplayName}s : %.3f"
+          else
+            s"%-${maxLengthOfDisplayName}s : %s"
+        println(fmt.format(metricName, value))
+      }
     }
   }
 }

--- a/core/src/main/scala/kafka/utils/ToolsUtils.scala
+++ b/core/src/main/scala/kafka/utils/ToolsUtils.scala
@@ -56,14 +56,12 @@ object ToolsUtils {
     }
     println(s"\n%-${maxLengthOfDisplayName}s   %s".format("Metric Name", "Value"))
     sortedMap.foreach {
-      case (metricName, value) => {
-        val fmt =
-          if (value.isInstanceOf[java.lang.Float] || value.isInstanceOf[java.lang.Double])
-            s"%-${maxLengthOfDisplayName}s : %.3f"
-          else
-            s"%-${maxLengthOfDisplayName}s : %s"
+      case (metricName, value) =>
+        val fmt = value match {
+          case _ @ (_: java.lang.Float | _: java.lang.Double) => s"%-${maxLengthOfDisplayName}s : %.3f"
+          case _ => s"%-${maxLengthOfDisplayName}s : %s"
+        }
         println(fmt.format(metricName, value))
-      }
     }
   }
 }

--- a/core/src/test/scala/kafka/utils/ToolsUtilsTest.scala
+++ b/core/src/test/scala/kafka/utils/ToolsUtilsTest.scala
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.utils
+
+import java.io.ByteArrayOutputStream
+import java.util.Collections
+
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.metrics.internals.IntGaugeSuite
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+class ToolsUtilsTest {
+  private val log = LoggerFactory.getLogger(classOf[ToolsUtilsTest])
+
+  @Test def testIntegerMetric(): Unit = {
+    val outContent = new ByteArrayOutputStream()
+    val metrics = new Metrics
+    val suite = new IntGaugeSuite[String](log, "example", metrics, (k: String) => new MetricName(k + "-bar", "test", "A test metric", Collections.singletonMap("key", "value")), 1)
+    suite.increment("foo")
+    Console.withOut(outContent) {
+      ToolsUtils.printMetrics(metrics.metrics.asScala)
+      assertTrue(outContent.toString.split("\n").exists(line => line.trim.matches("^test:foo-bar:\\{key=value\\}     : 1$")))
+    }
+  }
+
+}

--- a/core/src/test/scala/kafka/utils/ToolsUtilsTest.scala
+++ b/core/src/test/scala/kafka/utils/ToolsUtilsTest.scala
@@ -26,7 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ToolsUtilsTest {
   private val log = LoggerFactory.getLogger(classOf[ToolsUtilsTest])

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -65,7 +65,8 @@ class ConsumerPerformanceTest {
     val args: Array[String] = Array(
       "--bootstrap-server", "localhost:9092",
       "--topic", "test",
-      "--messages", "10"
+      "--messages", "10",
+      "--print-metrics"
     )
 
     //When


### PR DESCRIPTION
The runtime type of Metric.metricValue() needn't always be a Double,
for example, if it's a gauge from IntGaugeSuite.
Since it's impossible to format non-double values with 3 point precision
IllegalFormatConversionException resulted.

