### PR TITLE
KAFKA-8955: Add an AbstractResponse#errorCounts(Stream) and tidy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class AbstractResponse implements AbstractRequestResponse {
     public static final int DEFAULT_THROTTLE_TIME = 0;
@@ -55,6 +57,10 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
 
     protected Map<Errors, Integer> errorCounts(Errors error) {
         return Collections.singletonMap(error, 1);
+    }
+
+    protected Map<Errors, Integer> errorCounts(Stream<Errors> errors) {
+        return errors.collect(Collectors.groupingBy(e -> e, Collectors.summingInt(e -> 1)));
     }
 
     protected Map<Errors, Integer> errorCounts(Collection<Errors> errors) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -78,8 +78,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
     }
 
     protected void updateErrorCounts(Map<Errors, Integer> errorCounts, Errors error) {
-        Integer count = errorCounts.get(error);
-        errorCounts.put(error, count == null ? 1 : count + 1);
+        Integer count = errorCounts.getOrDefault(error, 0);
+        errorCounts.put(error, count + 1);
     }
 
     protected abstract Struct toStruct(short version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
@@ -100,10 +100,9 @@ public class AlterClientQuotasResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        for (EntryData entry : data.entries()) {
-            Errors error = Errors.forCode(entry.errorCode());
-            updateErrorCounts(counts, error);
-        }
+        data.entries().forEach(entry ->
+            updateErrorCounts(counts, Errors.forCode(entry.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
@@ -102,7 +102,7 @@ public class AlterClientQuotasResponse extends AbstractResponse {
         Map<Errors, Integer> counts = new HashMap<>();
         for (EntryData entry : data.entries()) {
             Errors error = Errors.forCode(entry.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
+            updateErrorCounts(counts, error);
         }
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -67,10 +67,9 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
         updateErrorCounts(counts, topLevelErr);
 
         data.responses().forEach(topicResponse ->
-                topicResponse.partitions().forEach(partitionResponse ->
-                updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()))
-            )
-        );
+            topicResponse.partitions().forEach(partitionResponse ->
+            updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()))
+        ));
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -66,12 +66,12 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
         Errors topLevelErr = Errors.forCode(data.errorCode());
-        counts.put(topLevelErr, counts.getOrDefault(topLevelErr, 0) + 1);
+        updateErrorCounts(counts, topLevelErr);
 
         for (ReassignableTopicResponse topicResponse : data.responses()) {
             for (ReassignablePartitionResponse partitionResponse : topicResponse.partitions()) {
                 Errors error = Errors.forCode(partitionResponse.errorCode());
-                counts.put(error, counts.getOrDefault(error, 0) + 1);
+                updateErrorCounts(counts, error);
             }
         }
         return counts;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -63,12 +63,11 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        Errors topLevelErr = Errors.forCode(data.errorCode());
-        updateErrorCounts(counts, topLevelErr);
+        updateErrorCounts(counts, Errors.forCode(data.errorCode()));
 
         data.responses().forEach(topicResponse ->
             topicResponse.partitions().forEach(partitionResponse ->
-            updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()))
+                updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()))
         ));
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -18,8 +18,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
-import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignableTopicResponse;
-import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignablePartitionResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -68,12 +66,11 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
         Errors topLevelErr = Errors.forCode(data.errorCode());
         updateErrorCounts(counts, topLevelErr);
 
