### PR TITLE
KAFKA-9731: No need to propagate HWM to followers when using default …

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1079,9 +1079,10 @@ class ReplicaManager(val config: KafkaConfig,
             fetchOnlyFromLeader = fetchOnlyFromLeader,
             minOneMessage = minOneMessage)
 
+          // If there is non-default ReplicaSelector, we need to propagate the HWM to followers
           // Check if the HW known to the follower is behind the actual HW
-          val followerNeedsHwUpdate: Boolean = partition.getReplica(replicaId)
-            .exists(replica => replica.lastSentHighWatermark < readInfo.highWatermark)
+          val followerNeedsHwUpdate: Boolean = replicaSelectorOpt.nonEmpty &&
+            partition.getReplica(replicaId).exists(replica => replica.lastSentHighWatermark < readInfo.highWatermark)
 
           val fetchDataInfo = if (shouldLeaderThrottle(quota, partition, replicaId)) {
             // If the partition is being throttled, simply return an empty set.


### PR DESCRIPTION
Attempted fix to the unnecessary fetch request responses detected by @vahidhashemian in KAFKA-9731. 

I did not add tests (under the assumption that the correctness of HWM propagation is already tested, and those tests will validate my change). I also didn't attempt to reproduce the issue that Vahid spotted, but rather implemented the solution he suggested.