### PR TITLE
MINOR: Allow single struct to be a field in protocol spec

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
@@ -605,6 +606,22 @@ public final class MessageTest {
                 testEquivalentMessageRoundTrip(version, responseData);
             }
         }
+    }
+
+    @Test
+    public void testSimpleMessage() throws Exception {
+        final SimpleExampleMessageData message = new SimpleExampleMessageData();
+        message.setMyStruct(new SimpleExampleMessageData.MyStruct().setStructId(25).setArrayInStruct(
+            Collections.singletonList(new SimpleExampleMessageData.StructArray().setArrayFieldId(20))
+        ));
+        message.setMyTaggedStruct(new SimpleExampleMessageData.MyTaggedStruct().setStructId("abc"));
+
+        message.setProcessId(UUID.randomUUID());
+        message.setMyNullableString("notNull");
+        message.setMyInt16((short) 3);
+        message.setMyString("test string");
+
+        testAllMessageRoundTripsFromVersion((short) 2, message);
     }
 
     private void testAllMessageRoundTrips(Message message) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -301,6 +301,26 @@ public class SimpleExampleMessageTest {
             __ -> { }, (short) 1);
     }
 
+    /**
+     * Check following cases:
+     * 1. Tagged struct can be serialized/deserialized for version it is supported
+     * 2. Tagged struct doesn't matter for versions it is not declared.
+     */
+    @Test
+    public void testMyTaggedStruct() {
+        // Verify that we can set and retrieve a nullable struct object.
+        SimpleExampleMessageData.MyTaggedStruct myStruct =
+            new SimpleExampleMessageData.MyTaggedStruct().setStructId("abc");
+        testRoundTrip(new SimpleExampleMessageData().setMyTaggedStruct(myStruct),
+            message -> assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
+
+        // Not setting field works for both version 1 and version 2 protocol
+        testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
+            message -> assertEquals("abc", message.myString()), (short) 1);
+        testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
+            message -> assertEquals("abc", message.myString()), (short) 2);
+    }
+
     private void testRoundTrip(SimpleExampleMessageData message,
                                Consumer<SimpleExampleMessageData> validator) {
         testRoundTrip(message, validator, (short) 1);

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -281,10 +281,53 @@ public class SimpleExampleMessageTest {
                 message.taggedLong()));
     }
 
+    @Test
+    public void testMyStruct() {
+        // Verify that we can set and retrieve a nullable struct object.
+        SimpleExampleMessageData.MyStruct myStruct =
+            new SimpleExampleMessageData.MyStruct().setStructId(10).setArrayInStruct(
+                Collections.singletonList(new SimpleExampleMessageData.StructArray().setArrayFieldId(20))
+            );
+        testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct),
+            message -> assertEquals(myStruct, message.myStruct()), (short) 2);
+    }
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testMyStructUnsupportedVersion() {
+        SimpleExampleMessageData.MyStruct myStruct =
+                new SimpleExampleMessageData.MyStruct().setStructId(10);
+        // Check serialization throws exception for unsupported version
+        testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct),
+            __ -> { }, (short) 1);
+    }
+
+    @Test
+    public void testMyNullableStruct() {
+        // Verify that we can set and retrieve a nullable struct object.
+        SimpleExampleMessageData.MyNullableStruct myNullableStruct =
+                new SimpleExampleMessageData.MyNullableStruct().setStructId(10);
+        testRoundTrip(new SimpleExampleMessageData().setMyNullableStruct(myNullableStruct),
+            message -> assertEquals(myNullableStruct, message.myNullableStruct()), (short) 2);
+    }
+
+    @Test(expected = UnsupportedVersionException.class)
+    public void testMyNullableStructUnsupportedVersion() {
+        SimpleExampleMessageData.MyNullableStruct myNullableStruct =
+                new SimpleExampleMessageData.MyNullableStruct().setStructId(10);
+        // Check serialization throws exception for unsupported version
+        testRoundTrip(new SimpleExampleMessageData().setMyNullableStruct(myNullableStruct),
+            message -> assertEquals(myNullableStruct, message.myNullableStruct()), (short) 1);
+    }
+
     private void testRoundTrip(SimpleExampleMessageData message,
                                Consumer<SimpleExampleMessageData> validator) {
+        testRoundTrip(message, validator, (short) 1);
+    }
+
+    private void testRoundTrip(SimpleExampleMessageData message,
+                               Consumer<SimpleExampleMessageData> validator,
+                               short version) {
         validator.accept(message);
-        short version = 1;
         ObjectSerializationCache cache = new ObjectSerializationCache();
         int size = message.size(cache, version);
         ByteBuffer buf = ByteBuffer.allocate(size);

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -301,24 +301,6 @@ public class SimpleExampleMessageTest {
             __ -> { }, (short) 1);
     }
 
