### PR TITLE
KAFKA-9901:Fix streams_broker_bounce_test error

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_bounce_test.py
@@ -164,7 +164,7 @@ class StreamsBrokerBounceTest(Test):
 
         # Start test harness
         self.driver = StreamsSmokeTestDriverService(self.test_context, self.kafka)
-        self.processor1 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, num_threads)
+        self.processor1 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, 'at_least_once', num_threads)
 
         self.driver.start()
 


### PR DESCRIPTION
The constructor of StreamsSmokeTestJobRunnerService has been changed.
But it's not updated in streams_broker_bounce_test.py, which makes
num_threads = 3 to be processing_guarantee's value and causes that
StreamsTest can't startup

Change-Id: I07ebc3e007e0ddd0b5182d5cf9467cdfac993eae
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
