### PR TITLE
MINOR: Remove redundant braces from log message in FetchSessionHandler

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -478,7 +478,7 @@ public class FetchSessionHandler {
      * @param t     The exception.
      */
     public void handleError(Throwable t) {
-        log.info("Error sending fetch request {} to node {}: {}.", nextMetadata, node, t);
+        log.info("Error sending fetch request {} to node {}:", nextMetadata, node, t);
         nextMetadata = nextMetadata.nextCloseExisting();
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8889 attempted to fill in the missing stacktrace in the log message when handling errors in `FetchSessionHandler#handleError`

But the fix is not effective without KAFKA-7016

The current fix removes the redundant pair of braces {} at the end of the log message. If and when the Throwable that is passed as argument to this method has a stacktrace, the log message will include it. Currently it doesn't because the Throwable argument does not have a stacktrace. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
