### PR TITLE
HOTFIX: don't close or wipe out someone else's state

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -209,15 +209,12 @@ public class StandbyTask extends AbstractTask implements Task {
                 stateMgr.checkpoint(Collections.emptyMap());
                 offsetSnapshotSinceLastCommit = new HashMap<>(stateMgr.changelogOffsets());
             }
-            final boolean wipeStateStore = !clean && eosEnabled;
-            log.info("standby task clean {}, eos enabled {}", clean, eosEnabled);
-
             executeAndMaybeSwallow(clean, () ->
                 StateManagerUtil.closeStateManager(
                     log,
                     logPrefix,
                     clean,
-                    wipeStateStore,
+                    eosEnabled,
                     stateMgr,
                     stateDirectory,
                     TaskType.STANDBY),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -492,11 +492,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             case RUNNING:
             case RESTORING:
             case SUSPENDED:
-                // if EOS is enabled, we wipe out the whole state store for unclean close
-                // since they are invalid to use anymore
-                final boolean wipeStateStore = !clean && eosEnabled;
-
-                // first close state manager (which is idempotent) then close the record collector (which could throw),
+                // first close state manager (which is idempotent) then close the record collector
                 // if the latter throws and we re-close dirty which would close the state manager again.
                 executeAndMaybeSwallow(
                     clean,
@@ -504,7 +500,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                         log,
                         logPrefix,
                         clean,
-                        wipeStateStore,
+                        eosEnabled,
                         stateMgr,
                         stateDirectory,
                         TaskType.ACTIVE

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -459,7 +459,6 @@ public class TaskManager {
         final Iterator<Task> iterator = tasks.values().iterator();
         while (iterator.hasNext()) {
             final Task task = iterator.next();
-            final Set<TopicPartition> inputPartitions = task.inputPartitions();
             // Even though we've apparently dropped out of the group, we can continue safely to maintain our
             // standby tasks while we rejoin.
             if (task.isActive()) {
@@ -470,10 +469,6 @@ public class TaskManager {
                 } catch (final RuntimeException e) {
                     log.warn("Error closing task producer for " + task.id() + " while handling lostAll", e);
                 }
-            }
-
-            for (final TopicPartition inputPartition : inputPartitions) {
-                partitionToTask.remove(inputPartition);
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.TestUtils;
 import org.easymock.IMocksControl;
@@ -39,7 +38,6 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -48,7 +46,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.mockStatic;
 import static org.powermock.api.easymock.PowerMock.replayAll;
 
@@ -179,14 +176,10 @@ public class StateManagerUtilTest {
     }
 
     @Test
-    public void testShouldThrowWhenCleanAndWipeStateAreBothTrue() {
-        assertThrows(IllegalArgumentException.class, () -> StateManagerUtil.closeStateManager(logger,
-            "logPrefix:", true, true, stateManager, stateDirectory, TaskType.ACTIVE));
-    }
-
-    @Test
     public void testCloseStateManagerClean() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(true);
 
         stateManager.close();
         expectLastCall();
@@ -206,6 +199,9 @@ public class StateManagerUtilTest {
     @Test
     public void testCloseStateManagerThrowsExceptionWhenClean() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(true);
+
         stateManager.close();
         expectLastCall();
 
@@ -219,7 +215,6 @@ public class StateManagerUtilTest {
             ProcessorStateException.class, () -> StateManagerUtil.closeStateManager(logger,
             "logPrefix:", true, false, stateManager, stateDirectory, TaskType.ACTIVE));
 
-        assertEquals("logPrefix:Failed to release state dir lock", thrown.getMessage());
         assertEquals(IOException.class, thrown.getCause().getClass());
 
         ctrl.verify();
@@ -228,6 +223,9 @@ public class StateManagerUtilTest {
     @Test
     public void testCloseStateManagerOnlyThrowsFirstExceptionWhenClean() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(true);
+
         stateManager.close();
         expectLastCall().andThrow(new ProcessorStateException("state manager failed to close"));
 
@@ -249,32 +247,35 @@ public class StateManagerUtilTest {
     }
 
     @Test
-    public void testCloseStateManagerDirtyShallSwallowException() throws IOException {
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-
+    public void testCloseStateManagerThrowsExceptionWhenDirty() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(true);
+
         stateManager.close();
-        expectLastCall().andThrow(new ProcessorStateException("state manager failed to close"));
+        expectLastCall();
 
         stateDirectory.unlock(taskId);
-        expectLastCall();
+        expectLastCall().andThrow(new IOException("Timeout"));
 
         ctrl.checkOrder(true);
         ctrl.replay();
 
-        StateManagerUtil.closeStateManager(logger,
-            "logPrefix:", false, false, stateManager, stateDirectory, TaskType.ACTIVE);
+        final ProcessorStateException thrown = assertThrows(
+            ProcessorStateException.class,
+            () -> StateManagerUtil.closeStateManager(
+                logger, "logPrefix:", false, false, stateManager, stateDirectory, TaskType.ACTIVE));
+
+        assertEquals(IOException.class, thrown.getCause().getClass());
 
         ctrl.verify();
-
-        LogCaptureAppender.unregister(appender);
-        final List<String> strings = appender.getMessages();
-        assertTrue(strings.contains("testClosing ACTIVE task 0_0 uncleanly and swallows an exception"));
     }
 
     @Test
     public void testCloseStateManagerWithStateStoreWipeOut() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
+        expect(stateDirectory.lock(taskId)).andReturn(true);
+
         stateManager.close();
         expectLastCall();
 
@@ -299,6 +300,8 @@ public class StateManagerUtilTest {
         mockStatic(Utils.class);
 
         expect(stateManager.taskId()).andReturn(taskId);
+        expect(stateDirectory.lock(taskId)).andReturn(true);
+
         stateManager.close();
         expectLastCall();
 
@@ -319,9 +322,47 @@ public class StateManagerUtilTest {
             ProcessorStateException.class, () -> StateManagerUtil.closeStateManager(logger,
                 "logPrefix:", false, true, stateManager, stateDirectory, TaskType.ACTIVE));
 
-        assertEquals("Failed to wiping state stores for task 0_0", thrown.getMessage());
         assertEquals(IOException.class, thrown.getCause().getClass());
 
         ctrl.verify();
+    }
+
+    @Test
+    public void shouldNotStateManagerIfUnableToLockTaskDirectory() throws IOException {
+        expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(false);
+
+        stateManager.close();
+        expectLastCall().andThrow(new StreamsException("Should not be trying to close state you don't own!"));
+
+        ctrl.checkOrder(true);
+        ctrl.replay();
+
+        replayAll();
+
+        StateManagerUtil.closeStateManager(
+            logger, "logPrefix:", false, true, stateManager, stateDirectory, TaskType.ACTIVE);
+    }
+
+    @Test
+    public void shouldNotWipeStateStoresIfUnableToLockTaskDirectory() throws IOException {
+        final File unknownFile = new File("/unknown/path");
+        expect(stateManager.taskId()).andReturn(taskId);
+
+        expect(stateDirectory.lock(taskId)).andReturn(false);
+
+        expect(stateManager.baseDir()).andReturn(unknownFile);
+
+        Utils.delete(unknownFile);
+        expectLastCall().andThrow(new StreamsException("Should not be trying to wipe state you don't own!"));
+
+        ctrl.checkOrder(true);
+        ctrl.replay();
+
+        replayAll();
+
+        StateManagerUtil.closeStateManager(
+            logger, "logPrefix:", false, true, stateManager, stateDirectory, TaskType.ACTIVE);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -328,13 +328,13 @@ public class StateManagerUtilTest {
     }
 
     @Test
-    public void shouldNotStateManagerIfUnableToLockTaskDirectory() throws IOException {
+    public void shouldNotCloseStateManagerIfUnableToLockTaskDirectory() throws IOException {
         expect(stateManager.taskId()).andReturn(taskId);
 
         expect(stateDirectory.lock(taskId)).andReturn(false);
 
         stateManager.close();
-        expectLastCall().andThrow(new StreamsException("Should not be trying to close state you don't own!"));
+        expectLastCall().andThrow(new AssertionError("Should not be trying to close state you don't own!"));
 
         ctrl.checkOrder(true);
         ctrl.replay();
@@ -342,7 +342,7 @@ public class StateManagerUtilTest {
         replayAll();
 
         StateManagerUtil.closeStateManager(
-            logger, "logPrefix:", false, true, stateManager, stateDirectory, TaskType.ACTIVE);
+            logger, "logPrefix:", true, false, stateManager, stateDirectory, TaskType.ACTIVE);
     }
 
     @Test
@@ -355,7 +355,7 @@ public class StateManagerUtilTest {
         expect(stateManager.baseDir()).andReturn(unknownFile);
 
         Utils.delete(unknownFile);
-        expectLastCall().andThrow(new StreamsException("Should not be trying to wipe state you don't own!"));
+        expectLastCall().andThrow(new AssertionError("Should not be trying to wipe state you don't own!"));
 
         ctrl.checkOrder(true);
         ctrl.replay();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -253,6 +253,9 @@ public class StreamTaskTest {
 
         EasyMock.expect(stateManager.taskId()).andReturn(taskId);
 
+        EasyMock.expect(stateDirectory.lock(taskId)).andReturn(true);
+        EasyMock.expectLastCall();
+
         stateManager.close();
         EasyMock.expectLastCall();
 


### PR DESCRIPTION
When it comes to actually closing a task we now treat all states exactly the same, and call `StateManagerUtil#closeStateManager` regardless of whether it's in `CREATED` or `RESTORING` or `RUNNING`

Unfortunately `StateManagerUtil` doesn't actually check to make sure that we actually own the lock for this task's state. During a dirty close with eos enabled, we wipe the state -- but in some cases, this means deleting the state out from under another StreamThread who is still in the process of revoking this task