### PR TITLE
KAFKA-9881: Convert integration test to verify measurements from RocksDB to unit test

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -190,13 +190,13 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BulkLoadingSt
 
         // Setup metrics before the database is opened, otherwise the metrics are not updated
         // with the measurements from Rocks DB
-        maybeSetUpMetricsRecorder(context, configs);
+        maybeSetUpMetricsRecorder(configs);
 
         openRocksDB(dbOptions, columnFamilyOptions);
         open = true;
     }
 
-    private void maybeSetUpMetricsRecorder(final ProcessorContext context, final Map<String, Object> configs) {
+    private void maybeSetUpMetricsRecorder(final Map<String, Object> configs) {
         if (userSpecifiedOptions.statistics() == null &&
             RecordingLevel.forName((String) configs.get(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -181,40 +181,6 @@ public class RocksDBMetricsIntegrationTest {
         );
     }
 
-    @Test
-    public void shouldVerifyThatMetricsGetMeasurementsFromRocksDBForNonSegmentedStateStore() throws Exception {
-        final Properties streamsConfiguration = streamsConfig();
-        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
-        final StreamsBuilder builder = builderForNonSegmentedStateStore();
-        final String metricsScope = "rocksdb-state-id";
-
-        cleanUpStateRunVerifyAndClose(
-            builder,
-            streamsConfiguration,
-            IntegerDeserializer.class,
-            StringDeserializer.class,
-            this::verifyThatBytesWrittenTotalIncreases,
-            metricsScope
-        );
-    }
-
-    @Test
-    public void shouldVerifyThatMetricsGetMeasurementsFromRocksDBForSegmentedStateStore() throws Exception {
-        final Properties streamsConfiguration = streamsConfig();
-        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
-        final StreamsBuilder builder = builderForSegmentedStateStore();
-        final String metricsScope = "rocksdb-window-state-id";
-
-        cleanUpStateRunVerifyAndClose(
-            builder,
-            streamsConfiguration,
-            LongDeserializer.class,
-            LongDeserializer.class,
-            this::verifyThatBytesWrittenTotalIncreases,
-            metricsScope
-        );
-    }
-
     private Properties streamsConfig() {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-application");


### PR DESCRIPTION
The integration test RocksDBMetricsIntegrationTest takes pretty long to complete.
Most of the runtime is spent in the two tests that verify whether the RocksDB
metrics get actual measurements from RocksDB. Those tests need to wait for the thread
that collects the measurements of the RocksDB metrics to trigger the first recordings
of the metrics.

This PR adds a unit test that verifies whether the Kafka Streams metrics get the
measurements from RocksDB and removes the two integration tests that verified it
before. The verification of the creation and scheduling of the RocksDB metrics
recording trigger thread is already contained in KafkaStreamsTest and consequently
it is not part of this PR.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
