### PR TITLE
KAFKA-8107; Flaky Test kafka.api.ClientIdQuotaTest.testQuotaOverrideDelete

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -59,7 +59,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   // Low enough quota that a producer sending a small payload in a tight loop should get throttled
   val defaultProducerQuota: Long = 8000
   val defaultConsumerQuota: Long = 2500
-  val defaultRequestQuota: Double = Long.MaxValue
+  val defaultRequestQuota: Double = Long.MaxValue.toDouble
 
   val topic1 = "topic-1"
   var leaderNode: KafkaServer = _
@@ -95,8 +95,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     props.put(DynamicConfig.Client.ProducerByteRateOverrideProp, Long.MaxValue.toString)
     props.put(DynamicConfig.Client.ConsumerByteRateOverrideProp, Long.MaxValue.toString)
 
-    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue)
+    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue.toDouble)
+    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue.toDouble)
 
     val numRecords = 1000
     assertEquals(numRecords, quotaTestClients.produceUntilThrottled(numRecords))
@@ -112,8 +112,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     // consumer quota is set such that consumer quota * default quota window (10 seconds) is less than
     // MAX_PARTITION_FETCH_BYTES_CONFIG, so that we can test consumer ability to fetch in this case
     // In this case, 250 * 10 < 4096
-    quotaTestClients.overrideQuotas(2000, 250, Long.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(2000, 250, Long.MaxValue)
+    quotaTestClients.overrideQuotas(2000, 250, Long.MaxValue.toDouble)
+    quotaTestClients.waitForQuotaUpdate(2000, 250, Long.MaxValue.toDouble)
 
     val numRecords = 1000
     val produced = quotaTestClients.produceUntilThrottled(numRecords)
@@ -127,8 +127,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   @Test
   def testQuotaOverrideDelete(): Unit = {
     // Override producer and consumer quotas to unlimited
-    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue)
+    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue.toDouble)
+    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue.toDouble)
 
     val numRecords = 1000
     assertEquals(numRecords, quotaTestClients.produceUntilThrottled(numRecords))

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -57,9 +57,9 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   this.consumerConfig.setProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, "0")
 
   // Low enough quota that a producer sending a small payload in a tight loop should get throttled
-  protected def defaultProducerQuota: Long = 8000
-  protected def defaultConsumerQuota: Long = 2500
-  protected def defaultRequestQuota: Double = Int.MaxValue
+  val defaultProducerQuota: Long = 8000
+  val defaultConsumerQuota: Long = 2500
+  val defaultRequestQuota: Double = Long.MaxValue
 
   val topic1 = "topic-1"
   var leaderNode: KafkaServer = _
@@ -95,8 +95,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     props.put(DynamicConfig.Client.ProducerByteRateOverrideProp, Long.MaxValue.toString)
     props.put(DynamicConfig.Client.ConsumerByteRateOverrideProp, Long.MaxValue.toString)
 
-    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Int.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Int.MaxValue)
+    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue)
+    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue)
 
     val numRecords = 1000
     assertEquals(numRecords, quotaTestClients.produceUntilThrottled(numRecords))
@@ -112,8 +112,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     // consumer quota is set such that consumer quota * default quota window (10 seconds) is less than
     // MAX_PARTITION_FETCH_BYTES_CONFIG, so that we can test consumer ability to fetch in this case
     // In this case, 250 * 10 < 4096
-    quotaTestClients.overrideQuotas(2000, 250, Int.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(2000, 250, Int.MaxValue)
+    quotaTestClients.overrideQuotas(2000, 250, Long.MaxValue)
+    quotaTestClients.waitForQuotaUpdate(2000, 250, Long.MaxValue)
 
     val numRecords = 1000
     val produced = quotaTestClients.produceUntilThrottled(numRecords)
@@ -127,8 +127,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   @Test
   def testQuotaOverrideDelete(): Unit = {
     // Override producer and consumer quotas to unlimited
-    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Int.MaxValue)
-    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Int.MaxValue)
+    quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, Long.MaxValue)
+    quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, Long.MaxValue)
 
     val numRecords = 1000
     assertEquals(numRecords, quotaTestClients.produceUntilThrottled(numRecords))

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -57,9 +57,9 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   this.consumerConfig.setProperty(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, "0")
 
   // Low enough quota that a producer sending a small payload in a tight loop should get throttled
-  val defaultProducerQuota = 8000
-  val defaultConsumerQuota = 2500
-  val defaultRequestQuota = Int.MaxValue
+  protected def defaultProducerQuota: Long = 8000
+  protected def defaultConsumerQuota: Long = 2500
+  protected def defaultRequestQuota: Double = Int.MaxValue
 
   val topic1 = "topic-1"
   var leaderNode: KafkaServer = _
@@ -139,6 +139,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     // Delete producer and consumer quota overrides. Consumer and producer should now be
     // throttled since broker defaults are very small
     quotaTestClients.removeQuotaOverrides()
+    quotaTestClients.waitForQuotaUpdate(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
     val produced = quotaTestClients.produceUntilThrottled(numRecords)
     quotaTestClients.verifyProduceThrottle(expectThrottle = true)
 

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -26,6 +26,10 @@ class ClientIdQuotaTest extends BaseQuotaTest {
   override def producerClientId = "QuotasTestProducer-!@#$%^&*()"
   override def consumerClientId = "QuotasTestConsumer-!@#$%^&*()"
 
+  // The test does not setup a default request limit and thus default to Long.MaxValue
+  // which is the default value used when a quota does not exist.
+  override def defaultRequestQuota: Double = Long.MaxValue
+
   @Before
   override def setUp(): Unit = {
     this.serverConfig.setProperty(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp, defaultProducerQuota.toString)

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -26,10 +26,6 @@ class ClientIdQuotaTest extends BaseQuotaTest {
   override def producerClientId = "QuotasTestProducer-!@#$%^&*()"
   override def consumerClientId = "QuotasTestConsumer-!@#$%^&*()"
 
-  // The test does not setup a default request limit and thus default to Long.MaxValue
-  // which is the default value used when a quota does not exist.
-  override def defaultRequestQuota: Double = Long.MaxValue
-
   @Before
   override def setUp(): Unit = {
     this.serverConfig.setProperty(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp, defaultProducerQuota.toString)


### PR DESCRIPTION
This PR adds a `waitForQuotaUpdate` after the quotas are removed. It also changes the default request quota to Long.MaxValue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
