### PR TITLE
MINOR: Improve usage of LogCaptureAppender

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -30,7 +30,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.d
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1, V1> {
-    private static final Logger LOG = LoggerFactory.getLogger(KStreamKTableJoinProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KStreamKTableJoin.class);
 
     private final KTableValueGetter<K2, V2> valueGetter;
     private final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -801,9 +801,9 @@ public class StoreChangelogReader implements ChangelogReader {
                 }
                 changelogMetadata.clear();
             } else {
-                log.debug("Changelog partition {} could not be found, " +
-                    "it could be already cleaned up during the handling" +
-                    "of task corruption and never restore again", partition);
+                log.debug("Changelog partition {} could not be found," +
+                    " it could be already cleaned up during the handling" +
+                    " of task corruption and never restore again", partition);
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -800,15 +800,15 @@ public class KafkaStreamsTest {
     public void shouldWarnAboutRocksDBConfigSetterIsNotGuaranteedToBeBackwardsCompatible() {
         props.setProperty(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, TestRocksDbConfigSetter.class.getName());
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
-        LogCaptureAppender.unregister(appender);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
+            new KafkaStreams(new StreamsBuilder().build(), props, supplier, time);
 
-        assertThat(appender.getMessages(), hasItem("stream-client [" + CLIENT_ID + "] "
-            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
-            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
-            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
-            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
+            assertThat(appender.getMessages(), hasItem("stream-client [" + CLIENT_ID + "] "
+                + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
+                + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
+                + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
+                + "(or `org.rocksdb.ColumnFamilyOptions`)."));
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -147,7 +147,10 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
         Map<String, Object> returnedProps = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG), equalTo("group-instance-id-1-" + threadIdx));
+        assertThat(
+            returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG),
+            equalTo("group-instance-id-1-" + threadIdx)
+        );
 
         returnedProps = streamsConfig.getRestoreConsumerConfigs(clientId);
         assertNull(returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
@@ -170,7 +173,10 @@ public class StreamsConfigTest {
 
         assertEquals(42, returnedProps.get(StreamsConfig.REPLICATION_FACTOR_CONFIG));
         assertEquals(1, returnedProps.get(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG));
-        assertEquals(StreamsPartitionAssignor.class.getName(), returnedProps.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
+        assertEquals(
+            StreamsPartitionAssignor.class.getName(),
+            returnedProps.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG)
+        );
         assertEquals(7L, returnedProps.get(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
         assertEquals("dummy:host", returnedProps.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
         assertNull(returnedProps.get(StreamsConfig.RETRIES_CONFIG));
@@ -220,12 +226,18 @@ public class StreamsConfigTest {
         final String topic = "my topic";
 
         serializer.configure(serializerConfigs, true);
-        assertEquals("Should get the original string after serialization and deserialization with the configured encoding",
-            str, streamsConfig.defaultKeySerde().deserializer().deserialize(topic, serializer.serialize(topic, str)));
+        assertEquals(
+            "Should get the original string after serialization and deserialization with the configured encoding",
+            str,
+            streamsConfig.defaultKeySerde().deserializer().deserialize(topic, serializer.serialize(topic, str))
+        );
 
         serializer.configure(serializerConfigs, false);
-        assertEquals("Should get the original string after serialization and deserialization with the configured encoding",
-            str, streamsConfig.defaultValueSerde().deserializer().deserialize(topic, serializer.serialize(topic, str)));
+        assertEquals(
+            "Should get the original string after serialization and deserialization with the configured encoding",
+            str,
+            streamsConfig.defaultValueSerde().deserializer().deserialize(topic, serializer.serialize(topic, str))
+        );
     }
 
     @Test
@@ -598,7 +610,10 @@ public class StreamsConfigTest {
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "anyValue");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG), equalTo(READ_COMMITTED.name().toLowerCase(Locale.ROOT)));
+        assertThat(
+            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+            equalTo(READ_COMMITTED.name().toLowerCase(Locale.ROOT))
+        );
     }
 
     @Test
@@ -606,7 +621,10 @@ public class StreamsConfigTest {
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_UNCOMMITTED.name().toLowerCase(Locale.ROOT));
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG), equalTo(READ_UNCOMMITTED.name().toLowerCase(Locale.ROOT)));
+        assertThat(
+            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+            equalTo(READ_UNCOMMITTED.name().toLowerCase(Locale.ROOT))
+        );
     }
 
     @Test
@@ -654,7 +672,10 @@ public class StreamsConfigTest {
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
-        assertThat(consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG), equalTo(READ_COMMITTED.name().toLowerCase(Locale.ROOT)));
+        assertThat(
+            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+            equalTo(READ_COMMITTED.name().toLowerCase(Locale.ROOT))
+        );
         assertTrue((Boolean) producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
         assertThat(producerConfigs.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG), equalTo(Integer.MAX_VALUE));
         assertThat(streamsConfig.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), equalTo(100L));
@@ -731,7 +752,10 @@ public class StreamsConfigTest {
             new StreamsConfig(props);
             fail("Should throw ConfigException when commitIntervalMs is set to a negative value");
         } catch (final ConfigException e) {
-            assertEquals("Invalid value -1 for configuration commit.interval.ms: Value must be at least 0", e.getMessage());
+            assertEquals(
+                "Invalid value -1 for configuration commit.interval.ms: Value must be at least 0",
+                e.getMessage()
+            );
         }
     }
 
