### PR TITLE
KAFKA-7613: Enable -Xlint:rawtypes in clients, fixing warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1040,8 +1040,14 @@ project(':clients') {
   }
 
   compileJava.dependsOn 'processMessages'
+  compileJava {
+    options.compilerArgs << "-Xlint:rawtypes"
+  }
 
   compileTestJava.dependsOn 'processTestMessages'
+  compileTestJava {
+    options.compilerArgs << "-Xlint:rawtypes"
+  }
 
   javadoc {
     include "**/org/apache/kafka/clients/admin/*"

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,8 @@ subprojects {
     options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:all"
     // temporary exclusions until all the warnings are fixed
-    options.compilerArgs << "-Xlint:-rawtypes"
+    if (!project.name.equals('clients'))
+      options.compilerArgs << "-Xlint:-rawtypes"
     options.compilerArgs << "-Xlint:-serial"
     options.compilerArgs << "-Xlint:-try"
     options.compilerArgs << "-Werror"
@@ -1045,9 +1046,6 @@ project(':clients') {
   }
 
   compileTestJava.dependsOn 'processTestMessages'
-  compileTestJava {
-    options.compilerArgs << "-Xlint:rawtypes"
-  }
 
   javadoc {
     include "**/org/apache/kafka/clients/admin/*"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
@@ -21,7 +21,7 @@ package org.apache.kafka.clients.admin;
 /*
  * This class implements the common APIs that are shared by Options classes for various AdminClient commands
  */
-public abstract class AbstractOptions<T extends AbstractOptions> {
+public abstract class AbstractOptions<T extends AbstractOptions<T>> {
 
     protected Integer timeoutMs = null;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterClientQuotasResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterClientQuotasResult.java
@@ -53,6 +53,6 @@ public class AlterClientQuotasResult {
      * Returns a future which succeeds only if all quota alterations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
@@ -48,7 +48,7 @@ public class AlterConfigsResult {
      * Return a future which succeeds only if all the alter configs operations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterPartitionReassignmentsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterPartitionReassignmentsResult.java
@@ -54,6 +54,6 @@ public class AlterPartitionReassignmentsResult {
      * Return a future which succeeds only if all the reassignments were successfully initiated.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterReplicaLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterReplicaLogDirsResult.java
@@ -74,6 +74,6 @@ public class AlterReplicaLogDirsResult {
      * if not, it throws an {@link Exception} described in {@link #values()} method.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
@@ -49,6 +49,6 @@ public class CreateAclsResult {
      * Return a future which succeeds only if all the ACL creations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
@@ -48,6 +48,6 @@ public class CreatePartitionsResult {
      * Return a future which succeeds if all the partition creations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(values.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(values.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -52,7 +52,7 @@ public class CreateTopicsResult {
      * Return a future which succeeds if all the topic creations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
@@ -101,7 +101,7 @@ public class DeleteAclsResult {
      * Note that it if the filters don't match any ACLs, this is not considered an error.
      */
     public KafkaFuture<Collection<AclBinding>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(v -> getAclBindings(futures));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).thenApply(v -> getAclBindings(futures));
     }
 
     private List<AclBinding> getAclBindings(Map<AclBindingFilter, KafkaFuture<FilterResults>> futures) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -47,6 +47,6 @@ public class DeleteConsumerGroupsResult {
      * Return a future which succeeds only if all the consumer group deletions succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteRecordsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteRecordsResult.java
@@ -49,6 +49,6 @@ public class DeleteRecordsResult {
      * Return a future which succeeds only if all the records deletions succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
@@ -48,6 +48,6 @@ public class DeleteTopicsResult {
      * Return a future which succeeds only if all the topic deletions succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
@@ -52,7 +52,7 @@ public class DescribeConfigsResult {
      * Return a future which succeeds only if all the config descriptions succeed.
      */
     public KafkaFuture<Map<ConfigResource, Config>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).
                 thenApply(new KafkaFuture.BaseFunction<Void, Map<ConfigResource, Config>>() {
                     @Override
                     public Map<ConfigResource, Config> apply(Void v) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -51,7 +51,7 @@ public class DescribeConsumerGroupsResult {
      * Return a future which yields all ConsumerGroupDescription objects, if all the describes succeed.
      */
     public KafkaFuture<Map<String, ConsumerGroupDescription>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).thenApply(
             new KafkaFuture.BaseFunction<Void, Map<String, ConsumerGroupDescription>>() {
                 @Override
                 public Map<String, ConsumerGroupDescription> apply(Void v) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
@@ -50,7 +50,7 @@ public class DescribeLogDirsResult {
      * Return a future which succeeds only if all the brokers have responded without error
      */
     public KafkaFuture<Map<Integer, Map<String, LogDirInfo>>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).
             thenApply(new KafkaFuture.BaseFunction<Void, Map<Integer, Map<String, LogDirInfo>>>() {
                 @Override
                 public Map<Integer, Map<String, LogDirInfo>> apply(Void v) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
@@ -51,7 +51,7 @@ public class DescribeReplicaLogDirsResult {
      * Return a future which succeeds if log directory information of all replicas are available
      */
     public KafkaFuture<Map<TopicPartitionReplica, ReplicaLogDirInfo>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).
             thenApply(new KafkaFuture.BaseFunction<Void, Map<TopicPartitionReplica, ReplicaLogDirInfo>>() {
                 @Override
                 public Map<TopicPartitionReplica, ReplicaLogDirInfo> apply(Void v) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
@@ -50,7 +50,7 @@ public class DescribeTopicsResult {
      * Return a future which succeeds only if all the topic descriptions succeed.
      */
     public KafkaFuture<Map<String, TopicDescription>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0])).
             thenApply(v -> {
                 Map<String, TopicDescription> descriptions = new HashMap<>(futures.size());
                 for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListOffsetsResult.java
@@ -56,7 +56,7 @@ public class ListOffsetsResult {
      * retrieved.
      */
     public KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture<?>[0]))
                 .thenApply(new KafkaFuture.BaseFunction<Void, Map<TopicPartition, ListOffsetsResultInfo>>() {
                     @Override
                     public Map<TopicPartition, ListOffsetsResultInfo> apply(Void v) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -612,7 +612,7 @@ public class Fetcher<K, V> implements Closeable {
                             // The first condition ensures that the completedFetches is not stuck with the same completedFetch
                             // in cases such as the TopicAuthorizationException, and the second condition ensures that no
                             // potential data loss due to an exception in a following record.
-                            FetchResponse.PartitionData partition = records.partitionData;
+                            FetchResponse.PartitionData<?> partition = records.partitionData;
                             if (fetched.isEmpty() && (partition.records == null || partition.records.sizeInBytes() == 0)) {
                                 completedFetches.poll();
                             }

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
@@ -62,7 +62,7 @@ public abstract class AbstractRecords implements Records {
     }
 
     @Override
-    public RecordsSend toSend(String destination) {
+    public RecordsSend<?> toSend(String destination) {
         return new DefaultRecordsSend(destination, this);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
@@ -30,5 +30,5 @@ public interface BaseRecords {
      * Encapsulate this {@link BaseRecords} object into {@link RecordsSend}
      * @return Initialized {@link RecordsSend} object
      */
-    RecordsSend toSend(String destination);
+    RecordsSend<?> toSend(String destination);
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
@@ -33,7 +33,7 @@ public class LazyDownConversionRecords implements BaseRecords {
     private final Records records;
     private final byte toMagic;
     private final long firstOffset;
-    private ConvertedRecords firstConvertedBatch;
+    private ConvertedRecords<?> firstConvertedBatch;
     private final int sizeInBytes;
     private final Time time;
 
@@ -118,7 +118,7 @@ public class LazyDownConversionRecords implements BaseRecords {
     public java.util.Iterator<ConvertedRecords<?>> iterator(long maximumReadSize) {
         // We typically expect only one iterator instance to be created, so null out the first converted batch after
         // first use to make it available for GC.
-        ConvertedRecords firstBatch = firstConvertedBatch;
+        ConvertedRecords<?> firstBatch = firstConvertedBatch;
         firstConvertedBatch = null;
         return new Iterator(records, maximumReadSize, firstBatch);
     }
@@ -131,7 +131,7 @@ public class LazyDownConversionRecords implements BaseRecords {
     private class Iterator extends AbstractIterator<ConvertedRecords<?>> {
         private final AbstractIterator<? extends RecordBatch> batchIterator;
         private final long maximumReadSize;
-        private ConvertedRecords firstConvertedBatch;
+        private ConvertedRecords<?> firstConvertedBatch;
 
         /**
          * @param recordsToDownConvert Records that require down-conversion
@@ -153,10 +153,10 @@ public class LazyDownConversionRecords implements BaseRecords {
          * @return Down-converted records
          */
         @Override
-        protected ConvertedRecords makeNext() {
+        protected ConvertedRecords<?> makeNext() {
             // If we have cached the first down-converted batch, return that now
             if (firstConvertedBatch != null) {
-                ConvertedRecords convertedBatch = firstConvertedBatch;
+                ConvertedRecords<?> convertedBatch = firstConvertedBatch;
                 firstConvertedBatch = null;
                 return convertedBatch;
             }
@@ -175,7 +175,7 @@ public class LazyDownConversionRecords implements BaseRecords {
                     isFirstBatch = false;
                 }
 
-                ConvertedRecords convertedRecords = RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
+                ConvertedRecords<?> convertedRecords = RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
                 // During conversion, it is possible that we drop certain batches because they do not have an equivalent
                 // representation in the message format we want to convert to. For example, V0 and V1 message formats
                 // have no notion of transaction markers which were introduced in V2 so they get dropped during conversion.

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -36,7 +36,7 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
     static final int MIN_OVERFLOW_MESSAGE_LENGTH = Records.LOG_OVERHEAD;
 
     private RecordConversionStats recordConversionStats;
-    private RecordsSend convertedRecordsWriter;
+    private RecordsSend<?> convertedRecordsWriter;
     private Iterator<ConvertedRecords<?>> convertedRecordsIterator;
 
     public LazyDownConversionRecordsSend(String destination, LazyDownConversionRecords records) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -317,7 +317,7 @@ public class FetchResponse<T extends BaseRecords> extends AbstractResponse {
             if (o == null || getClass() != o.getClass())
                 return false;
 
-            PartitionData that = (PartitionData) o;
+            PartitionData<?> that = (PartitionData<?>) o;
 
             return error == that.error &&
                     highWatermark == that.highWatermark &&
@@ -524,7 +524,7 @@ public class FetchResponse<T extends BaseRecords> extends AbstractResponse {
         sends.add(new ByteBufferSend(dest, buffer));
 
         // finally the send for the record set itself
-        RecordsSend recordsSend = records.toSend(dest);
+        RecordsSend<?> recordsSend = records.toSend(dest);
         if (recordsSend.size() > 0)
             sends.add(recordsSend);
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/LoggingSignalHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LoggingSignalHandler.java
@@ -93,7 +93,7 @@ public class LoggingSignalHandler {
                 return null;
             }
         };
-        return Proxy.newProxyInstance(Utils.getContextOrKafkaClassLoader(), new Class[] {signalHandlerClass},
+        return Proxy.newProxyInstance(Utils.getContextOrKafkaClassLoader(), new Class<?>[] {signalHandlerClass},
                 invocationHandler);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -488,7 +488,7 @@ public class KafkaConsumerTest {
         Assert.assertEquals(0, requests.size());
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "rawtypes"})
     @Test
     public void verifyDeprecatedPollDoesNotTimeOutDuringMetadataUpdate() {
         final Time time = new MockTime();
@@ -1546,12 +1546,12 @@ public class KafkaConsumerTest {
     public void testMetricConfigRecordingLevel() {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
-        try (KafkaConsumer consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
+        try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
             assertEquals(Sensor.RecordingLevel.INFO, consumer.metrics.config().recordLevel());
         }
 
         props.put(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG, "DEBUG");
-        try (KafkaConsumer consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
+        try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
             assertEquals(Sensor.RecordingLevel.DEBUG, consumer.metrics.config().recordLevel());
         }
     }
@@ -2168,7 +2168,7 @@ public class KafkaConsumerTest {
         return new FetchResponse<>(Errors.NONE, tpResponses, 0, INVALID_SESSION_ID);
     }
 
-    private FetchResponse fetchResponse(TopicPartition partition, long fetchOffset, int count) {
+    private FetchResponse<MemoryRecords> fetchResponse(TopicPartition partition, long fetchOffset, int count) {
         FetchInfo fetchInfo = new FetchInfo(fetchOffset, count);
         return fetchResponse(Collections.singletonMap(partition, fetchInfo));
     }
@@ -2300,7 +2300,7 @@ public class KafkaConsumerTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testCloseWithTimeUnit() {
-        KafkaConsumer consumer = mock(KafkaConsumer.class);
+        KafkaConsumer<?, ?> consumer = mock(KafkaConsumer.class);
         doCallRealMethod().when(consumer).close(anyLong(), any());
         consumer.close(1, TimeUnit.SECONDS);
         verify(consumer).close(Duration.ofSeconds(1));
@@ -2429,7 +2429,7 @@ public class KafkaConsumerTest {
         assertEquals((1.0d + 0.0d + 0.5d) / 3, consumer.metrics().get(pollIdleRatio).metricValue());
     }
 
-    private static boolean consumerMetricPresent(KafkaConsumer consumer, String name) {
+    private static boolean consumerMetricPresent(KafkaConsumer<?, ?> consumer, String name) {
         MetricName metricName = new MetricName(name, "consumer-metrics", "", Collections.emptyMap());
         return consumer.metrics.metrics().containsKey(metricName);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -174,7 +174,7 @@ public class KafkaProducerTest {
     public void testNoSerializerProvided() {
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
-        new KafkaProducer(producerProps);
+        new KafkaProducer<>(producerProps);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -158,9 +158,9 @@ public class KafkaFutureTest {
         for (int i = 0; i < numThreads; i++) {
             futures.add(new KafkaFutureImpl<>());
         }
-        KafkaFuture<Void> allFuture = KafkaFuture.allOf(futures.toArray(new KafkaFuture[0]));
-        final List<CompleterThread> completerThreads = new ArrayList<>();
-        final List<WaiterThread> waiterThreads = new ArrayList<>();
+        KafkaFuture<Void> allFuture = KafkaFuture.allOf(futures.toArray(new KafkaFuture<?>[0]));
+        final List<CompleterThread<Integer>> completerThreads = new ArrayList<>();
+        final List<WaiterThread<Integer>> waiterThreads = new ArrayList<>();
         for (int i = 0; i < numThreads; i++) {
             completerThreads.add(new CompleterThread<>(futures.get(i), i));
             waiterThreads.add(new WaiterThread<>(futures.get(i), i));


### PR DESCRIPTION
Fix all existing javac warnings about use of raw types in clients add -Xlint:rawtypes to the clients the javac options in build.gradle. This addresses part of KAFKA-7613, but further work will be needed for the other warnings.
