### PR TITLE
[WIP]KAFKA-9893: Configurable TCP connection timeout and improve the initial metadata fetch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -92,6 +92,9 @@ public class CommonClientConfigs {
         Utils.join(SecurityProtocol.names(), ", ") + ".";
     public static final String DEFAULT_SECURITY_PROTOCOL = "PLAINTEXT";
 
+    public static final String CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG = "connections.setup.timeout.ms";
+    public static final String CONNECTIONS_SETUP_TIMEOUT_MS_DOC = "The configuration controls the maximum amount of time the client will wait for socket channels finish connecting. The connection will be closed if it is not built before the timeout elapses.";
+
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = "connections.max.idle.ms";
     public static final String CONNECTIONS_MAX_IDLE_MS_DOC = "Close idle connections after the number of milliseconds specified by this config.";
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -71,6 +71,10 @@ public class AdminClientConfig extends AbstractConfig {
                 "retry a failed request. This avoids repeatedly sending requests in a tight loop under " +
                 "some failure scenarios.";
 
+    /** <code>connections.setup.timeout.ms</code> */
+    public static final String CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG;
+    private static final String CONNECTIONS_SETUP_TIMEOUT_MS_DOC = CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_DOC;
+
     /** <code>connections.max.idle.ms</code> */
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
     private static final String CONNECTIONS_MAX_IDLE_MS_DOC = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC;
@@ -149,6 +153,11 @@ public class AdminClientConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.MEDIUM,
                                         REQUEST_TIMEOUT_MS_DOC)
+                                .define(CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG,
+                                        Type.LONG,
+                                        10 * 1000,
+                                        Importance.MEDIUM,
+                                        CONNECTIONS_SETUP_TIMEOUT_MS_DOC)
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                                         Type.LONG,
                                         5 * 60 * 1000,

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -480,6 +480,7 @@ public class KafkaAdminClient extends AdminClient {
                 config.getInt(AdminClientConfig.SEND_BUFFER_CONFIG),
                 config.getInt(AdminClientConfig.RECEIVE_BUFFER_CONFIG),
                 (int) TimeUnit.HOURS.toMillis(1),
+                config.getLong(AdminClientConfig.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG),
                 ClientDnsLookup.forConfig(config.getString(AdminClientConfig.CLIENT_DNS_LOOKUP_CONFIG)),
                 time,
                 true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -229,6 +229,9 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String VALUE_DESERIALIZER_CLASS_CONFIG = "value.deserializer";
     public static final String VALUE_DESERIALIZER_CLASS_DOC = "Deserializer class for value that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
 
+    /** <code>connections.setup.timeout.ms</code> */
+    public static final String CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG;
+
     /** <code>connections.max.idle.ms</code> */
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
 
@@ -478,6 +481,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.MEDIUM,
                                         CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_DOC)
+                                .define(CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG,
+                                        Type.LONG,
+                                        10 * 1000,
+                                        Importance.MEDIUM,
+                                        CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG)
                                 /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                                         Type.LONG,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -752,6 +752,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG),
                     config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                    config.getLong(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                     ClientDnsLookup.forConfig(config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG)),
                     time,
                     true,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -455,6 +455,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 producerConfig.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
                 producerConfig.getInt(ProducerConfig.RECEIVE_BUFFER_CONFIG),
                 requestTimeoutMs,
