### PR TITLE
MINOR: Refactor StreamsProducer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1007,7 +1007,7 @@ public class StreamsConfig extends AbstractConfig {
         checkIfUnexpectedUserSpecifiedConsumerConfig(clientProvidedProps, NON_CONFIGURABLE_CONSUMER_EOS_CONFIGS);
 
         final Map<String, Object> consumerProps = new HashMap<>(eosEnabled ? CONSUMER_EOS_OVERRIDES : CONSUMER_DEFAULT_OVERRIDES);
-        if (StreamThread.eosBetaEnabled(this)) {
+        if (StreamThread.processingMode(this) == StreamThread.ProcessingMode.EXACTLY_ONCE_BETA) {
             consumerProps.put("internal.throw.on.fetch.stable.offset.unsupported", true);
         }
         consumerProps.putAll(getClientCustomProps());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -16,15 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.time.Duration;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec;
@@ -35,6 +26,16 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ClientUtils {
 
@@ -77,7 +78,7 @@ public class ClientUtils {
     public static Map<MetricName, Metric> producerMetrics(final Collection<StreamsProducer> producers) {
         final Map<MetricName, Metric> result = new LinkedHashMap<>();
         for (final StreamsProducer producer : producers) {
-            final Map<MetricName, ? extends Metric> producerMetrics = producer.kafkaProducer().metrics();
+            final Map<MetricName, ? extends Metric> producerMetrics = producer.metrics();
             if (producerMetrics != null) {
                 result.putAll(producerMetrics);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -25,22 +25,29 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.Future;
 
-import static org.apache.kafka.streams.processor.internals.StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA;
+import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
+import static org.apache.kafka.streams.processor.internals.ClientUtils.getThreadProducerClientId;
 import static org.apache.kafka.streams.processor.internals.StreamThread.ProcessingMode.EXACTLY_ONCE_BETA;
 
 /**
@@ -55,20 +62,68 @@ public class StreamsProducer {
     private final Logger log;
     private final String logPrefix;
 
-    private Producer<byte[], byte[]> producer;
+    private final Map<String, Object> eosBetaProducerConfigs;
+    private final KafkaClientSupplier clientSupplier;
     private final StreamThread.ProcessingMode processingMode;
 
+    private Producer<byte[], byte[]> producer;
     private boolean transactionInFlight = false;
     private boolean transactionInitialized = false;
 
-    public StreamsProducer(final Producer<byte[], byte[]> producer,
-                           final StreamThread.ProcessingMode processingMode,
+    public StreamsProducer(final StreamsConfig config,
+                           final String threadId,
+                           final KafkaClientSupplier clientSupplier,
+                           final TaskId taskId,
+                           final UUID processId,
                            final LogContext logContext) {
-        this.producer = Objects.requireNonNull(producer, "producer cannot be null");
-        this.processingMode = Objects.requireNonNull(processingMode, "processingMode cannot be null");
-
+        Objects.requireNonNull(config, "config cannot be null");
+        Objects.requireNonNull(threadId, "threadId cannot be null");
+        this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier cannot be null");
         log = Objects.requireNonNull(logContext, "logContext cannot be null").logger(getClass());
         logPrefix = logContext.logPrefix().trim();
+
+        processingMode = StreamThread.processingMode(config);
+
+        final Map<String, Object> producerConfigs;
+        switch (processingMode) {
+            case AT_LEAST_ONCE: {
+                producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
+                eosBetaProducerConfigs = null;
+
+                break;
+            }
+            case EXACTLY_ONCE_ALPHA: {
+                producerConfigs = config.getProducerConfigs(
+                    getTaskProducerClientId(
+                        threadId,
+                        Objects.requireNonNull(taskId, "taskId cannot be null for exactly-once alpha")
+                    )
+                );
+
+                final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+                producerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, applicationId + "-" + taskId);
+
+                eosBetaProducerConfigs = null;
+
+                break;
+            }
+            case EXACTLY_ONCE_BETA: {
+                producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
+
+                final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+                producerConfigs.put(
+                    ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+                    applicationId + "-" + Objects.requireNonNull(processId, "processId cannot be null for exactly-once beta"));
+
+                eosBetaProducerConfigs = producerConfigs;
+
+                break;
+            }
+            default:
+                throw new IllegalArgumentException("Unknown processing mode: " + processingMode);
+        }
+
+        producer = clientSupplier.getProducer(producerConfigs);
     }
 
     private String formatException(final String message) {
@@ -76,7 +131,8 @@ public class StreamsProducer {
     }
 
     boolean eosEnabled() {
-        return processingMode == EXACTLY_ONCE_ALPHA || processingMode == EXACTLY_ONCE_BETA;
+        return processingMode == StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA ||
+            processingMode == StreamThread.ProcessingMode.EXACTLY_ONCE_BETA;
     }
 
     /**
@@ -113,12 +169,14 @@ public class StreamsProducer {
         }
     }
 
-    public void resetProducer(final Producer<byte[], byte[]> producer) {
+    public void resetProducer() {
         if (processingMode != EXACTLY_ONCE_BETA) {
             throw new IllegalStateException(formatException("Exactly-once beta is not enabled"));
         }
 
-        this.producer = Objects.requireNonNull(producer, "producer cannot be null");
+        producer.close();
+
+        producer = clientSupplier.getProducer(eosBetaProducerConfigs);
         transactionInitialized = false;
     }
 
@@ -233,10 +291,19 @@ public class StreamsProducer {
         return producer.partitionsFor(topic);
     }
 
+    Map<MetricName, ? extends Metric> metrics() {
+        return producer.metrics();
+    }
+
     void flush() {
         producer.flush();
     }
 
+    void close() {
+        producer.close();
+    }
+
+    // for testing only
     Producer<byte[], byte[]> kafkaProducer() {
         return producer;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -148,7 +148,7 @@ public class KafkaStreamsTest {
     public void before() throws Exception {
         time = new MockTime();
         supplier = new MockClientSupplier();
-        supplier.setClusterForAdminClient(Cluster.bootstrap(singletonList(new InetSocketAddress("localhost", 9999))));
+        supplier.setCluster(Cluster.bootstrap(singletonList(new InetSocketAddress("localhost", 9999))));
         streamsStateListener = new StateListenerStub();
         threadStatelistenerCapture = EasyMock.newCapture();
         metricsReportersCapture = EasyMock.newCapture();
@@ -212,8 +212,7 @@ public class KafkaStreamsTest {
         )).andReturn(streamThreadOne).andReturn(streamThreadTwo);
 
         EasyMock.expect(StreamThread.eosEnabled(anyObject(StreamsConfig.class))).andReturn(false).anyTimes();
-        EasyMock.expect(StreamThread.eosAlphaEnabled(anyObject(StreamsConfig.class))).andReturn(false).anyTimes();
-        EasyMock.expect(StreamThread.eosBetaEnabled(anyObject(StreamsConfig.class))).andReturn(false).anyTimes();
+        EasyMock.expect(StreamThread.processingMode(anyObject(StreamsConfig.class))).andReturn(StreamThread.ProcessingMode.AT_LEAST_ONCE).anyTimes();
         EasyMock.expect(streamThreadOne.getId()).andReturn(0L).anyTimes();
         EasyMock.expect(streamThreadTwo.getId()).andReturn(1L).anyTimes();
         prepareStreamThread(streamThreadOne, true);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -188,7 +188,7 @@ public class StreamThreadTest {
             clientSupplier.setApplicationIdForProducer(APPLICATION_ID);
         }
 
-        clientSupplier.setClusterForAdminClient(createCluster());
+        clientSupplier.setCluster(createCluster());
 
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,
@@ -1174,7 +1174,7 @@ public class StreamThreadTest {
     public void shouldReturnActiveTaskMetadataWhileRunningState() {
         internalTopologyBuilder.addSource(null, "source", null, null, null, topic1);
 
-        clientSupplier.setClusterForAdminClient(createCluster());
+        clientSupplier.setCluster(createCluster());
 
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -16,14 +16,8 @@
  */
 package org.apache.kafka.streams.state;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
-import org.apache.kafka.clients.producer.MockProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
@@ -39,12 +33,12 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
-import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.state.internals.MeteredKeyValueStore;
 import org.apache.kafka.streams.state.internals.RocksDBKeyValueStoreTest;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 
@@ -193,15 +187,26 @@ public class KeyValueStoreTestDriver<K, V> {
     private final StateSerdes<K, V> stateSerdes;
 
     private KeyValueStoreTestDriver(final StateSerdes<K, V> serdes) {
-        final ByteArraySerializer rawSerializer = new ByteArraySerializer();
-        final Producer<byte[], byte[]> producer = new MockProducer<>(true, rawSerializer, rawSerializer);
-        final Consumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "application-id");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class);
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, serdes.keySerde().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, serdes.valueSerde().getClass());
+        props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, RocksDBKeyValueStoreTest.TheRocksDbConfigSetter.class);
+        props.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "DEBUG");
 
         final LogContext logContext = new LogContext("KeyValueStoreTestDriver ");
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             new TaskId(0, 0),
-            new StreamsProducer(producer, StreamThread.ProcessingMode.AT_LEAST_ONCE, logContext),
+            new StreamsProducer(
+                new StreamsConfig(props),
+                "threadId",
+                new MockClientSupplier(),
+                null,
+                null,
+                logContext),
             new DefaultProductionExceptionHandler(),
             new MockStreamsMetrics(new Metrics())
         ) {
@@ -239,15 +244,6 @@ public class KeyValueStoreTestDriver<K, V> {
         //noinspection ResultOfMethodCallIgnored
         stateDir.mkdirs();
         stateSerdes = serdes;
-
-        props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "application-id");
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        props.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class);
-        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, serdes.keySerde().getClass());
-        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, serdes.valueSerde().getClass());
-        props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, RocksDBKeyValueStoreTest.TheRocksDbConfigSetter.class);
-        props.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "DEBUG");
 
         context = new InternalMockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, null) {
             ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -370,20 +371,15 @@ public class StreamThreadStateStoreProviderTest {
                 clientSupplier.restoreConsumer,
                 new MockStateRestoreListener()),
             topology.storeToChangelogTopic(), partitions);
