### PR TITLE
MINOR: smoke test for jmh benchmark functionality

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -32,7 +32,7 @@
 # Verify that at least one JMH benchmark is able to compile and be run
 # runs this benchmark with 0 warmup forks, 0 warmup iterations
 ./jmh-benchmarks/jmh.sh -wf 0 -f 1 -wi 0 -i 1 org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance \
-    || { echo 'Benchmark steps failed'; exit 1; }
+    || { echo 'Benchmark smoke test step failed'; exit 1; }
 
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then
   echo "Skipping Kafka Streams archetype test for Java 11"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -31,7 +31,8 @@
 
 # Verify that at least one JMH benchmark is able to compile and be run
 # runs this benchmark with 0 warmup forks, 0 warmup iterations
-./jmh-benchmarks/jmh.sh -wf 0 -f 1 -wi 0 -i 1 org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance 
+./jmh-benchmarks/jmh.sh -wf 0 -f 1 -wi 0 -i 1 org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance \
+    || { echo 'Benchmark steps failed'; exit 1; }
 
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then
   echo "Skipping Kafka Streams archetype test for Java 11"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -30,6 +30,7 @@
     || { echo 'Test steps failed'; exit 1; }
 
 # Verify that at least one JMH benchmark is able to compile and be run
+# runs this benchmark with 0 warmup forks, 0 warmup iterations
 ./jmh-benchmarks/jmh.sh -wf 0 -f 1 -wi 0 -i 1 org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance 
 
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -29,6 +29,9 @@
     --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
     || { echo 'Test steps failed'; exit 1; }
 
+# Verify that at least one JMH benchmark is able to compile and be run
+./jmh-benchmarks/jmh.sh -wf 0 -f 1 -wi 0 -i 1 org.apache.kafka.jmh.cache.LRUCacheBenchmark.testCachePerformance 
+
 if [ $JAVA_HOME = "/home/jenkins/tools/java/latest11" ] ; then
   echo "Skipping Kafka Streams archetype test for Java 11"
   exit 0


### PR DESCRIPTION
Adds a smoke test to run a single jmh benchmark on each CI build. Without this change it is possible for the jmh benchmarks to break if we change our build setup.