@@ -765,7 +789,10 @@ public class StreamsConfigTest {
             config.defaultKeySerde();
             fail("Test should throw a StreamsException");
         } catch (final StreamsException e) {
-            assertEquals("Failed to configure key serde class org.apache.kafka.streams.StreamsConfigTest$MisconfiguredSerde", e.getMessage());
+            assertEquals(
+                "Failed to configure key serde class org.apache.kafka.streams.StreamsConfigTest$MisconfiguredSerde",
+                e.getMessage()
+            );
         }
     }
 
@@ -778,7 +805,10 @@ public class StreamsConfigTest {
             config.defaultValueSerde();
             fail("Test should throw a StreamsException");
         } catch (final StreamsException e) {
-            assertEquals("Failed to configure value serde class org.apache.kafka.streams.StreamsConfigTest$MisconfiguredSerde", e.getMessage());
+            assertEquals(
+                "Failed to configure value serde class org.apache.kafka.streams.StreamsConfigTest$MisconfiguredSerde",
+                e.getMessage()
+            );
         }
     }
 
@@ -801,7 +831,11 @@ public class StreamsConfigTest {
             streamsConfig.getProducerConfigs(clientId);
             fail("Should throw ConfigException when ESO is enabled and maxInFlight requests exceeds 5");
         } catch (final ConfigException e) {
-            assertEquals("Invalid value 7 for configuration max.in.flight.requests.per.connection: Can't exceed 5 when exactly-once processing is enabled", e.getMessage());
+            assertEquals(
+                "Invalid value 7 for configuration max.in.flight.requests.per.connection:" +
+                    " Can't exceed 5 when exactly-once processing is enabled",
+                e.getMessage()
+            );
         }
     }
 
@@ -842,7 +876,11 @@ public class StreamsConfigTest {
             new StreamsConfig(props).getProducerConfigs(clientId);
             fail("Should throw ConfigException when EOS is enabled and maxInFlight cannot be paresed into an integer");
         } catch (final ConfigException e) {
-            assertEquals("Invalid value not-a-number for configuration max.in.flight.requests.per.connection: String value could not be parsed as 32-bit integer", e.getMessage());
+            assertEquals(
+                "Invalid value not-a-number for configuration max.in.flight.requests.per.connection:" +
+                " String value could not be parsed as 32-bit integer",
+                e.getMessage()
+            );
         }
     }
 
