### PR TITLE
KAFKA-9854 Re-authenticating causes mismatched parse of response

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.ProduceRequest;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseHeader;
+import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.DelayedReceive;
@@ -53,6 +54,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 import static org.junit.Assert.assertEquals;
@@ -860,6 +864,16 @@ public class NetworkClientTest {
         assertTrue(client.canConnect(node, time.milliseconds()));
         client.disconnect(node.idString());
         assertTrue(client.canConnect(node, time.milliseconds()));
+    }
+
+    @Test
+    public void testCorrelationId() {
+        int count = 100;
+        Set<Integer> ids = IntStream.range(0, count)
+            .mapToObj(i -> client.nextCorrelationId())
+            .collect(Collectors.toSet());
+        assertEquals(count, ids.size());
+        ids.forEach(id -> assertTrue(id < SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID));
     }
 
     private RequestHeader parseHeader(ByteBuffer buffer) {


### PR DESCRIPTION
the schema of LIST_OFFSETS consists of 

1. throttle_time_ms:INT32 and 
1. responses:ARRAY

If throttle_time is zero and size of responses is small enough, its binary is compatible to schema of SASL_HANDSHAKE which is composed of 

1. error_code:INT16 and 
1. mechanisms:ARRAY(STRING)

Hence, there is no Schema error when SASL_HANDSHAKE tries to parse resoponse of LIST_OFFSETS but the check of correction id still throw IllegalStateException due to mismatched parse. The IllegalStateException is NOT caught and it is not sent back to Selector so the cascading error happens that all following responses are parsed by incorrect Schema.

https://issues.apache.org/jira/browse/KAFKA-9854

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
