### PR TITLE
KAFKA-9852: Change the max duration that calls to the buffer pool can block from 2000ms to 10ms

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.verify;
 public class BufferPoolTest {
     private final MockTime time = new MockTime();
     private final Metrics metrics = new Metrics(time);
-    private final long maxBlockTimeMs = 2000;
+    private final long maxBlockTimeMs = 10;
     private final String metricGroup = "TestMetrics";
 
     @After
@@ -185,7 +185,7 @@ public class BufferPoolTest {
             // this is good
         }
         // Thread scheduling sometimes means that deallocation varies by this point
-        assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
+        assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 7 && pool.availableMemory() <= 10);
         long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
         assertTrue("BufferExhaustedException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
         assertTrue("BufferExhaustedException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 1000);


### PR DESCRIPTION
This is to reduce overall test runtime, as this is wallclock time.

Adjusted one assert condition on a testcase as the success was dependant on thread runtimes and the much lower tolerances due to the reduced time broke this test.

Ran a couple thousand iterations of the test class on my machine without failed test cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
