### PR TITLE
KAFKA-9819: Fix flaky test in StoreChangelogReaderTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -946,8 +946,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
     @Test
     public void shouldNotThrowOnUnknownRevokedPartition() {
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         LogCaptureAppender.setClassLoggerToDebug(changelogReader.getClass());
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(changelogReader.getClass());
 
         try {
             changelogReader.remove(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
@@ -60,6 +60,12 @@ public class LogCaptureAppender extends AppenderSkeleton {
         return logCaptureAppender;
     }
 
+    public static LogCaptureAppender createAndRegister(final Class<?> clazz) {
+        final LogCaptureAppender logCaptureAppender = new LogCaptureAppender();
+        Logger.getLogger(clazz).addAppender(logCaptureAppender);
+        return logCaptureAppender;
+    }
+
     public static void setClassLoggerToDebug(final Class<?> clazz) {
         Logger.getLogger(clazz).setLevel(Level.DEBUG);
     }


### PR DESCRIPTION
Call for review @ableegoldman @vvcephei 

The test failed with some log message from `AdminClient` however, we don't use any admin client in this test. Thus, we should not get the JVM shared root logger, but only the logger for the test class.