### PR TITLE
MINOR: fix docs typo baseTimestamp to firstTimestamp

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -67,7 +67,7 @@
     <p>On compaction: unlike the older message formats, magic v2 and above preserves the first and last offset/sequence numbers from the original batch when the log is cleaned. This is required in order to be able to restore the
     producer's state when the log is reloaded. If we did not retain the last sequence number, for example, then after a partition leader failure, the producer might see an OutOfSequence error. The base sequence number must
     be preserved for duplicate checking (the broker checks incoming Produce requests for duplicates by verifying that the first and last sequence numbers of the incoming batch match the last from that producer). As a result,
-    it is possible to have empty batches in the log when all the records in the batch are cleaned but batch is still retained in order to preserve a producer's last sequence number. One oddity here is that the baseTimestamp
+    it is possible to have empty batches in the log when all the records in the batch are cleaned but batch is still retained in order to preserve a producer's last sequence number. One oddity here is that the firstTimestamp
     field is not preserved during compaction, so it will change if the first record in the batch is compacted away.</p>
 
     <h5><a id="controlbatch" href="#controlbatch">5.3.1.1 Control Batches</a></h5>


### PR DESCRIPTION
nit. `baseTimestamp` is used when `firstTimestamp` is defined on the on-disk format and implementation.