### PR TITLE
KAFKA-9797; Fix TestSecurityRollingUpgrade.test_enable_separate_interbroker_listener

### DIFF
--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -96,10 +96,15 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.set_authorizer_and_bounce(security_protocol, security_protocol, KafkaService.SIMPLE_AUTHORIZER)
 
     def add_separate_broker_listener(self, broker_security_protocol, broker_sasl_mechanism):
+        # Enable the new internal listener on all brokers first
+        self.kafka.open_port(self.kafka.INTERBROKER_LISTENER_NAME)
+        self.kafka.port_mappings[self.kafka.INTERBROKER_LISTENER_NAME].security_protocol = broker_security_protocol
+        self.kafka.client_sasl_mechanism = broker_sasl_mechanism
+        self.bounce()
+
+        # Update inter-broker listener after all brokers have been updated to enable the new listener
         self.kafka.setup_interbroker_listener(broker_security_protocol, True)
         self.kafka.interbroker_sasl_mechanism = broker_sasl_mechanism
-        # kafka opens interbroker port automatically in start() but not in bounce()
-        self.kafka.open_port(self.kafka.INTERBROKER_LISTENER_NAME)
         self.bounce()
 
     def remove_separate_broker_listener(self, client_security_protocol, client_sasl_mechanism):


### PR DESCRIPTION
In order to perform non-disruptive update of inter-broker listener to a different security protocol, we need to first ensure that the listener is enabled on all brokers. Once the listener is available on all brokers, inter-broker listener can be updated using rolling update.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
