### PR TITLE
KAFKA-9807; Protect LSO reads from concurrent high-watermark updates

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -20,6 +20,7 @@ package kafka.log
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
+import java.util.concurrent.{Callable, Executors}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
 
@@ -3647,6 +3648,61 @@ class LogTest {
 
     // now there should be no first unstable offset
     assertEquals(None, log.firstUnstableOffset)
+  }
+
+  @Test
+  def testReadCommittedWithConcurrentHighWatermarkUpdates(): Unit = {
+    val logConfig = LogTest.createLogConfig(segmentBytes = 1024 * 1024 * 5)
+    val log = createLog(logDir, logConfig)
+    val lastOffset = 50L
+
+    val producerEpoch = 0.toShort
+    val producerId = 15L
+    val appendProducer = appendTransactionalAsLeader(log, producerId, producerEpoch)
+
+    // Thread 1 writes single-record transactions and attempts to read them
+    // before they have been aborted, and then aborts them
+    val txnVerifier = new Callable[Int]() {
+      override def call(): Int = {
+        var nonEmptyReads = 0
+        while (log.logEndOffset < lastOffset) {
+          val currentLogEndOffset = log.logEndOffset
+
+          appendProducer(1)
+
+          val readInfo = log.read(
+            startOffset = currentLogEndOffset,
+            maxLength = Int.MaxValue,
+            isolation = FetchTxnCommitted,
+            minOneMessage = false)
+
+          if (readInfo.records.sizeInBytes() > 0)
+            nonEmptyReads += 1
+
+          appendEndTxnMarkerAsLeader(log, producerId, producerEpoch, ControlRecordType.ABORT)
+        }
+        nonEmptyReads
+      }
+    }
+
+    // Thread 2 watches the log and updates the high watermark
+    val hwUpdater = new Runnable() {
+      override def run(): Unit = {
+        while (log.logEndOffset < lastOffset) {
+          log.updateHighWatermark(log.logEndOffset)
+        }
+      }
+    }
+
+    val executor = Executors.newFixedThreadPool(2)
+    executor.submit(hwUpdater)
+
+    val future = executor.submit(txnVerifier)
+    val nonEmptyReads = future.get()
+
+    assertEquals(0, nonEmptyReads)
+
+    executor.shutdownNow()
   }
 
   @Test


### PR DESCRIPTION
If the high-watermark is updated in the middle of a read with the `read_committed` isolation level, it is possible to return data above the LSO. In the worst case, this can lead to the read of an aborted transaction. The root cause is that the logic depends on reading the high-watermark twice. We fix the problem by reading it once and caching the value.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
