### PR TITLE
KAFKA-9919: Add logging to KafkaBasedLog::readToLogEnd

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -285,14 +285,11 @@ public class KafkaBasedLog<K, V> {
                 Long endOffset = entry.getValue();
                 long lastConsumedOffset = consumer.position(topicPartition);
                 if (lastConsumedOffset >= endOffset) {
-                    log.trace("Reached end offset {} for {}", endOffset, topicPartition);
+                    log.trace("Read to end offset {} for {}", endOffset, topicPartition);
                     it.remove();
                 } else {
-                    log.trace(
-                        "Behind end offset {} for {}; last-consumed offset is {}",
-                        endOffset,
-                        topicPartition,
-                        lastConsumedOffset);
+                    log.trace("Behind end offset {} for {}; last-consumed offset is {}",
+                            endOffset, topicPartition, lastConsumedOffset);
                     poll(Integer.MAX_VALUE);
                     break;
                 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -282,13 +282,13 @@ public class KafkaBasedLog<K, V> {
             while (it.hasNext()) {
                 Map.Entry<TopicPartition, Long> entry = it.next();
                 TopicPartition topicPartition = entry.getKey();
-                Long endOffset = entry.getValue();
+                long endOffset = entry.getValue();
                 long lastConsumedOffset = consumer.position(topicPartition);
                 if (lastConsumedOffset >= endOffset) {
                     log.trace("Read to end offset {} for {}", endOffset, topicPartition);
                     it.remove();
                 } else {
-                    log.trace("Behind end offset {} for {}; last-consumed offset is {}",
+                    log.trace("Behind end offset {} for {}; last-read offset is {}",
                             endOffset, topicPartition, lastConsumedOffset);
                     poll(Integer.MAX_VALUE);
                     break;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -281,9 +281,18 @@ public class KafkaBasedLog<K, V> {
             Iterator<Map.Entry<TopicPartition, Long>> it = endOffsets.entrySet().iterator();
             while (it.hasNext()) {
                 Map.Entry<TopicPartition, Long> entry = it.next();
-                if (consumer.position(entry.getKey()) >= entry.getValue())
+                TopicPartition topicPartition = entry.getKey();
+                Long endOffset = entry.getValue();
+                long lastConsumedOffset = consumer.position(topicPartition);
+                if (lastConsumedOffset >= endOffset) {
+                    log.trace("Reached end offset {} for {}", endOffset, topicPartition);
                     it.remove();
-                else {
+                } else {
+                    log.trace(
+                        "Behind end offset {} for {}; last-consumed offset is {}",
+                        endOffset,
+                        topicPartition,
+                        lastConsumedOffset);
                     poll(Integer.MAX_VALUE);
                     break;
                 }


### PR DESCRIPTION
[Jira ticket](https://issues.apache.org/jira/browse/KAFKA-9919)

Just some simple logging additions that should make life easier when the worker can't get caught up to the end of an internal topic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
