### PR TITLE
MINOR: Exclude '**/*Suite.class' from test, unitTest and integrationTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,6 +327,7 @@ subprojects {
     // The suites are for running sets of tests in IDEs.
     // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
     exclude '**/*Suite.class'
+
     useJUnit {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
@@ -349,11 +350,12 @@ subprojects {
       exceptionFormat = testExceptionFormat
     }
     logTestStdout.rehydrate(delegate, owner, this)()
+    
+    // The suites are for running sets of tests in IDEs.
+    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
+    exclude '**/*Suite.class'
 
     if (it.project.name != 'generator') {
-      // The suites are for running sets of tests in IDEs.
-      // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
-      exclude '**/*Suite.class'
       useJUnit {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }

--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,10 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
+    // The suites are for running sets of tests in IDEs.
+    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
+    exclude '**/*Suite.class'
+
     retry {
       maxRetries = userMaxTestRetries
       maxFailures = userMaxTestRetryFailures
@@ -320,6 +324,9 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
+    // The suites are for running sets of tests in IDEs.
+    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
+    exclude '**/*Suite.class'
     useJUnit {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
@@ -344,6 +351,9 @@ subprojects {
     logTestStdout.rehydrate(delegate, owner, this)()
 
     if (it.project.name != 'generator') {
+      // The suites are for running sets of tests in IDEs.
+      // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
+      exclude '**/*Suite.class'
       useJUnit {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }
@@ -1278,12 +1288,6 @@ project(':streams') {
     main = 'org.apache.kafka.streams.StreamsConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "streams_config.html").newOutputStream()
-  }
-
-  test {
-    // The suites are for running sets of tests in IDEs.
-    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
-    exclude '**/*Suite.class'
   }
 }
 


### PR DESCRIPTION
```
./gradlew unitTest integrationTest \
    --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
    || { echo 'Test steps failed'; exit 1; }
```

The tasks ```unitTest``` and ```integrationTest``` used to run tests don't exclude the ```**/*Suite``` so the tests included by Suite class are executed two times. For example:
```
11:42:25 org.apache.kafka.streams.integration.StoreQuerySuite > org.apache.kafka.streams.integration.QueryableStateIntegrationTest.shouldBeAbleToQueryMapValuesState STARTED
11:42:26 
11:42:26 org.apache.kafka.streams.integration.GlobalKTableIntegrationTest > shouldKStreamGlobalKTableJoin PASSED
11:42:30 
11:42:30 org.apache.kafka.streams.integration.StoreQuerySuite > org.apache.kafka.streams.integration.QueryableStateIntegrationTest.shouldBeAbleToQueryMapValuesState PASSED
...
11:48:42 org.apache.kafka.streams.integration.QueryableStateIntegrationTest > shouldBeAbleToQueryMapValuesState STARTED
11:48:46 
11:48:46 org.apache.kafka.streams.integration.QueryableStateIntegrationTest > shouldBeAbleToQueryMapValuesState PASSED
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
