### PR TITLE
MINOR: Fix ProcessorContext JavaDocs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -34,28 +34,28 @@ import java.util.Map;
 public interface ProcessorContext<K, V> {
 
     /**
-     * Returns the application id
+     * Returns the application id.
      *
      * @return the application id
      */
     String applicationId();
 
     /**
-     * Returns the task id
+     * Returns the task id.
      *
      * @return the task id
      */
     TaskId taskId();
 
     /**
-     * Returns the default key serde
+     * Returns the default key serde.
      *
      * @return the key serializer
      */
     Serde<?> keySerde();
 
     /**
-     * Returns the default value serde
+     * Returns the default value serde.
      *
      * @return the value serializer
      */
@@ -69,7 +69,7 @@ public interface ProcessorContext<K, V> {
     File stateDir();
 
     /**
-     * Returns Metrics instance
+     * Returns Metrics instance.
      *
      * @return StreamsMetrics
      */
@@ -188,7 +188,8 @@ public interface ProcessorContext<K, V> {
     <K1 extends K, V1 extends V> void forward(final K1 key, final V1 value, final To to);
 
     /**
-     * Forwards a key/value pair to one of the downstream processors designated by childIndex
+     * Forwards a key/value pair to one of the downstream processors designated by childIndex.
+     *
      * @param key key
      * @param value value
      * @param childIndex index in list of children of this node
@@ -199,7 +200,8 @@ public interface ProcessorContext<K, V> {
     <K1 extends K, V1 extends V> void forward(final K1 key, final V1 value, final int childIndex);
 
     /**
-     * Forwards a key/value pair to one of the downstream processors designated by the downstream processor name
+     * Forwards a key/value pair to one of the downstream processors designated by the downstream processor name.
+     *
      * @param key key
      * @param value value
      * @param childName name of downstream processor
@@ -209,13 +211,13 @@ public interface ProcessorContext<K, V> {
     <K1 extends K, V1 extends V> void forward(final K1 key, final V1 value, final String childName);
 
     /**
-     * Requests a commit
+     * Requests a commit.
      */
     void commit();
 
     /**
      * Returns the topic name of the current input record; could be null if it is not
-     * available (for example, if this method is invoked from the punctuate call)
+     * available (for example, if this method is invoked from the punctuate call).
      *
      * @return the topic name
      */
@@ -223,7 +225,7 @@ public interface ProcessorContext<K, V> {
 
     /**
      * Returns the partition id of the current input record; could be -1 if it is not
-     * available (for example, if this method is invoked from the punctuate call)
+     * available (for example, if this method is invoked from the punctuate call).
      *
      * @return the partition id
      */
@@ -231,14 +233,16 @@ public interface ProcessorContext<K, V> {
 
     /**
      * Returns the offset of the current input record; could be -1 if it is not
-     * available (for example, if this method is invoked from the punctuate call)
+     * available (for example, if this method is invoked from the punctuate call).
      *
      * @return the offset
      */
     long offset();
 
     /**
-     * Returns the headers of the current input record; could be null if it is not available
+     * Returns the headers of the current input record; could be null if it is not
+     * available (for example, if this method is invoked from the punctuate call).
+     *
      * @return the headers
      */
     Headers headers();
@@ -246,12 +250,13 @@ public interface ProcessorContext<K, V> {
     /**
      * Returns the current timestamp.
      *
-     * If it is triggered while processing a record streamed from the source processor, timestamp is defined as the timestamp of the current input record; the timestamp is extracted from
+     * <p> If it is triggered while processing a record streamed from the source processor,
+     * timestamp is defined as the timestamp of the current input record; the timestamp is extracted from
      * {@link org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord} by {@link TimestampExtractor}.
      *
-     * If it is triggered while processing a record generated not from the source processor (for example,
+     * <p> If it is triggered while processing a record generated not from the source processor (for example,
      * if this method is invoked from the punctuate call), timestamp is defined as the current
-     * task's stream time, which is defined as the smallest among all its input stream partition timestamps.
+     * task's stream time, which is defined as the largest among all its input stream partition timestamps.
      *
      * @return the timestamp
      */
@@ -260,10 +265,10 @@ public interface ProcessorContext<K, V> {
     /**
      * Returns all the application config properties as key/value pairs.
      *
-     * The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
+     * <p> The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
      * object and associated to the ProcessorContext.
-     * <p>
-     * The type of the values is dependent on the {@link org.apache.kafka.common.config.ConfigDef.Type type} of the property
+     *
+     * <p> The type of the values is dependent on the {@link org.apache.kafka.common.config.ConfigDef.Type type} of the property
      * (e.g. the value of {@link org.apache.kafka.streams.StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG DEFAULT_KEY_SERDE_CLASS_CONFIG}
      * will be of type {@link Class}, even if it was specified as a String to
      * {@link org.apache.kafka.streams.StreamsConfig#StreamsConfig(Map) StreamsConfig(Map)}).
@@ -276,12 +281,11 @@ public interface ProcessorContext<K, V> {
      * Returns all the application config properties with the given key prefix, as key/value pairs
      * stripping the prefix.
      *
-     * The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
+     * <p> The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
      * object and associated to the ProcessorContext.
      *
      * @param prefix the properties prefix
      * @return the key/values matching the given prefix from the StreamsConfig properties.
-     *
      */
     Map<String, Object> appConfigsWithPrefix(final String prefix);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -256,7 +256,7 @@ public interface ProcessorContext<K, V> {
      *
      * <p> If it is triggered while processing a record generated not from the source processor (for example,
      * if this method is invoked from the punctuate call), timestamp is defined as the current
-     * task's stream time, which is defined as the largest among all its input stream partition timestamps.
+     * task's stream time, which is defined as the largest timestamp of any record processed by the task.
      *
      * @return the timestamp
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -122,6 +122,7 @@ public class RecordQueue {
     public StampedRecord poll() {
         final StampedRecord recordToReturn = headRecord;
         headRecord = null;
+        partitionTime = Math.max(partitionTime, recordToReturn.timestamp);
 
         updateHead();
 
@@ -201,8 +202,6 @@ public class RecordQueue {
                 continue;
             }
             headRecord = new StampedRecord(deserialized, timestamp);
-
-            partitionTime = Math.max(partitionTime, timestamp);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -98,8 +99,8 @@ public class PartitionGroupTest {
     private void testFirstBatch() {
         StampedRecord record;
         final PartitionGroup.RecordInfo info = new PartitionGroup.RecordInfo();
+        assertThat(group.numBuffered(), is(0));
 
-        assertEquals(0, group.numBuffered());
         // add three 3 records with timestamp 1, 3, 5 to partition-1
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
             new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
@@ -120,39 +121,36 @@ public class PartitionGroupTest {
         // st: -1 since no records was being processed yet
 
         verifyBuffered(6, 3, 3);
-        assertEquals(1L, group.partitionTimestamp(partition1));
-        assertEquals(2L, group.partitionTimestamp(partition2));
-        assertEquals(1L, group.headRecordOffset(partition1).longValue());
-        assertEquals(2L, group.headRecordOffset(partition2).longValue());
-        assertEquals(-1L, group.streamTime());
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(group.partitionTimestamp(partition1), is(RecordQueue.UNKNOWN));
+        assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
+        assertThat(group.headRecordOffset(partition1), is(1L));
+        assertThat(group.headRecordOffset(partition2), is(2L));
+        assertThat(group.streamTime(), is(RecordQueue.UNKNOWN));
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, now the time should be advanced
         record = group.nextRecord(info);
         // 1:[3, 5]
         // 2:[2, 4, 6]
         // st: 1
-        assertEquals(partition1, info.partition());
-        assertEquals(3L, group.partitionTimestamp(partition1));
-        assertEquals(2L, group.partitionTimestamp(partition2));
-        assertEquals(3L, group.headRecordOffset(partition1).longValue());
-        assertEquals(2L, group.headRecordOffset(partition2).longValue());
-        assertEquals(1L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition1));
+        assertThat(group.partitionTimestamp(partition1), is(1L));
+        assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
+        assertThat(group.headRecordOffset(partition1), is(3L));
+        assertThat(group.headRecordOffset(partition2), is(2L));
         verifyTimes(record, 1L, 1L);
-        verifyBuffered(5, 2, 3);
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, now the time should be advanced
         record = group.nextRecord(info);
         // 1:[3, 5]
         // 2:[4, 6]
         // st: 2
-        assertEquals(partition2, info.partition());
-        assertEquals(3L, group.partitionTimestamp(partition1));
-        assertEquals(4L, group.partitionTimestamp(partition2));
-        assertEquals(3L, group.headRecordOffset(partition1).longValue());
-        assertEquals(4L, group.headRecordOffset(partition2).longValue());
-        assertEquals(2L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition2));
+        assertThat(group.partitionTimestamp(partition1), is(1L));
+        assertThat(group.partitionTimestamp(partition2), is(2L));
+        assertThat(group.headRecordOffset(partition1), is(3L));
+        assertThat(group.headRecordOffset(partition2), is(4L));
         verifyTimes(record, 2L, 2L);
         verifyBuffered(4, 2, 2);
         assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
@@ -172,102 +170,96 @@ public class PartitionGroupTest {
         // 2:[4, 6]
         // st: 2 (just adding records shouldn't change it)
         verifyBuffered(6, 4, 2);
-        assertEquals(3L, group.partitionTimestamp(partition1));
-        assertEquals(4L, group.partitionTimestamp(partition2));
-        assertEquals(3L, group.headRecordOffset(partition1).longValue());
-        assertEquals(4L, group.headRecordOffset(partition2).longValue());
-        assertEquals(2L, group.streamTime());
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(group.partitionTimestamp(partition1), is(1L));
+        assertThat(group.partitionTimestamp(partition2), is(2L));
+        assertThat(group.headRecordOffset(partition1), is(3L));
+        assertThat(group.headRecordOffset(partition2), is(4L));
+        assertThat(group.streamTime(), is(2L));
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, time should be advanced
         record = group.nextRecord(info);
         // 1:[5, 2, 4]
         // 2:[4, 6]
         // st: 3
-        assertEquals(partition1, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(4L, group.partitionTimestamp(partition2));
-        assertEquals(5L, group.headRecordOffset(partition1).longValue());
-        assertEquals(4L, group.headRecordOffset(partition2).longValue());
-        assertEquals(3L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition1));
+        assertThat(group.partitionTimestamp(partition1), is(3L));
+        assertThat(group.partitionTimestamp(partition2), is(2L));
+        assertThat(group.headRecordOffset(partition1), is(5L));
+        assertThat(group.headRecordOffset(partition2), is(4L));
         verifyTimes(record, 3L, 3L);
         verifyBuffered(5, 3, 2);
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, time should be advanced
         record = group.nextRecord(info);
         // 1:[5, 2, 4]
         // 2:[6]
         // st: 4
-        assertEquals(partition2, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(6L, group.partitionTimestamp(partition2));
-        assertEquals(5L, group.headRecordOffset(partition1).longValue());
-        assertEquals(6L, group.headRecordOffset(partition2).longValue());
-        assertEquals(4L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition2));
+        assertThat(group.partitionTimestamp(partition1), is(3L));
+        assertThat(group.partitionTimestamp(partition2), is(4L));
+        assertThat(group.headRecordOffset(partition1), is(5L));
+        assertThat(group.headRecordOffset(partition2), is(6L));
         verifyTimes(record, 4L, 4L);
         verifyBuffered(4, 3, 1);
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one more record, time should be advanced
         record = group.nextRecord(info);
         // 1:[2, 4]
         // 2:[6]
         // st: 5
-        assertEquals(partition1, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(6L, group.partitionTimestamp(partition2));
-        assertEquals(2L, group.headRecordOffset(partition1).longValue());
-        assertEquals(6L, group.headRecordOffset(partition2).longValue());
-        assertEquals(5L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition1));
+        assertThat(group.partitionTimestamp(partition1), is(5L));
+        assertThat(group.partitionTimestamp(partition2), is(4L));
+        assertThat(group.headRecordOffset(partition1), is(2L));
+        assertThat(group.headRecordOffset(partition2), is(6L));
         verifyTimes(record, 5L, 5L);
         verifyBuffered(3, 2, 1);
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one more record, time should not be advanced
         record = group.nextRecord(info);
         // 1:[4]
         // 2:[6]
         // st: 5
-        assertEquals(partition1, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(6L, group.partitionTimestamp(partition2));
-        assertEquals(4L, group.headRecordOffset(partition1).longValue());
-        assertEquals(6L, group.headRecordOffset(partition2).longValue());
-        assertEquals(5L, group.streamTime());
+        assertThat(info.partition(), equalTo(partition1));
+        assertThat(group.partitionTimestamp(partition1), is(5L));
+        assertThat(group.partitionTimestamp(partition2), is(4L));
+        assertThat(group.headRecordOffset(partition1), is(4L));
+        assertThat(group.headRecordOffset(partition2), is(6L));
         verifyTimes(record, 2L, 5L);
         verifyBuffered(2, 1, 1);
-        assertEquals(3.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(3.0));
 
         // get one more record, time should not be advanced
         record = group.nextRecord(info);
         // 1:[]
         // 2:[6]
         // st: 5
-        assertEquals(partition1, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(6L, group.partitionTimestamp(partition2));
+        assertThat(info.partition(), equalTo(partition1));
+        assertThat(group.partitionTimestamp(partition1), is(5L));
+        assertThat(group.partitionTimestamp(partition2), is(4L));
         assertNull(group.headRecordOffset(partition1));
-        assertEquals(6L, group.headRecordOffset(partition2).longValue());
-        assertEquals(5L, group.streamTime());
+        assertThat(group.headRecordOffset(partition2), is(6L));
         verifyTimes(record, 4L, 5L);
         verifyBuffered(1, 0, 1);
-        assertEquals(1.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(1.0));
 
         // get one more record, time should be advanced
         record = group.nextRecord(info);
         // 1:[]
         // 2:[]
         // st: 6
-        assertEquals(partition2, info.partition());
-        assertEquals(5L, group.partitionTimestamp(partition1));
-        assertEquals(6L, group.partitionTimestamp(partition2));
+        assertThat(info.partition(), equalTo(partition2));
+        assertThat(group.partitionTimestamp(partition1), is(5L));
+        assertThat(group.partitionTimestamp(partition2), is(6L));
         assertNull(group.headRecordOffset(partition1));
         assertNull(group.headRecordOffset(partition2));
-        assertEquals(6L, group.streamTime());
         verifyTimes(record, 6L, 6L);
         verifyBuffered(0, 0, 0);
-        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
+        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
     }
 
     @Test
@@ -319,8 +311,8 @@ public class PartitionGroupTest {
     }
 
     private void verifyTimes(final StampedRecord record, final long recordTime, final long streamTime) {
-        assertEquals(recordTime, record.timestamp);
-        assertEquals(streamTime, group.streamTime());
+        assertThat(record.timestamp, is(recordTime));
+        assertThat(group.streamTime(), is(streamTime));
     }
 
     private void verifyBuffered(final int totalBuffered, final int partitionOneBuffered, final int partitionTwoBuffered) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -192,11 +193,11 @@ public class RecordQueueTest {
     }
 
     @Test
-    public void shouldTrackPartitionTimeAsMaxSeenTimestamp() {
-
+    public void shouldTrackPartitionTimeAsMaxProcessedTimestamp() {
         assertTrue(queue.isEmpty());
-        assertEquals(0, queue.size());
-        assertEquals(RecordQueue.UNKNOWN, queue.headRecordTimestamp());
+        assertThat(queue.size(), is(0));
+        assertThat(queue.headRecordTimestamp(), is(RecordQueue.UNKNOWN));
+        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
 
         // add three 3 out-of-order records with timestamp 2, 1, 3, 4
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
@@ -205,25 +206,28 @@ public class RecordQueueTest {
             new ConsumerRecord<>("topic", 1, 3, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue),
             new ConsumerRecord<>("topic", 1, 4, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue));
 
-        assertEquals(queue.partitionTime(), RecordQueue.UNKNOWN);
-
         queue.addRawRecords(list1);
-
-        assertEquals(queue.partitionTime(), 2L);
-
-        queue.poll();
-        assertEquals(queue.partitionTime(), 2L);
+        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
 
         queue.poll();
-        assertEquals(queue.partitionTime(), 3L);
+        assertThat(queue.partitionTime(), is(2L));
+
+        queue.poll();
+        assertThat(queue.partitionTime(), is(2L));
+
+        queue.poll();
+        assertThat(queue.partitionTime(), is(3L));
     }
 
     @Test
     public void shouldSetTimestampAndRespectMaxTimestampPolicy() {
         assertTrue(queue.isEmpty());
-        assertEquals(0, queue.size());
-        assertEquals(RecordQueue.UNKNOWN, queue.headRecordTimestamp());
+        assertThat(queue.size(), is(0));
+        assertThat(queue.headRecordTimestamp(), is(RecordQueue.UNKNOWN));
+        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
+
         queue.setPartitionTime(150L);
+        assertThat(queue.partitionTime(), is(150L));
 
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
             new ConsumerRecord<>("topic", 1, 200, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue),
@@ -231,18 +235,17 @@ public class RecordQueueTest {
             new ConsumerRecord<>("topic", 1, 300, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue),
             new ConsumerRecord<>("topic", 1, 400, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue));
 
-        assertEquals(150L, queue.partitionTime());
-
         queue.addRawRecords(list1);
+        assertThat(queue.partitionTime(), is(150L));
 
-        assertEquals(200L, queue.partitionTime());
+        queue.poll();
+        assertThat(queue.partitionTime(), is(200L));
 
         queue.setPartitionTime(500L);
-        queue.poll();
-        assertEquals(500L, queue.partitionTime());
+        assertThat(queue.partitionTime(), is(500L));
 
         queue.poll();
-        assertEquals(500L, queue.partitionTime());
+        assertThat(queue.partitionTime(), is(500L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -784,12 +784,18 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
 
-        task.addRecords(partition1, Arrays.asList(getConsumerRecord(partition1, 0L), getConsumerRecord(partition1, 5L)));
+        task.addRecords(partition1, Arrays.asList(
+            getConsumerRecord(partition1, 0L),
+            getConsumerRecord(partition1, 3L),
+            getConsumerRecord(partition1, 5L)));
+
         task.process(0L);
+        task.process(0L);
+
         task.prepareCommit();
         final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = task.committableOffsetsAndMetadata();
 
-        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, encodeTimestamp(5L))))));
+        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, encodeTimestamp(3L))))));
     }
 
     @Test


### PR DESCRIPTION
We changed how "stream time" is computed in `2.3` release. This should be cherry-picked to older branches.