### PR TITLE
KAFKA-9950: Construct new ConfigDef for MirrorTaskConfig before defining new properties

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorTaskConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorTaskConfig.java
@@ -59,7 +59,7 @@ public class MirrorTaskConfig extends MirrorConnectorConfig {
         return metrics;
     }
  
-    protected static final ConfigDef TASK_CONFIG_DEF = CONNECTOR_CONFIG_DEF
+    protected static final ConfigDef TASK_CONFIG_DEF = new ConfigDef(CONNECTOR_CONFIG_DEF)
         .define(
             TASK_TOPIC_PARTITIONS,
             ConfigDef.Type.LIST,


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-9950)

MM2 is currently sharing the same `ConfigDef` object for all its connectors and tasks, which would be fine _if_ that object were used as-is. However, the `MirrorTaskConfig` class mutates the `ConfigDef` by defining additional properties, which leads to a potential `ConcurrentModificationException` during worker configuration validation and unintended inclusion of those new properties in the `ConfigDef` for the connectors which in turn is then visible via the REST API's `/connectors/{name}/config/validate` endpoint.

The fix here is a one-liner that just creates a copy of the `ConfigDef` before defining new properties.

A unit test is added that fails without this fix and passes with it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
