### PR TITLE
HOTFIX: fix flaky shouldEnforceRebalance test in StreamThreadTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -508,13 +508,16 @@ public class StreamThreadTest {
             10 * 1000,
             "Thread never started.");
 
+        TestUtils.retryOnExceptionWithTimeout(
+            () -> EasyMock.verify(mockConsumer)
+        );
+
         thread.shutdown();
         TestUtils.waitForCondition(
             () -> thread.state() == StreamThread.State.DEAD,
             10 * 1000,
             "Thread never shut down.");
 
-        EasyMock.verify(mockConsumer);
     }
 
     private static class EasyMockConsumerClientSupplier extends MockClientSupplier {


### PR DESCRIPTION
We need to make sure the StreamThread actually makes it through the `runOnce` method in the main run loop at least once before shutting it down.

There's no particularly clean or direct way to do so at the moment, so we leverage the StreamThread's `now` variable as a proxy for whether the thread has entered the `runOnce` method.