### PR TITLE
MINOR: Rename description of flatMapValues transformation

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -463,7 +463,7 @@ KStream&lt;String, Integer&gt; transformed = stream.flatMap(
 // Java 7 example: cf. `map` for how to create `KeyValueMapper` instances</code></pre>
                         </td>
                     </tr>
-                    <tr class="row-even"><td><p class="first"><strong>FlatMap (values only)</strong></p>
+                    <tr class="row-even"><td><p class="first"><strong>FlatMapValues</strong></p>
                         <ul class="last simple">
                             <li>KStream &rarr; KStream</li>
                         </ul>


### PR DESCRIPTION
The table of (stateless) transformations uses the transformation name in the first column and a description in the second column. I adjusted the transformation name for FlatMapValues accordingly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
