### PR TITLE
KAFKA-9846: Filter active tasks for running state in KafkaStreams#allLocalStorePartitionLags()

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1223,6 +1223,7 @@ public class KafkaStreams implements AutoCloseable {
             }
 
             final Set<TaskId> restoringTaskIds = streamThread.restoringTaskIds();
+            final Set<TaskId> runningActiveTaskIds = streamThread.runningActiveTaskIds();
             for (final StreamTask activeTask : streamThread.allStreamsTasks()) {
                 final Collection<TopicPartition> taskChangelogPartitions = activeTask.changelogPartitions();
                 allPartitions.addAll(taskChangelogPartitions);
@@ -1232,7 +1233,7 @@ public class KafkaStreams implements AutoCloseable {
                 for (final TopicPartition topicPartition : taskChangelogPartitions) {
                     if (isRestoring && restoredOffsets.containsKey(topicPartition)) {
                         allChangelogPositions.put(topicPartition, restoredOffsets.get(topicPartition));
-                    } else {
+                    } else if (runningActiveTaskIds.contains(activeTask.id())) {
                         allChangelogPositions.put(topicPartition, latestSentinel);
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedStreamsTasks.java
@@ -554,4 +554,7 @@ class AssignedStreamsTasks extends AssignedTasks<StreamTask> implements Restorin
         return new HashSet<>(restoring.keySet());
     }
 
+    Set<TaskId> runningTaskIds() {
+        return new HashSet<>(running.keySet());
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1214,6 +1214,10 @@ public class StreamThread extends Thread {
         return taskManager.allStreamsTasks();
     }
 
+    public Set<TaskId> runningActiveTaskIds() {
+        return taskManager.runningActiveTaskIds();
+    }
+
     public List<StandbyTask> allStandbyTasks() {
         return taskManager.allStandbyTasks();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -385,6 +385,10 @@ public class TaskManager {
         return active.restoringTaskIds();
     }
 
+    Set<TaskId> runningActiveTaskIds() {
+        return active.runningTaskIds();
+    }
+
     List<StandbyTask> allStandbyTasks() {
         return standby.allTasks();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -322,6 +322,7 @@ public class KafkaStreamsTest {
         EasyMock.expect(thread.allStandbyTasks()).andStubReturn(Collections.emptyList());
         EasyMock.expect(thread.restoringTaskIds()).andStubReturn(Collections.emptySet());
         EasyMock.expect(thread.allStreamsTasks()).andStubReturn(Collections.emptyList());
+        EasyMock.expect(thread.runningActiveTaskIds()).andStubReturn(Collections.emptySet());
     }
 
     @Test


### PR DESCRIPTION

  - Added check that only treats running active tasks as having 0 lag
  - Tasks that are neither restoring, nor running will report 0 as currentoffset position
  - Fixed LagFetchIntegrationTest to wait till thread/instance reaches RUNNING before checking lag


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
