### PR TITLE
KAFKA-9806: __consumer_offsets is not created under insufficient ACLs

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1280,7 +1280,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       authorizeClusterOperation(request, CLUSTER_ACTION)
       val (partition, topicMetadata) = CoordinatorType.forId(findCoordinatorRequest.data.keyType) match {
         case CoordinatorType.GROUP =>
-          authorizeClusterOperation(request, CLUSTER_ACTION)
           val partition = groupCoordinator.partitionFor(findCoordinatorRequest.data.key)
           val metadata = getOrCreateInternalTopic(GROUP_METADATA_TOPIC_NAME, request.context.listenerName)
           (partition, metadata)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1277,6 +1277,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       sendErrorResponseMaybeThrottle(request, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED.exception)
     else {
       // get metadata (and create the topic if necessary)
+      authorizeClusterOperation(request, CLUSTER_ACTION)
       val (partition, topicMetadata) = CoordinatorType.forId(findCoordinatorRequest.data.keyType) match {
         case CoordinatorType.GROUP =>
           val partition = groupCoordinator.partitionFor(findCoordinatorRequest.data.key)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1279,6 +1279,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       // get metadata (and create the topic if necessary)
       val (partition, topicMetadata) = CoordinatorType.forId(findCoordinatorRequest.data.keyType) match {
         case CoordinatorType.GROUP =>
+          authorizeClusterOperation(request, CLUSTER_ACTION)
           val partition = groupCoordinator.partitionFor(findCoordinatorRequest.data.key)
           val metadata = getOrCreateInternalTopic(GROUP_METADATA_TOPIC_NAME, request.context.listenerName)
           (partition, metadata)


### PR DESCRIPTION
Fixing KAFKA-9806 bug: the __consumer_offsets topic gets created when a consumer try to consume on a new cluster for the first time. If there aren't sufficient cluster-level ACLs, FindCoordinator request succeed, anche __consumer_offsets gets created in zk, but subsequent UpdateMetadata and LeaderAndIsr requests fail, putting the offsets topic in a bad state. When this happens, it is not possible to consume even after updating ACLs (5a).

This PR aims to introduce a new check before creating the __consumer_offsets topic, so that it does not get created if there aren't sufficient ACLs.

This change was tested by following the steps reported in KAFKA-9806, and verifying that it is possible to consume after the code change (5b). Eg:
1. Create a topic
2. Set insufficient cluster level ACLs. Which precise ACL does not matter as long as ClusterAction initiated by administrative messages between brokers is denied. 
3. Consume on the topic -> this request will fail with unauthorized errors on the client side as well
4. Remove ACLs or set ACLs to allow inter-broker communication
5a. (Before code change) Produce/consume on topic. Consumer won't be able to read any data.
5b. (After code change) Produce/consume on topic. Consumer are able to read data.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
