### PR TITLE
KAFKA-9865: Expose output topic names from TopologyTestDriver

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -102,6 +102,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -853,6 +854,20 @@ public class TopologyTestDriver implements Closeable {
                                                                 final Deserializer<K> keyDeserializer,
                                                                 final Deserializer<V> valueDeserializer) {
         return new TestOutputTopic<>(this, topicName, keyDeserializer, valueDeserializer);
+    }
+
+    /**
+     * Get all the names of all the topics to which records have been output.
+     * <p>
+     * Call this method after piping the input into the test driver to retrieve the full set of topics the topology
+     * produced records to.
+     * <p>
+     * The returned set of topic names includes changelog, repartition and sink topic names.
+     *
+     * @return the set of output topic names.
+     */
+    public final Set<String> getOutputTopicNames() {
+        return Collections.unmodifiableSet(outputRecordsByTopic.keySet());
     }
 
     ProducerRecord<byte[], byte[]> readRecord(final String topic) {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -862,9 +862,10 @@ public class TopologyTestDriver implements Closeable {
      * Call this method after piping the input into the test driver to retrieve the full set of topic names the topology
      * produced records to.
      * <p>
-     * The returned set of topic names includes changelog, repartition and output topic names.
+     * The returned set of topic names may include user (e.g., output) and internal (e.g., changelog, repartition) topic
+     * names.
      *
-     * @return the set of topic names the topology has produced to.
+     * @return The set of topic names the topology has produced to
      */
     public final Set<String> producedTopicNames() {
         return Collections.unmodifiableSet(outputRecordsByTopic.keySet());

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -857,16 +857,16 @@ public class TopologyTestDriver implements Closeable {
     }
 
     /**
-     * Get all the names of all the topics to which records have been output.
+     * Get all the names of all the topics to which records have been produced during the test run.
      * <p>
-     * Call this method after piping the input into the test driver to retrieve the full set of topics the topology
+     * Call this method after piping the input into the test driver to retrieve the full set of topic names the topology
      * produced records to.
      * <p>
-     * The returned set of topic names includes changelog, repartition and sink topic names.
+     * The returned set of topic names includes changelog, repartition and output topic names.
      *
-     * @return the set of output topic names.
+     * @return the set of topic names the topology has produced to.
      */
-    public final Set<String> getOutputTopicNames() {
+    public final Set<String> producedTopicNames() {
         return Collections.unmodifiableSet(outputRecordsByTopic.keySet());
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -74,6 +74,8 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -448,6 +450,24 @@ public class TopologyTestDriverTest {
         } catch (final IllegalArgumentException exception) {
             assertEquals("Unknown topic: " + unknownTopic, exception.getMessage());
         }
+    }
+
+    @Test
+    public void shouldGetSinkTopicNames() {
+        testDriver = new TopologyTestDriver(setupSourceSinkTopology(), config);
+
+        pipeRecord(SOURCE_TOPIC_1, testRecord1);
+
+        assertThat(testDriver.getOutputTopicNames(), hasItem(SINK_TOPIC_1));
+    }
+
+    @Test
+    public void shouldGetInternalTopicNames() {
+        testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies(), config);
+
+        pipeRecord(SOURCE_TOPIC_1, testRecord1);
+
+        assertThat(testDriver.getOutputTopicNames(), hasItems(SINK_TOPIC_1, SINK_TOPIC_2));
     }
 
     @Test
@@ -1643,6 +1663,8 @@ public class TopologyTestDriverTest {
                     new KeyValue<>("A", "recurse-alpha")
                 ))
             );
+
+            assertThat(topologyTestDriver.getOutputTopicNames(), hasItem("globule-topic"));
         }
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -458,7 +458,7 @@ public class TopologyTestDriverTest {
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
 
-        assertThat(testDriver.getOutputTopicNames(), hasItem(SINK_TOPIC_1));
+        assertThat(testDriver.producedTopicNames(), hasItem(SINK_TOPIC_1));
     }
 
     @Test
@@ -467,7 +467,7 @@ public class TopologyTestDriverTest {
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
 
-        assertThat(testDriver.getOutputTopicNames(), hasItems(SINK_TOPIC_1, SINK_TOPIC_2));
+        assertThat(testDriver.producedTopicNames(), hasItems(SINK_TOPIC_1, SINK_TOPIC_2));
     }
 
     @Test
@@ -1664,7 +1664,7 @@ public class TopologyTestDriverTest {
                 ))
             );
 
