### PR TITLE
KAFKA-7613: Enable -Xlint:try, fixing warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,6 @@ subprojects {
     // temporary exclusions until all the warnings are fixed
     options.compilerArgs << "-Xlint:-rawtypes"
     options.compilerArgs << "-Xlint:-serial"
-    options.compilerArgs << "-Xlint:-try"
     options.compilerArgs << "-Werror"
     // --release is the recommended way to select the target release, but it's only supported in Java 9 so we also
     // set --source and --target via `sourceCompatibility` and `targetCompatibility`. If/when Gradle supports `--release`

--- a/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
+@SuppressWarnings("try")
 public interface AlterConfigPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
+@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface AlterConfigPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
@@ -32,7 +32,6 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
-@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface AlterConfigPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
@@ -33,6 +33,7 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
+@SuppressWarnings("try")
 public interface CreateTopicPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
@@ -33,6 +33,7 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
+@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface CreateTopicPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
@@ -33,7 +33,6 @@ import java.util.Map;
  * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
  * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
  */
-@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface CreateTopicPolicy extends Configurable, AutoCloseable {
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -290,8 +290,7 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testCloseAdminClient() {
-        try (AdminClientUnitTestEnv env = mockClientEnv()) {
-        }
+        mockClientEnv().close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -192,12 +192,18 @@ public class KafkaProducerTest {
 
         final int oldInitCount = MockMetricsReporter.INIT_COUNT.get();
         final int oldCloseCount = MockMetricsReporter.CLOSE_COUNT.get();
-        try (KafkaProducer<byte[], byte[]> ignored = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
+        KafkaProducer<byte[], byte[]> producer = null;
+        try {
+            producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
             fail("should have caught an exception and returned");
         } catch (KafkaException e) {
             assertEquals(oldInitCount + 1, MockMetricsReporter.INIT_COUNT.get());
             assertEquals(oldCloseCount + 1, MockMetricsReporter.CLOSE_COUNT.get());
             assertEquals("Failed to construct kafka producer", e.getMessage());
+        } finally {
+            if (producer != null) {
+                producer.close();
+            }
         }
     }
 
@@ -206,10 +212,16 @@ public class KafkaProducerTest {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         props.put(1, "not string key");
-        try (KafkaProducer<?, ?> ff = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer())) {
+        KafkaProducer<?, ?> producer = null;
+        try {
+            producer = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
             fail("Constructor should throw exception");
         } catch (ConfigException e) {
             assertTrue("Unexpected exception message: " + e.getMessage(), e.getMessage().contains("not string key"));
+        } finally {
+            if (producer != null) {
+                producer.close();
+            }
         }
     }
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -28,6 +28,7 @@ import java.util.List;
  * <p>Common use cases are ability to provide principal per connector, <code>sasl.jaas.config</code>
  * and/or enforcing that the producer/consumer configurations for optimizations are within acceptable ranges.
  */
+@SuppressWarnings("try")
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -28,7 +28,6 @@ import java.util.List;
  * <p>Common use cases are ability to provide principal per connector, <code>sasl.jaas.config</code>
  * and/or enforcing that the producer/consumer configurations for optimizations are within acceptable ranges.
  */
-@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -28,6 +28,7 @@ import java.util.List;
  * <p>Common use cases are ability to provide principal per connector, <code>sasl.jaas.config</code>
  * and/or enforcing that the producer/consumer configurations for optimizations are within acceptable ranges.
  */
+@SuppressWarnings("try") // can't override close() to now declare throws Exception until Kafka 3.0
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractConnectorClientConfigOverridePolicy implements ConnectorClientConfigOverridePolicy {
 
     @Override
-    public void close() throws Exception {
+    public void close() {
 
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("try")
 public abstract class AbstractConnectorClientConfigOverridePolicy implements ConnectorClientConfigOverridePolicy {
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AbstractConnectorClientConfigOverridePolicy.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractConnectorClientConfigOverridePolicy implements ConnectorClientConfigOverridePolicy {
 
     @Override
-    public void close() {
+    public void close() throws Exception {
 
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AllConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/AllConnectorClientConfigOverridePolicy.java
@@ -26,6 +26,7 @@ import java.util.Map;
 /**
  * Allows all client configurations to be overridden via the connector configs by setting {@code connector.client.config.override.policy} to {@code All}
  */
+@SuppressWarnings("try")
 public class AllConnectorClientConfigOverridePolicy extends AbstractConnectorClientConfigOverridePolicy {
     private static final Logger log = LoggerFactory.getLogger(AllConnectorClientConfigOverridePolicy.class);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/NoneConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/NoneConnectorClientConfigOverridePolicy.java
@@ -27,6 +27,7 @@ import java.util.Map;
  * Disallow any client configuration to be overridden via the connector configs by setting {@code connector.client.config.override.policy} to {@code None}.
  * This is the default behavior.
  */
+@SuppressWarnings("try")
 public class NoneConnectorClientConfigOverridePolicy extends AbstractConnectorClientConfigOverridePolicy {
     private static final Logger log = LoggerFactory.getLogger(NoneConnectorClientConfigOverridePolicy.class);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/PrincipalConnectorClientConfigOverridePolicy.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/connector/policy/PrincipalConnectorClientConfigOverridePolicy.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
  * Allows all {@code sasl} configurations to be overridden via the connector configs by setting {@code connector.client.config.override.policy} to
  * {@code Principal}. This allows to set a principal per connector.
  */
+@SuppressWarnings("try")
 public class PrincipalConnectorClientConfigOverridePolicy extends AbstractConnectorClientConfigOverridePolicy {
     private static final Logger log = LoggerFactory.getLogger(PrincipalConnectorClientConfigOverridePolicy.class);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -108,8 +108,8 @@ public class WorkerConnector implements Runnable {
     public void run() {
         // Clear all MDC parameters, in case this thread is being reused
         LoggingContext.clear();
-
-        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+        LoggingContext loggingContext = LoggingContext.forConnector(connName);
+        try {
             ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
             String savedName = Thread.currentThread().getName();
             try {
@@ -120,6 +120,7 @@ public class WorkerConnector implements Runnable {
                 Plugins.compareAndSwapLoaders(savedLoader);
             }
         } finally {
+            loggingContext.close();
             // In the rare case of an exception being thrown outside the doRun() method, or an
             // uncaught one being thrown from within it, mark the connector as shut down to avoid
             // unnecessarily blocking and eventually timing out during awaitShutdown

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -193,9 +193,12 @@ class WorkerSinkTask extends WorkerTask {
         initializeAndStart();
         // Make sure any uncommitted data has been committed and the task has
         // a chance to clean up its state
-        try (UncheckedCloseable suppressible = this::closePartitions) {
+        UncheckedCloseable suppressible = this::closePartitions;
+        try {
             while (!isStopping())
                 iteration();
+        } finally {
+            suppressible.close();
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -226,8 +226,8 @@ abstract class WorkerTask implements Runnable {
     public void run() {
         // Clear all MDC parameters, in case this thread is being reused
         LoggingContext.clear();
-
-        try (LoggingContext loggingContext = LoggingContext.forTask(id())) {
+        LoggingContext loggingContext = LoggingContext.forTask(id());
+        try {
             ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
             String savedName = Thread.currentThread().getName();
             try {
@@ -244,6 +244,8 @@ abstract class WorkerTask implements Runnable {
                 Plugins.compareAndSwapLoaders(savedLoader);
                 shutdownLatch.countDown();
             }
+        } finally {
+            loggingContext.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -192,7 +192,6 @@ public class AssignmentInfo {
             }
 
             out.flush();
-            out.close();
 
             return ByteBuffer.wrap(baos.toByteArray());
         } catch (final IOException ex) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -555,6 +555,7 @@ public class KafkaStreamsTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testInitializesAndDestroysMetricsReporters() {
         final int oldInitCount = MockMetricsReporter.INIT_COUNT.get();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -174,6 +174,7 @@ public class StandbyTaskEOSIntegrationTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void shouldWipeOutStandbyStateDirectoryIfCheckpointIsMissing() throws Exception {
         final String base = TestUtils.tempDirectory(appId).getPath();
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -372,7 +372,6 @@ public class StreamsUpgradeTest {
                 } catch (final BufferUnderflowException expectedWhenAllDataCopied) { }
 
                 out.flush();
-                out.close();
 
                 return ByteBuffer.wrap(baos.toByteArray());
             } catch (final IOException ex) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -137,6 +137,8 @@ public class ConnectionStressWorker implements TaskWorker {
         }
 
         boolean tryConnect();
+
+        void close();
     }
 
     static class ConnectStressor implements Stressor {
@@ -192,7 +194,7 @@ public class ConnectionStressWorker implements TaskWorker {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             Utils.closeQuietly(updater, "ManualMetadataUpdater");
             Utils.closeQuietly(channelBuilder, "ChannelBuilder");
         }
@@ -220,7 +222,7 @@ public class ConnectionStressWorker implements TaskWorker {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
@@ -140,6 +140,7 @@ public class SustainedConnectionWorker implements TaskWorker {
         boolean needsRefresh(long milliseconds);
         void refresh();
         void claim();
+        void close();
     }
 
     private abstract class ClaimableConnection implements SustainedConnection {
@@ -159,7 +160,7 @@ public class SustainedConnectionWorker implements TaskWorker {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             this.closeQuietly();
         }
 

--- a/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
@@ -356,7 +356,7 @@ public class AgentTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             Utils.delete(tempDir);
         }
     }

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/MiniTrogdorCluster.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/MiniTrogdorCluster.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * MiniTrogdorCluster sets up a local cluster of Trogdor Agents and Coordinators.
  */
+@SuppressWarnings("try")
 public class MiniTrogdorCluster implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(MiniTrogdorCluster.class);
 

--- a/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -75,6 +75,7 @@ public class CoordinatorTest {
     final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
+    @SuppressWarnings("try")
     public void testCoordinatorStatus() throws Exception {
         try (MiniTrogdorCluster cluster = new MiniTrogdorCluster.Builder().
                 addCoordinator("node01").
@@ -85,6 +86,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testCoordinatorUptime() throws Exception {
         MockTime time = new MockTime(0, 200, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -101,6 +103,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testCreateTask() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -153,6 +156,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskDistribution() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -210,6 +214,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskCancellation() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -274,6 +279,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskDestruction() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -378,6 +384,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testNetworkPartitionFault() throws Exception {
         CapturingCommandRunner runner = new CapturingCommandRunner();
         MockTime time = new MockTime(0, 0, 0);
@@ -461,6 +468,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTasksRequest() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -521,6 +529,7 @@ public class CoordinatorTest {
      * we want the task to be marked as DONE and not re-sent should a second failure happen.
      */
     @Test
+    @SuppressWarnings("try")
     public void testAgentFailureAndTaskExpiry() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -572,6 +581,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskRequestWithOldStartMsGetsUpdated() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -597,6 +607,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskRequestWithFutureStartMsDoesNotGetRun() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -621,6 +632,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testTaskRequest() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);
@@ -655,6 +667,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @SuppressWarnings("try")
     public void testWorkersExitingAtDifferentTimes() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);


### PR DESCRIPTION
Fix all existing javac warnings about try statements and remove `-Xlint:-try` from the javac options in build.gradle. This addresses part of KAFKA-7613, but further work will be needed for the other warnings.

A couple of `@SuppressWarnings("try")` were needed to avoid having to override `close()` on interfaces extending `AutoCloseable`. The problem with those is `AutoCloseable.close()` is declared to throw `Exception`, which allows `InterruptedException`, which generates a warning.

try-with-resources with an ignored variable causes a warning, and I favoured rewriting these rather than suppressing the warning. 

