### PR TITLE
Test compilation fixes for Scala 2.11

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConcurrencyTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
@@ -94,7 +95,7 @@ class LogConcurrencyTest {
           isolation = FetchHighWatermark,
           minOneMessage = true
         )
-        readInfo.records.batches().forEach { batch =>
+        readInfo.records.batches().asScala.foreach { batch =>
           consumedBatches += FetchedBatch(batch.baseOffset, batch.partitionLeaderEpoch)
           fetchOffset = batch.lastOffset + 1
         }
@@ -156,7 +157,7 @@ class LogConcurrencyTest {
   private def validateConsumedData(log: Log, consumedBatches: Iterable[FetchedBatch]): Unit = {
     val iter = consumedBatches.iterator
     log.logSegments.foreach { segment =>
-      segment.log.batches.forEach { batch =>
+      segment.log.batches.asScala.foreach { batch =>
         if (iter.hasNext) {
           val consumedBatch = iter.next()
           try {

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -245,9 +245,10 @@ class ReplicaAlterLogDirsThreadTest {
       responseCallback = callbackCaptor.capture(),
       isolationLevel = ArgumentMatchers.eq(IsolationLevel.READ_UNCOMMITTED),
       clientMetadata = ArgumentMatchers.eq(None)
-    )) thenAnswer new Answer[Unit] {
+    ))
+    .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = callbackCaptor.getValue.apply(Seq((topicPartition, responseData)))
-    }
+    })
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -35,6 +35,8 @@ import org.easymock.{Capture, CaptureType, EasyMock, IAnswer, IExpectationSetter
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.Mockito.{doNothing, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
 
 import scala.collection.{Map, Seq}
@@ -243,9 +245,9 @@ class ReplicaAlterLogDirsThreadTest {
       responseCallback = callbackCaptor.capture(),
       isolationLevel = ArgumentMatchers.eq(IsolationLevel.READ_UNCOMMITTED),
       clientMetadata = ArgumentMatchers.eq(None)
-    )).thenAnswer(_ => {
-      callbackCaptor.getValue.apply(Seq((topicPartition, responseData)))
-    })
+    )) thenAnswer new Answer[Unit] {
+      override def answer(invocation: InvocationOnMock): Unit = callbackCaptor.getValue.apply(Seq((topicPartition, responseData)))
+    }
   }
 
   @Test


### PR DESCRIPTION
What
====
Earlier log test changes went into trunk (for KAFKA-9807, KAFKA-9838) and were cherry-picked to 2.4, but they broke the Scala 2.11 build.
This change cherry-picks the fixes needed to make those tests build for 2.11.

Testing
=====
These are compilation errors; rebuild and ran unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