@@ -871,18 +909,21 @@ public class StreamsConfigTest {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldLogWarningWhenPartitionGrouperIsUsed() {
-        props.put(StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG, org.apache.kafka.streams.processor.DefaultPartitionGrouper.class);
+        props.put(
+            StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG,
+            org.apache.kafka.streams.processor.DefaultPartitionGrouper.class
+        );
 
         LogCaptureAppender.setClassLoggerToDebug(StreamsConfig.class);
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            new StreamsConfig(props);
 
-        new StreamsConfig(props);
-
-        LogCaptureAppender.unregister(appender);
-
-        assertThat(
-            appender.getMessages(),
-            hasItem("Configuration parameter `" + StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG + "` is deprecated and will be removed in 3.0.0 release."));
+            assertThat(
+                appender.getMessages(),
+                hasItem("Configuration parameter `" + StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG +
+                    "` is deprecated and will be removed in 3.0.0 release.")
+            );
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -21,10 +21,10 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -41,7 +41,6 @@ import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.MockProcessorSupplier;
@@ -50,9 +49,7 @@ import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -65,7 +62,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
-@SuppressWarnings("unchecked")
 public class KGroupedStreamImplTest {
 
     private static final String TOPIC = "topic";
@@ -105,7 +101,7 @@ public class KGroupedStreamImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullWindowsWithWindowedReduce() {
-        groupedStream.windowedBy((Windows) null);
+        groupedStream.windowedBy((Windows<?>) null);
     }
 
     @Test(expected = TopologyException.class)
@@ -149,7 +145,7 @@ public class KGroupedStreamImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotHaveNullWindowsOnWindowedAggregate() {
-        groupedStream.windowedBy((Windows) null);
+        groupedStream.windowedBy((Windows<?>) null);
     }
 
     @Test(expected = TopologyException.class)
@@ -397,22 +393,19 @@ public class KGroupedStreamImplTest {
                 Materialized.as(INVALID_STORE_NAME));
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnReduceWhenMaterializedIsNull() {
-        groupedStream.reduce(MockReducer.STRING_ADDER, (Materialized) null);
+        groupedStream.reduce(MockReducer.STRING_ADDER, null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnAggregateWhenMaterializedIsNull() {
-        groupedStream.aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, (Materialized) null);
+        groupedStream.aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnCountWhenMaterializedIsNull() {
-        groupedStream.count((Materialized) null);
+        groupedStream.count((Materialized<String, Long, KeyValueStore<Bytes, byte[]>>) null);
     }
 
     @Test
@@ -451,11 +444,12 @@ public class KGroupedStreamImplTest {
 
     private void shouldLogAndMeasureSkipsInAggregate(final String builtInMetricsVersion) {
         groupedStream.count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("count").withKeySerde(Serdes.String()));
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamAggregate.class);
+             final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
             processData(driver);
-            LogCaptureAppender.unregister(appender);
 
             if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
                 final Map<MetricName, ? extends Metric> metrics = driver.metrics();
@@ -521,12 +515,12 @@ public class KGroupedStreamImplTest {
                 .withKeySerde(Serdes.String())
                 .withValueSerde(Serdes.String())
         );
-
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamReduce.class);
+             final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
             processData(driver);
-            LogCaptureAppender.unregister(appender);
 
             if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
                 final Map<MetricName, ? extends Metric> metrics = driver.metrics();
@@ -659,7 +653,6 @@ public class KGroupedStreamImplTest {
     @Test
     public void shouldCountWindowedWithInternalStoreName() {
         final MockProcessorSupplier<Windowed<String>, Long> supplier = new MockProcessorSupplier<>();
-        final List<KeyValue<Windowed<String>, KeyValue<Long, Long>>> results = new ArrayList<>();
         groupedStream
             .windowedBy(TimeWindows.of(ofMillis(500L)))
             .count()

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -52,7 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamKTableJoinTest {
-    private final static KeyValueTimestamp[] EMPTY = new KeyValueTimestamp[0];
+    private final static KeyValueTimestamp<?, ?>[] EMPTY = new KeyValueTimestamp[0];
 
     private final String streamTopic = "streamTopic";
     private final String tableTopic = "tableTopic";
@@ -205,24 +205,25 @@ public class KStreamKTableJoinTest {
     }
 
     private void shouldLogAndMeterWhenSkippingNullLeftKey(final String builtInMetricsVersion) {
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        driver = new TopologyTestDriver(builder.build(), props);
-        final TestInputTopic<Integer, String> inputTopic =
-            driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
-        inputTopic.pipeInput(null, "A");
-        LogCaptureAppender.unregister(appender);
 
-        if (builtInMetricsVersion.equals(StreamsConfig.METRICS_0100_TO_24)) {
-            assertEquals(
-                1.0,
-                getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue()
-            );
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+            driver = new TopologyTestDriver(builder.build(), props);
+            final TestInputTopic<Integer, String> inputTopic =
+                driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
+            inputTopic.pipeInput(null, "A");
+
+            if (builtInMetricsVersion.equals(StreamsConfig.METRICS_0100_TO_24)) {
+                assertEquals(
+                    1.0,
+                    getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue()
+                );
+            }
+            assertThat(
+                appender.getMessages(),
+                hasItem("Skipping record due to null key or value. key=[null] value=[A] topic=[streamTopic] partition=[0] "
+                    + "offset=[0]"));
         }
-        assertThat(
-            appender.getMessages(),
-            hasItem("Skipping record due to null key or value. key=[null] value=[A] topic=[streamTopic] partition=[0] "
-                + "offset=[0]"));
     }
 
     @Test
@@ -236,13 +237,21 @@ public class KStreamKTableJoinTest {
     }
 
     private void shouldLogAndMeterWhenSkippingNullLeftValue(final String builtInMetricsVersion) {
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_0100_TO_24);
+
         driver = new TopologyTestDriver(builder.build(), props);
         final TestInputTopic<Integer, String> inputTopic =
             driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
-        inputTopic.pipeInput(1, null);
-        LogCaptureAppender.unregister(appender);
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+            inputTopic.pipeInput(1, null);
+
+            assertThat(
+                appender.getMessages(),
+                hasItem("Skipping record due to null key or value. key=[1] value=[null] topic=[streamTopic] partition=[0] "
+                    + "offset=[0]")
+            );
+        }
 
         if (builtInMetricsVersion.equals(StreamsConfig.METRICS_0100_TO_24)) {
             assertEquals(
@@ -250,10 +259,5 @@ public class KStreamKTableJoinTest {
                 getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
-        assertThat(
-            appender.getMessages(),
-            hasItem("Skipping record due to null key or value. key=[1] value=[null] topic=[streamTopic] partition=[0] "
-                + "offset=[0]")
-        );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -189,8 +189,8 @@ public class KStreamWindowAggregateTest {
                 new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)),  "0+1+1",  9),
                 new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)),  "0+1",  9)
             );
-            processors.get(1).checkAndClearProcessResult(new KeyValueTimestamp[0]);
-            processors.get(2).checkAndClearProcessResult(new KeyValueTimestamp[0]);
+            processors.get(1).checkAndClearProcessResult();
+            processors.get(2).checkAndClearProcessResult();
 
             inputTopic1.pipeInput("A", "1", 5L);
             inputTopic1.pipeInput("B", "2", 6L);
@@ -210,8 +210,8 @@ public class KStreamWindowAggregateTest {
                 new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(0, 10)),  "0+3+3",  9),
                 new KeyValueTimestamp<>(new Windowed<>("C", new TimeWindow(5, 15)),  "0+3",  9)
             );
-            processors.get(1).checkAndClearProcessResult(new KeyValueTimestamp[0]);
-            processors.get(2).checkAndClearProcessResult(new KeyValueTimestamp[0]);
+            processors.get(1).checkAndClearProcessResult();
+            processors.get(2).checkAndClearProcessResult();
 
             inputTopic2.pipeInput("A", "a", 0L);
             inputTopic2.pipeInput("B", "b", 1L);
@@ -219,7 +219,7 @@ public class KStreamWindowAggregateTest {
             inputTopic2.pipeInput("D", "d", 20L);
             inputTopic2.pipeInput("A", "a", 20L);
 
-            processors.get(0).checkAndClearProcessResult(new KeyValueTimestamp[0]);
+            processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
                 new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)),  "0+a",  0),
                 new KeyValueTimestamp<>(new Windowed<>("B", new TimeWindow(0, 10)),  "0+b",  1),
