### PR TITLE
HOTFIX: ambiguous reference of Properties#putAll in java 11 and scala…

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -249,7 +249,7 @@ object ConfigCommand extends Config {
     val props = new Properties
     if (opts.options.has(opts.addConfigFile)) {
       val file = opts.options.valueOf(opts.addConfigFile)
-      props.putAll(Utils.loadProps(file))
+      props ++= Utils.loadProps(file)
     }
     if (opts.options.has(opts.addConfig)) {
       // Split list by commas, but avoid those in [], then into KV pairs


### PR DESCRIPTION
this is a bug of scala 2.12 (https://github.com/scala/bug/issues/10418#issuecomment-524582693). 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
