### PR TITLE
MINOR: cleaner resume log message is misleading

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -518,7 +518,7 @@ class LogManager(logDirs: Seq[File],
         } finally {
           if (needToStopCleaner && !isFuture) {
             cleaner.resumeCleaning(Seq(topicPartition))
-            info(s"Compaction for partition $topicPartition is resumed")
+            info(s"Cleaning for partition $topicPartition is resumed")
           }
         }
       }


### PR DESCRIPTION
When the LogManager resumes cleaning it states that compaction is resumed, however the topic in question is not necessarily a compacted one.