### PR TITLE
KAFKA-9864: avoid expensive QuotaViolationException usage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
@@ -48,6 +48,16 @@ public class QuotaViolationException extends KafkaException {
         return bound;
     }
 
+    @Override
+    public String toString() {
+        return String.format(
+                "%s: '%s' violated quota. Actual: %f, Threshold: %f",
+                getClass().getName(),
+                metricName,
+                value,
+                bound);
+    }
+
     /* avoid the expensive and stack trace for quota violation exceptions */
     @Override
     public Throwable fillInStackTrace() {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
@@ -30,11 +30,7 @@ public class QuotaViolationException extends KafkaException {
     private final double bound;
 
     public QuotaViolationException(MetricName metricName, double value, double bound) {
-        super(String.format(
-                "'%s' violated quota. Actual: %f, Threshold: %f",
-                metricName,
-                value,
-                bound));
+        super(metricName + " violated quota.");
         this.metricName = metricName;
         this.value = value;
         this.bound = bound;
@@ -50,5 +46,11 @@ public class QuotaViolationException extends KafkaException {
 
     public double bound() {
         return bound;
+    }
+
+    /* avoid the expensive and stack trace for quota violation exceptions */
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
@@ -30,7 +30,6 @@ public class QuotaViolationException extends KafkaException {
     private final double bound;
 
     public QuotaViolationException(MetricName metricName, double value, double bound) {
-        super("Quota violated");
         this.metricName = metricName;
         this.value = value;
         this.bound = bound;
@@ -50,12 +49,13 @@ public class QuotaViolationException extends KafkaException {
 
     @Override
     public String toString() {
-        return String.format(
-                "%s: '%s' violated quota. Actual: %f, Threshold: %f",
-                getClass().getName(),
-                metricName,
-                value,
-                bound);
+        return getClass().getName()
+                + ": '"
+                + metricName
+                + "' violated quota. Actual: "
+                + value
+                + ", Threshold: "
+                + bound;
     }
 
     /* avoid the expensive and stack trace for quota violation exceptions */

--- a/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/QuotaViolationException.java
@@ -30,7 +30,7 @@ public class QuotaViolationException extends KafkaException {
     private final double bound;
 
     public QuotaViolationException(MetricName metricName, double value, double bound) {
-        super(metricName + " violated quota.");
+        super("Quota violated");
         this.metricName = metricName;
         this.value = value;
         this.bound = bound;

--- a/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
@@ -133,12 +133,7 @@ class ReplicationQuotaManager(val config: ReplicationQuotaManagerConfig,
     * @param value
     */
   def record(value: Long): Unit = {
-    try {
-      sensor().record(value.toDouble)
-    } catch {
-      case qve: QuotaViolationException =>
-        trace(s"Record: Quota violated, but ignored, for sensor (${sensor.name}), metric: (${qve.metricName}), value : (${qve.value}), bound: (${qve.bound}), recordedValue ($value)")
-    }
+    sensor().record(value, time.milliseconds(), false)
   }
 
   /**


### PR DESCRIPTION
QuotaViolationException generates an exception message via String.format which uses regexes, and it does not use it as it is only used for control flow, e.g. https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/ClientQuotaManager.scala#L258. It also generates an unnecessary stack trace, which is now avoided using the same pattern as in ApiException.

I have also avoided use of QuotaViolationException for control flow in ReplicationQuotaManager which is another hotspot that we have seen in practice.

Example profile showing a small overall cost, measuring 0.5%. This could be large in cases where quotas are exceeded frequently.
![image](https://user-images.githubusercontent.com/252189/79177311-68dca800-7db7-11ea-8937-8bee1ad3cc92.png)
