### PR TITLE
MINOR: Further reduce runtime for metrics integration tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.integration;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.IntegerSerializer;
-import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -264,63 +264,43 @@ public class MetricsIntegrationTest {
 
     private void produceRecordsForTwoSegments(final Duration segmentInterval) throws Exception {
         final MockTime mockTime = new MockTime(Math.max(segmentInterval.toMillis(), 60_000L));
+        final Properties props = TestUtils.producerConfig(
+            CLUSTER.bootstrapServers(),
+            IntegerSerializer.class,
+            StringSerializer.class,
+            new Properties());
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             STREAM_INPUT,
             Collections.singletonList(new KeyValue<>(1, "A")),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                IntegerSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            props,
             mockTime.milliseconds()
         );
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             STREAM_INPUT,
             Collections.singletonList(new KeyValue<>(1, "B")),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                IntegerSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            props,
             mockTime.milliseconds()
         );
     }
 
     private void produceRecordsForClosingWindow(final Duration windowSize) throws Exception {
         final MockTime mockTime = new MockTime(windowSize.toMillis() + 1);
+        final Properties props = TestUtils.producerConfig(
+            CLUSTER.bootstrapServers(),
+            IntegerSerializer.class,
+            StringSerializer.class,
+            new Properties());
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             STREAM_INPUT,
             Collections.singletonList(new KeyValue<>(1, "A")),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                IntegerSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            props,
             mockTime.milliseconds()
         );
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             STREAM_INPUT,
             Collections.singletonList(new KeyValue<>(1, "B")),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                IntegerSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            props,
             mockTime.milliseconds()
-        );
-    }
-
-    private void waitUntilAllRecordsAreConsumed(final int numberOfExpectedRecords) throws Exception {
-        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
-            TestUtils.consumerConfig(
-                CLUSTER.bootstrapServers(),
-                "consumerApp",
-                LongDeserializer.class,
-                LongDeserializer.class,
-                new Properties()
-            ),
-            STREAM_OUTPUT_1,
-            numberOfExpectedRecords
         );
     }
 
@@ -423,8 +403,6 @@ public class MetricsIntegrationTest {
 
         verifyStateMetric(State.RUNNING);
 
-        waitUntilAllRecordsAreConsumed(1);
-
         checkWindowStoreAndSuppressionBufferMetrics(builtInMetricsVersion);
 
         closeApplication();
@@ -464,8 +442,6 @@ public class MetricsIntegrationTest {
         startApplication();
 
         verifyStateMetric(State.RUNNING);
-
-        waitUntilAllRecordsAreConsumed(2);
 
         checkSessionStoreMetrics(builtInMetricsVersion);
 


### PR DESCRIPTION
1. In both RocksDBMetrics and Metrics integration tests, we do not need to wait for consumer to consume records from output topics since the sensors / metrics are registered upon task creation.

2. Merged the two test cases of RocksDB with one app that creates two state stores (non-segmented and segmented).

With these two changes, local runtime of these two tests reduced from 2min+ and 3min+ to under a minute.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