@@ -240,7 +240,7 @@ public class KStreamWindowAggregateTest {
             inputTopic2.pipeInput("D", "d", 18L);
             inputTopic2.pipeInput("A", "a", 21L);
 
-            processors.get(0).checkAndClearProcessResult(new KeyValueTimestamp[0]);
+            processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
                 new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(0, 10)),  "0+a+a",  5),
                 new KeyValueTimestamp<>(new Windowed<>("A", new TimeWindow(5, 15)),  "0+a",  5),
@@ -288,13 +288,14 @@ public class KStreamWindowAggregateTest {
                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("topic1-Canonicalized").withValueSerde(Serdes.String())
             );
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
+             final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
             final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(topic, new StringSerializer(), new StringSerializer());
             inputTopic.pipeInput(null, "1");
-            LogCaptureAppender.unregister(appender);
 
             if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
                 assertEquals(
@@ -333,10 +334,11 @@ public class KStreamWindowAggregateTest {
                .map((key, value) -> new KeyValue<>(key.toString(), value))
                .to("output");
 
-        LogCaptureAppender.setClassLoggerToDebug(KStreamWindowAggregate.class);
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
+             final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic(topic, new StringSerializer(), new StringSerializer());
             inputTopic.pipeInput("k", "100", 100L);
@@ -347,7 +349,6 @@ public class KStreamWindowAggregateTest {
             inputTopic.pipeInput("k", "4", 4L);
             inputTopic.pipeInput("k", "5", 5L);
             inputTopic.pipeInput("k", "6", 6L);
-            LogCaptureAppender.unregister(appender);
 
             assertLatenessMetrics(
                 driver,
@@ -370,10 +371,10 @@ public class KStreamWindowAggregateTest {
             final TestOutputTopic<String, String> outputTopic =
                     driver.createOutputTopic("output", new StringDeserializer(), new StringDeserializer());
 
-            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<String, String>("[k@95/105]", "+100", null, 100L)));
-            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<String, String>("[k@100/110]", "+100", null, 100L)));
-            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<String, String>("[k@5/15]", "+5", null, 5L)));
-            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<String, String>("[k@5/15]", "+5+6", null, 6L)));
+            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>("[k@95/105]", "+100", null, 100L)));
+            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>("[k@100/110]", "+100", null, 100L)));
+            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>("[k@5/15]", "+5", null, 5L)));
+            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>("[k@5/15]", "+5+6", null, 6L)));
             assertTrue(outputTopic.isEmpty());
         }
     }
