### PR TITLE
KAFKA-9920:Fix NetworkDegradeTest.test_rate test error

### DIFF
--- a/tests/kafkatest/tests/core/network_degrade_test.py
+++ b/tests/kafkatest/tests/core/network_degrade_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import re
+import time
 
 from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
@@ -102,6 +103,8 @@ class NetworkDegradeTest(Test):
                    timeout_sec=10,
                    err_msg="%s failed to start within 10 seconds." % rate_limit)
 
+        # rate_limt doesn't take effect immediately after starting. Wait a few seconds
+        time.sleep(15)
         # Run iperf server on zk1, iperf client on zk0
         iperf_server = zk1.account.ssh_capture("iperf -s")
 


### PR DESCRIPTION
The test case of kafkatest.tests.core.network_degrade_test.NetworkDegradeTest.test_rate.
rate_limit_kbit=1000000.device_name=eth0.task_name=rate-1000-latency-50.latency_ms=50
failed. And the error log was "Expected most of the measured rates to be within an order
of magnitude of target 1000000. This means `tc` did not limit the bandwidth as expected."
It was because that the rate_limt didn't take immediately after starting.

Change-Id: I2de1d3fc696e11b411986bb2e3ce43f074fbac4a
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
