### PR TITLE
KAFKA-9631: Fix support for optional fields in MockAdminClient

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -238,7 +238,7 @@ public class MockAdminClient extends AdminClient {
                 createTopicResult.put(topicName, future);
                 continue;
             }
-            int replicationFactor = newTopic.replicationFactor();
+            int replicationFactor = Math.max(newTopic.replicationFactor(), 0);
             if (replicationFactor > brokers.size())
                 throw new IllegalArgumentException(
                     String.format("NewTopic %s cannot have a replication factor of %d that is larger than the number of brokers %s",
@@ -249,7 +249,7 @@ public class MockAdminClient extends AdminClient {
                 replicas.add(brokers.get(i));
             }
 
-            int numberOfPartitions = newTopic.numPartitions();
+            int numberOfPartitions = Math.max(newTopic.numPartitions(), 0);
             List<TopicPartitionInfo> partitions = new ArrayList<>(numberOfPartitions);
             // Partitions start off on the first log directory of each broker, for now.
             List<String> logDirs = new ArrayList<>(numberOfPartitions);


### PR DESCRIPTION
AdminClient's createTopics() method has a variant with two optional fields. However, using those two fields as empty would cause the MockAdminClient to throw an Exception while attempting to create a list with size -1. This PR fixes that by defaulting the value to 0 when those values are not passed.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
