### PR TITLE
MINOR: Should cleanup the tasks after dirty close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -249,8 +249,12 @@ public class TaskManager {
             } catch (final RuntimeException e) {
                 log.error("Failed to batch commit tasks, " +
                     "will close all tasks involved in this commit as dirty by the end", e);
+
                 dirtyTasks.addAll(additionalTasksForCommitting);
                 dirtyTasks.addAll(checkpointPerTask.keySet());
+
+                // Remove all the closing tasks from the TaskManager bookkeeping to avoid re-closing them.
+                dirtyTasks.forEach(task -> tasks.remove(task.id()));
 
                 checkpointPerTask.clear();
                 // Just add first taskId to re-throw by the end.
@@ -277,7 +281,6 @@ public class TaskManager {
         for (final Task task : dirtyTasks) {
             task.closeDirty();
             cleanUpTaskProducer(task, taskCloseExceptions);
-            tasks.remove(task.id());
         }
 
         if (!taskCloseExceptions.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -277,6 +277,7 @@ public class TaskManager {
         for (final Task task : dirtyTasks) {
             task.closeDirty();
             cleanUpTaskProducer(task, taskCloseExceptions);
+            tasks.remove(task.id());
         }
 
         if (!taskCloseExceptions.isEmpty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1278,6 +1278,7 @@ public class TaskManagerTest {
         assertThat(task01.state(), is(Task.State.CLOSED));
         assertThat(task02.state(), is(Task.State.CLOSED));
 
+        // All the tasks involving in the commit should already be removed.
         assertThat(taskManager.tasks(), is(Collections.singletonMap(taskId00, task00)));
 
         verify(activeTaskCreator);
@@ -1323,6 +1324,7 @@ public class TaskManagerTest {
         assertThat(task01.state(), is(Task.State.CLOSED));
         assertThat(task02.state(), is(Task.State.CLOSED));
 
+        // All the tasks involving in the commit should already be removed.
         assertThat(taskManager.tasks(), is(Collections.singletonMap(taskId00, task00)));
 
         verify(activeTaskCreator);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1278,6 +1278,8 @@ public class TaskManagerTest {
         assertThat(task01.state(), is(Task.State.CLOSED));
         assertThat(task02.state(), is(Task.State.CLOSED));
 
+        assertThat(taskManager.tasks(), is(Collections.singletonMap(taskId00, task00)));
+
         verify(activeTaskCreator);
     }
 
@@ -1320,6 +1322,8 @@ public class TaskManagerTest {
         assertThat(task00.state(), is(Task.State.CREATED));
         assertThat(task01.state(), is(Task.State.CLOSED));
         assertThat(task02.state(), is(Task.State.CLOSED));
+
+        assertThat(taskManager.tasks(), is(Collections.singletonMap(taskId00, task00)));
 
         verify(activeTaskCreator);
     }


### PR DESCRIPTION
Some tasks get closed inside HandleAssignment and did not remove from the task manager bookkeep list. The next time they would be re-closed which is illegal state.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
