### PR TITLE
KAFKA-6145: KIP-441 avoid unnecessary movement of standbys

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignor.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
-import static org.apache.kafka.streams.processor.internals.assignment.RankedClient.tasksToCaughtUpClients;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignor.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import static org.apache.kafka.streams.processor.internals.assignment.RankedClient.tasksToCaughtUpClients;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
@@ -62,16 +62,24 @@ public class TaskMovement {
     }
 
     /**
-     * Computes the movement of tasks from the state constrained to the balanced assignment. Tasks whose destination
-     * clients are caught-up, or whose source clients are not caught-up, will be moved immediately.
+     * Computes the movement of tasks from the state constrained to the balanced assignment, up to the configured
+     * {@code max.warmup.replicas}. A movement corresponds to a warmup replica on the destination client, with
+     * a few exceptional cases:
+     * <p>
+     * 1. Tasks whose destination clients are caught-up, or whose source clients are not caught-up, will be moved
+     * immediately from the source to the destination in the state constrained assignment
+     * 2. Tasks whose destination client previously had this task as a standby will not be counted towards the total
+     * {@code max.warmup.replicas}. Instead they will be counted against that task's total {@code num.standby.replicas}.
      *
-     * @param statefulActiveTaskAssignment the initial assignment, with source clients
-     * @param balancedStatefulActiveTaskAssignment the final assignment, with destination clients
+     * @param statefulActiveTaskAssignment the initial, state constrained assignment, with the source clients
+     * @param balancedStatefulActiveTaskAssignment the final, balanced assignment, with the destination clients
      * @return list of the task movements from statefulActiveTaskAssignment to balancedStatefulActiveTaskAssignment
      */
     static List<TaskMovement> getMovements(final Map<UUID, List<TaskId>> statefulActiveTaskAssignment,
                                            final Map<UUID, List<TaskId>> balancedStatefulActiveTaskAssignment,
                                            final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients,
+                                           final Map<UUID, ClientState> clientStates,
+                                           final Map<TaskId, Integer> tasksToRemainingStandbys,
                                            final int maxWarmupReplicas) {
         if (statefulActiveTaskAssignment.size() != balancedStatefulActiveTaskAssignment.size()) {
             throw new IllegalStateException("Tried to compute movements but assignments differ in size.");
@@ -85,6 +93,7 @@ public class TaskMovement {
             }
         }
 
+        int remainingAllowedWarmupReplicas = maxWarmupReplicas;
         final List<TaskMovement> movements = new LinkedList<>();
         for (final Map.Entry<UUID, List<TaskId>> sourceClientEntry : statefulActiveTaskAssignment.entrySet()) {
             final UUID source = sourceClientEntry.getKey();
@@ -102,8 +111,14 @@ public class TaskMovement {
                         sourceClientTasksIterator.remove();
                         statefulActiveTaskAssignment.get(destination).add(task);
                     } else {
+                        if (clientStates.get(destination).prevStandbyTasks().contains(task)) {
+                            decrementRemainingStandbys(task, tasksToRemainingStandbys);
+                        } else {
+                            --remainingAllowedWarmupReplicas;
+                        }
+
                         movements.add(new TaskMovement(task, source, destination));
-                        if (movements.size() == maxWarmupReplicas) {
+                        if (remainingAllowedWarmupReplicas == 0) {
                             return movements;
                         }
                     }
@@ -118,5 +133,9 @@ public class TaskMovement {
                                                        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients) {
         final Set<UUID> caughtUpClients = tasksToCaughtUpClients.get(task);
         return caughtUpClients != null && caughtUpClients.contains(destination);
+    }
+
+    private static void decrementRemainingStandbys(final TaskId task, final Map<TaskId, Integer> tasksToRemainingStandbys) {
+        tasksToRemainingStandbys.compute(task, (t, numstandbys) -> numstandbys - 1);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
@@ -111,7 +111,9 @@ public class TaskMovement {
                         sourceClientTasksIterator.remove();
                         statefulActiveTaskAssignment.get(destination).add(task);
                     } else {
-                        if (clientStates.get(destination).prevStandbyTasks().contains(task)) {
+                        if (clientStates.get(destination).prevStandbyTasks().contains(task)
+                                && tasksToRemainingStandbys.get(task) > 0
+                        ) {
                             decrementRemainingStandbys(task, tasksToRemainingStandbys);
                         } else {
                             --remainingAllowedWarmupReplicas;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/DefaultStateConstrainedBalancedAssignorTest.java
@@ -160,6 +160,7 @@ public class DefaultStateConstrainedBalancedAssignorTest {
                 rankForTask12OnClient1,
                 rankForTask12OnClient2
             );
+
         final Map<UUID, List<TaskId>> assignment = new DefaultStateConstrainedBalancedAssignor().assign(
             statefulTasksToRankedCandidates,
             balanceFactor,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -199,7 +199,6 @@ public class TaskMovementTest {
         expectedMovements.add(new TaskMovement(TASK_1_2, UUID_1, UUID_3));
         expectedMovements.add(new TaskMovement(TASK_1_0, UUID_2, UUID_1));
 
-
         assertThat(
             getMovements(
                 stateConstrainedAssignment,
@@ -271,6 +270,7 @@ public class TaskMovementTest {
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_0)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1))
         );
+
         assertThrows(
             IllegalStateException.class,
             () -> getMovements(
@@ -296,6 +296,8 @@ public class TaskMovementTest {
             mkEntry(UUID_1, mkTaskList(TASK_0_0)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1))
         );
+        expectNoPreviousStandbys(client1, client2);
+
         assertThrows(
             IllegalStateException.class,
             () -> getMovements(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -19,9 +19,11 @@ package org.apache.kafka.streams.processor.internals.assignment;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
@@ -32,6 +34,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.TaskMovement.getMovements;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -48,14 +52,22 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.kafka.streams.processor.TaskId;
+import org.easymock.EasyMock;
 import org.junit.Test;
 
 public class TaskMovementTest {
 
+    private final ClientState client1 = EasyMock.createMock(ClientState.class);
+    private final ClientState client2 = EasyMock.createMock(ClientState.class);
+    private final ClientState client3 = EasyMock.createMock(ClientState.class);
+
     @Test
     public void shouldGetMovementsFromStateConstrainedToBalancedAssignment() {
         final int maxWarmupReplicas = Integer.MAX_VALUE;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
+
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_2)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_0)),
@@ -69,6 +81,8 @@ public class TaskMovementTest {
         final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(
             mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2)
         );
+
+        expectNoPreviousStandbys(client1, client2, client3);
 
         final Queue<TaskMovement> expectedMovements = new LinkedList<>();
         expectedMovements.add(new TaskMovement(TASK_1_2, UUID_1, UUID_3));
@@ -76,13 +90,21 @@ public class TaskMovementTest {
         expectedMovements.add(new TaskMovement(TASK_1_1, UUID_3, UUID_2));
 
         assertThat(
-            getMovements(stateConstrainedAssignment, balancedAssignment, tasksToCaughtUpClients, maxWarmupReplicas),
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                tasksToCaughtUpClients,
+                getClientStatesWithThreeClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas),
             equalTo(expectedMovements));
     }
 
     @Test
     public void shouldImmediatelyMoveTasksWithCaughtUpDestinationClients() {
         final int maxWarmupReplicas = Integer.MAX_VALUE;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
+
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_2)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_0)),
@@ -93,18 +115,27 @@ public class TaskMovementTest {
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1)),
             mkEntry(UUID_3, mkTaskList(TASK_0_2, TASK_1_2))
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(
-            mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2)
-        );
+
+        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(allTasks);
         tasksToCaughtUpClients.get(TASK_1_0).add(UUID_1);
+
+        expectNoPreviousStandbys(client1, client2, client3);
 
         final Queue<TaskMovement> expectedMovements = new LinkedList<>();
         expectedMovements.add(new TaskMovement(TASK_1_2, UUID_1, UUID_3));
         expectedMovements.add(new TaskMovement(TASK_1_1, UUID_3, UUID_2));
 
+
         assertThat(
-            getMovements(stateConstrainedAssignment, balancedAssignment, tasksToCaughtUpClients, maxWarmupReplicas),
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                tasksToCaughtUpClients,
+                getClientStatesWithThreeClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas),
             equalTo(expectedMovements));
+
         assertFalse(stateConstrainedAssignment.get(UUID_2).contains(TASK_1_0));
         assertTrue(stateConstrainedAssignment.get(UUID_1).contains(TASK_1_0));
     }
@@ -112,6 +143,8 @@ public class TaskMovementTest {
     @Test
     public void shouldOnlyGetUpToMaxWarmupReplicaMovements() {
         final int maxWarmupReplicas = 1;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
+
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_2)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_0)),
@@ -122,15 +155,59 @@ public class TaskMovementTest {
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1)),
             mkEntry(UUID_3, mkTaskList(TASK_0_2, TASK_1_2))
         );
