### PR TITLE
HOTFIX: need to cleanup any tasks closed in TaskManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -262,7 +262,7 @@ public class ProcessorStateManager implements StateManager {
         }
 
         if (stores.containsKey(storeName)) {
-            throw new IllegalStateException(format("%sStore %s has already been registered.", logPrefix, storeName));
+            throw new IllegalArgumentException(format("%sStore %s has already been registered.", logPrefix, storeName));
         }
 
         final String topic = storeToChangelogTopic.get(storeName);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -262,7 +262,7 @@ public class ProcessorStateManager implements StateManager {
         }
 
         if (stores.containsKey(storeName)) {
-            throw new IllegalArgumentException(format("%sStore %s has already been registered.", logPrefix, storeName));
+            throw new IllegalStateException(format("%sStore %s has already been registered.", logPrefix, storeName));
         }
 
         final String topic = storeToChangelogTopic.get(storeName);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -317,7 +317,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 stateMgr.flush();
                 recordCollector.flush();
 
-                log.info("Prepared task for committing");
+                log.debug("Prepared task for committing");
 
                 break;
 
@@ -337,7 +337,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     stateMgr.checkpoint(checkpointableOffsets());
                 }
 
-                log.info("Committed");
+                log.debug("Committed");
 
                 break;
 
@@ -347,7 +347,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
                 stateMgr.checkpoint(checkpointableOffsets());
 
