### PR TITLE
MINOR: Fix broken JMX URL in docs

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -794,7 +794,7 @@
   control your broker or application as well as the platform on which these are running. Note that authentication is disabled for
   JMX by default in Kafka and security configs must be overridden for production deployments by setting the environment variable
   <code>KAFKA_JMX_OPTS</code> for processes started using the CLI or by setting appropriate Java system properties. See
-  <a href=https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html">Monitoring and Management Using JMX Technology</a>
+  <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html">Monitoring and Management Using JMX Technology</a>
   for details on securing JMX.
   <p>
   We do graphing and alerting on the following metrics:


### PR DESCRIPTION
The "Monitoring and Management Using JMX Technology" link on the operations page is broken because of a missing double quote in the html a tag.

1. Open http://kafka.apache.org/documentation/#operations and search for "JMX Technology"
2. Click the "Monitoring and Management Using JMX Technology" link, you will get "Page not found
" error 
3. notice the URL in the browser address bar, there is a extra double quote at end of the URL https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html"