-        final StreamThread.ProcessingMode processingMode;
-        if (StreamThread.eosAlphaEnabled(streamsConfig)) {
-            processingMode = StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA;
-        } else if (StreamThread.eosBetaEnabled(streamsConfig)) {
-            processingMode = StreamThread.ProcessingMode.EXACTLY_ONCE_BETA;
-        } else {
-            processingMode = StreamThread.ProcessingMode.AT_LEAST_ONCE;
-        }
         final RecordCollector recordCollector = new RecordCollectorImpl(
             logContext,
             taskId,
             new StreamsProducer(
-                clientSupplier.getProducer(new HashMap<>()),
-                processingMode,
+                streamsConfig,
+                "threadId",
+                clientSupplier,
+                new TaskId(0, 0),
+                UUID.randomUUID(),
                 logContext
             ),
             streamsConfig.defaultProductionExceptionHandler(),

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -52,7 +53,7 @@ public class MockClientSupplier implements KafkaClientSupplier {
         this.applicationId = applicationId;
     }
 
-    public void setClusterForAdminClient(final Cluster cluster) {
+    public void setCluster(final Cluster cluster) {
         this.cluster = cluster;
     }
 
@@ -68,7 +69,7 @@ public class MockClientSupplier implements KafkaClientSupplier {
         } else {
             assertFalse(config.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
         }
-        final MockProducer<byte[], byte[]> producer = new MockProducer<>(true, BYTE_ARRAY_SERIALIZER, BYTE_ARRAY_SERIALIZER);
+        final MockProducer<byte[], byte[]> producer = new MockProducer<>(cluster, true, new DefaultPartitioner(), BYTE_ARRAY_SERIALIZER, BYTE_ARRAY_SERIALIZER);
         producers.add(producer);
         return producer;
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/internals/TestDriverProducer.java
@@ -18,19 +18,22 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.Map;
+import java.util.UUID;
 
 public class TestDriverProducer extends StreamsProducer {
 
-    public TestDriverProducer(final Producer<byte[], byte[]> producer,
-                              final StreamThread.ProcessingMode processingMode,
+    public TestDriverProducer(final StreamsConfig config,
+                              final KafkaClientSupplier clientSupplier,
                               final LogContext logContext) {
-        super(producer, processingMode, logContext);
+        super(config, "TopologyTestDriver-Thread", clientSupplier, new TaskId(0, 0), UUID.randomUUID(), logContext);
     }
 
     @Override


### PR DESCRIPTION
To get better encapsulation, it seems to make sense to move the ownership (ie, creation and closing) of `KafkaProducer` inside of `StreamsProducer` instead of letting the `ActiveTaskCreator` handle it.

This will also simplify `ActiveTaskCreator#reInitializeThreadProducer()`  as introduced in #8331 (ie, there is a PR overlap and which ever PR is merged later, needs a rebase).

Call for review @guozhangwang @abbccdda 