### PR TITLE
KAFKA-9754: Add an option to ignore ProduceBench errors

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -104,35 +104,10 @@ public final class WorkerUtils {
     }
 
     public static final int DEFAULT_TOPIC_VERIFY_BACKOFF = 2500;
+    public static final int DEFAULT_TOPIC_VERIFY_RETRIES = 3;
     private static final int ADMIN_REQUEST_TIMEOUT = 25000;
     private static final int CREATE_TOPICS_CALL_TIMEOUT = 180000;
     private static final int MAX_CREATE_TOPICS_BATCH_SIZE = 10;
-
-            //Map<String, Map<Integer, List<Integer>>> topics) throws Throwable {
-
-    /**
-     * Create some Kafka topics.
-     *
-     * @param log               The logger to use.
-     * @param bootstrapServers  The bootstrap server list.
-     * @param commonClientConf  Common client config
-     * @param adminClientConf   AdminClient config. This config has precedence over fields in
-     *                          common client config.
-     * @param topics            Maps topic names to partition assignments.
-     * @param failOnExisting    If true, the method will throw TopicExistsException if one or
-     *                          more topics already exist. Otherwise, the existing topics are
-     *                          verified for number of partitions. In this case, if number of
-     *                          partitions of an existing topic does not match the requested
-     *                          number of partitions, the method throws RuntimeException.
-     */
-    public static void createTopics(
-        Logger log, String bootstrapServers, Map<String, String> commonClientConf,
-        Map<String, String> adminClientConf,
-        Map<String, NewTopic> topics, boolean failOnExisting) throws Throwable {
-        // This method allows backward compatibility with the original signature of createTopics.
-        createTopics(log, bootstrapServers, commonClientConf, adminClientConf, topics, failOnExisting, 3,
-                DEFAULT_TOPIC_VERIFY_BACKOFF);
-    }
 
     /**
      * Create some Kafka topics.

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -103,6 +103,7 @@ public final class WorkerUtils {
         }
     }
 
+    public static final int DEFAULT_TOPIC_VERIFY_BACKOFF = 2500;
     private static final int ADMIN_REQUEST_TIMEOUT = 25000;
     private static final int CREATE_TOPICS_CALL_TIMEOUT = 180000;
     private static final int MAX_CREATE_TOPICS_BATCH_SIZE = 10;
@@ -128,12 +129,38 @@ public final class WorkerUtils {
         Logger log, String bootstrapServers, Map<String, String> commonClientConf,
         Map<String, String> adminClientConf,
         Map<String, NewTopic> topics, boolean failOnExisting) throws Throwable {
+        // This method allows backward compatibility with the original signature of createTopics.
+        createTopics(log, bootstrapServers, commonClientConf, adminClientConf, topics, failOnExisting, 3,
+                DEFAULT_TOPIC_VERIFY_BACKOFF);
+    }
+
+    /**
+     * Create some Kafka topics.
+     *
+     * @param log                  The logger to use.
+     * @param bootstrapServers     The bootstrap server list.
+     * @param commonClientConf     Common client config
+     * @param adminClientConf      AdminClient config. This config has precedence over fields in
+     *                             common client config.
+     * @param topics               Maps topic names to partition assignments.
+     * @param failOnExisting       If true, the method will throw TopicExistsException if one or
+     *                             more topics already exist. Otherwise, the existing topics are
+     *                             verified for number of partitions. In this case, if number of
+     *                             partitions of an existing topic does not match the requested
+     *                             number of partitions, the method throws RuntimeException.
+     * @param verifyRetryCount     The number of times to retry verifying the topic.
+     * @param verifyRetryBackoffMs The amount of time to wait between verify retries.
+     */
+    public static void createTopics(
+        Logger log, String bootstrapServers, Map<String, String> commonClientConf,
+        Map<String, String> adminClientConf, Map<String, NewTopic> topics,
+        boolean failOnExisting, int verifyRetryCount, long verifyRetryBackoffMs) throws Throwable {
         // this method wraps the call to createTopics() that takes admin client, so that we can
         // unit test the functionality with MockAdminClient. The exception is caught and
         // re-thrown so that admin client is closed when the method returns.
         try (Admin adminClient
                  = createAdminClient(bootstrapServers, commonClientConf, adminClientConf)) {
-            createTopics(log, adminClient, topics, failOnExisting);
+            createTopics(log, adminClient, topics, failOnExisting, verifyRetryCount, verifyRetryBackoffMs);
         } catch (Exception e) {
             log.warn("Failed to create or verify topics {}", topics, e);
             throw e;
@@ -149,7 +176,8 @@ public final class WorkerUtils {
      */
     static void createTopics(
         Logger log, Admin adminClient,
-        Map<String, NewTopic> topics, boolean failOnExisting) throws Throwable {
+        Map<String, NewTopic> topics, boolean failOnExisting,
+        int verifyRetryCount, long verifyRetryBackoffMs) throws Throwable {
         if (topics.isEmpty()) {
             log.warn("Request to create topics has an empty topic list.");
             return;
@@ -161,7 +189,7 @@ public final class WorkerUtils {
                 log.warn("Topic(s) {} already exist.", topicsExists);
                 throw new TopicExistsException("One or more topics already exist.");
             } else {
-                verifyTopics(log, adminClient, topicsExists, topics, 3, 2500);
+                verifyTopics(log, adminClient, topicsExists, topics, verifyRetryCount, verifyRetryBackoffMs);
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -72,6 +72,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final TopicsSpec activeTopics;
     private final TopicsSpec inactiveTopics;
     private final boolean useConfiguredPartitioner;
+    private final boolean ignoreProduceErrors;
     private final boolean skipFlush;
 
     @JsonCreator
@@ -89,7 +90,8 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                          @JsonProperty("activeTopics") TopicsSpec activeTopics,
                          @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics,
-                         @JsonProperty("useConfiguredPartitioner") boolean useConfiguredPartitioner, 
+                         @JsonProperty("useConfiguredPartitioner") boolean useConfiguredPartitioner,
+                         @JsonProperty("ignoreProduceErrors") boolean ignoreProduceErrors,
                          @JsonProperty("skipFlush") boolean skipFlush) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
@@ -109,6 +111,7 @@ public class ProduceBenchSpec extends TaskSpec {
         this.inactiveTopics = (inactiveTopics == null) ?
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
         this.useConfiguredPartitioner = useConfiguredPartitioner;
+        this.ignoreProduceErrors = ignoreProduceErrors;
         this.skipFlush = skipFlush;
     }
 
@@ -175,6 +178,11 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public boolean useConfiguredPartitioner() {
         return useConfiguredPartitioner;
+    }
+
+    @JsonProperty
+    public boolean ignoreProduceErrors() {
+        return ignoreProduceErrors;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -43,6 +43,8 @@ import java.util.Optional;
  *      "bootstrapServers": "localhost:9092",
  *      "targetMessagesPerSec": 10,
  *      "maxMessages": 100,
+ *      "topicVerificationRetries": 3,
+ *      "ignoreProduceErrors": false,
  *      "activeTopics": {
  *        "foo[1-3]": {
  *          "numPartitions": 3,
@@ -73,6 +75,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final TopicsSpec inactiveTopics;
     private final boolean useConfiguredPartitioner;
     private final boolean ignoreProduceErrors;
+    private final int topicVerificationRetries;
     private final boolean skipFlush;
 
     @JsonCreator
@@ -91,8 +94,9 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("activeTopics") TopicsSpec activeTopics,
                          @JsonProperty("inactiveTopics") TopicsSpec inactiveTopics,
                          @JsonProperty("useConfiguredPartitioner") boolean useConfiguredPartitioner,
+                         @JsonProperty("skipFlush") boolean skipFlush,
                          @JsonProperty("ignoreProduceErrors") boolean ignoreProduceErrors,
-                         @JsonProperty("skipFlush") boolean skipFlush) {
+                         @JsonProperty("topicVerificationRetries") int topicVerificationRetries) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
@@ -112,6 +116,7 @@ public class ProduceBenchSpec extends TaskSpec {
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
         this.useConfiguredPartitioner = useConfiguredPartitioner;
         this.ignoreProduceErrors = ignoreProduceErrors;
+        this.topicVerificationRetries = (topicVerificationRetries == 0) ? 3 : topicVerificationRetries;
         this.skipFlush = skipFlush;
     }
 
@@ -188,6 +193,11 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public boolean skipFlush() {
         return skipFlush;
+    }
+
+    @JsonProperty
+    public int topicVerificationRetries() {
+        return topicVerificationRetries;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -19,6 +19,7 @@ package org.apache.kafka.trogdor.workload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kafka.trogdor.common.WorkerUtils;
 import org.apache.kafka.trogdor.task.TaskController;
 import org.apache.kafka.trogdor.task.TaskSpec;
 import org.apache.kafka.trogdor.task.TaskWorker;
@@ -116,7 +117,8 @@ public class ProduceBenchSpec extends TaskSpec {
             TopicsSpec.EMPTY : inactiveTopics.immutableCopy();
         this.useConfiguredPartitioner = useConfiguredPartitioner;
         this.ignoreProduceErrors = ignoreProduceErrors;
-        this.topicVerificationRetries = (topicVerificationRetries == 0) ? 3 : topicVerificationRetries;
+        this.topicVerificationRetries = (topicVerificationRetries == 0) ?
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES : topicVerificationRetries;
         this.skipFlush = skipFlush;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -131,10 +131,12 @@ public class ProduceBenchWorker implements TaskWorker {
     private static class SendRecordsCallback implements Callback {
         private final SendRecords sendRecords;
         private final long startMs;
+        private final AtomicLong totalCallbackErrors;
 
-        SendRecordsCallback(SendRecords sendRecords, long startMs) {
+        SendRecordsCallback(SendRecords sendRecords, long startMs, AtomicLong totalCallbackErrors) {
             this.sendRecords = sendRecords;
             this.startMs = startMs;
+            this.totalCallbackErrors = totalCallbackErrors;
         }
 
         @Override
@@ -143,6 +145,7 @@ public class ProduceBenchWorker implements TaskWorker {
             long durationMs = now - startMs;
             sendRecords.recordDuration(durationMs);
             if (exception != null) {
+                totalCallbackErrors.getAndIncrement();
                 log.error("SendRecordsCallback: error", exception);
             }
         }
@@ -190,7 +193,10 @@ public class ProduceBenchWorker implements TaskWorker {
         private Iterator<TopicPartition> partitionsIterator;
         private Future<RecordMetadata> sendFuture;
         private AtomicLong transactionsCommitted;
+        private AtomicLong totalProduceErrors;
+        private AtomicLong totalCallbackErrors;
         private boolean enableTransactions;
+        private boolean ignoreProduceErrors;
 
         SendRecords(HashSet<TopicPartition> activePartitions) {
             this.activePartitions = activePartitions;
@@ -198,12 +204,15 @@ public class ProduceBenchWorker implements TaskWorker {
             this.histogram = new Histogram(5000);
 
             this.transactionGenerator = spec.transactionGenerator();
+            this.ignoreProduceErrors = spec.ignoreProduceErrors();
             this.enableTransactions = this.transactionGenerator.isPresent();
             this.transactionsCommitted = new AtomicLong();
+            this.totalProduceErrors = new AtomicLong();
+            this.totalCallbackErrors = new AtomicLong();
 
             int perPeriod = WorkerUtils.perSecToPerPeriod(spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
             this.statusUpdaterFuture = executor.scheduleWithFixedDelay(
-                new StatusUpdater(histogram, transactionsCommitted), 30, 30, TimeUnit.SECONDS);
+                new StatusUpdater(histogram, transactionsCommitted, totalProduceErrors, totalCallbackErrors), 30, 30, TimeUnit.SECONDS);
 
             Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.bootstrapServers());
@@ -259,7 +268,7 @@ public class ProduceBenchWorker implements TaskWorker {
                 WorkerUtils.abort(log, "SendRecords", e, doneFuture);
             } finally {
                 statusUpdaterFuture.cancel(false);
-                StatusData statusData = new StatusUpdater(histogram, transactionsCommitted).update();
+                StatusData statusData = new StatusUpdater(histogram, transactionsCommitted, totalProduceErrors, totalCallbackErrors).update();
                 long curTimeMs = Time.SYSTEM.milliseconds();
                 log.info("Sent {} total record(s) in {} ms.  status: {}",
                     histogram.summarize().numSamples(), curTimeMs - startTimeMs, statusData);
@@ -305,8 +314,15 @@ public class ProduceBenchWorker implements TaskWorker {
                 record = new ProducerRecord<>(
                     partition.topic(), partition.partition(), keys.next(), values.next());
             }
-            sendFuture = producer.send(record,
-                new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
+            try {
+                sendFuture = producer.send(record,
+                    new SendRecordsCallback(this, Time.SYSTEM.milliseconds(), totalCallbackErrors));
+            } catch (Exception e) {
+                totalProduceErrors.getAndIncrement();
+                if (!ignoreProduceErrors) {
+                    throw e;
+                }
+            }
             throttle.increment();
         }
 
@@ -318,10 +334,14 @@ public class ProduceBenchWorker implements TaskWorker {
     public class StatusUpdater implements Runnable {
         private final Histogram histogram;
         private final AtomicLong transactionsCommitted;
+        private final AtomicLong totalProduceErrors;
+        private final AtomicLong totalCallbackErrors;
 
-        StatusUpdater(Histogram histogram, AtomicLong transactionsCommitted) {
+        StatusUpdater(Histogram histogram, AtomicLong transactionsCommitted, AtomicLong totalProduceErrors, AtomicLong totalCallbackErrors) {
             this.histogram = histogram;
             this.transactionsCommitted = transactionsCommitted;
+            this.totalProduceErrors = totalProduceErrors;
+            this.totalCallbackErrors = totalCallbackErrors;
         }
 
         @Override
@@ -339,7 +359,9 @@ public class ProduceBenchWorker implements TaskWorker {
                 summary.percentiles().get(0).value(),
                 summary.percentiles().get(1).value(),
                 summary.percentiles().get(2).value(),
-                transactionsCommitted.get());
+                transactionsCommitted.get(),
+                totalProduceErrors.get(),
+                totalCallbackErrors.get());
             status.update(JsonUtil.JSON_SERDE.valueToTree(statusData));
             return statusData;
         }
@@ -352,6 +374,8 @@ public class ProduceBenchWorker implements TaskWorker {
         private final int p95LatencyMs;
         private final int p99LatencyMs;
         private final long transactionsCommitted;
+        private final long totalProduceErrors;
+        private final long totalCallbackErrors;
 
         /**
          * The percentiles to use when calculating the histogram data.
@@ -365,18 +389,32 @@ public class ProduceBenchWorker implements TaskWorker {
                    @JsonProperty("p50LatencyMs") int p50latencyMs,
                    @JsonProperty("p95LatencyMs") int p95latencyMs,
                    @JsonProperty("p99LatencyMs") int p99latencyMs,
-                   @JsonProperty("transactionsCommitted") long transactionsCommitted) {
+                   @JsonProperty("transactionsCommitted") long transactionsCommitted,
+                   @JsonProperty("totalProduceErrors") long totalProduceErrors,
+                   @JsonProperty("totalCallbackErrors") long totalCallbackErrors) {
             this.totalSent = totalSent;
             this.averageLatencyMs = averageLatencyMs;
             this.p50LatencyMs = p50latencyMs;
             this.p95LatencyMs = p95latencyMs;
             this.p99LatencyMs = p99latencyMs;
             this.transactionsCommitted = transactionsCommitted;
+            this.totalProduceErrors = totalProduceErrors;
+            this.totalCallbackErrors = totalCallbackErrors;
         }
 
         @JsonProperty
         public long totalSent() {
             return totalSent;
+        }
+
+        @JsonProperty
+        public long totalProduceErrors() {
+            return totalProduceErrors;
+        }
+
+        @JsonProperty
+        public long totalCallbackErrors() {
+            return totalCallbackErrors;
         }
 
         @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -119,7 +119,8 @@ public class ProduceBenchWorker implements TaskWorker {
                 }
                 status.update(new TextNode("Creating " + newTopics.keySet().size() + " topic(s)"));
                 WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
-                                         spec.adminClientConf(), newTopics, false);
+                                         spec.adminClientConf(), newTopics, false, spec.topicVerificationRetries(),
+                                         WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
                 executor.submit(new SendRecords(active));
             } catch (Throwable e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -147,7 +147,8 @@ public class RoundTripWorker implements TaskWorker {
                 }
                 status.update(new TextNode("Creating " + newTopics.keySet().size() + " topic(s)"));
                 WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
-                    spec.adminClientConf(), newTopics, true);
+                    spec.adminClientConf(), newTopics, true, WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES,
+                    WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
                 toSendTracker = new ToSendTracker(spec.maxMessages());
                 toReceiveTracker = new ToReceiveTracker();

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -55,7 +55,7 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, null, 0, null));
         verify(new WorkerStopping(null, null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, Optional.empty(), null, null, null, null, null, false, false, false));
+            0, 0, null, null, Optional.empty(), null, null, null, null, null, false, false, false, 0));
         verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null,
             0, null, null, 0));
         verify(new TopicsSpec());

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -55,7 +55,7 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, null, 0, null));
         verify(new WorkerStopping(null, null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, Optional.empty(), null, null, null, null, null, false, false));
+            0, 0, null, null, Optional.empty(), null, null, null, null, null, false, false, false));
         verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null,
             0, null, null, 0));
         verify(new TopicsSpec());

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -73,7 +73,7 @@ public class WorkerUtilsTest {
     public void testCreateOneTopic() throws Throwable {
         Map<String, NewTopic> newTopics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
 
-        WorkerUtils.createTopics(log, adminClient, newTopics, true);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
         assertEquals(
             new TopicDescription(
@@ -90,7 +90,7 @@ public class WorkerUtilsTest {
         adminClient.timeoutNextRequest(1);
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true, 3, 2500);
 
         assertEquals(
             new TopicDescription(
@@ -104,7 +104,7 @@ public class WorkerUtilsTest {
 
     @Test
     public void testCreateZeroTopicsDoesNothing() throws Throwable {
-        WorkerUtils.createTopics(log, adminClient, Collections.<String, NewTopic>emptyMap(), true);
+        WorkerUtils.createTopics(log, adminClient, Collections.<String, NewTopic>emptyMap(), true, 3, 2500);
         assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
@@ -123,7 +123,7 @@ public class WorkerUtilsTest {
         newTopics.put("one-more-topic",
                       new NewTopic("one-more-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
 
-        WorkerUtils.createTopics(log, adminClient, newTopics, true);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
     }
 
     @Test(expected = RuntimeException.class)
@@ -138,7 +138,7 @@ public class WorkerUtilsTest {
             null);
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false, 3, 2500);
     }
 
     @Test
@@ -158,7 +158,8 @@ public class WorkerUtilsTest {
             log, adminClient,
             Collections.singletonMap(
                 existingTopic,
-                new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR)), false);
+                new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR)), false,
+            3, 2500);
 
         assertEquals(Collections.singleton(existingTopic), adminClient.listTopics().names().get());
     }
@@ -169,7 +170,7 @@ public class WorkerUtilsTest {
         assertEquals(0, adminClient.listTopics().names().get().size());
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false, 3, 2500);
 
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
         assertEquals(
@@ -198,7 +199,7 @@ public class WorkerUtilsTest {
                    new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR));
         topics.put(TEST_TOPIC, NEW_TEST_TOPIC);
 
-        WorkerUtils.createTopics(log, adminClient, topics, false);
+        WorkerUtils.createTopics(log, adminClient, topics, false, 3, 2500);
 
         assertEquals(Utils.mkSet(existingTopic, TEST_TOPIC), adminClient.listTopics().names().get());
     }
@@ -206,7 +207,7 @@ public class WorkerUtilsTest {
     @Test
     public void testCreateNonExistingTopicsWithZeroTopicsDoesNothing() throws Throwable {
         WorkerUtils.createTopics(
-            log, adminClient, Collections.<String, NewTopic>emptyMap(), false);
+            log, adminClient, Collections.<String, NewTopic>emptyMap(), false, 3, 2500);
         assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
@@ -320,7 +321,7 @@ public class WorkerUtilsTest {
     @Test
     public void testVerifyTopics() throws Throwable {
         Map<String, NewTopic> newTopics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
-        WorkerUtils.createTopics(log, adminClient, newTopics, true);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
         adminClient.setFetchesRemainingUntilVisible(TEST_TOPIC, 2);
         WorkerUtils.verifyTopics(log, adminClient, Collections.singleton(TEST_TOPIC),
             Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), 3, 1);

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -73,7 +73,8 @@ public class WorkerUtilsTest {
     public void testCreateOneTopic() throws Throwable {
         Map<String, NewTopic> newTopics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
 
-        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
         assertEquals(
             new TopicDescription(
@@ -90,7 +91,8 @@ public class WorkerUtilsTest {
         adminClient.timeoutNextRequest(1);
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true, 3, 2500);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
 
         assertEquals(
             new TopicDescription(
@@ -104,7 +106,8 @@ public class WorkerUtilsTest {
 
     @Test
     public void testCreateZeroTopicsDoesNothing() throws Throwable {
-        WorkerUtils.createTopics(log, adminClient, Collections.<String, NewTopic>emptyMap(), true, 3, 2500);
+        WorkerUtils.createTopics(log, adminClient, Collections.<String, NewTopic>emptyMap(), true,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
         assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
@@ -123,7 +126,8 @@ public class WorkerUtilsTest {
         newTopics.put("one-more-topic",
                       new NewTopic("one-more-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
 
-        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
     }
 
     @Test(expected = RuntimeException.class)
@@ -138,7 +142,8 @@ public class WorkerUtilsTest {
             null);
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false, 3, 2500);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
     }
 
     @Test
@@ -159,7 +164,7 @@ public class WorkerUtilsTest {
             Collections.singletonMap(
                 existingTopic,
                 new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR)), false,
-            3, 2500);
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
 
         assertEquals(Collections.singleton(existingTopic), adminClient.listTopics().names().get());
     }
@@ -170,7 +175,9 @@ public class WorkerUtilsTest {
         assertEquals(0, adminClient.listTopics().names().get().size());
 
         WorkerUtils.createTopics(
-            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false, 3, 2500);
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
+
 
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
         assertEquals(
@@ -199,7 +206,8 @@ public class WorkerUtilsTest {
                    new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR));
         topics.put(TEST_TOPIC, NEW_TEST_TOPIC);
 
-        WorkerUtils.createTopics(log, adminClient, topics, false, 3, 2500);
+        WorkerUtils.createTopics(log, adminClient, topics, false, WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
 
         assertEquals(Utils.mkSet(existingTopic, TEST_TOPIC), adminClient.listTopics().names().get());
     }
@@ -207,7 +215,8 @@ public class WorkerUtilsTest {
     @Test
     public void testCreateNonExistingTopicsWithZeroTopicsDoesNothing() throws Throwable {
         WorkerUtils.createTopics(
-            log, adminClient, Collections.<String, NewTopic>emptyMap(), false, 3, 2500);
+            log, adminClient, Collections.<String, NewTopic>emptyMap(), false,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES, WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
         assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
@@ -321,7 +330,8 @@ public class WorkerUtilsTest {
     @Test
     public void testVerifyTopics() throws Throwable {
         Map<String, NewTopic> newTopics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
-        WorkerUtils.createTopics(log, adminClient, newTopics, true, 3, 2500);
+        WorkerUtils.createTopics(log, adminClient, newTopics, true, WorkerUtils.DEFAULT_TOPIC_VERIFY_RETRIES,
+            WorkerUtils.DEFAULT_TOPIC_VERIFY_BACKOFF);
         adminClient.setFetchesRemainingUntilVisible(TEST_TOPIC, 2);
         WorkerUtils.verifyTopics(log, adminClient, Collections.singleton(TEST_TOPIC),
             Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), 3, 1);


### PR DESCRIPTION
This change adds the following features to the Trogdor ProduceBenchWorker:

Ability to ignore errors caused by SendRecords.
Tracking of the number of errors ignored.
Additional tracking of the number of callbacks with exceptions.
Ability to extend ProduceBenchWorker's verify phase to deal with large topics.

In order to maintain backward compatibility, ignoring errors is disabled by default.

All build-time integration tests passed:

BUILD SUCCESSFUL in 42m 8s
334 actionable tasks: 255 executed, 79 up-to-date