-        for (ReassignableTopicResponse topicResponse : data.responses()) {
-            for (ReassignablePartitionResponse partitionResponse : topicResponse.partitions()) {
-                Errors error = Errors.forCode(partitionResponse.errorCode());
-                updateErrorCounts(counts, error);
-            }
-        }
+        data.responses().forEach(topicResponse ->
+                topicResponse.partitions().forEach(partitionResponse ->
+                updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()))
+            )
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownResponse.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,7 +53,7 @@ public class ControlledShutdownResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     public static ControlledShutdownResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.types.Struct;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class CreateAclsResponse extends AbstractResponse {
     private final CreateAclsResponseData data;
@@ -53,7 +52,7 @@ public class CreateAclsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(results().stream().map(r -> Errors.forCode(r.errorCode())).collect(Collectors.toList()));
+        return errorCounts(results().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
     public static CreateAclsResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 public class CreateDelegationTokenResponse extends AbstractResponse {
@@ -73,7 +72,7 @@ public class CreateDelegationTokenResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
-import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -52,10 +51,9 @@ public class CreatePartitionsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        for (CreatePartitionsTopicResult result : data.results()) {
-            Errors error = Errors.forCode(result.errorCode());
-            updateErrorCounts(counts, error);
-        }
+        data.results().forEach(result ->
+            updateErrorCounts(counts, Errors.forCode(result.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -54,7 +54,7 @@ public class CreatePartitionsResponse extends AbstractResponse {
         Map<Errors, Integer> counts = new HashMap<>();
         for (CreatePartitionsTopicResult result : data.results()) {
             Errors error = Errors.forCode(result.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
+            updateErrorCounts(counts, error);
         }
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateTopicsResponseData;
-import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -71,10 +70,9 @@ public class CreateTopicsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (CreatableTopicResult result : data.topics()) {
-            Errors error = Errors.forCode(result.errorCode());
-            updateErrorCounts(counts, error);
-        }
+        data.topics().forEach(result ->
+            updateErrorCounts(counts, Errors.forCode(result.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
@@ -73,7 +73,7 @@ public class CreateTopicsResponse extends AbstractResponse {
         HashMap<Errors, Integer> counts = new HashMap<>();
         for (CreatableTopicResult result : data.topics()) {
             Errors error = Errors.forCode(result.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
+            updateErrorCounts(counts, error);
         }
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
@@ -69,7 +69,7 @@ public class DeleteAclsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(filterResults().stream().map(r -> Errors.forCode(r.errorCode())).collect(Collectors.toList()));
+        return errorCounts(filterResults().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
     public static DeleteAclsResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
@@ -78,10 +78,9 @@ public class DeleteGroupsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        for (DeletableGroupResult result : data.results()) {
-            Errors error = Errors.forCode(result.errorCode());
-            updateErrorCounts(counts, error);
-        }
+        data.results().forEach(result ->
+            updateErrorCounts(counts, Errors.forCode(result.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
@@ -80,7 +80,7 @@ public class DeleteGroupsResponse extends AbstractResponse {
         Map<Errors, Integer> counts = new HashMap<>();
         for (DeletableGroupResult result : data.results()) {
             Errors error = Errors.forCode(result.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
+            updateErrorCounts(counts, error);
         }
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
@@ -66,11 +66,11 @@ public class DeleteRecordsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (DeleteRecordsResponseData.DeleteRecordsTopicResult topicResponses : data.topics()) {
-            for (DeleteRecordsResponseData.DeleteRecordsPartitionResult response : topicResponses.partitions()) {
-                updateErrorCounts(errorCounts, Errors.forCode(response.errorCode()));
-            }
-        }
+        data.topics().forEach(topicResponses ->
+            topicResponses.partitions().forEach(response ->
+                updateErrorCounts(errorCounts, Errors.forCode(response.errorCode()))
+            )
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
@@ -68,7 +68,7 @@ public class DeleteTopicsResponse extends AbstractResponse {
         HashMap<Errors, Integer> counts = new HashMap<>();
         for (DeletableTopicResult result : data.responses()) {
             Errors error = Errors.forCode(result.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
+            updateErrorCounts(counts, error);
         }
         return counts;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
-import org.apache.kafka.common.message.DeleteTopicsResponseData.DeletableTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -66,10 +65,9 @@ public class DeleteTopicsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (DeletableTopicResult result : data.responses()) {
-            Errors error = Errors.forCode(result.errorCode());
-            updateErrorCounts(counts, error);
-        }
+        data.responses().forEach(result ->
+            updateErrorCounts(counts, Errors.forCode(result.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +108,7 @@ public class DescribeClientQuotasResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -306,8 +306,9 @@ public class DescribeConfigsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (Config response : configs.values())
-            updateErrorCounts(errorCounts, response.error.error());
+        configs.values().forEach(response ->
+            updateErrorCounts(errorCounts, response.error.error())
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
@@ -129,9 +129,9 @@ public class DescribeGroupsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        data.groups().forEach(describedGroup -> {
+        for (DescribedGroup describedGroup : data.groups()) {
             updateErrorCounts(errorCounts, Errors.forCode(describedGroup.errorCode()));
-        });
+        }
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
@@ -129,9 +129,9 @@ public class DescribeGroupsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (DescribedGroup describedGroup : data.groups()) {
+        data.groups().forEach(describedGroup -> {
             updateErrorCounts(errorCounts, Errors.forCode(describedGroup.errorCode()));
-        }
+        });
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -62,9 +62,9 @@ public class DescribeLogDirsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (DescribeLogDirsResult result : data.results()) {
+        data.results().forEach(result -> {
             updateErrorCounts(errorCounts, Errors.forCode(result.errorCode()));
-        }
+        });
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -62,9 +62,9 @@ public class DescribeLogDirsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        data.results().forEach(result -> {
+        for (DescribeLogDirsResult result : data.results()) {
             updateErrorCounts(errorCounts, Errors.forCode(result.errorCode()));
-        });
+        }
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
@@ -22,10 +22,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.ElectLeadersResponseData.PartitionResult;
-import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
+import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -90,12 +90,11 @@ public class ElectLeadersResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (ReplicaElectionResult result : data.replicaElectionResults()) {
-            for (PartitionResult partitionResult : result.partitionResult()) {
-                Errors error = Errors.forCode(partitionResult.errorCode());
-                counts.put(error, counts.getOrDefault(error, 0) + 1);
-            }
-        }
+        data.replicaElectionResults().forEach(result ->
+            result.partitionResult().forEach(partitionResult ->
+                updateErrorCounts(counts, Errors.forCode(partitionResult.errorCode()))
+            )
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
@@ -51,7 +50,7 @@ public class ExpireDelegationTokenResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -459,8 +459,9 @@ public class FetchResponse<T extends BaseRecords> extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (PartitionData response : responseData.values())
-            updateErrorCounts(errorCounts, response.error);
+        responseData.values().forEach(response ->
+            updateErrorCounts(errorCounts, response.error)
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 
@@ -72,7 +71,7 @@ public class FindCoordinatorResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 
@@ -59,7 +58,7 @@ public class HeartbeatResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
@@ -70,10 +70,9 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         HashMap<Errors, Integer> counts = new HashMap<>();
-        for (AlterConfigsResourceResponse response : data.responses()) {
-            Errors error = Errors.forCode(response.errorCode());
-            counts.put(error, counts.getOrDefault(error, 0) + 1);
-        }
+        data.responses().forEach(response ->
+            updateErrorCounts(counts, Errors.forCode(response.errorCode()))
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 public class JoinGroupResponse extends AbstractResponse {
@@ -61,7 +60,7 @@ public class JoinGroupResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     public static JoinGroupResponse parse(ByteBuffer buffer, short versionId) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class LeaderAndIsrResponse extends AbstractResponse {
 
@@ -60,7 +59,7 @@ public class LeaderAndIsrResponse extends AbstractResponse {
         if (error != Errors.NONE)
             // Minor optimization since the top-level error applies to all partitions
             return Collections.singletonMap(error, data.partitionErrors().size());
-        return errorCounts(data.partitionErrors().stream().map(l -> Errors.forCode(l.errorCode())).collect(Collectors.toList()));
+        return errorCounts(data.partitionErrors().stream().map(l -> Errors.forCode(l.errorCode())));
     }
 
     public static LeaderAndIsrResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
@@ -125,12 +125,12 @@ public class LeaveGroupResponse extends AbstractResponse {
         }
 
         // Member level error.
-        for (MemberResponse memberResponse : data.members()) {
+        data.members().forEach(memberResponse -> {
             Errors memberError = Errors.forCode(memberResponse.errorCode());
             if (memberError != Errors.NONE) {
                 updateErrorCounts(combinedErrorCounts, memberError);
             }
-        }
+        });
         return combinedErrorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 public class ListGroupsResponse extends AbstractResponse {
@@ -48,7 +47,7 @@ public class ListGroupsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -242,8 +242,9 @@ public class ListOffsetResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (PartitionData response : responseData.values())
-            updateErrorCounts(errorCounts, response.error);
+        responseData.values().forEach(response ->
+            updateErrorCounts(errorCounts, response.error)
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 
 public class ListPartitionReassignmentsResponse extends AbstractResponse {
@@ -61,11 +60,7 @@ public class ListPartitionReassignmentsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        Map<Errors, Integer> counts = new HashMap<>();
-        Errors topLevelErr = Errors.forCode(data.errorCode());
-        counts.put(topLevelErr, 1);
-
-        return counts;
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -109,8 +109,8 @@ public class MetadataResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (MetadataResponseTopic metadata : data.topics())
-            updateErrorCounts(errorCounts, Errors.forCode(metadata.errorCode()));
+        data.topics().forEach(metadata ->
+            updateErrorCounts(errorCounts, Errors.forCode(metadata.errorCode())));
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
@@ -94,8 +94,9 @@ public class OffsetCommitResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(data.topics().stream().flatMap(topicResult -> topicResult.partitions().stream())
-            .map(partitionResult -> Errors.forCode(partitionResult.errorCode())));
+        return errorCounts(data.topics().stream().flatMap(topicResult ->
+                topicResult.partitions().stream().map(partitionResult ->
+                        Errors.forCode(partitionResult.errorCode()))));
     }
 
     public static OffsetCommitResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.protocol.types.Struct;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -95,13 +94,8 @@ public class OffsetCommitResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        List<Errors> errors = new ArrayList<>();
-        for (OffsetCommitResponseTopic topic : data.topics()) {
-            for (OffsetCommitResponsePartition partition : topic.partitions()) {
-                errors.add(Errors.forCode(partition.errorCode()));
-            }
-        }
-        return errorCounts(errors);
+        return errorCounts(data.topics().stream().flatMap(topicResult -> topicResult.partitions().stream())
+            .map(partitionResult -> Errors.forCode(partitionResult.errorCode())));
     }
 
     public static OffsetCommitResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
@@ -17,8 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
-import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponsePartition;
-import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -70,12 +68,11 @@ public class OffsetDeleteResponse extends AbstractResponse {
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
         updateErrorCounts(counts, Errors.forCode(data.errorCode()));
-        for (OffsetDeleteResponseTopic topic : data.topics()) {
-            for (OffsetDeleteResponsePartition partition : topic.partitions()) {
-                Errors error = Errors.forCode(partition.errorCode());
-                updateErrorCounts(counts, error);
-            }
-        }
+        data.topics().forEach(topic ->
+            topic.partitions().forEach(partition ->
+                updateErrorCounts(counts, Errors.forCode(partition.errorCode()))
+            )
+        );
         return counts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
@@ -69,11 +69,11 @@ public class OffsetDeleteResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        counts.put(Errors.forCode(data.errorCode()), 1);
+        updateErrorCounts(counts, Errors.forCode(data.errorCode()));
         for (OffsetDeleteResponseTopic topic : data.topics()) {
             for (OffsetDeleteResponsePartition partition : topic.partitions()) {
                 Errors error = Errors.forCode(partition.errorCode());
-                counts.put(error, counts.getOrDefault(error, 0) + 1);
+                updateErrorCounts(counts, error);
             }
         }
         return counts;

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -130,8 +130,9 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (EpochEndOffset response : epochEndOffsetsByPartition.values())
-            updateErrorCounts(errorCounts, response.error());
+        epochEndOffsetsByPartition.values().forEach(response ->
+            updateErrorCounts(errorCounts, response.error())
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -313,8 +313,9 @@ public class ProduceResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (PartitionResponse response : responses.values())
-            updateErrorCounts(errorCounts, response.error);
+        responses.values().forEach(response ->
+            updateErrorCounts(errorCounts, response.error)
+        );
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.requests;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
@@ -43,7 +42,7 @@ public class RenewDelegationTokenResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(error(), 1);
+        return errorCounts(error());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 
@@ -52,7 +51,7 @@ public class SaslAuthenticateResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     public String errorMessage() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +52,7 @@ public class SaslHandshakeResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaResponse.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class StopReplicaResponse extends AbstractResponse {
 
@@ -59,7 +58,7 @@ public class StopReplicaResponse extends AbstractResponse {
         if (data.errorCode() != Errors.NONE.code())
             // Minor optimization since the top-level error applies to all partitions
             return Collections.singletonMap(error(), data.partitionErrors().size());
-        return errorCounts(data.partitionErrors().stream().map(p -> Errors.forCode(p.errorCode())).collect(Collectors.toList()));
+        return errorCounts(data.partitionErrors().stream().map(p -> Errors.forCode(p.errorCode())));
     }
 
     public static StopReplicaResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 public class SyncGroupResponse extends AbstractResponse {
@@ -53,7 +52,7 @@ public class SyncGroupResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return errorCounts(Errors.forCode(data.errorCode()));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -91,9 +91,9 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(data.topics().stream()
-                .flatMap(topic -> topic.partitions().stream())
-                .map(partition -> Errors.forCode(partition.errorCode())));
+        return errorCounts(data.topics().stream().flatMap(topic ->
+                topic.partitions().stream().map(partition ->
+                        Errors.forCode(partition.errorCode()))));
     }
 
     public Map<TopicPartition, Errors> errors() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -91,7 +91,9 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return errorCounts(errors().values());
+        return errorCounts(data.topics().stream()
+                .flatMap(topic -> topic.partitions().stream())
+                .map(partition -> Errors.forCode(partition.errorCode())));
     }
 
     public Map<TopicPartition, Errors> errors() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.protocol.types.Struct;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -94,6 +95,24 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
         return errorCounts(data.topics().stream()
                 .flatMap(topic -> topic.partitions().stream())
                 .map(partition -> Errors.forCode(partition.errorCode())));
+
+//        return errorCounts(errors().values());
+
+//        Map<Errors, Integer> errorMap = new HashMap<>();
+//        data.topics().forEach(topic ->
+//            topic.partitions().forEach(partition ->
+//                updateErrorCounts(errorMap, Errors.forCode(partition.errorCode()))
+//            )
+//        );
+//        return errorMap;
+
+//        Map<Errors, Integer> errorMap = new HashMap<>();
+//        for (TxnOffsetCommitResponseTopic topic : data.topics()) {
+//            for (TxnOffsetCommitResponsePartition partition : topic.partitions()) {
+//                updateErrorCounts(errorMap, Errors.forCode(partition.errorCode()));
+//            }
+//        }
+//        return errorMap;
     }
 
     public Map<TopicPartition, Errors> errors() {
@@ -119,5 +138,41 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
     @Override
     public boolean shouldClientThrottle(short version) {
         return version >= 1;
+    }
+
+    public static void main(String[] args) {
+        int numTopics = 100;
+        int numPartitions = 100;
+        List<TxnOffsetCommitResponseTopic> topics = new ArrayList<>(numTopics);
+        for (int i = 0; i < numTopics; i++) {
+            List<TxnOffsetCommitResponsePartition> partitions = new ArrayList<>(numPartitions);
+            for (int j = 0; j < numPartitions; j++) {
+                partitions.add(new TxnOffsetCommitResponsePartition().setErrorCode(Errors.NONE.code()).setPartitionIndex(j));
+            }
+            topics.add(new TxnOffsetCommitResponseTopic().setName("topic-" + i).setPartitions(partitions));
+        }
+        TxnOffsetCommitResponse resp = new TxnOffsetCommitResponse(new TxnOffsetCommitResponseData().setTopics(topics));
+
+        int times = 20_000;
+        for (int i = 0; i < 20; i++) {
+            // timed run
+            long t0 = System.nanoTime();
+            Map<Errors, Integer> map = c(resp, times);
+            long t1 = System.nanoTime();
+            System.out.println(map);
+            long nanos = t1 - t0;
+            System.out.println("run " + i + ", times=" + times + " took " + nanos + "ns, " + ((times * 1.0E9) / nanos) + "ops/s");
+        }
+    }
+
+    private static Map<Errors, Integer> c(TxnOffsetCommitResponse resp, int times) {
+        Map<Errors, Integer> map = new HashMap<>();
+        for (int i = 0; i < times; i++) {
+            Map<Errors, Integer> errorsIntegerMap = resp.errorCounts();
+            for (Map.Entry<Errors, Integer> entry : errorsIntegerMap.entrySet()) {
+                map.compute(entry.getKey(), (key, value) -> value != null ? value + entry.getValue() : entry.getValue());
+            }
+        }
+        return map;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersResponse.java
@@ -107,10 +107,11 @@ public class WriteTxnMarkersResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        for (Map<TopicPartition, Errors> allErrors : errors.values()) {
-            for (Errors error : allErrors.values())
-                updateErrorCounts(errorCounts, error);
-        }
+        errors.values().forEach(allErrors ->
+            allErrors.values().forEach(error ->
+                updateErrorCounts(errorCounts, error)
+            )
+        );
         return errorCounts;
     }
 


### PR DESCRIPTION
* Add AbstractResponse#errorCounts(Stream) to avoid having to call
  AbstractResponse#errorCounts(Collection) with a computed collection.
* A microbenchmark showed that using errorCounts(Stream) was 
  around 7.5 times faster than errorCounts(Collection). Using forEach() 
  loops with updateErrorCounts() is slightly faster, but is usually more 
  code.
* Use updateErrorMap() consistently.
* Replace for statements with forEach() for consistency.
* Use singleton errorMap() consistently.

