### PR TITLE
KAFKA-9844; Maximum number of members within a group is not always enforced due to a race condition in join group

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -147,7 +147,7 @@ class GroupCoordinator(val brokerId: Int,
       val isUnknownMember = memberId == JoinGroupRequest.UNKNOWN_MEMBER_ID
       // group is created if it does not exist and the member id is UNKNOWN. if member
       // is specified but group does not exist, request is rejected with UNKNOWN_MEMBER_ID
-      groupManager.getGroup(groupId, isUnknownMember) match {
+      groupManager.getOrMaybeCreateGroup(groupId, isUnknownMember) match {
         case None =>
           responseCallback(JoinGroupResult(memberId, Errors.UNKNOWN_MEMBER_ID))
         case Some(group) =>

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -145,11 +145,10 @@ class GroupCoordinator(val brokerId: Int,
       responseCallback(JoinGroupResult(memberId, Errors.INVALID_SESSION_TIMEOUT))
     } else {
       val isUnknownMember = memberId == JoinGroupRequest.UNKNOWN_MEMBER_ID
+      // group is created if it does not exist and the member id is UNKNOWN. if member
+      // is specified but group does not exist, request is rejected with UNKNOWN_MEMBER_ID
       groupManager.getGroup(groupId, isUnknownMember) match {
         case None =>
-          // only try to create the group if the group is UNKNOWN AND
-          // the member id is UNKNOWN, if member is specified but group does not
-          // exist we should reject the request.
           responseCallback(JoinGroupResult(memberId, Errors.UNKNOWN_MEMBER_ID))
         case Some(group) =>
           group.inLock {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -208,11 +208,19 @@ class GroupMetadataManager(brokerId: Int,
     case None =>
       false
   }
+
+  /**
+   * Get the group associated with the given groupId or null if not found
+   */
+  def getGroup(groupId: String): Option[GroupMetadata] = {
+    Option(groupMetadataCache.get(groupId))
+  }
+
   /**
    * Get the group associated with the given groupId - the group is created if createIfNotExist
    * is true - or null if not found
    */
-  def getGroup(groupId: String, createIfNotExist: Boolean = false): Option[GroupMetadata] = {
+  def getOrMaybeCreateGroup(groupId: String, createIfNotExist: Boolean): Option[GroupMetadata] = {
     if (createIfNotExist)
       Option(groupMetadataCache.getAndMaybePut(groupId, new GroupMetadata(groupId, Empty, time)))
     else

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -209,10 +209,14 @@ class GroupMetadataManager(brokerId: Int,
       false
   }
   /**
-   * Get the group associated with the given groupId, or null if not found
+   * Get the group associated with the given groupId - the group is created if createIfNotExist
+   * is true - or null if not found
    */
-  def getGroup(groupId: String): Option[GroupMetadata] = {
-    Option(groupMetadataCache.get(groupId))
+  def getGroup(groupId: String, createIfNotExist: Boolean = false): Option[GroupMetadata] = {
+    if (createIfNotExist)
+      Option(groupMetadataCache.getAndMaybePut(groupId, new GroupMetadata(groupId, Empty, time)))
+    else
+      Option(groupMetadataCache.get(groupId))
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.coordinator.group
 
+import java.util.Properties
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import kafka.common.OffsetAndMetadata
@@ -129,8 +130,9 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
   @Test
   def testConcurrentJoinGroupEnforceGroupMaxSize(): Unit = {
     val groupMaxSize = 1
-    serverProps.put(KafkaConfig.GroupMaxSizeProp, groupMaxSize.toString)
-    val config = KafkaConfig.fromProps(serverProps)
+    val newProperties = new Properties
+    newProperties.put(KafkaConfig.GroupMaxSizeProp, groupMaxSize.toString)
+    val config = KafkaConfig.fromProps(serverProps, newProperties)
 
     if (groupCoordinator != null)
       groupCoordinator.shutdown()


### PR DESCRIPTION
This patch fixes a race condition in the join group request handling which sometimes results in not enforcing the maximum number of members allowed in a group. The JIRA provides an example: https://issues.apache.org/jira/browse/KAFKA-9844

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
