### PR TITLE
Minor: avoid duplicate unwrapping when end of stream has been reached

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -293,6 +293,11 @@ public class SslTransportLayer implements TransportLayer {
                 updateBytesBuffered(true);
         } catch (SSLException e) {
             maybeProcessHandshakeFailure(e, true, null);
+        } catch (EOFException e) {
+            // it is impossible to complete handshake successfully due to end-of-stream. Hence, it should throw either
+            // EOFException or SslAuthenticationException directly.
+            maybeThrowSslAuthenticationException();
+            throw e;
         } catch (IOException e) {
             maybeThrowSslAuthenticationException();
 


### PR DESCRIPTION
It is impossible to complete handshake successfully when end of stream has been reached. We should catch the EOFException and then throw exception directly to save a bit cost of unwrapping.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
