### PR TITLE
Adding github whitelist

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,3 +20,7 @@ notifications:
   issues:       jira@kafka.apache.org
   pullrequests: jira@kafka.apache.org
   jira_options: link label
+
+jenkins:
+  github_whitelist:
+    - ConcurrencyPractitioner


### PR DESCRIPTION
This PR is meant to add ConcurrencyPractitioner to the Jenkins whitelist so that this user can trigger tests.
