### PR TITLE
MINOR: Fix broken JMX link by adding missing starting double quote

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -794,7 +794,7 @@
   control your broker or application as well as the platform on which these are running. Note that authentication is disabled for
   JMX by default in Kafka and security configs must be overridden for production deployments by setting the environment variable
   <code>KAFKA_JMX_OPTS</code> for processes started using the CLI or by setting appropriate Java system properties. See
-  <a href=https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html">Monitoring and Management Using JMX Technology</a>
+  <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html">Monitoring and Management Using JMX Technology</a>
   for details on securing JMX.
   <p>
   We do graphing and alerting on the following metrics:


### PR DESCRIPTION
The `href` attribute missed the starting double quote, so the hyperlink is interpreted as `https://docs.oracle.com/.../agent.html"`, with a redundant tailing double quote. Add the missing starting double quote back to fix this issue.

![image](https://user-images.githubusercontent.com/43372967/80663698-5193ff00-8ac7-11ea-817e-885b5b322da8.png)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
