### PR TITLE
KAFKA-9832: fix attempt to commit non-running tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -574,6 +574,7 @@ public class StreamThread extends Thread {
                     taskManager.tasks()
                         .values()
                         .stream()
+                        .filter(t -> t.state() == Task.State.RUNNING)
                         .filter(t -> !e.corruptedTaskWithChangelogs().containsKey(t.id()))
                         .collect(Collectors.toSet())
                 );

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -574,7 +574,7 @@ public class StreamThread extends Thread {
                     taskManager.tasks()
                         .values()
                         .stream()
-                        .filter(t -> t.state() == Task.State.RUNNING)
+                        .filter(t -> t.state() == Task.State.RUNNING || t.state() == Task.State.RESTORING)
                         .filter(t -> !e.corruptedTaskWithChangelogs().containsKey(t.id()))
                         .collect(Collectors.toSet())
                 );


### PR DESCRIPTION
Fixes an attempt to commit potentially non-running tasks while recovering from task corruption.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
