### PR TITLE
KAFKA-6024: Consider moving validation in KafkaConsumer ahead of call to acquireAndEnsureOpen()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1388,9 +1388,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      */
     @Override
     public void commitSync(Duration timeout) {
+        maybeThrowInvalidGroupIdException();
         acquireAndEnsureOpen();
         try {
-            maybeThrowInvalidGroupIdException();
             if (!coordinator.commitOffsetsSync(subscriptions.allConsumed(), time.timer(timeout))) {
                 throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before successfully " +
                         "committing the current consumed offsets");


### PR DESCRIPTION
In commitSync method in KafkaConsumer , acquireAndEnsureOpen() is called before parameter validation , which is not really required .
```

  @Override
    public void commitSync(Duration timeout) {
        acquireAndEnsureOpen();
        try {
               maybeThrowInvalidGroupIdException();
   

```        

Since the value of parameter would not change per invocation, it seems performing validation ahead of acquireAndEnsureOpen() call would be better.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