@@ -404,10 +405,11 @@ public class KStreamWindowAggregateTest {
                .map((key, value) -> new KeyValue<>(key.toString(), value))
                .to("output");
 
-        LogCaptureAppender.setClassLoggerToDebug(KStreamWindowAggregate.class);
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
+             final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
             final TestInputTopic<String, String> inputTopic =
                     driver.createInputTopic(topic, new StringSerializer(), new StringSerializer());
             inputTopic.pipeInput("k", "100", 200L);
@@ -418,7 +420,6 @@ public class KStreamWindowAggregateTest {
             inputTopic.pipeInput("k", "4", 104L);
             inputTopic.pipeInput("k", "5", 105L);
             inputTopic.pipeInput("k", "6", 6L);
-            LogCaptureAppender.unregister(appender);
 
             assertLatenessMetrics(driver, builtInMetricsVersion, is(7.0), is(194.0), is(97.375));
 
@@ -434,7 +435,7 @@ public class KStreamWindowAggregateTest {
 
             final TestOutputTopic<String, String> outputTopic =
                     driver.createOutputTopic("output", new StringDeserializer(), new StringDeserializer());
-            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<String, String>("[k@200/210]", "+100", null, 200L)));
+            assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>("[k@200/210]", "+100", null, 200L)));
             assertTrue(outputTopic.isEmpty());
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -19,8 +19,9 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -29,7 +30,6 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.MockProcessorContext;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
-import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
@@ -430,9 +430,15 @@ public class KTableKTableOuterJoinTest {
         final MockProcessorContext context = new MockProcessorContext(props);
         context.setRecordMetadata("left", -1, -2, null, -3);
         join.init(context);
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        join.process(null, new Change<>("new", "old"));
-        LogCaptureAppender.unregister(appender);
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KTableKTableOuterJoin.class)) {
+            join.process(null, new Change<>("new", "old"));
+
+            assertThat(
+                appender.getMessages(),
+                hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]")
+            );
+        }
 
         if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
             assertEquals(
@@ -440,14 +446,13 @@ public class KTableKTableOuterJoinTest {
                 getMetricByName(context.metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
-        assertThat(appender.getMessages(), hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]"));
     }
 
     private void assertOutputKeyValueTimestamp(final TestOutputTopic<Integer, String> outputTopic,
                                                final Integer expectedKey,
                                                final String expectedValue,
                                                final long expectedTimestamp) {
-        assertThat(outputTopic.readRecord(), equalTo(new TestRecord<Integer, String>(expectedKey, expectedValue, null, expectedTimestamp)));
+        assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp)));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -58,7 +58,6 @@ import static org.junit.Assert.fail;
 
 public class InternalTopicManagerTest {
 
-    private final String threadName = "threadName";
     private final Node broker1 = new Node(0, "dummyHost-1", 1234);
     private final Node broker2 = new Node(1, "dummyHost-2", 1234);
     private final List<Node> cluster = new ArrayList<Node>(2) {
@@ -71,6 +70,8 @@ public class InternalTopicManagerTest {
     private final String topic2 = "test_topic_2";
     private final String topic3 = "test_topic_3";
     private final List<Node> singleReplica = Collections.singletonList(broker1);
+
+    private String threadName;
 
     private MockAdminClient mockAdminClient;
     private InternalTopicManager internalTopicManager;
@@ -87,9 +88,7 @@ public class InternalTopicManagerTest {
 
     @Before
     public void init() {
-        // When executing on Jenkins, the thread name is set to an unknown value,
-        // hence, we need to set it explicitly to make our log-assertions pass
-        Thread.currentThread().setName(threadName);
+        threadName = Thread.currentThread().getName();
 
         mockAdminClient = new MockAdminClient(cluster, broker1);
         internalTopicManager = new InternalTopicManager(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -63,6 +63,8 @@ import static org.apache.kafka.streams.processor.internals.StoreChangelogReader.
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -131,7 +133,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     };
 
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-    private final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+    private final StoreChangelogReader changelogReader =
+        new StoreChangelogReader(time, config, logContext, consumer, callback);
 
     @Before
     public void setUp() {
@@ -149,7 +152,15 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
     @After
     public void tearDown() {
-        EasyMock.reset(stateManager, activeStateManager, standbyStateManager, storeMetadata, storeMetadataOne, storeMetadataTwo, store);
+        EasyMock.reset(
+            stateManager,
+            activeStateManager,
+            standbyStateManager,
+            storeMetadata,
+            storeMetadataOne,
+            storeMetadataTwo,
+            store
+        );
     }
 
     @Test
@@ -185,16 +196,24 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, stateManager);
         changelogReader.restore();
 
-        assertEquals(type == ACTIVE ? StoreChangelogReader.ChangelogState.COMPLETED : StoreChangelogReader.ChangelogState.RESTORING,
-                     changelogReader.changelogMetadata(tp).state());
+        assertEquals(
+            type == ACTIVE ?
+                StoreChangelogReader.ChangelogState.COMPLETED :
+                StoreChangelogReader.ChangelogState.RESTORING,
+            changelogReader.changelogMetadata(tp).state()
+        );
         assertEquals(type == ACTIVE ? 10L : null, changelogReader.changelogMetadata(tp).endOffset());
         assertEquals(0L, changelogReader.changelogMetadata(tp).totalRestored());
-        assertEquals(type == ACTIVE ? Collections.singleton(tp) : Collections.emptySet(), changelogReader.completedChangelogs());
+        assertEquals(
+            type == ACTIVE ? Collections.singleton(tp) : Collections.emptySet(),
+            changelogReader.completedChangelogs()
+        );
         assertEquals(10L, consumer.position(tp));
         assertEquals(Collections.singleton(tp), consumer.paused());
 
@@ -218,7 +237,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, stateManager);
 
@@ -289,7 +309,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         };
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, stateManager);
 
@@ -363,7 +384,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore();
@@ -402,7 +424,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore();
@@ -437,7 +460,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, activeStateManager);
 
@@ -468,7 +492,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore();
@@ -496,7 +521,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         changelogReader.register(tp, activeStateManager);
 
@@ -515,7 +541,9 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             @Override
             public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions) {
                 if (functionCalled.get()) {
-                    return partitions.stream().collect(Collectors.toMap(Function.identity(), partition -> new OffsetAndMetadata(10L)));
+                    return partitions
+                        .stream()
+                        .collect(Collectors.toMap(Function.identity(), partition -> new OffsetAndMetadata(10L)));
                 } else {
                     functionCalled.set(true);
                     throw new TimeoutException("KABOOM!");
@@ -528,14 +556,19 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
             }
         };
 
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
         changelogReader.setMainConsumer(consumer);
 
         changelogReader.register(tp, stateManager);
         changelogReader.restore();
 
-        assertEquals(type == ACTIVE ? StoreChangelogReader.ChangelogState.REGISTERED : StoreChangelogReader.ChangelogState.RESTORING,
-                     changelogReader.changelogMetadata(tp).state());
+        assertEquals(
+            type == ACTIVE ?
+                StoreChangelogReader.ChangelogState.REGISTERED :
+                StoreChangelogReader.ChangelogState.RESTORING,
+            changelogReader.changelogMetadata(tp).state()
+        );
         if (type == ACTIVE) {
             assertNull(changelogReader.changelogMetadata(tp).endOffset());
         } else {
@@ -567,7 +600,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
                 throw kaboom;
             }
         };
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
         changelogReader.setMainConsumer(consumer);
 
         changelogReader.register(tp, stateManager);
@@ -586,7 +620,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
                 throw kaboom;
             }
         };
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, callback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, callback);
 
         final StreamsException thrown = assertThrows(StreamsException.class, changelogReader::clear);
         assertEquals(kaboom, thrown.getCause());
@@ -689,7 +724,9 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
             @Override
             public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions) {
-                return partitions.stream().collect(Collectors.toMap(Function.identity(), partition -> new OffsetAndMetadata(offset.get())));
+                return partitions
+                    .stream()
+                    .collect(Collectors.toMap(Function.identity(), partition -> new OffsetAndMetadata(offset.get())));
             }
         };
 