-                log.info("Committed");
+                log.debug("Committed");
 
                 break;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -194,9 +194,7 @@ public class TaskManager {
         final Set<Task> additionalTasksForCommitting = new HashSet<>();
         final Set<Task> dirtyTasks = new HashSet<>();
 
-        final Iterator<Task> iterator = tasks.values().iterator();
-        while (iterator.hasNext()) {
-            final Task task = iterator.next();
+        for (final Task task : tasks.values()) {
             if (activeTasks.containsKey(task.id()) && task.isActive()) {
                 task.resume();
                 if (task.commitNeeded()) {
@@ -207,23 +205,23 @@ public class TaskManager {
                 task.resume();
                 standbyTasksToCreate.remove(task.id());
             } else /* we previously owned this task, and we don't have it anymore, or it has changed active/standby state */ {
-                cleanupTask(task);
-
                 try {
                     final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
-                    final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.committableOffsetsAndMetadata();
+                    final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task
+                        .committableOffsetsAndMetadata();
 
                     checkpointPerTask.put(task, checkpoint);
                     if (!committableOffsets.isEmpty()) {
                         consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
                     }
                 } catch (final RuntimeException e) {
-                    final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
+                    final String uncleanMessage = String.format(
+                        "Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:",
+                        task.id());
                     log.error(uncleanMessage, e);
                     taskCloseExceptions.put(task.id(), e);
                     // We've already recorded the exception (which is the point of clean).
                     // Now, we should go ahead and complete the close because a half-closed task is no good to anyone.
-                    task.prepareCloseDirty();
                     dirtyTasks.add(task);
                 }
             }
@@ -258,25 +256,24 @@ public class TaskManager {
 
         for (final Map.Entry<Task, Map<TopicPartition, Long>> taskAndCheckpoint : checkpointPerTask.entrySet()) {
             final Task task = taskAndCheckpoint.getKey();
+            final Map<TopicPartition, Long> checkpoint = taskAndCheckpoint.getValue();
 
             try {
-                task.closeClean(checkpointPerTask.get(task));
+                completeTaskCloseClean(task, checkpoint);
+                cleanUpTaskProducer(task, taskCloseExceptions);
+                tasks.remove(task.id());
             } catch (final RuntimeException e) {
                 final String uncleanMessage = String.format("Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:", task.id());
                 log.error(uncleanMessage, e);
                 taskCloseExceptions.put(task.id(), e);
                 // We've already recorded the exception (which is the point of clean).
                 // Now, we should go ahead and complete the close because a half-closed task is no good to anyone.
-                task.closeDirty();
-            } finally {
-                cleanUpTaskProducer(task, taskCloseExceptions);
-                tasks.remove(task.id());
+                dirtyTasks.add(task);
             }
         }
 
         for (final Task task : dirtyTasks) {
-            cleanupTask(task);
-            task.closeDirty();
+            closeTaskDirty(task);
             cleanUpTaskProducer(task, taskCloseExceptions);
             tasks.remove(task.id());
         }
@@ -466,9 +463,7 @@ public class TaskManager {
             // Even though we've apparently dropped out of the group, we can continue safely to maintain our
             // standby tasks while we rejoin.
             if (task.isActive()) {
-                cleanupTask(task);
-                task.prepareCloseDirty();
-                task.closeDirty();
+                closeTaskDirty(task);
                 iterator.remove();
                 try {
                     activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(task.id());
@@ -589,6 +584,18 @@ public class TaskManager {
         return offsetSum;
     }
 
+    private void closeTaskDirty(final Task task) {
+        task.prepareCloseDirty();
+        cleanupTask(task);
+        task.closeDirty();
+    }
+
+    private void completeTaskCloseClean(final Task task, final Map<TopicPartition, Long> checkpoint) {
+        cleanupTask(task);
+        task.closeClean(checkpoint);
+    }
+
+    // Note: this MUST be called *before* actually closing the task
     private void cleanupTask(final Task task) {
         // 1. remove the changelog partitions from changelog reader;
         // 2. remove the input partitions from the materialized map;
@@ -612,8 +619,6 @@ public class TaskManager {
         final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadataPerTask = new HashMap<>();
 
         for (final Task task : tasks.values()) {
-            cleanupTask(task);
-
             if (clean) {
                 try {
                     final Map<TopicPartition, Long> checkpoint = task.prepareCloseClean();
@@ -625,16 +630,13 @@ public class TaskManager {
                     }
                 } catch (final TaskMigratedException e) {
                     // just ignore the exception as it doesn't matter during shutdown
-                    task.prepareCloseDirty();
-                    task.closeDirty();
+                    closeTaskDirty(task);
                 } catch (final RuntimeException e) {
                     firstException.compareAndSet(null, e);
-                    task.prepareCloseDirty();
-                    task.closeDirty();
+                    closeTaskDirty(task);
                 }
             } else {
-                task.prepareCloseDirty();
-                task.closeDirty();
+                closeTaskDirty(task);
             }
         }
 
@@ -644,11 +646,12 @@ public class TaskManager {
 
         for (final Map.Entry<Task, Map<TopicPartition, Long>> taskAndCheckpoint : checkpointPerTask.entrySet()) {
             final Task task = taskAndCheckpoint.getKey();
+            final Map<TopicPartition, Long> checkpoint = taskAndCheckpoint.getValue();
             try {
-                task.closeClean(checkpointPerTask.get(task));
+                completeTaskCloseClean(task, checkpoint);
             } catch (final RuntimeException e) {
                 firstException.compareAndSet(null, e);
-                task.closeDirty();
+                closeTaskDirty(task);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -258,6 +258,7 @@ public class TaskManager {
 
         for (final Map.Entry<Task, Map<TopicPartition, Long>> taskAndCheckpoint : checkpointPerTask.entrySet()) {
             final Task task = taskAndCheckpoint.getKey();
+
             try {
                 task.closeClean(checkpointPerTask.get(task));
             } catch (final RuntimeException e) {
@@ -274,6 +275,7 @@ public class TaskManager {
         }
 
         for (final Task task : dirtyTasks) {
+            cleanupTask(task);
             task.closeDirty();
             cleanUpTaskProducer(task, taskCloseExceptions);
             tasks.remove(task.id());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -886,6 +886,57 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void shouldCleanupAnyTasksClosedAsDirtyAfterCommitException() {
+        final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true);
+        final Map<TopicPartition, OffsetAndMetadata> offsets00 = singletonMap(t1p0, new OffsetAndMetadata(0L, null));
+        task00.setCommittableOffsetsAndMetadata(offsets00);
+
+        final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, true);
+        final Map<TopicPartition, OffsetAndMetadata> offsets01 = singletonMap(t1p1, new OffsetAndMetadata(1L, null));
+        task01.setCommittableOffsetsAndMetadata(offsets01);
+        task01.setCommitNeeded();
+
+        task01.setChangelogOffsets(singletonMap(t1p1, 0L));
+
+        final StateMachineTask task02 = new StateMachineTask(taskId02, taskId02Partitions, true);
+        final Map<TopicPartition, OffsetAndMetadata> offsets02 = singletonMap(t1p2, new OffsetAndMetadata(2L, null));
+        task02.setCommittableOffsetsAndMetadata(offsets02);
+
+        final Map<TopicPartition, OffsetAndMetadata> expectedCommittedOffsets = new HashMap<>();
+        expectedCommittedOffsets.putAll(offsets00);
+        expectedCommittedOffsets.putAll(offsets01);
+
+        final Map<TaskId, Set<TopicPartition>> assignmentActive = mkMap(
+            mkEntry(taskId00, taskId00Partitions),
+            mkEntry(taskId01, taskId01Partitions),
+            mkEntry(taskId02, taskId02Partitions)
+        );
+
+        expect(activeTaskCreator.createTasks(anyObject(), eq(assignmentActive)))
+            .andReturn(asList(task00, task01, task02));
+        activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(EasyMock.anyObject(TaskId.class));
+        expectLastCall().anyTimes();
+
+        consumer.commitSync(expectedCommittedOffsets);
+        expectLastCall().andThrow(new RuntimeException("Something went wrong!"));
+
+        changeLogReader.remove(singleton(t1p1));
+        expectLastCall();
+
+        replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
+
+        taskManager.handleAssignment(assignmentActive, emptyMap());
+
+        assignmentActive.remove(taskId00);
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> taskManager.handleAssignment(assignmentActive,emptyMap())
+        );
+
+        verify(changeLogReader);
+    }
+
+    @Test
     public void shouldCommitAllActiveTasksTheNeedCommittingOnRevocation() {
         final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true);
         final Map<TopicPartition, OffsetAndMetadata> offsets00 = singletonMap(t1p0, new OffsetAndMetadata(0L, null));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -928,9 +928,9 @@ public class TaskManagerTest {
         taskManager.handleAssignment(assignmentActive, emptyMap());
 
         assignmentActive.remove(taskId00);
-        final RuntimeException thrown = assertThrows(
+        assertThrows(
             RuntimeException.class,
-            () -> taskManager.handleAssignment(assignmentActive,emptyMap())
+            () -> taskManager.handleAssignment(assignmentActive, emptyMap())
         );
 
         verify(changeLogReader);
@@ -1339,14 +1339,11 @@ public class TaskManagerTest {
     public void shouldCloseActiveTasksDirtyAndPropagateCommitException() {
         setUpTaskManager(StreamThread.ProcessingMode.EXACTLY_ONCE_ALPHA);
 
-        final TopicPartition changelogPartition = new TopicPartition("changelog", 1);
-
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true);
 
         final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, true);
         task01.setCommittableOffsetsAndMetadata(singletonMap(t1p1, new OffsetAndMetadata(0L, null)));
         task01.setCommitNeeded();
-        task01.setChangelogOffsets(singletonMap(changelogPartition, 0L));
 
         final StateMachineTask task02 = new StateMachineTask(taskId02, taskId02Partitions, true);
         final Map<TopicPartition, OffsetAndMetadata> offsetsT02 = singletonMap(t1p2, new OffsetAndMetadata(1L, null));
@@ -1368,10 +1365,7 @@ public class TaskManagerTest {
         activeTaskCreator.closeAndRemoveTaskProducerIfNeeded(taskId02);
         expectLastCall();
 
-        changeLogReader.remove(singleton(changelogPartition));
-        expectLastCall();
-
-        replay(activeTaskCreator, changeLogReader);
+        replay(activeTaskCreator);
 
         final RuntimeException thrown = assertThrows(RuntimeException.class,
             () -> taskManager.handleAssignment(mkMap(mkEntry(taskId00, taskId00Partitions)), Collections.emptyMap()));
@@ -1384,7 +1378,7 @@ public class TaskManagerTest {
         // All the tasks involving in the commit should already be removed.
         assertThat(taskManager.tasks(), is(Collections.singletonMap(taskId00, task00)));
 
-        verify(activeTaskCreator, changeLogReader);
+        verify(activeTaskCreator);
     }
 
     @Test


### PR DESCRIPTION
We were hitting an `IllegalStateException: There is already a changelog registered for ...` in trunk-eos due to failing to call `TaskManager#cleanup` on unrevoekd tasks that we end up closing in `handleAssignment` after failing to batch commit