### PR TITLE
[WIP] KAFKA-9590: Add configuration to limit number of partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/WillExceedPartitionLimitsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/WillExceedPartitionLimitsException.java
@@ -1,0 +1,14 @@
+package org.apache.kafka.common.errors;
+
+public class WillExceedPartitionLimitsException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public WillExceedPartitionLimitsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WillExceedPartitionLimitsException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -107,6 +107,7 @@ import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
+import org.apache.kafka.common.errors.WillExceedPartitionLimitsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,7 +320,8 @@ public enum Errors {
     GROUP_SUBSCRIBED_TO_TOPIC(86, "Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it.",
         GroupSubscribedToTopicException::new),
     INVALID_RECORD(87, "This record has failed the validation on broker and hence be rejected.", InvalidRecordException::new),
-    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared.", UnstableOffsetCommitException::new);
+    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared.", UnstableOffsetCommitException::new),
+    WILL_EXCEED_PARTITION_LIMITS(89, "Cannot satisfy request without exceeding the partition limits", WillExceedPartitionLimitsException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -82,7 +82,8 @@ object DynamicBrokerConfig {
     DynamicThreadPool.ReconfigurableConfigs ++
     Set(KafkaConfig.MetricReporterClassesProp) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
-    SocketServer.ReconfigurableConfigs
+    SocketServer.ReconfigurableConfigs ++
+    PartitionLimitsConfig.ReconfigurableConfigs
 
   private val ClusterLevelListenerConfigs = Set(KafkaConfig.MaxConnectionsProp)
   private val PerBrokerConfigs = DynamicSecurityConfigs  ++
@@ -594,6 +595,10 @@ trait BrokerReconfigurable {
   def validateReconfiguration(newConfig: KafkaConfig): Unit
 
   def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit
+}
+
+object PartitionLimitsConfig {
+  val ReconfigurableConfigs = Set(KafkaConfig.MaxPartitionsProp, KafkaConfig.MaxBrokerPartitionsProp)
 }
 
 object DynamicLogConfig {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -131,6 +131,9 @@ object Defaults {
   val MinInSyncReplicas = 1
   val MessageDownConversionEnable = true
 
+  val MaxPartitions = Int.MaxValue
+  val MaxBrokerPartitions = Int.MaxValue
+
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMs = RequestTimeoutMs
   val ControllerMessageQueueSize = Int.MaxValue
@@ -414,6 +417,10 @@ object KafkaConfig {
   val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
   val AlterConfigPolicyClassNameProp = "alter.config.policy.class.name"
   val LogMessageDownConversionEnableProp = LogConfigPrefix + "message.downconversion.enable"
+
+  val MaxPartitionsProp = "max.partitions"
+  val MaxBrokerPartitionsProp = "max.broker.partitions"
+
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
   val DefaultReplicationFactorProp = "default.replication.factor"
@@ -767,6 +774,15 @@ object KafkaConfig {
     "implement the <code>org.apache.kafka.server.policy.AlterConfigPolicy</code> interface."
   val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC;
 
+  val MaxPartitionsDoc = "The maximum number of partitions in all brokers combined. " +
+    "If the number of partitions in all the brokers combined already exceed this configuration " +
+    "at the time at which this configuration is set, then the cluster will continue to funtion normally, " +
+    "however, it won' t be possible to create new partitions."
+  val MaxBrokerPartitionsDoc = "The maximum number of partitions per broker. " +
+    "If the number of partitions in a given broker already exceeds this configuration at the time at which " +
+    "this configuration is set, then the broker will continue to function normally. However, it won't be possible " +
+    "to assign more replicas to that broker."
+
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels"
   val ControllerMessageQueueSizeDoc = "The buffer size for controller-to-broker-channels"
@@ -1063,6 +1079,8 @@ object KafkaConfig {
       .define(CreateTopicPolicyClassNameProp, CLASS, null, LOW, CreateTopicPolicyClassNameDoc)
       .define(AlterConfigPolicyClassNameProp, CLASS, null, LOW, AlterConfigPolicyClassNameDoc)
       .define(LogMessageDownConversionEnableProp, BOOLEAN, Defaults.MessageDownConversionEnable, LOW, LogMessageDownConversionEnableDoc)
+      .define(MaxPartitionsProp, INT, Defaults.MaxPartitions, HIGH, MaxPartitionsDoc)
+      .define(MaxBrokerPartitionsProp, INT, Defaults.MaxBrokerPartitions, HIGH, MaxBrokerPartitionsDoc)
 
       /** ********* Replication configuration ***********/
       .define(ControllerSocketTimeoutMsProp, INT, Defaults.ControllerSocketTimeoutMs, MEDIUM, ControllerSocketTimeoutMsDoc)
@@ -1458,6 +1476,9 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def logMessageTimestampType = TimestampType.forName(getString(KafkaConfig.LogMessageTimestampTypeProp))
   def logMessageTimestampDifferenceMaxMs: Long = getLong(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp)
   def logMessageDownConversionEnable: Boolean = getBoolean(KafkaConfig.LogMessageDownConversionEnableProp)
+
+  def maxPartitions = getInt(KafkaConfig.MaxPartitionsProp)
+  def maxBrokerPartitions = getInt(KafkaConfig.MaxBrokerPartitionsProp)
 
   /** ********* Replication configuration ***********/
   val controllerSocketTimeoutMs: Int = getInt(KafkaConfig.ControllerSocketTimeoutMsProp)

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -146,6 +146,16 @@ class MetadataCache(brokerId: Int) extends Logging {
     snapshot.aliveNodes.get(brokerId).flatMap(_.get(listenerName))
   }
 
+  def getPartitionCountByBroker(): Map[Int, Int] = {
+    val snapshot = metadataSnapshot
+
+    snapshot.partitionStates.flatMap { case (_, partitionsAndStates) =>
+      partitionsAndStates.flatMap { case (_, partitionInfo) =>
+        partitionInfo.replicas().asScala.map(_.toInt)
+      }
+    }.groupBy(identity).mapValues(_.size)
+  }
+
   // errorUnavailableEndpoints exists to support v0 MetadataResponses
   def getTopicMetadata(topics: Set[String],
                        listenerName: ListenerName,


### PR DESCRIPTION
This is a prototype (which works) for the Admin API path for creating topics and adding partitions to existing topics. The goal is to motivate the discussion of the KIP 578 (https://cwiki.apache.org/confluence/display/KAFKA/KIP-578%3A+Add+configuration+to+limit+number+of+partitions), so that reviewers have some more concrete details on approach.

For now, I have tested manually. Once the KIP is approved, I will write some unit and integration tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