-            assertThat(topologyTestDriver.getOutputTopicNames(), hasItem("globule-topic"));
+            assertThat(topologyTestDriver.producedTopicNames(), hasItem("globule-topic"));
         }
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -73,6 +73,7 @@ import java.util.regex.Pattern;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -390,6 +391,19 @@ public class TopologyTestDriverTest {
         return topology;
     }
 
+    private Topology setupTopologyWithInternalTopic() {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.stream(SOURCE_TOPIC_1)
+            .selectKey((k, v) -> v)
+            .groupByKey()
+            .count()
+            .toStream()
+            .to(SINK_TOPIC_1);
+
+        return builder.build(config);
+    }
+
     @Test
     public void shouldInitProcessor() {
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
@@ -463,11 +477,13 @@ public class TopologyTestDriverTest {
 
     @Test
     public void shouldGetInternalTopicNames() {
-        testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies(), config);
+        testDriver = new TopologyTestDriver(setupTopologyWithInternalTopic(), config);
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
 
-        assertThat(testDriver.producedTopicNames(), hasItems(SINK_TOPIC_1, SINK_TOPIC_2));
+        assertThat(testDriver.producedTopicNames(), hasItems(
+            endsWith("-changelog"), endsWith("-repartition")
+        ));
     }
 
     @Test
@@ -1599,19 +1615,19 @@ public class TopologyTestDriverTest {
         final Topology topology = new Topology();
         topology.addSource("source", new StringDeserializer(), new StringDeserializer(), "input");
         topology.addGlobalStore(
-            Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore("globule-store"), Serdes.String(), Serdes.String()).withLoggingDisabled(),
-            "globuleSource",
+            Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore("global-store"), Serdes.String(), Serdes.String()).withLoggingDisabled(),
+            "globalSource",
             new StringDeserializer(),
             new StringDeserializer(),
-            "globule-topic",
-            "globuleProcessor",
+            "global-topic",
+            "globalProcessor",
             () -> new Processor<String, String>() {
                 private KeyValueStore<String, String> stateStore;
 
                 @SuppressWarnings("unchecked")
                 @Override
                 public void init(final ProcessorContext context) {
-                    stateStore = (KeyValueStore<String, String>) context.getStateStore("globule-store");
+                    stateStore = (KeyValueStore<String, String>) context.getStateStore("global-store");
                 }
 
                 @Override
@@ -1634,23 +1650,23 @@ public class TopologyTestDriverTest {
                         context().forward(key, "recurse-" + value, To.child("recursiveSink"));
                     }
                     context().forward(key, value, To.child("sink"));
-                    context().forward(key, value, To.child("globuleSink"));
+                    context().forward(key, value, To.child("globalSink"));
                 }
             },
             "source"
         );
         topology.addSink("recursiveSink", "input", new StringSerializer(), new StringSerializer(), "recursiveProcessor");
         topology.addSink("sink", "output", new StringSerializer(), new StringSerializer(), "recursiveProcessor");
-        topology.addSink("globuleSink", "globule-topic", new StringSerializer(), new StringSerializer(), "recursiveProcessor");
+        topology.addSink("globalSink", "global-topic", new StringSerializer(), new StringSerializer(), "recursiveProcessor");
 
         try (final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(topology, properties)) {
             final TestInputTopic<String, String> in = topologyTestDriver.createInputTopic("input", new StringSerializer(), new StringSerializer());
-            final TestOutputTopic<String, String> globalTopic = topologyTestDriver.createOutputTopic("globule-topic", new StringDeserializer(), new StringDeserializer());
+            final TestOutputTopic<String, String> globalTopic = topologyTestDriver.createOutputTopic("global-topic", new StringDeserializer(), new StringDeserializer());
 
             in.pipeInput("A", "alpha");
 
             // expect the global store to correctly reflect the last update
-            final KeyValueStore<String, String> keyValueStore = topologyTestDriver.getKeyValueStore("globule-store");
+            final KeyValueStore<String, String> keyValueStore = topologyTestDriver.getKeyValueStore("global-store");
             assertThat(keyValueStore, notNullValue());
             assertThat(keyValueStore.get("A"), is("recurse-alpha"));
 
@@ -1663,8 +1679,6 @@ public class TopologyTestDriverTest {
                     new KeyValue<>("A", "recurse-alpha")
                 ))
             );
-
-            assertThat(topologyTestDriver.producedTopicNames(), hasItem("globule-topic"));
         }
     }
 


### PR DESCRIPTION
fixes: https://issues.apache.org/jira/browse/KAFKA-9865
kip: https://cwiki.apache.org/confluence/display/KAFKA/KIP-594%3A+Expose+output+topic+names+from+TopologyTestDriver 

This commit exposes the names of the topics the topology produced output to during its run.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
