### PR TITLE
MINOR: Annotate KafkaAdminClientTest.testAlterClientQuotas() with @Test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -3355,6 +3355,7 @@ public class KafkaAdminClientTest {
             ClientQuotaFilterComponent.ofEntityType(ClientQuotaEntity.USER));
     }
 
+    @Test
     public void testAlterClientQuotas() throws Exception {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());


### PR DESCRIPTION
KafkaAdminClientTest.testAlterClientQuotas() is uncalled. It is clearly intended to be a test method, but lacks `@Test`. 
