### PR TITLE
KAFKA-9777; Use asynchronous write to log after txn marker completion

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
@@ -23,12 +23,12 @@ import kafka.server.DelayedOperation
 import org.apache.kafka.common.protocol.Errors
 
 /**
-  * Delayed transaction state change operations that are added to the purgatory without timeout (i.e. these operations should never time out)
-  */
+ * Delayed transaction state change operations that are added to the purgatory without
+ * timeout (i.e. these operations should never time out)
+ */
 private[transaction] class DelayedTxnMarker(txnMetadata: TransactionMetadata,
-                                           completionCallback: Errors => Unit,
-                                           lock: Lock)
-  extends DelayedOperation(TimeUnit.DAYS.toMillis(100 * 365), Some(lock)) {
+                                            completionCallback: Errors => Unit)
+  extends DelayedOperation(TimeUnit.DAYS.toMillis(100 * 365)) {
 
   override def tryComplete(): Boolean = {
     txnMetadata.inLock {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -111,8 +111,6 @@ class TransactionStateManager(brokerId: Int,
       loadingPartitions.add(partitionAndLeaderEpoch)
     }
   }
-  private[transaction] def stateReadLock = stateLock.readLock
-
   // this is best-effort expiration of an ongoing transaction which has been open for more than its
   // txn timeout value, we do not need to grab the lock on the metadata object upon checking its state
   // since the timestamp is volatile and we will get the lock when actually trying to transit the transaction

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -299,7 +299,9 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         /* start transaction coordinator, with a separate background thread scheduler for transaction expiration and log loading */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
-        transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"), zkClient, metrics, metadataCache, Time.SYSTEM)
+        transactionCoordinator = TransactionCoordinator(config, replicaManager,
+          new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"),
+          zkClient, metrics, metadataCache, Time.SYSTEM)
         transactionCoordinator.startup()
 
         /* Get the authorizer and initialize it if one is specified.*/

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -17,7 +17,6 @@
 package kafka.coordinator.transaction
 
 import java.util.Arrays.asList
-import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
 import kafka.utils.timer.MockTimer
@@ -92,10 +91,6 @@ class TransactionMarkerChannelManagerTest {
       .anyTimes()
     EasyMock.expect(txnStateManager.getTransactionState(EasyMock.eq(transactionalId2)))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata2))))
-      .anyTimes()
-    val stateLock = new ReentrantReadWriteLock
-    EasyMock.expect(txnStateManager.stateReadLock)
-      .andReturn(stateLock.readLock)
       .anyTimes()
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
 import kafka.utils.timer.MockTimer
-import kafka.utils.TestUtils
+import kafka.utils.{MockScheduler, TestUtils}
 import org.apache.kafka.clients.{ClientResponse, NetworkClient}
 import org.apache.kafka.common.requests.{RequestHeader, TransactionResult, WriteTxnMarkersRequest, WriteTxnMarkersResponse}
 import org.apache.kafka.common.utils.MockTime
@@ -69,6 +69,7 @@ class TransactionMarkerChannelManagerTest {
     new MockTimer,
     reaperEnabled = false)
   private val time = new MockTime
+  private val txnCompletionScheduler = new MockScheduler(time)
 
   private val channelManager = new TransactionMarkerChannelManager(
     KafkaConfig.fromProps(TestUtils.createBrokerConfig(1, "localhost:2181")),
@@ -76,6 +77,7 @@ class TransactionMarkerChannelManagerTest {
     networkClient,
     txnStateManager,
     txnMarkerPurgatory,
+    txnCompletionScheduler,
     time)
 
   private def mockCache(): Unit = {


### PR DESCRIPTION
This patch addresses a locking issue with `DelayTxnMarker` completion. Because of the reliance on the read lock in `TransactionStateManager`, we cannot guarantee that a call to `checkAndComplete` will offer an opportunity to complete the job. This patch removes the reliance on this lock. Instead when the operation is completed, we write the completion message to the log asynchronously.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