-    @Test
-    public void testMyNullableStruct() {
-        // Verify that we can set and retrieve a nullable struct object.
-        SimpleExampleMessageData.MyNullableStruct myNullableStruct =
-                new SimpleExampleMessageData.MyNullableStruct().setStructId(10);
-        testRoundTrip(new SimpleExampleMessageData().setMyNullableStruct(myNullableStruct),
-            message -> assertEquals(myNullableStruct, message.myNullableStruct()), (short) 2);
-    }
-
-    @Test(expected = UnsupportedVersionException.class)
-    public void testMyNullableStructUnsupportedVersion() {
-        SimpleExampleMessageData.MyNullableStruct myNullableStruct =
-                new SimpleExampleMessageData.MyNullableStruct().setStructId(10);
-        // Check serialization throws exception for unsupported version
-        testRoundTrip(new SimpleExampleMessageData().setMyNullableStruct(myNullableStruct),
-            message -> assertEquals(myNullableStruct, message.myNullableStruct()), (short) 1);
-    }
-
     private void testRoundTrip(SimpleExampleMessageData message,
                                Consumer<SimpleExampleMessageData> validator) {
         testRoundTrip(message, validator, (short) 1);

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -15,7 +15,7 @@
 {
   "name": "SimpleExampleMessage",
   "type": "header",
-  "validVersions": "0-1",
+  "validVersions": "0-2",
   "flexibleVersions": "1+",
   "fields": [
     { "name": "processId", "versions": "1+", "type": "uuid" },
@@ -36,6 +36,19 @@
         "taggedVersions": "1+", "tag": 7 },
     { "name": "zeroCopyByteBuffer", "versions": "1", "type": "bytes", "zeroCopy": true },
     { "name": "nullableZeroCopyByteBuffer", "versions": "1", "nullableVersions": "0+",
-      "type": "bytes", "zeroCopy": true }
+      "type": "bytes", "zeroCopy": true },
+    { "name": "myStruct", "type": "MyStruct", "versions": "2+", "about": "Test Struct field",
+      "fields": [
+        { "name": "structId", "type": "int32", "versions": "2+", "about": "Int field in struct"},
+        { "name": "arrayInStruct", "type": "[]StructArray", "versions": "2+",
+          "fields": [
+            { "name": "arrayFieldId", "type": "int32", "versions": "2+"}
+          ]}
+    ]},
+    { "name": "myNullableStruct", "type": "MyNullableStruct", "versions": "2+", "about": "Test Struct field #2",
+      "nullableVersions": "0-1", "default": null,
+      "fields": [
+        { "name": "structId", "type": "int32", "versions": "2+", "about": "Int field in struct"}
+    ]}
   ]
 }

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -44,11 +44,6 @@
           "fields": [
             { "name": "arrayFieldId", "type": "int32", "versions": "2+"}
           ]}
