### PR TITLE
MINOR: Use .asf.yaml to direct github notifications to JIRA and mailing lists

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+notifications:
+  commits:      commits@kafka.apache.org
+  issues:       github@kafka.apache.org
+  pullrequests: github@kafka.apache.org
+  jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,6 @@
 
 notifications:
   commits:      commits@kafka.apache.org
-  issues:       github@kafka.apache.org
-  pullrequests: github@kafka.apache.org
+  issues:       jira@kafka.apache.org
+  pullrequests: jira@kafka.apache.org
   jira_options: link label


### PR DESCRIPTION
Following the instructions from: https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories#id-.asf.yamlfeaturesforgitrepositories-ImplementedFeatures

This PR redirects all github `commit` notifications to `commits@kafka.apache.org` and `issues`, `pullrequests` notifications to `github@kafka.apache.org` mailing list. 

Also enable `link` `label` JIRA notification options.
