### PR TITLE
KAFKA-9761: Use Admin Client default timeout instead of using 5sec timeout default

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -645,8 +645,10 @@ object ConsumerGroupCommand extends Logging {
     }
 
     private def withTimeoutMs [T <: AbstractOptions[T]] (options : T) =  {
-      val t = opts.options.valueOf(opts.timeoutMsOpt).intValue()
-      options.timeoutMs(t)
+      if (opts.options.has(opts.timeoutMsOpt)){
+        options.timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+      }
+      options
     }
 
     private def parseTopicPartitionsToReset(groupId: String, topicArgs: Seq[String]): Seq[TopicPartition] = topicArgs.flatMap {
@@ -964,7 +966,6 @@ object ConsumerGroupCommand extends Logging {
                              .withRequiredArg
                              .describedAs("timeout (ms)")
                              .ofType(classOf[Long])
-                             .defaultsTo(5000)
     val commandConfigOpt = parser.accepts("command-config", CommandConfigDoc)
                                   .withRequiredArg
                                   .describedAs("command config property file")

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -132,6 +132,45 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
   }
 
   @Test
+  def testDescribeExistingGroupWithSufficientInitializationTimeoutSpecified(): Unit = {
+    TestUtils.createOffsetsTopic(zkClient, servers)
+
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run one consumer in the group consuming from a single-partition topic
+      addConsumerGroupExecutor(numConsumers = 1, group = group)
+      // 5000ms is less than the admin client default but should be sufficient in the test
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--timeout", "5000") ++ describeType
+      val service = getConsumerGroupService(cgcArgs)
+
+      TestUtils.waitUntilTrue(() => {
+        val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroups())
+        output.trim.split("\n").length == 2 && error.isEmpty
+      }, s"Expected a data row and no error in describe results with describe type ${describeType.mkString(" ")}.")
+    }
+  }
+
+  @Test
+  def testDescribeExistingGroupWithInitializationTimeoutGreaterThanDefault(): Unit = {
+    TestUtils.createOffsetsTopic(zkClient, servers)
+
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run one consumer in the group consuming from a single-partition topic
+      addConsumerGroupExecutor(numConsumers = 1, group = group)
+      // 31000 ms is 1000 greater than the admin client default of 30000ms, but uses the minimum of the two so uses the admin client default of 30000ms
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--timeout", "31000") ++ describeType
+      val service = getConsumerGroupService(cgcArgs)
+
+      TestUtils.waitUntilTrue(() => {
+        val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroups())
+        output.trim.split("\n").length == 2 && error.isEmpty
+      }, s"Expected a data row and no error in describe results with describe type ${describeType.mkString(" ")}.")
+    }
+  }
+
+
+  @Test
   def testDescribeExistingGroups(): Unit = {
     TestUtils.createOffsetsTopic(zkClient, servers)
 

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -39,6 +39,23 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     }, s"Expected --list to show groups $expectedGroups, but found $foundGroups.")
   }
 
+  @Test
+  def testListConsumerGroupsWithSufficientInitializationTimeoutSpecified(): Unit = {
+    val simpleGroup = "simple-group"
+    addSimpleGroupExecutor(group = simpleGroup)
+    addConsumerGroupExecutor(numConsumers = 1)
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--list", "--timeout", "5000")
+    val service = getConsumerGroupService(cgcArgs)
+
+    val expectedGroups = Set(group, simpleGroup)
+    var foundGroups = Set.empty[String]
+    TestUtils.waitUntilTrue(() => {
+      foundGroups = service.listGroups().toSet
+      expectedGroups == foundGroups
+    }, s"Expected --list to show groups $expectedGroups, but found $foundGroups.")
+  }
+
   @Test(expected = classOf[OptionException])
   def testListWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", brokerList, "--list")


### PR DESCRIPTION
Corresponds to: https://issues.apache.org/jira/browse/KAFKA-9761

Changes the `timeout` flag in the `kafka-consumer-groups` tool to not default to 5000ms. It now uses the Admin Client default(30s currently) by not setting `options.timeoutMs` unless the timeout flag is specified, in which case it ends up using `(min(30s, timeout flag))` in the `AdminClientRunnable` method `sendEligibleCalls`.

Unit tests are provided that work with the default value and the old default 5000ms. There were already tests for an unreasonably short timeout.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
