### PR TITLE
KAFKA-9918 SslEngineFactory is NOT closed when channel is closing

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -236,6 +236,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
         loginManagers.clear();
         for (AuthenticateCallbackHandler handler : saslCallbackHandlers.values())
             handler.close();
+        if (sslFactory != null) sslFactory.close();
     }
 
     // Visible to override for testing

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -112,7 +112,9 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        if (sslFactory != null) sslFactory.close();
+    }
 
     protected SslTransportLayer buildTransportLayer(SslFactory sslFactory, String id, SelectionKey key,
                                                     String host, ChannelMetadataRegistry metadataRegistry) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -47,7 +48,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 
-public class SslFactory implements Reconfigurable {
+public class SslFactory implements Reconfigurable, Closeable {
     private static final Logger log = LoggerFactory.getLogger(SslFactory.class);
 
     private final Mode mode;
@@ -228,6 +229,11 @@ public class SslFactory implements Reconfigurable {
         if (srcMap.containsKey(key)) {
             destMap.put(key, srcMap.get(key));
         }
+    }
+
+    @Override
+    public void close() {
+        Utils.closeQuietly(sslEngineFactory, "close engine factory");
     }
 
     static class CertificateEntries {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -385,6 +385,22 @@ public class SslFactoryTest {
                 sslFactory.sslEngineFactory() instanceof TestSslUtils.TestSslEngineFactory);
     }
 
+    @Test
+    public void testEngineFactoryClosed() throws Exception {
+        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
+                .createNewTrustStore(trustStoreFile)
+                .useClientCert(false)
+                .build();
+        clientSslConfig.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
+        SslFactory sslFactory = new SslFactory(Mode.CLIENT);
+        sslFactory.configure(clientSslConfig);
+        TestSslUtils.TestSslEngineFactory engine = (TestSslUtils.TestSslEngineFactory) sslFactory.sslEngineFactory();
+        assertFalse(engine.closed);
+        sslFactory.close();
+        assertTrue(engine.closed);
+    }
+
     /**
      * Tests server side ssl.engine.factory configuration is used when specified
      */

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -367,6 +367,8 @@ public class TestSslUtils {
 
     public static final class TestSslEngineFactory implements SslEngineFactory {
 
+        public boolean closed = false;
+
         DefaultSslEngineFactory defaultSslEngineFactory = new DefaultSslEngineFactory();
 
         @Override
@@ -402,6 +404,7 @@ public class TestSslUtils {
         @Override
         public void close() throws IOException {
             defaultSslEngineFactory.close();
+            closed = true;
         }
 
         @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9918

the default implementation (**DefaultSslEngineFactory**) does not have any releasable object so we didn't notice this issue. However, it would be better to fix this issue for the custom engine factory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