+                producerConfig.getInt(ProducerConfig.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG),
                 ClientDnsLookup.forConfig(producerConfig.getString(ProducerConfig.CLIENT_DNS_LOOKUP_CONFIG)),
                 time,
                 true,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -218,6 +218,9 @@ public class ProducerConfig extends AbstractConfig {
     public static final String VALUE_SERIALIZER_CLASS_CONFIG = "value.serializer";
     public static final String VALUE_SERIALIZER_CLASS_DOC = "Serializer class for value that implements the <code>org.apache.kafka.common.serialization.Serializer</code> interface.";
 
+    /** <code>connections.setup.timeout.ms</code> */
+    public static final String CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG;
+
     /** <code>connections.max.idle.ms</code> */
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
 
@@ -361,6 +364,11 @@ public class ProducerConfig extends AbstractConfig {
                                         Type.CLASS,
                                         Importance.HIGH,
                                         VALUE_SERIALIZER_CLASS_DOC)
+                                .define(CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG,
+                                        Type.LONG,
+                                        10 * 1000,
+                                        Importance.MEDIUM,
+                                        CommonClientConfigs.CONNECTIONS_SETUP_TIMEOUT_MS_CONFIG)
                                 /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                                         Type.LONG,

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -84,26 +84,26 @@ public class NetworkClientTest {
     private NetworkClient createNetworkClient(long reconnectBackoffMaxMs) {
         return new NetworkClient(selector, metadataUpdater, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, reconnectBackoffMaxMs, 64 * 1024, 64 * 1024,
-                defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext());
+                defaultRequestTimeoutMs, 10 * 1000, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext());
     }
 
     private NetworkClient createNetworkClientWithStaticNodes() {
         return new NetworkClient(selector, metadataUpdater,
                 "mock-static", Integer.MAX_VALUE, 0, 0, 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
-                ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext());
+                10 * 1000, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext());
     }
 
     private NetworkClient createNetworkClientWithNoVersionDiscovery(Metadata metadata) {
         return new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, 0, 64 * 1024, 64 * 1024,
-                defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, false, new ApiVersions(), new LogContext());
+                defaultRequestTimeoutMs, 10 * 1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions(), new LogContext());
     }
 
     private NetworkClient createNetworkClientWithNoVersionDiscovery() {
         return new NetworkClient(selector, metadataUpdater, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, reconnectBackoffMaxMsTest,
                 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
-                ClientDnsLookup.DEFAULT, time, false, new ApiVersions(), new LogContext());
+                10 * 1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions(), new LogContext());
     }
 
     @Before

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1993,7 +1993,7 @@ public class FetcherTest {
         Cluster cluster = TestUtils.singletonCluster("test", 1);
         Node node = cluster.nodes().get(0);
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
-                1000, 1000, 64 * 1024, 64 * 1024, 1000,  ClientDnsLookup.DEFAULT,
+                1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, ClientDnsLookup.DEFAULT,
                 time, true, new ApiVersions(), throttleTimeSensor, new LogContext());
 
         ByteBuffer buffer = ApiVersionsResponse.

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -262,7 +262,7 @@ public class SenderTest {
         Cluster cluster = TestUtils.singletonCluster("test", 1);
         Node node = cluster.nodes().get(0);
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
-                1000, 1000, 64 * 1024, 64 * 1024, 1000,  ClientDnsLookup.DEFAULT,
+                1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, ClientDnsLookup.DEFAULT,
                 time, true, new ApiVersions(), throttleTimeSensor, logContext);
 
         ByteBuffer buffer = ApiVersionsResponse.createApiVersionsResponse(400, RecordBatch.CURRENT_MAGIC_VALUE).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -111,7 +111,7 @@ public class WorkerGroupMember {
                     config.getInt(CommonClientConfigs.SEND_BUFFER_CONFIG),
                     config.getInt(CommonClientConfigs.RECEIVE_BUFFER_CONFIG),
                     config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG),
-                    ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)),
+                    10 * 1000, ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)),
                     time,
                     true,
                     new ApiVersions(),

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -286,21 +286,7 @@ object BrokerApiVersionsCommand {
         channelBuilder,
         logContext)
 
