### PR TITLE
MINOR: Fix MockAdminClient to not throw IndexOutOfBoundsException when brokerId is above the known one.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -473,13 +473,12 @@ public class MockAdminClient extends AdminClient {
     synchronized private Config getResourceDescription(ConfigResource resource) {
         switch (resource.type()) {
             case BROKER: {
-                Map<String, String> map =
-                    brokerConfigs.get(Integer.valueOf(resource.name()));
-                if (map == null) {
+                int brokerId = Integer.valueOf(resource.name());
+                if (brokerId >= brokerConfigs.size()) {
                     throw new InvalidRequestException("Broker " + resource.name() +
                         " not found.");
                 }
-                return toConfigObject(map);
+                return toConfigObject(brokerConfigs.get(brokerId));
             }
             case TOPIC: {
                 TopicMetadata topicMetadata = allTopics.get(resource.name());
@@ -538,11 +537,10 @@ public class MockAdminClient extends AdminClient {
                 } catch (NumberFormatException e) {
                     return e;
                 }
-                Map<String, String> map = brokerConfigs.get(brokerId);
-                if (map == null) {
+                if (brokerId >= brokerConfigs.size()) {
                     return new InvalidRequestException("no such broker as " + brokerId);
                 }
-                HashMap<String, String> newMap = new HashMap<>(map);
+                HashMap<String, String> newMap = new HashMap<>(brokerConfigs.get(brokerId));
                 for (AlterConfigOp op : ops) {
                     switch (op.opType()) {
                         case SET:


### PR DESCRIPTION
When `brokerId` is above the known one, an `IndexOutOfBoundsException` is thrown. The current handling logic likely assumed that the collection was a Map.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
