### PR TITLE
KAFKA-9938; Debug consumer should be able to fetch from followers

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -949,8 +949,11 @@ class ReplicaManager(val config: KafkaConfig,
     else
       FetchHighWatermark
 
-    // Restrict fetching to leader if request is from follower or from a client with older version (no ClientMetadata)
-    val fetchOnlyFromLeader = isFromFollower || (isFromConsumer && clientMetadata.isEmpty)
+    // Restrict fetching to leader if request is from follower or from an ordinary consumer
+    // with an older version (which is implied by no ClientMetadata)
+    val fetchOnlyFromLeader = isFromFollower ||
+      (isFromConsumer && clientMetadata.isEmpty && replicaId != Request.DebuggingConsumerId)
+
     def readFromLog(): Seq[(TopicPartition, LogReadResult)] = {
       val result = readFromLocalLog(
         replicaId = replicaId,


### PR DESCRIPTION
There was a minor regression in the fetch protocol introduced in 2.4 as part of the KIP-392 work. We should allow the "debug consumer" to read from follower regardless of the protocol version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
