### PR TITLE
KAFKA-9796; Broker shutdown could be stuck forever under certain conditions

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -200,7 +200,7 @@ class SocketServer(val config: KafkaConfig,
     debug(s"Wait for authorizer to complete start up on listener ${endpoint.listenerName}")
     waitForAuthorizerFuture(acceptor, authorizerFutures)
     debug(s"Start processors on listener ${endpoint.listenerName}")
-    acceptor.startProcessors(DataPlaneThreadPrefix)
+    acceptor.startProcessors(threadPrefix)
     debug(s"Start acceptor thread on listener ${endpoint.listenerName}")
     if (!acceptor.isStarted()) {
       KafkaThread.nonDaemon(
@@ -209,7 +209,7 @@ class SocketServer(val config: KafkaConfig,
       ).start()
       acceptor.awaitStartup()
     }
-    info(s"Started $DataPlaneThreadPrefix acceptor and processor(s) for endpoint : ${endpoint.listenerName}")
+    info(s"Started $threadPrefix acceptor and processor(s) for endpoint : ${endpoint.listenerName}")
   }
 
   /**

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -571,10 +571,10 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
   }
 
   override def awaitShutdown(): Unit = {
+    super.awaitShutdown()
     synchronized {
       processors.foreach(_.awaitShutdown())
     }
-    super.awaitShutdown()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -270,7 +270,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         // Delay starting processors until the end of the initialization sequence to ensure
         // that credentials have been loaded before processing authentications.
         socketServer = new SocketServer(config, metrics, time, credentialProvider)
-        socketServer.startup(startupProcessors = false)
+        socketServer.startup(startProcessingRequests = false)
 
         /* start replica manager */
         replicaManager = createReplicaManager(isShuttingDown)
@@ -339,6 +339,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         Mx4jLoader.maybeLoad()
 
+        socketServer.startProcessingRequests(authorizerFutures)
+
         /* Add all reconfigurables for config change notification before starting config handlers */
         config.dynamicConfig.addReconfigurables(this)
 
@@ -352,8 +354,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         dynamicConfigManager = new DynamicConfigManager(zkClient, dynamicConfigHandlers)
         dynamicConfigManager.startup()
 
-        socketServer.startControlPlaneProcessor(authorizerFutures)
-        socketServer.startDataPlaneProcessors(authorizerFutures)
         brokerState.newState(RunningAsBroker)
         shutdownLatch = new CountDownLatch(1)
         startupComplete.set(true)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -339,8 +339,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         Mx4jLoader.maybeLoad()
 
-        socketServer.startProcessingRequests(authorizerFutures)
-
         /* Add all reconfigurables for config change notification before starting config handlers */
         config.dynamicConfig.addReconfigurables(this)
 
@@ -353,6 +351,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         // Create the config manager. start listening to notifications
         dynamicConfigManager = new DynamicConfigManager(zkClient, dynamicConfigHandlers)
         dynamicConfigManager.startup()
+
+        socketServer.startProcessingRequests(authorizerFutures)
 
         brokerState.newState(RunningAsBroker)
         shutdownLatch = new CountDownLatch(1)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -344,7 +344,6 @@ class SocketServerTest {
       externalReadyFuture.complete(null)
       TestUtils.waitUntilTrue(() => listenerStarted(externalListener), "External listener not started")
     } finally {
-      externalReadyFuture.complete(null)
       executor.shutdownNow()
       shutdownServerAndMetrics(testableServer)
     }
@@ -363,11 +362,10 @@ class SocketServerTest {
     val testableServer = new TestableSocketServer(config, connectionQueueSize)
     testableServer.startup(startProcessingRequests = false)
 
-    connect(testableServer, new ListenerName("EXTERNAL"), localAddr = InetAddress.getLocalHost)
-    connect(testableServer, new ListenerName("EXTERNAL"), localAddr = InetAddress.getLocalHost)
-
-    // Wait to let the acceptor accepts the connections
-    Thread.sleep(100)
+    val socket1 = connect(testableServer, new ListenerName("EXTERNAL"), localAddr = InetAddress.getLocalHost)
+    sendRequest(socket1, producerRequestBytes())
+    val socket2 = connect(testableServer, new ListenerName("EXTERNAL"), localAddr = InetAddress.getLocalHost)
+    sendRequest(socket2, producerRequestBytes())
 
     testableServer.shutdown()
   }


### PR DESCRIPTION
This patch reworks the SocketServer to always start the acceptor threads after the processor threads and to always stop the acceptor threads before the processor threads. It ensures that the acceptor shutdown is not blocked waiting on the processors to be fully shutdown by decoupling the shutdown signal and the awaiting. It also ensure that the processor threads drain its newConnection queue to unblock acceptors that may be waiting. However, the acceptors still bind during the startup, only the processing of new connections and requests is further delayed.

The flow looks like this now:

```
val socketServer = ...

socketServer.startup(startProcessingRequests = false)
// Acceptors are bound.

socketServer.startProcessingRequests(authorizerFutures)
// Acceptors and Processors process new connections and requests

socketServer.stopProcessingRequests()
// Acceptors and Processors are stopped

socketServer.shutdown()
// SocketServer is shutdown (metrics, etc.)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
