### PR TITLE
MINOR: Update raft broken link

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -366,7 +366,7 @@
     <p>
     There are a rich variety of algorithms in this family including ZooKeeper's
     <a href="http://web.archive.org/web/20140602093727/http://www.stanford.edu/class/cs347/reading/zab.pdf">Zab</a>,
-    <a href="https://www.usenix.org/conference/atc14/technical-sessions/presentation/ongaro">Raft</a>,
+    <a href="https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf">Raft</a>,
     and <a href="http://pmg.csail.mit.edu/papers/vr-revisited.pdf">Viewstamped Replication</a>.
     The most similar academic publication we are aware of to Kafka's actual implementation is
     <a href="http://research.microsoft.com/apps/pubs/default.aspx?id=66814">PacificA</a> from Microsoft.

--- a/docs/design.html
+++ b/docs/design.html
@@ -366,7 +366,7 @@
     <p>
     There are a rich variety of algorithms in this family including ZooKeeper's
     <a href="http://web.archive.org/web/20140602093727/http://www.stanford.edu/class/cs347/reading/zab.pdf">Zab</a>,
-    <a href="https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf">Raft</a>,
+    <a href="https://www.usenix.org/conference/atc14/technical-sessions/presentation/ongaro">Raft</a>,
     and <a href="http://pmg.csail.mit.edu/papers/vr-revisited.pdf">Viewstamped Replication</a>.
     The most similar academic publication we are aware of to Kafka's actual implementation is
     <a href="http://research.microsoft.com/apps/pubs/default.aspx?id=66814">PacificA</a> from Microsoft.


### PR DESCRIPTION
Update the raft introduction link. The old link is not accessible now. Update to the official usenix conference link where the raft paper published. It also contains the paper introduction, paper pdf, and presentation video/audio in this link.

old broken link: https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf
new link: https://www.usenix.org/conference/atc14/technical-sessions/presentation/ongaro

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
