### PR TITLE
KAFKA-9903

### DIFF
--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -109,5 +109,5 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
     info("Stopped")
   }
 
-  def isRunning: Boolean = !isShutdownInitiated
+  def isRunning: Boolean = !isShutdownInitiated && !isShutdownComplete
 }


### PR DESCRIPTION
ShutdownComplete will countdown in the finally block when thread shutdown due to an error, and in this case thread is not running.
So isRunning logic should check isShutdownInitiated and isShutdownComplete.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
