### PR TITLE
KAFKA-9810: Document Connect Root REST API on /

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -252,6 +252,12 @@
         <li><code>PUT /connector-plugins/{connector-type}/config/validate</code> - validate the provided configuration values against the configuration definition. This API performs per config validation, returns suggested values and error messages during validation.</li>
     </ul>
 
+    <p>Finally, supported REST requests at the top-level endpoint are:</p>
+
+    <ul>
+        <li><code>GET /</code>- return basic information about the Kafka Connect cluster such as the version of the Connect worker that serves the REST request (including git commit ID of the source code) and the Kafka cluster ID that is connected to.
+    </ul>
+
     <h3><a id="connect_development" href="#connect_development">8.3 Connector Development Guide</a></h3>
 
     <p>This guide describes how developers can write new connectors for Kafka Connect to move data between Kafka and other systems. It briefly reviews a few key concepts and then describes how to create a simple connector.</p>

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -252,7 +252,7 @@
         <li><code>PUT /connector-plugins/{connector-type}/config/validate</code> - validate the provided configuration values against the configuration definition. This API performs per config validation, returns suggested values and error messages during validation.</li>
     </ul>
 
-    <p>Finally, supported REST requests at the top-level endpoint are:</p>
+    <p>The following is a supported REST request at the top-level (root) endpoint:</p>
 
     <ul>
         <li><code>GET /</code>- return basic information about the Kafka Connect cluster such as the version of the Connect worker that serves the REST request (including git commit ID of the source code) and the Kafka cluster ID that is connected to.


### PR DESCRIPTION
Document the supported endpoint at the top-level (root) REST API resource and the information that it returns when a request is made to a Connect worker. 

Fixes an omission in documentation after KAFKA-2369 and KAFKA-6311 (KIP-238)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
