### PR TITLE
MINOR: Fix partition numbering from 0 to P-1 instead of P in docs

### DIFF
--- a/docs/protocol.html
+++ b/docs/protocol.html
@@ -75,7 +75,7 @@
 
 <h5><a id="protocol_partitioning" href="#protocol_partitioning">Partitioning and bootstrapping</a></h5>
 
-<p>Kafka is a partitioned system so not all servers have the complete data set. Instead recall that topics are split into a pre-defined number of partitions, P, and each partition is replicated with some replication factor, N. Topic partitions themselves are just ordered "commit logs" numbered 0, 1, ..., P.</p>
+<p>Kafka is a partitioned system so not all servers have the complete data set. Instead recall that topics are split into a pre-defined number of partitions, P, and each partition is replicated with some replication factor, N. Topic partitions themselves are just ordered "commit logs" numbered 0, 1, ..., P-1.</p>
 
 <p>All systems of this nature have the question of how a particular piece of data is assigned to a particular partition. Kafka clients directly control this assignment, the brokers themselves enforce no particular semantics of which messages should be published to a particular partition. Rather, to publish messages the client directly addresses messages to a particular partition, and when fetching messages, fetches from a particular partition. If two clients want to use the same partitioning scheme they must use the same method to compute the mapping of key to partition.</p>
 


### PR DESCRIPTION
nit. Protocol docs describe partition numbers as follows:

> Topic partitions themselves are just ordered "commit logs" numbered 0, 1, ..., P.

I assume this is a typo, as partition numbers start from 0 up to P-1.