### PR TITLE
KAFKA-7599: Don't throttle in Trogdor when targetMessagesPerSec is 0

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -235,7 +235,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             long startBatchMs = startTimeMs;
             long maxMessages = spec.maxMessages();
             try {
-                while (messagesConsumed < maxMessages) {
+                while (messagesConsumed < maxMessages || maxMessages == 0) {
                     ConsumerRecords<byte[], byte[]> records = consumer.poll();
                     if (records.isEmpty()) {
                         continue;
@@ -254,10 +254,12 @@ public class ConsumeBenchWorker implements TaskWorker {
                         latencyHistogram.add(elapsedBatchMs);
                         messageSizeHistogram.add(messageBytes);
                         bytesConsumed += messageBytes;
-                        if (messagesConsumed >= maxMessages)
+                        if (messagesConsumed >= maxMessages && maxMessages > 0)
                             break;
 
-                        throttle.increment();
+                        if (spec.targetMessagesPerSec() > 0) {
+                            throttle.increment();
+                        }
                     }
                     startBatchMs = Time.SYSTEM.milliseconds();
                 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -205,11 +205,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             this.clientId = consumer.clientId();
             this.statusUpdaterFuture = executor.scheduleAtFixedRate(
                 new ConsumeStatusUpdater(latencyHistogram, messageSizeHistogram, consumer), 1, 1, TimeUnit.MINUTES);
-            int perPeriod;
-            if (spec.targetMessagesPerSec() <= 0)
-                perPeriod = Integer.MAX_VALUE;
-            else
-                perPeriod = WorkerUtils.perSecToPerPeriod(spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
+            int perPeriod = WorkerUtils.perSecToPerPeriod(spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
 
             this.throttle = new Throttle(perPeriod, THROTTLE_PERIOD_MS);
             this.consumer = consumer;
@@ -235,7 +231,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             long startBatchMs = startTimeMs;
             long maxMessages = spec.maxMessages();
             try {
-                while (messagesConsumed < maxMessages || maxMessages == 0) {
+                while (messagesConsumed < maxMessages || maxMessages <= 0) {
                     ConsumerRecords<byte[], byte[]> records = consumer.poll();
                     if (records.isEmpty()) {
                         continue;
@@ -256,10 +252,8 @@ public class ConsumeBenchWorker implements TaskWorker {
                         bytesConsumed += messageBytes;
                         if (messagesConsumed >= maxMessages && maxMessages > 0)
                             break;
-
-                        if (spec.targetMessagesPerSec() > 0) {
-                            throttle.increment();
-                        }
+                        
+                        throttle.increment();
                     }
                     startBatchMs = Time.SYSTEM.milliseconds();
                 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -230,7 +230,7 @@ public class ProduceBenchWorker implements TaskWorker {
                         producer.initTransactions();
 
                     long sentMessages = 0;
-                    while (sentMessages < spec.maxMessages()) {
+                    while (sentMessages < spec.maxMessages() || spec.maxMessages() == 0) {
                         if (enableTransactions) {
                             boolean tookAction = takeTransactionAction();
                             if (tookAction)
@@ -307,7 +307,9 @@ public class ProduceBenchWorker implements TaskWorker {
             }
             sendFuture = producer.send(record,
                 new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
-            throttle.increment();
+            if (spec.targetMessagesPerSec() > 0) {
+                throttle.increment();
+            }
         }
 
         void recordDuration(long durationMs) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -230,7 +230,7 @@ public class ProduceBenchWorker implements TaskWorker {
                         producer.initTransactions();
 
                     long sentMessages = 0;
-                    while (sentMessages < spec.maxMessages() || spec.maxMessages() == 0) {
+                    while (sentMessages < spec.maxMessages() || spec.maxMessages() <= 0) {
                         if (enableTransactions) {
                             boolean tookAction = takeTransactionAction();
                             if (tookAction)
@@ -307,9 +307,7 @@ public class ProduceBenchWorker implements TaskWorker {
             }
             sendFuture = producer.send(record,
                 new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
-            if (spec.targetMessagesPerSec() > 0) {
-                throttle.increment();
-            }
+            throttle.increment();
         }
 
         void recordDuration(long durationMs) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/Throttle.java
@@ -37,7 +37,7 @@ public class Throttle {
     synchronized public boolean increment() throws InterruptedException {
         boolean throttled = false;
         while (true) {
-            if (count < maxPerPeriod) {
+            if (count < maxPerPeriod || maxPerPeriod <= 0) {
                 count++;
                 return throttled;
             }


### PR DESCRIPTION
This PR solves the feature request [KAFKA-7599](https://issues.apache.org/jira/browse/KAFKA-7599)
Instead of disabling throttling when targetMessagesPerSec is absent, it will disable when the value is set to 0. This commit also allows an unrestricted number of messages when maxMessages is set to 0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