-    ]},
-    { "name": "myNullableStruct", "type": "MyNullableStruct", "versions": "2+", "about": "Test Struct field #2",
-      "nullableVersions": "0-1", "default": null,
-      "fields": [
-        { "name": "structId", "type": "int32", "versions": "2+", "about": "Int field in struct"}
     ]}
   ]
 }

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -44,6 +44,11 @@
           "fields": [
             { "name": "arrayFieldId", "type": "int32", "versions": "2+"}
           ]}
+    ]},
+    { "name": "myTaggedStruct", "type": "MyTaggedStruct", "versions": "2+", "about": "Test Tagged Struct field",
+      "taggedVersions": "2+", "tag": 8,
+      "fields": [
+        { "name": "structId", "type": "string", "versions": "2+", "about": "String field in struct"}
     ]}
   ]
 }

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -101,6 +101,11 @@ public final class FieldSpec {
         this.entityType.verifyTypeMatches(name, this.type);
 
         this.about = about == null ? "" : about;
+        if (!this.fields().isEmpty()) {
+            if (!this.type.isArray() && !this.type.isStruct()) {
+                throw new RuntimeException("Non-array or Struct field " + name + " cannot have fields");
+            }
+        }
 
         if (flexibleVersions == null || flexibleVersions.isEmpty()) {
             this.flexibleVersions = Optional.empty();

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -101,11 +101,7 @@ public final class FieldSpec {
         this.entityType.verifyTypeMatches(name, this.type);
 
         this.about = about == null ? "" : about;
-        if (!this.fields().isEmpty()) {
-            if (!this.type.isArray()) {
-                throw new RuntimeException("Non-array field " + name + " cannot have fields");
-            }
-        }
+
         if (flexibleVersions == null || flexibleVersions.isEmpty()) {
             this.flexibleVersions = Optional.empty();
         } else {

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -199,6 +199,10 @@ public interface FieldType {
             return true;
         }
 
+        public boolean canBeNullable() {
+            return true;
+        }
+
         @Override
         public String toString() {
             return type;

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -199,10 +199,6 @@ public interface FieldType {
             return true;
         }
 
-        public boolean canBeNullable() {
-            return true;
-        }
-
         @Override
         public String toString() {
             return type;

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1187,7 +1187,8 @@ public final class MessageDataGenerator {
                 return String.format("struct.getByteArray(\"%s\")", name);
             }
         } else if (type.isStruct()) {
-            return String.format("new %s(struct, _version)", type.toString());
+            return String.format("new %s((Struct) struct.get(\"%s\"), _version)",
+                    type.toString(), name);
         } else {
             throw new RuntimeException("Unsupported field type " + type);
         }

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1529,7 +1529,7 @@ public final class MessageDataGenerator {
                         field.camelCaseName(), field.camelCaseName());
                 }
             }
-        } else if (field.type().isString()) {
+        } else if (field.type().isString() || field.type().isStruct()) {
             if (fieldDefault(field).equals("null")) {
                 buffer.printf("if (%s != null) {%n", field.camelCaseName());
             } else if (nullableVersions.empty()) {

--- a/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
@@ -121,4 +121,30 @@ public class StructRegistryTest {
             assertTrue(e.getMessage().contains("Common struct TestCommonStruct was specified twice."));
         }
     }
+
+    @Test
+    public void testSingleStruct() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"LeaderAndIsrRequest\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"TestInlineStruct\", \"versions\": \"0+\", ",
+                "    \"fields\": [",
+                "      { \"name\": \"inlineField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ]",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        structRegistry.register(testMessageSpec);
+
+        FieldSpec field2 = testMessageSpec.fields().get(1);
+        assertTrue(field2.type().isStruct());
+        assertEquals("TestInlineStruct", field2.type().toString());
+
+        assertEquals("field2", structRegistry.findStruct(field2).name());
+        assertFalse(structRegistry.isStructArrayWithKeys(field2));
+    }
 }


### PR DESCRIPTION
Currently protocol generation code has this restriction that a structure
field need to be an array. There are however some case where fields need
to be grouped but not be an array. This is for organizational purposes
and mirrors program structure.

This change adds this capability to the protocol generation.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
