### PR TITLE
KAFKA-9853: Improve performance of Log.fetchOffsetByTimestamp

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1615,16 +1615,8 @@ class Log(@volatile private var _dir: File,
         return Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logEndOffset, epochOptional))
       }
 
-      val targetSeg = {
-        // Get all the segments whose largest timestamp is smaller than target timestamp
-        val earlierSegs = segmentsCopy.takeWhile(_.largestTimestamp < targetTimestamp)
-        // We need to search the first segment whose largest timestamp is greater than the target timestamp if there is one.
-        if (earlierSegs.length < segmentsCopy.length)
-          Some(segmentsCopy(earlierSegs.length))
-        else
-          None
-      }
-
+      // We need to search the first segment whose largest timestamp is >= the target timestamp if there is one.
+      val targetSeg = segmentsCopy.find(_.largestTimestamp >= targetTimestamp)
       targetSeg.flatMap(_.findOffsetByTimestamp(targetTimestamp, logStartOffset))
     }
   }


### PR DESCRIPTION
The previous code did not use the collection produced by `takeWhile()`.  It only used the length of that collection to select the next element.
Perhaps some people would consider this a MINOR change.  I created the JIRA ticket because this is part of the core library & probably warrants some discussion.

This contribution is my original work and I license the work to the project under the project's open source license.
