### PR TITLE
Minor: Add a note to Drop older staging artifacts during RC process

### DIFF
--- a/release.py
+++ b/release.py
@@ -688,6 +688,8 @@ if not user_ok("Have you sufficiently verified the release artifacts (y/n)?: "):
 print("Next, we need to get the Maven artifacts we published into the staging repository.")
 # TODO: Can we get this closed via a REST API since we already need to collect credentials for this repo?
 print("Go to https://repository.apache.org/#stagingRepositories and hit 'Close' for the new repository that was created by uploading artifacts.")
+print("If this is not the first RC, you need to 'Drop' the previous artifacts.")
+print("Confirm the correct artifacts are visible at https://repository.apache.org/content/groups/staging/org/apache/kafka/")
 if not user_ok("Have you successfully deployed the artifacts (y/n)?: "):
     fail("Ok, giving up")
 if not user_ok("Ok to push RC tag %s (y/n)?: " % rc_tag):


### PR DESCRIPTION
Per the generated instructions in the release script, we just 'Close' the newly uploaded release candidate artifacts on the staging repository. However, if we don't also 'Drop' any older artifacts, the new artifacts won't be published to https://repository.apache.org/content/groups/staging/org/apache/kafka/

Thanks to @omkreddy for catching this!