-        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(
-            mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2)
-        );
+        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(allTasks);
+
+        expectNoPreviousStandbys(client1, client2, client3);
 
         final Queue<TaskMovement> expectedMovements = new LinkedList<>();
         expectedMovements.add(new TaskMovement(TASK_1_2, UUID_1, UUID_3));
 
         assertThat(
-            getMovements(stateConstrainedAssignment, balancedAssignment, tasksToCaughtUpClients, maxWarmupReplicas),
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                tasksToCaughtUpClients,
+                getClientStatesWithThreeClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas),
+            equalTo(expectedMovements));
+    }
+
+    @Test
+    public void shouldNotCountPreviousStandbyTasksTowardsMaxWarmupReplicas() {
+        final int maxWarmupReplicas = 1;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
+
+        final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
+            mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_2)),
+            mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_0)),
+            mkEntry(UUID_3, mkTaskList(TASK_0_2, TASK_1_1))
+        );
+        final Map<UUID, List<TaskId>> balancedAssignment = mkMap(
+            mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_3, mkTaskList(TASK_0_2, TASK_1_2))
+        );
+
+        final Map<TaskId, SortedSet<UUID>> tasksToCaughtUpClients = getMapWithNoCaughtUpClients(allTasks);
+
+        expectNoPreviousStandbys(client1, client2);
+        expect(client3.prevStandbyTasks()).andStubReturn(singleton(TASK_1_2));
+        replay(client3);
+
+        final Queue<TaskMovement> expectedMovements = new LinkedList<>();
+        expectedMovements.add(new TaskMovement(TASK_1_2, UUID_1, UUID_3));
+        expectedMovements.add(new TaskMovement(TASK_1_0, UUID_2, UUID_1));
+
+
+        assertThat(
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                tasksToCaughtUpClients,
+                getClientStatesWithThreeClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas),
             equalTo(expectedMovements));
     }
 
