### PR TITLE
MINOR: reduce garbage in operation and resource java conversions

### DIFF
--- a/core/src/main/scala/kafka/security/auth/Operation.scala
+++ b/core/src/main/scala/kafka/security/auth/Operation.scala
@@ -91,7 +91,22 @@ object Operation {
     op.getOrElse(throw new KafkaException(operation + " not a valid operation name. The valid names are " + values.mkString(",")))
   }
 
-  def fromJava(operation: AclOperation): Operation = fromString(operation.toString.replaceAll("_", ""))
+  def fromJava(operation: AclOperation): Operation = {
+    operation match {
+      case AclOperation.READ => Read
+      case AclOperation.WRITE => Write
+      case AclOperation.CREATE => Create
+      case AclOperation.DELETE => Delete
+      case AclOperation.ALTER => Alter
+      case AclOperation.DESCRIBE => Describe
+      case AclOperation.CLUSTER_ACTION => ClusterAction
+      case AclOperation.ALTER_CONFIGS => AlterConfigs
+      case AclOperation.DESCRIBE_CONFIGS => DescribeConfigs
+      case AclOperation.IDEMPOTENT_WRITE => IdempotentWrite
+      case AclOperation.ALL => All
+      case _ => throw new KafkaException("Unexpected conversion of operation " + operation)
+    }
+  }
 
   def values: Seq[Operation] = List(Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs,
      DescribeConfigs, IdempotentWrite, All)

--- a/core/src/main/scala/kafka/security/auth/Operation.scala
+++ b/core/src/main/scala/kafka/security/auth/Operation.scala
@@ -104,7 +104,7 @@ object Operation {
       case AclOperation.DESCRIBE_CONFIGS => DescribeConfigs
       case AclOperation.IDEMPOTENT_WRITE => IdempotentWrite
       case AclOperation.ALL => All
-      case _ => throw new KafkaException("Unexpected conversion of operation " + operation)
+      case _ => throw new KafkaException(operation + " is not a convertible operation name. The valid names are " + values.mkString(","))
     }
   }
 

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -80,14 +80,14 @@ object ResourceType {
 
   def values: Seq[ResourceType] = List(Topic, Group, Cluster, TransactionalId, DelegationToken)
 
-  def fromJava(operation: JResourceType): ResourceType = {
-    operation match {
+  def fromJava(resourceType: JResourceType): ResourceType = {
+    resourceType match {
       case JResourceType.TOPIC => Topic
       case JResourceType.GROUP => Group
       case JResourceType.CLUSTER => Cluster
       case JResourceType.TRANSACTIONAL_ID => TransactionalId
       case JResourceType.DELEGATION_TOKEN => DelegationToken
-      case _ => throw new KafkaException("Unexpected conversion of operation " + operation)
+      case _ => throw new KafkaException("Unexpected conversion of operation " + resourceType)
     }
   }
 }

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -80,5 +80,14 @@ object ResourceType {
 
   def values: Seq[ResourceType] = List(Topic, Group, Cluster, TransactionalId, DelegationToken)
 
-  def fromJava(operation: JResourceType): ResourceType = fromString(operation.toString.replaceAll("_", ""))
+  def fromJava(operation: JResourceType): ResourceType = {
+    operation match {
+      case JResourceType.TOPIC => Topic
+      case JResourceType.GROUP => Group
+      case JResourceType.CLUSTER => Cluster
+      case JResourceType.TRANSACTIONAL_ID => TransactionalId
+      case JResourceType.DELEGATION_TOKEN => DelegationToken
+      case _ => throw new KafkaException("Unexpected conversion of operation " + operation)
+    }
+  }
 }

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -78,8 +78,6 @@ object ResourceType {
     rType.getOrElse(throw new KafkaException(resourceType + " not a valid resourceType name. The valid names are " + values.mkString(",")))
   }
 
-  def values: Seq[ResourceType] = List(Topic, Group, Cluster, TransactionalId, DelegationToken)
-
   def fromJava(resourceType: JResourceType): ResourceType = {
     resourceType match {
       case JResourceType.TOPIC => Topic
@@ -87,7 +85,9 @@ object ResourceType {
       case JResourceType.CLUSTER => Cluster
       case JResourceType.TRANSACTIONAL_ID => TransactionalId
       case JResourceType.DELEGATION_TOKEN => DelegationToken
-      case _ => throw new KafkaException("Unexpected conversion of operation " + resourceType)
+      case _ => throw new KafkaException(resourceType + " is not a convertible resource type. The valid types are " + values.mkString(","))
     }
   }
+
+  def values: Seq[ResourceType] = List(Topic, Group, Cluster, TransactionalId, DelegationToken)
 }


### PR DESCRIPTION
Minor change to reduce unnecessary garbage generation on Operation and ResourceType java/scala conversions.

The round-trip tests in https://github.com/apache/kafka/blob/dbeaba5d9e45846d89835c1d30c138147528d0f4/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala#L48 and https://github.com/apache/kafka/blob/dbeaba5d9e45846d89835c1d30c138147528d0f4/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala#L33 test this code path well so this change is very small risk.