@@ -925,7 +962,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
                 return partitions.stream().collect(Collectors.toMap(Function.identity(), partition -> 10L));
             }
         };
-        final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, consumer, exceptionCallback);
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, consumer, exceptionCallback);
 
         changelogReader.register(tp, activeStateManager);
 
@@ -946,20 +984,15 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
     @Test
     public void shouldNotThrowOnUnknownRevokedPartition() {
-        LogCaptureAppender.setClassLoggerToDebug(changelogReader.getClass());
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(changelogReader.getClass());
+        LogCaptureAppender.setClassLoggerToDebug(StoreChangelogReader.class);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StoreChangelogReader.class)) {
+            changelogReader.remove(Collections.singletonList(new TopicPartition("unknown", 0)));
 
-        try {
-            changelogReader.remove(
-                Collections.singletonList(new TopicPartition("unknown", 0)));
-
-            assertEquals(Collections.singletonList(
-                "test-reader Changelog partition unknown-0 could not be found, " +
-                    "it could be already cleaned up during the handling" +
-                    "of task corruption and never restore again"), appender.getMessages()
+            assertThat(
+                appender.getMessages(),
+                hasItem("test-reader Changelog partition unknown-0 could not be found," +
+                    " it could be already cleaned up during the handling of task corruption and never restore again")
             );
-        } finally {
-            LogCaptureAppender.unregister(appender);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals.testutil;
 
-
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -26,14 +25,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-public class LogCaptureAppender extends AppenderSkeleton {
-    private final LinkedList<LoggingEvent> events = new LinkedList<>();
+public class LogCaptureAppender extends AppenderSkeleton implements AutoCloseable {
+    private final List<LoggingEvent> events = new LinkedList<>();
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static class Event {
-        private String level;
-        private String message;
-        private Optional<String> throwableInfo;
+        private final String level;
+        private final String message;
+        private final Optional<String> throwableInfo;
 
         Event(final String level, final String message, final Optional<String> throwableInfo) {
             this.level = level;
@@ -117,7 +116,7 @@ public class LogCaptureAppender extends AppenderSkeleton {
 
     @Override
     public void close() {
-
+        unregister(this);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -246,7 +246,7 @@ public class KeyValueStoreTestDriver<K, V> {
         stateSerdes = serdes;
 
         context = new InternalMockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, null) {
-            ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics());
+            final ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics());
 
             @Override
             public ThreadCache getCache() {
@@ -331,7 +331,7 @@ public class KeyValueStoreTestDriver<K, V> {
      * @return the processing context; never null
      * @see #addEntryToRestoreLog(Object, Object)
      */
-    public ProcessorContext context() {
+    public ProcessorContext<Object, Object> context() {
         return context;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -87,7 +87,7 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext<Object, Object> context) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = Stores.keyValueStoreBuilder(
                 Stores.persistentKeyValueStore("cache-store"),
                 (Serde<K>) context.keySerde(),
@@ -285,7 +285,8 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
     @Test
     public void shouldIterateOverRange() {
         final int items = addItemsToCache();
-        final KeyValueIterator<Bytes, byte[]> range = store.range(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)));
+        final KeyValueIterator<Bytes, byte[]> range =
+            store.range(bytesKey(String.valueOf(0)), bytesKey(String.valueOf(items)));
         final List<Bytes> results = new ArrayList<>();
         while (range.hasNext()) {
             results.add(range.next().key);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -612,19 +612,21 @@ public class CachingWindowStoreTest {
 
     @Test
     public void shouldNotThrowInvalidRangeExceptionWithNegativeFromKey() {
-        LogCaptureAppender.setClassLoggerToDebug(InMemoryWindowStore.class);
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-
         final Bytes keyFrom = Bytes.wrap(Serdes.Integer().serializer().serialize("", -1));
         final Bytes keyTo = Bytes.wrap(Serdes.Integer().serializer().serialize("", 1));
 
-        final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.fetch(keyFrom, keyTo, 0L, 10L);
-        assertFalse(iterator.hasNext());
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingWindowStore.class)) {
+            final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = cachingStore.fetch(keyFrom, keyTo, 0L, 10L);
+            assertFalse(iterator.hasNext());
 
-        final List<String> messages = appender.getMessages();
-        assertThat(messages, hasItem("Returning empty iterator for fetch with invalid key range: from > to. "
-            + "This may be due to serdes that don't preserve ordering when lexicographically comparing the serialized bytes. "
-            + "Note that the built-in numerical serdes do not follow this for negative numbers"));
+            final List<String> messages = appender.getMessages();
+            assertThat(
+                messages,
+                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
+                    " This may be due to serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                    " Note that the built-in numerical serdes do not follow this for negative numbers")
+            );
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
@@ -28,7 +28,7 @@ public class InMemoryKeyValueLoggedStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext<Object, Object> context) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = Stores.keyValueStoreBuilder(
             Stores.inMemoryKeyValueStore("my-store"),
             (Serde<K>) context.keySerde(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -31,7 +31,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext<Object, Object> context) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = Stores.keyValueStoreBuilder(
                 Stores.inMemoryKeyValueStore("my-store"),
                 (Serde<K>) context.keySerde(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -36,7 +36,7 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext<Object, Object> context) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = Stores.keyValueStoreBuilder(
                 Stores.lruMap("my-store", 10),
                 (Serde<K>) context.keySerde(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -16,26 +16,23 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import static java.time.Duration.ofMillis;
-
-import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.SessionWindow;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
-import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.SessionStore;
-import org.apache.kafka.streams.state.Stores;
+import static java.time.Duration.ofMillis;
+import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
-import org.junit.Test;
-
-public class InMemorySessionStoreTest extends SessionBytesStoreTest {
+public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
 
     private static final String STORE_NAME = "in-memory session store";
 
@@ -54,11 +51,6 @@ public class InMemorySessionStoreTest extends SessionBytesStoreTest {
     @Override
     String getMetricsScope() {
         return new InMemorySessionBytesStoreSupplier(null, 0).metricsScope();
-    }
-
-    @Override
-    void setClassLoggerToDebug() {
-        LogCaptureAppender.setClassLoggerToDebug(InMemorySessionStore.class);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.junit.Test;
 
-public class InMemoryWindowStoreTest extends WindowBytesStoreTest {
+public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
 
     private final static String STORE_NAME = "InMemoryWindowStore";
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -241,7 +241,7 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
                     parameters[i] = new RemoveEmptyValueCompactionFilter();
                     break;
                 case "org.rocksdb.AbstractCompactionFilterFactory":
-                    parameters[i] = new AbstractCompactionFilterFactory() {
+                    parameters[i] = new AbstractCompactionFilterFactory<AbstractCompactionFilter<?>>() {
 
                         @Override
                         public AbstractCompactionFilter<?> createCompactionFilter(final Context context) {
@@ -292,15 +292,18 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
             = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        optionsFacadeDbOptions.setCompactionOptionsFIFO(new CompactionOptionsFIFO());
-        LogCaptureAppender.unregister(appender);
+        try (final LogCaptureAppender appender =
+            LogCaptureAppender.createAndRegister(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class)) {
+            optionsFacadeDbOptions.setCompactionOptionsFIFO(new CompactionOptionsFIFO());
 
-        assertThat(appender.getMessages(), hasItem(""
-            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
-            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
-            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
-            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
+            assertThat(
+                appender.getMessages(),
+                hasItem("RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release." +
+                    " If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite" +
+                    " your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options`" +
+                    " (or `org.rocksdb.ColumnFamilyOptions`).")
+            );
+        }
     }
 
     @Test
@@ -309,14 +312,17 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
         final RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter optionsFacadeDbOptions
             = new RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter(mockedDbOptions, new ColumnFamilyOptions());
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        optionsFacadeDbOptions.compactionOptionsFIFO();
-        LogCaptureAppender.unregister(appender);
+        try (final LogCaptureAppender appender =
+            LogCaptureAppender.createAndRegister(RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.class)) {
+            optionsFacadeDbOptions.compactionOptionsFIFO();
 
-        assertThat(appender.getMessages(), hasItem(""
-            + "RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release. "
-            + "If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite "
-            + "your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options` "
-            + "(or `org.rocksdb.ColumnFamilyOptions`)."));
+            assertThat(
+                appender.getMessages(),
+                hasItem("RocksDB's version will be bumped to version 6+ via KAFKA-8897 in a future release." +
+                    " If you use `org.rocksdb.CompactionOptionsFIFO#setTtl(long)` or `#ttl()` you will need to rewrite" +
+                    " your code after KAFKA-8897 is resolved and set TTL via `org.rocksdb.Options`" +
+                    " (or `org.rocksdb.ColumnFamilyOptions`).")
+            );
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -38,7 +38,7 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext<Object, Object> context) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = Stores.keyValueStoreBuilder(
                 Stores.persistentKeyValueStore("my-store"),
                 (Serde<K>) context.keySerde(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.Stores;
@@ -29,11 +28,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import static java.time.Duration.ofMillis;
-import static org.junit.Assert.assertEquals;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
+import static org.junit.Assert.assertEquals;
 
 
-public class RocksDBSessionStoreTest extends SessionBytesStoreTest {
+public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
 
     private static final String STORE_NAME = "rocksDB session store";
 
@@ -52,11 +51,6 @@ public class RocksDBSessionStoreTest extends SessionBytesStoreTest {
     @Override
     String getMetricsScope() {
         return new RocksDbSessionBytesStoreSupplier(null, 0).metricsScope();
-    }
-
-    @Override
-    void setClassLoggerToDebug() {
-        LogCaptureAppender.setClassLoggerToDebug(AbstractRocksDBSegmentedBytesStore.class);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -47,8 +47,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
-import org.rocksdb.Filter;
 import org.rocksdb.Cache;
+import org.rocksdb.Filter;
 import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.Statistics;
@@ -61,8 +61,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.mock;
@@ -143,7 +143,7 @@ public class RocksDBStoreTest {
 
     @Test
     public void shouldAddStatisticsToInjectedMetricsRecorderWhenRecordingLevelIsDebug() {
-        final RocksDBStore store = getRocksDBStoreWithRocksDBMetricsRecorder();
+        rocksDBStore = getRocksDBStoreWithRocksDBMetricsRecorder();
         context = getProcessorContext(RecordingLevel.DEBUG);
         reset(metricsRecorder);
         metricsRecorder.addStatistics(
@@ -152,9 +152,10 @@ public class RocksDBStoreTest {
         );
         replay(metricsRecorder);
 
-        store.openDB(context);
+        rocksDBStore.openDB(context);
 
         verify(metricsRecorder);
+        reset(metricsRecorder);
     }
 
     @Test
@@ -172,13 +173,15 @@ public class RocksDBStoreTest {
     @Test
     public void shouldRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenRecordingLevelIsDebug() {
         rocksDBStore = getRocksDBStoreWithRocksDBMetricsRecorder();
-        context = getProcessorContext(RecordingLevel.DEBUG);
-        rocksDBStore.openDB(context);
-        reset(metricsRecorder);
-        metricsRecorder.removeStatistics(DB_NAME);
-        replay(metricsRecorder);
-
-        rocksDBStore.close();
+        try {
+            context = getProcessorContext(RecordingLevel.DEBUG);
+            rocksDBStore.openDB(context);
+            reset(metricsRecorder);
+            metricsRecorder.removeStatistics(DB_NAME);
+            replay(metricsRecorder);
+        } finally {
+            rocksDBStore.close();
+        }
 
         verify(metricsRecorder);
     }
@@ -186,12 +189,14 @@ public class RocksDBStoreTest {
     @Test
     public void shouldNotRemoveStatisticsFromInjectedMetricsRecorderOnCloseWhenRecordingLevelIsInfo() {
         rocksDBStore = getRocksDBStoreWithRocksDBMetricsRecorder();
-        context = getProcessorContext(RecordingLevel.INFO);
-        rocksDBStore.openDB(context);
-        reset(metricsRecorder);
-        replay(metricsRecorder);
-
-        rocksDBStore.close();
+        try {
+            context = getProcessorContext(RecordingLevel.INFO);
+            rocksDBStore.openDB(context);
+            reset(metricsRecorder);
+            replay(metricsRecorder);
+        } finally {
+            rocksDBStore.close();
+        }
 
         verify(metricsRecorder);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreTest.java
@@ -48,12 +48,11 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
 
     @Test
     public void shouldOpenNewStoreInRegularMode() {
-        LogCaptureAppender.setClassLoggerToDebug(RocksDBTimestampedStore.class);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
+            rocksDBStore.init(context, rocksDBStore);
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        rocksDBStore.init(context, rocksDBStore);
-        assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
-        LogCaptureAppender.unregister(appender);
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+        }
 
         try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
             assertThat(iterator.hasNext(), is(false));
@@ -62,19 +61,19 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
 
     @Test
     public void shouldOpenExistingStoreInRegularMode() throws Exception {
-        LogCaptureAppender.setClassLoggerToDebug(RocksDBTimestampedStore.class);
-
         // prepare store
         rocksDBStore.init(context, rocksDBStore);
         rocksDBStore.put(new Bytes("key".getBytes()), "timestamped".getBytes());
         rocksDBStore.close();
 
         // re-open store
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        rocksDBStore.init(context, rocksDBStore);
-        assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
-        LogCaptureAppender.unregister(appender);
-        rocksDBStore.close();
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+        } finally {
+            rocksDBStore.close();
+        }
 
         // verify store
         final DBOptions dbOptions = new DBOptions();
@@ -121,12 +120,11 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
     public void shouldMigrateDataFromDefaultToTimestampColumnFamily() throws Exception {
         prepareOldStore();
 
-        LogCaptureAppender.setClassLoggerToDebug(RocksDBTimestampedStore.class);
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
+            rocksDBStore.init(context, rocksDBStore);
 
-        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        rocksDBStore.init(context, rocksDBStore);
-        assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
-        LogCaptureAppender.unregister(appender);
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+        }
 
         // approx: 7 entries on old CF, 0 in new CF
         assertThat(rocksDBStore.approximateNumEntries(), is(7L));
@@ -340,11 +338,13 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         }
 
         // check that still in upgrade mode
-        LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        rocksDBStore.init(context, rocksDBStore);
-        assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
-        LogCaptureAppender.unregister(appender);
-        rocksDBStore.close();
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+        } finally {
+            rocksDBStore.close();
+        }
 
         // clear old CF
         columnFamilies.clear();
@@ -372,10 +372,11 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         }
 
         // check that still in regular mode
-        appender = LogCaptureAppender.createAndRegister();
-        rocksDBStore.init(context, rocksDBStore);
-        assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
-        LogCaptureAppender.unregister(appender);
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+        }
     }
 
     private void prepareOldStore() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @SuppressWarnings("PointlessArithmeticExpression")
-public class RocksDBWindowStoreTest extends WindowBytesStoreTest {
+public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
 
     private static final String STORE_NAME = "rocksDB window store";
     private static final String METRICS_SCOPE = "test-state-id";

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessor.java
@@ -93,7 +93,7 @@ public class MockProcessor<K, V> extends AbstractProcessor<K, V> {
         }
     }
 
-    public void checkAndClearProcessResult(final KeyValueTimestamp... expected) {
+    public void checkAndClearProcessResult(final KeyValueTimestamp<?, ?>... expected) {
         assertEquals("the number of outputs:" + processed, expected.length, processed.size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals("output[" + i + "]:", expected[i], processed.get(i));


### PR DESCRIPTION
I started a "small" cleanup, and it ended up to become a "big" cleanup...

 - limit the usage of `LogCaptureAppender` to the class under test (if possible)
 - ensure that the registered appended is unregistered (via try-with-resource)
 - limit the "scope" of creating/unregistering the appended to a minimum 
 - cleanup all warning of all classes touched
 - some code reformatting
 - some class renaming

Call for review @vvcephei 