@@ -145,12 +222,23 @@ public class TaskMovementTest {
             mkEntry(UUID_1, emptyList()),
             mkEntry(UUID_2, emptyList())
         );
-        assertTrue(getMovements(stateConstrainedAssignment, balancedAssignment, emptyMap(), maxWarmupReplicas).isEmpty());
+
+        assertTrue(
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                emptyMap(),
+                getClientStatesWithTwoClients(),
+                emptyMap(),
+                maxWarmupReplicas
+            ).isEmpty());
     }
 
     @Test
     public void shouldReturnEmptyMovementsWhenPassedIdenticalTaskAssignments() {
         final int maxWarmupReplicas = 2;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
+
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_0)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1))
@@ -159,12 +247,22 @@ public class TaskMovementTest {
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_1_0)),
             mkEntry(UUID_2, mkTaskList(TASK_0_1, TASK_1_1))
         );
-        assertTrue(getMovements(stateConstrainedAssignment, balancedAssignment, emptyMap(), maxWarmupReplicas).isEmpty());
+
+        assertTrue(
+            getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                getMapWithNoCaughtUpClients(allTasks),
+                getClientStatesWithTwoClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas
+            ).isEmpty());
     }
 
     @Test
     public void shouldThrowIllegalStateExceptionIfAssignmentsAreOfDifferentSize() {
         final int maxWarmupReplicas = 2;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
 
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_0_1))
@@ -175,12 +273,20 @@ public class TaskMovementTest {
         );
         assertThrows(
             IllegalStateException.class,
-            () -> getMovements(stateConstrainedAssignment, balancedAssignment, emptyMap(), maxWarmupReplicas));
+            () -> getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                getMapWithNoCaughtUpClients(allTasks),
+                getClientStatesWithTwoClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas)
+        );
     }
 
     @Test
     public void shouldThrowIllegalStateExceptionWhenTaskHasNoDestinationClient() {
         final int maxWarmupReplicas = 2;
+        final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_1_0);
 
         final Map<UUID, List<TaskId>> stateConstrainedAssignment = mkMap(
             mkEntry(UUID_1, mkTaskList(TASK_0_0, TASK_0_1)),
@@ -192,7 +298,40 @@ public class TaskMovementTest {
         );
         assertThrows(
             IllegalStateException.class,
-            () -> getMovements(stateConstrainedAssignment, balancedAssignment, emptyMap(), maxWarmupReplicas));
+            () -> getMovements(
+                stateConstrainedAssignment,
+                balancedAssignment,
+                getMapWithNoCaughtUpClients(allTasks),
+                getClientStatesWithTwoClients(),
+                getMapWithNumStandbys(allTasks, 1),
+                maxWarmupReplicas)
+        );
+    }
+
+    private static void expectNoPreviousStandbys(final ClientState... states) {
+        for (final ClientState state : states) {
+            expect(state.prevStandbyTasks()).andStubReturn(EMPTY_TASKS);
+            replay(state);
+        }
+    }
+
+    private static Map<TaskId, Integer> getMapWithNumStandbys(final Set<TaskId> tasks, final int numStandbys) {
+        return tasks.stream().collect(Collectors.toMap(task -> task, t -> numStandbys));
+    }
+
+    private Map<UUID, ClientState> getClientStatesWithTwoClients() {
+        return mkMap(
+            mkEntry(UUID_1, client1),
+            mkEntry(UUID_2, client2)
+        );
+    }
+
+    private Map<UUID, ClientState> getClientStatesWithThreeClients() {
+        return mkMap(
+            mkEntry(UUID_1, client1),
+            mkEntry(UUID_2, client2),
+            mkEntry(UUID_3, client3)
+        );
     }
 
     private static List<TaskId> mkTaskList(final TaskId... tasks) {


### PR DESCRIPTION
Currently we add warmup and standby tasks, meaning we first assign up to max.warmup.replica warmup tasks, and then attempt to assign num.standby copies of each stateful task. This can cause unnecessary transient standbys to pop up for the lifetime of the warmup task, which are presumably not what the user wanted.

Note that we don’t want to simply count all warmups against the configured num.standbys, as this may cause the opposite problem where a standby we intend to keep is temporarily unassigned (which may lead to the cleanup thread deleting it). We should only count this as a standby if the destination client already had this task as a standby; otherwise, the standby already exists on some other client, so we should aim to give it back.