-      val networkClient = new NetworkClient(
-        selector,
-        metadata,
-        clientId,
-        DefaultMaxInFlightRequestsPerConnection,
-        DefaultReconnectBackoffMs,
-        DefaultReconnectBackoffMax,
-        DefaultSendBufferBytes,
-        DefaultReceiveBufferBytes,
-        requestTimeoutMs,
-        ClientDnsLookup.DEFAULT,
-        time,
-        true,
-        new ApiVersions,
-        logContext)
+      val networkClient = new NetworkClient(selector, metadata, clientId, DefaultMaxInFlightRequestsPerConnection, DefaultReconnectBackoffMs, DefaultReconnectBackoffMax, DefaultSendBufferBytes, DefaultReceiveBufferBytes, requestTimeoutMs, 10*1000, ClientDnsLookup.DEFAULT, time, true, new ApiVersions, logContext)
 
       val highLevelClient = new ConsumerNetworkClient(
         logContext,

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -143,22 +143,7 @@ class ControllerChannelManager(controllerContext: ControllerContext,
         channelBuilder,
         logContext
       )
-      val networkClient = new NetworkClient(
-        selector,
-        new ManualMetadataUpdater(Seq(brokerNode).asJava),
-        config.brokerId.toString,
-        1,
-        0,
-        0,
-        Selectable.USE_DEFAULT_BUFFER_SIZE,
-        Selectable.USE_DEFAULT_BUFFER_SIZE,
-        config.requestTimeoutMs,
-        ClientDnsLookup.DEFAULT,
-        time,
-        false,
-        new ApiVersions,
-        logContext
-      )
+      val networkClient = new NetworkClient(selector, new ManualMetadataUpdater(Seq(brokerNode).asJava), config.brokerId.toString, 1, 0, 0, Selectable.USE_DEFAULT_BUFFER_SIZE, Selectable.USE_DEFAULT_BUFFER_SIZE, config.requestTimeoutMs, 10*1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions, logContext)
       (networkClient, reconfigurableChannelBuilder)
     }
     val threadName = threadNamePrefix match {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -69,22 +69,7 @@ object TransactionMarkerChannelManager {
       channelBuilder,
       logContext
     )
-    val networkClient = new NetworkClient(
-      selector,
-      new ManualMetadataUpdater(),
-      s"broker-${config.brokerId}-txn-marker-sender",
-      1,
-      50,
-      50,
-      Selectable.USE_DEFAULT_BUFFER_SIZE,
-      config.socketReceiveBufferBytes,
-      config.requestTimeoutMs,
-      ClientDnsLookup.DEFAULT,
-      time,
-      false,
-      new ApiVersions,
-      logContext
-    )
+    val networkClient = new NetworkClient(selector, new ManualMetadataUpdater(), s"broker-${config.brokerId}-txn-marker-sender", 1, 50, 50, Selectable.USE_DEFAULT_BUFFER_SIZE, config.socketReceiveBufferBytes, config.requestTimeoutMs, 10*1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions, logContext)
 
     new TransactionMarkerChannelManager(config,
       metadataCache,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -477,21 +477,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           channelBuilder,
           logContext
         )
-        new NetworkClient(
-          selector,
-          metadataUpdater,
-          config.brokerId.toString,
-          1,
-          0,
-          0,
-          Selectable.USE_DEFAULT_BUFFER_SIZE,
-          Selectable.USE_DEFAULT_BUFFER_SIZE,
-          config.requestTimeoutMs,
-          ClientDnsLookup.DEFAULT,
-          time,
-          false,
-          new ApiVersions,
-          logContext)
+        new NetworkClient(selector, metadataUpdater, config.brokerId.toString, 1, 0, 0, Selectable.USE_DEFAULT_BUFFER_SIZE, Selectable.USE_DEFAULT_BUFFER_SIZE, config.requestTimeoutMs, 10*1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions, logContext)
       }
 
       var shutdownSucceeded: Boolean = false

--- a/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
@@ -79,22 +79,7 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
       channelBuilder,
       logContext
     )
