### PR TITLE
KAFKA-9740 Add a continue option for Kafka Connect error handling (KIP-582)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -190,7 +190,7 @@ public class ConnectorConfig extends AbstractConfig {
                 .define(ERRORS_RETRY_MAX_DELAY_CONFIG, Type.LONG, ERRORS_RETRY_MAX_DELAY_DEFAULT, Importance.MEDIUM,
                         ERRORS_RETRY_MAX_DELAY_DOC, ERROR_GROUP, ++orderInErrorGroup, Width.MEDIUM, ERRORS_RETRY_MAX_DELAY_DISPLAY)
                 .define(ERRORS_TOLERANCE_CONFIG, Type.STRING, ERRORS_TOLERANCE_DEFAULT.value(),
-                        in(ToleranceType.NONE.value(), ToleranceType.ALL.value()), Importance.MEDIUM,
+                        in(ToleranceType.NONE.value(), ToleranceType.ALL.value(), ToleranceType.CONTINUE.value()), Importance.MEDIUM,
                         ERRORS_TOLERANCE_DOC, ERROR_GROUP, ++orderInErrorGroup, Width.SHORT, ERRORS_TOLERANCE_DISPLAY)
                 .define(ERRORS_LOG_ENABLE_CONFIG, Type.BOOLEAN, ERRORS_LOG_ENABLE_DEFAULT, Importance.MEDIUM,
                         ERRORS_LOG_ENABLE_DOC, ERROR_GROUP, ++orderInErrorGroup, Width.SHORT, ERRORS_LOG_ENABLE_DISPLAY)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -111,6 +111,15 @@ public class RetryWithToleranceOperator {
     }
 
     /**
+     * Check whether error tolerance type is CONTINUE
+     *
+     * @return if the execution requires continue when error occurs
+     */
+    public boolean continueOnError() {
+        return errorToleranceType == ToleranceType.CONTINUE;
+    }
+
+    /**
      * Attempt to execute an operation. Retry if a {@link RetriableException} is raised. Re-throw everything else.
      *
      * @param operation the operation to be executed.
@@ -162,7 +171,9 @@ public class RetryWithToleranceOperator {
             V result = execAndRetry(operation);
             if (context.failed()) {
                 markAsFailed();
-                errorHandlingMetrics.recordSkipped();
+                if (!continueOnError()) {
+                    errorHandlingMetrics.recordSkipped();
+                }
             }
             return result;
         } catch (Exception e) {
@@ -178,7 +189,9 @@ public class RetryWithToleranceOperator {
                 throw new ConnectException("Tolerance exceeded in error handler", e);
             }
 
-            errorHandlingMetrics.recordSkipped();
+            if (!continueOnError()) {
+                errorHandlingMetrics.recordSkipped();
+            }
             return null;
         }
     }
@@ -196,6 +209,7 @@ public class RetryWithToleranceOperator {
             case NONE:
                 if (totalFailures > 0) return false;
             case ALL:
+            case CONTINUE:
                 return true;
             default:
                 throw new ConfigException("Unknown tolerance type: {}", errorToleranceType);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ToleranceType.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ToleranceType.java
@@ -31,7 +31,13 @@ public enum ToleranceType {
     /**
      * Tolerate all errors.
      */
-    ALL;
+    ALL,
+
+    /**
+     * Tolerate all errors and forward raw bytes to sink connector
+     * Behave like ALL for source connector
+     */
+    CONTINUE;
 
     public String value() {
         return name().toLowerCase(Locale.ROOT);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -54,6 +54,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_DEFAULT;
 import static org.apache.kafka.connect.runtime.errors.ToleranceType.ALL;
 import static org.apache.kafka.connect.runtime.errors.ToleranceType.NONE;
+import static org.apache.kafka.connect.runtime.errors.ToleranceType.CONTINUE;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -269,6 +270,18 @@ public class RetryWithToleranceOperatorTest {
     }
 
     @Test
+    public void testContinueOnError() {
+        RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, CONTINUE, SYSTEM);
+        assertTrue("should continue on errors", retryWithToleranceOperator.continueOnError());
+
+        retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, SYSTEM);
+        assertFalse("should not continue on errors", retryWithToleranceOperator.continueOnError());
+
+        retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);
+        assertFalse("should not continue on errors", retryWithToleranceOperator.continueOnError());
+    }
+
+    @Test
     public void testToleranceLimit() {
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
@@ -279,6 +292,9 @@ public class RetryWithToleranceOperatorTest {
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
         retryWithToleranceOperator.markAsFailed();
         retryWithToleranceOperator.markAsFailed();
+        assertTrue("should tolerate all errors", retryWithToleranceOperator.withinToleranceLimits());
+
+        retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, CONTINUE, SYSTEM);
         assertTrue("should tolerate all errors", retryWithToleranceOperator.withinToleranceLimits());
 
         retryWithToleranceOperator = new RetryWithToleranceOperator(ERRORS_RETRY_TIMEOUT_DEFAULT, ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);


### PR DESCRIPTION
**DO NOT MERGE UNTIL KIP-582 IS APPROVED**

### Pull Request for KIP-582

Some background: currently there are two error handling options in Kafka Connect, "none" and "all". Option "none" will config the connector to fail fast, and option "all" will ignore broken records.

If users want to store their broken records, they have to config a broken record queue, which is too much work for them in some cases. 

Some sink connectors have the ability to deal with broken records, for example, a JDBC sink connector can store the broken raw bytes into a separate table, a S3 connector can store that in a zipped file.

Therefore, it would be ideal if Kafka Connect provides an additional option that sends the broken raw bytes to SinkTask directly. 

Wiki: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=148642653 
JIRA: https://issues.apache.org/jira/browse/KAFKA-9740

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