-    val networkClient = new NetworkClient(
-      selector,
-      new ManualMetadataUpdater(),
-      clientId,
-      1,
-      0,
-      0,
-      Selectable.USE_DEFAULT_BUFFER_SIZE,
-      brokerConfig.replicaSocketReceiveBufferBytes,
-      brokerConfig.requestTimeoutMs,
-      ClientDnsLookup.DEFAULT,
-      time,
-      false,
-      new ApiVersions,
-      logContext
-    )
+    val networkClient = new NetworkClient(selector, new ManualMetadataUpdater(), clientId, 1, 0, 0, Selectable.USE_DEFAULT_BUFFER_SIZE, brokerConfig.replicaSocketReceiveBufferBytes, brokerConfig.requestTimeoutMs, 10*1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions, logContext)
     (networkClient, reconfigurableChannelBuilder)
   }
 

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -469,22 +469,7 @@ private class ReplicaFetcherBlockingSend(sourceNode: Node,
       channelBuilder,
       logContext
     )
-    new NetworkClient(
-      selector,
-      new ManualMetadataUpdater(),
-      clientId,
-      1,
-      0,
-      0,
-      Selectable.USE_DEFAULT_BUFFER_SIZE,
-      consumerConfig.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
-      consumerConfig.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-      ClientDnsLookup.DEFAULT,
-      time,
-      false,
-      new ApiVersions,
-      logContext
-    )
+    new NetworkClient(selector, new ManualMetadataUpdater(), clientId, 1, 0, 0, Selectable.USE_DEFAULT_BUFFER_SIZE, consumerConfig.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG), consumerConfig.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), 10*1000, ClientDnsLookup.DEFAULT, time, false, new ApiVersions, logContext)
   }
 
   def sendRequest(requestBuilder: Builder[_ <: AbstractRequest]): ClientResponse = {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -174,7 +174,7 @@ public class ConnectionStressWorker implements TaskWorker {
                             4096,
                             4096,
                             1000,
-                            ClientDnsLookup.forConfig(conf.getString(AdminClientConfig.CLIENT_DNS_LOOKUP_CONFIG)),
+                                10 * 1000, ClientDnsLookup.forConfig(conf.getString(AdminClientConfig.CLIENT_DNS_LOOKUP_CONFIG)),
                             TIME,
                             false,
                             new ApiVersions(),


### PR DESCRIPTION
*More detailed description of your change,

**Selector**
The Selector class will now take the new config CONNECTIONS_TIMEOUT_MS_CONFIG in its constructions. 


**idleExpiryManager**
Currently, we have an idleExpiryManager that uses the LRU algorithm evicting the oldest idle connected socket channels. Similarly, we can instantiate a new LinkedHashMap to keep those socket channels initiating the connection and evict the timeout channels.

Currently, all the channels will be kept on the same LRU map. We will split the connected socket channels and connecting socket channels into different LRU map (we will call them "lruConnectingConnections" and "lruConnectedConnections" later).

Here's the state transition:

When the socket channel is initiating the connection, we will put the socket channel to the lruConnectingConnections.

When the connection is successfully built, we will move the channel from lruConnectingConnections into lruConnectedConnections.

In each selector poll, we will remove the oldest timeout socket channel in both lruConnectingConnections and lruConnectedConnections, if possible.


**LeastLoadedNodeProvider**
Currently, when no nodes provided in --boostrap-server option is connected, the LeastLoadedNodeProvider will provide an unconnected node for the client. The Cluster class shuffled the nodes to balance the initial pressure and the LeastLoadedNodeProvider will always provide the same node, which is the last node after shuffling. Consequently, though we may provide several bootstrap servers, the client not be able to connect to the cluster if any of the servers in the --bootstrap-server list is offline.

I'm changing the provider to interact with the ClusterConnectionStates to determine which node to provide when no connection exists.


**ClusterConnectionStates**
ClusterConnectionStates will keep the index of the most recently provided node. Meanwhile, a public API looks like below will be added to simulate the round-robin node picking.

public synchronized int nextNodeIdx(int nodeSize) {
          return (this.nextNodeIdx++) % nodeSize;
}

The LeastLoadedNodeProvider will provide the nodeSize to prevent the out of bound excpetion. 

When the LeastLoadedNodeProvider iterates the node list, it can consult the ClusterConnectionStates for the index of the node it should provide.


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
