### PR TITLE
KAKFA-9942: --entity-default flag is not working for alternating / describing configs in AdminClient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/quota/ClientQuotaFilterComponent.java
+++ b/clients/src/main/java/org/apache/kafka/common/quota/ClientQuotaFilterComponent.java
@@ -59,7 +59,7 @@ public class ClientQuotaFilterComponent {
      * @param entityType the entity type the filter component applies to
      */
     public static ClientQuotaFilterComponent ofDefaultEntity(String entityType) {
-        return new ClientQuotaFilterComponent(entityType, Optional.empty());
+        return new ClientQuotaFilterComponent(entityType, null);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java
@@ -50,6 +50,9 @@ public class Sanitizer {
      * using URL-encoding.
      */
     public static String sanitize(String name) {
+        if (name.equals("<default>"))
+            return name;
+
         String encoded = "";
         try {
             encoded = URLEncoder.encode(name, StandardCharsets.UTF_8.name());

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -39,9 +39,9 @@ import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, S
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
 import org.apache.zookeeper.client.ZKClientConfig
 
-import scala.collection.JavaConverters._
+import scala.annotation.nowarn
+import scala.jdk.CollectionConverters._
 import scala.collection._
-
 
 /**
  * This script can be used to change configs for topics/clients/users/brokers dynamically
@@ -247,6 +247,10 @@ object ConfigCommand extends Config {
 
   private[admin] def parseConfigsToBeAdded(opts: ConfigCommandOptions): Properties = {
     val props = new Properties
+    if (opts.options.has(opts.addConfigFile)) {
+      val file = opts.options.valueOf(opts.addConfigFile)
+      props ++= Utils.loadProps(file)
+    }
     if (opts.options.has(opts.addConfig)) {
       // Split list by commas, but avoid those in [], then into KV pairs
       // Each KV pair is of format key=value, split them into key and value, using -1 as the limit for split() to
@@ -258,10 +262,10 @@ object ConfigCommand extends Config {
       require(configsToBeAdded.forall(config => config.length == 2), "Invalid entity config: all configs to be added must be in the format \"key=val\".")
       //Create properties, parsing square brackets from values if necessary
       configsToBeAdded.foreach(pair => props.setProperty(pair(0).trim, pair(1).replaceAll("\\[?\\]?", "").trim))
-      if (props.containsKey(LogConfig.MessageFormatVersionProp)) {
-        println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
-          s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
-      }
+    }
+    if (props.containsKey(LogConfig.MessageFormatVersionProp)) {
+      println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
+        s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
     }
     props
   }
@@ -285,7 +289,6 @@ object ConfigCommand extends Config {
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
     val adminClient = Admin.create(props)
 
-    warn(s"entityTypes = ${opts.entityTypes} entityNames = ${opts.entityNames}")
     if (opts.options.has(opts.alterOpt) && opts.entityTypes.size != opts.entityNames.size)
       throw new IllegalArgumentException(s"An entity name must be specified for every entity type")
 
@@ -299,6 +302,7 @@ object ConfigCommand extends Config {
     }
   }
 
+  @nowarn("cat=deprecation")
   private[admin] def alterConfig(adminClient: Admin, opts: ConfigCommandOptions): Unit = {
     val entityTypes = opts.entityTypes
     val entityNames = opts.entityNames
@@ -474,11 +478,10 @@ object ConfigCommand extends Config {
   }
 
   private def describeClientQuotasConfig(adminClient: Admin, entityTypes: List[String], entityNames: List[String]) = {
-    warn(s"entityNames = $entityNames")
     getAllClientQuotasConfigs(adminClient, entityTypes, entityNames).foreach { case (entity, entries) =>
       val entityEntries = entity.entries.asScala
-      val entityStr = (entityEntries.get(ClientQuotaEntity.USER).map(u => s"user-principal '${Option(u).filterNot(_.isEmpty).getOrElse("default")}'") ++
-        entityEntries.get(ClientQuotaEntity.CLIENT_ID).map(c => s"client-id '${Option(c).filterNot(_.isEmpty).getOrElse("default")}'")).mkString(", ")
+      val entityStr = (entityEntries.get(ClientQuotaEntity.USER).map(u => s"user-principal '${u}'") ++
+        entityEntries.get(ClientQuotaEntity.CLIENT_ID).map(c => s"client-id '${c}'")).mkString(", ")
       val entriesStr = entries.asScala.map(e => s"${e._1}=${e._2}").mkString(", ")
       println(s"Configs for ${entityStr} are ${entriesStr}")
     }
@@ -646,6 +649,9 @@ object ConfigCommand extends Config {
             s"Entity types '${ConfigType.User}' and '${ConfigType.Client}' may be specified together to update config for clients of a specific user.")
             .withRequiredArg
             .ofType(classOf[String])
+    val addConfigFile = parser.accepts("add-config-file", "Path to a properties file with configs to add. See add-config for a list of valid configurations.")
+            .withRequiredArg
+            .ofType(classOf[String])
     val deleteConfig = parser.accepts("delete-config", "config keys to remove 'k1,k2'")
             .withRequiredArg
             .ofType(classOf[String])
@@ -765,10 +771,15 @@ object ConfigCommand extends Config {
         } else if (!hasEntityName)
           throw new IllegalArgumentException(s"an entity name must be specified with --alter of ${entityTypeVals.mkString(",")}")
 
-        val isAddConfigPresent: Boolean = options.has(addConfig)
-        val isDeleteConfigPresent: Boolean = options.has(deleteConfig)
-        if (!isAddConfigPresent && !isDeleteConfigPresent)
-          throw new IllegalArgumentException("At least one of --add-config or --delete-config must be specified with --alter")
+        val isAddConfigPresent = options.has(addConfig)
+        val isAddConfigFilePresent = options.has(addConfigFile)
+        val isDeleteConfigPresent = options.has(deleteConfig)
+
+        if(isAddConfigPresent && isAddConfigFilePresent)
+          throw new IllegalArgumentException("Only one of --add-config or --add-config-file must be specified")
+
+        if(!isAddConfigPresent && !isAddConfigFilePresent && !isDeleteConfigPresent)
+          throw new IllegalArgumentException("At least one of --add-config, --add-config-file, or --delete-config must be specified with --alter")
       }
     }
   }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -285,6 +285,7 @@ object ConfigCommand extends Config {
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
     val adminClient = Admin.create(props)
 
+    warn(s"entityTypes = ${opts.entityTypes} entityNames = ${opts.entityNames}")
     if (opts.options.has(opts.alterOpt) && opts.entityTypes.size != opts.entityNames.size)
       throw new IllegalArgumentException(s"An entity name must be specified for every entity type")
 
@@ -473,10 +474,11 @@ object ConfigCommand extends Config {
   }
 
   private def describeClientQuotasConfig(adminClient: Admin, entityTypes: List[String], entityNames: List[String]) = {
+    warn(s"entityNames = $entityNames")
     getAllClientQuotasConfigs(adminClient, entityTypes, entityNames).foreach { case (entity, entries) =>
       val entityEntries = entity.entries.asScala
-      val entityStr = (entityEntries.get(ClientQuotaEntity.USER).map(u => s"user-principal '${u}'") ++
-        entityEntries.get(ClientQuotaEntity.CLIENT_ID).map(c => s"client-id '${c}'")).mkString(", ")
+      val entityStr = (entityEntries.get(ClientQuotaEntity.USER).map(u => s"user-principal '${Option(u).filterNot(_.isEmpty).getOrElse("default")}'") ++
+        entityEntries.get(ClientQuotaEntity.CLIENT_ID).map(c => s"client-id '${Option(c).filterNot(_.isEmpty).getOrElse("default")}'")).mkString(", ")
       val entriesStr = entries.asScala.map(e => s"${e._1}=${e._2}").mkString(", ")
       println(s"Configs for ${entityStr} are ${entriesStr}")
     }

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -329,11 +329,13 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   def getEntityConfigs(rootEntityType: String, sanitizedEntityName: String): Properties = {
     val getDataRequest = GetDataRequest(ConfigEntityZNode.path(rootEntityType, sanitizedEntityName))
     val getDataResponse = retryRequestUntilConnected(getDataRequest)
-
+    warn(s"rootEntityType = $rootEntityType sanitizedEntityName = $sanitizedEntityName")
     getDataResponse.resultCode match {
       case Code.OK =>
         ConfigEntityZNode.decode(getDataResponse.data)
-      case Code.NONODE => new Properties()
+      case Code.NONODE =>
+        warn(s"Code.NONODE reached, creating empty properties")
+        new Properties()
       case _ => throw getDataResponse.resultException.get
     }
   }

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -26,7 +26,7 @@ import org.junit.Test
 
 import java.util.concurrent.{ExecutionException, TimeUnit}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ClientQuotasRequestTest extends BaseRequestTest {
   private val ConsumerByteRateProp = DynamicConfig.Client.ConsumerByteRateOverrideProp
@@ -163,6 +163,18 @@ class ClientQuotasRequestTest extends BaseRequestTest {
   }
 
   @Test(expected = classOf[InvalidRequestException])
+  def testAlterClientQuotasBadUser(): Unit = {
+    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "")).asJava)
+    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
+  }
+
+  @Test(expected = classOf[InvalidRequestException])
+  def testAlterClientQuotasBadClientId(): Unit = {
+    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.CLIENT_ID -> "")).asJava)
+    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
+  }
+
+  @Test(expected = classOf[InvalidRequestException])
   def testAlterClientQuotasBadEntityType(): Unit = {
     val entity = new ClientQuotaEntity(Map(("" -> "name")).asJava)
     alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
@@ -260,7 +272,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
   def testDescribeClientQuotasMatchPartial(): Unit = {
     setupDescribeClientQuotasMatchTest()
 
-    def testMatchEntities(filter: ClientQuotaFilter, expectedMatchSize: Int, partition: ClientQuotaEntity => Boolean) {
+    def testMatchEntities(filter: ClientQuotaFilter, expectedMatchSize: Int, partition: ClientQuotaEntity => Boolean): Unit = {
       val result = describeClientQuotas(filter)
       val (expectedMatches, expectedNonMatches) = matchEntities.partition(e => partition(e._1))
       assertEquals(expectedMatchSize, expectedMatches.size)  // for test verification
@@ -347,7 +359,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
   }
 
   @Test
-  def testClientQuotasUnsupportedEntityTypes() {
+  def testClientQuotasUnsupportedEntityTypes(): Unit = {
     val entity = new ClientQuotaEntity(Map(("other" -> "name")).asJava)
     try {
       verifyDescribeEntityQuotas(entity, Map())

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -163,18 +163,6 @@ class ClientQuotasRequestTest extends BaseRequestTest {
   }
 
   @Test(expected = classOf[InvalidRequestException])
-  def testAlterClientQuotasBadUser(): Unit = {
-    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "")).asJava)
-    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
-  }
-
-  @Test(expected = classOf[InvalidRequestException])
-  def testAlterClientQuotasBadClientId(): Unit = {
-    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.CLIENT_ID -> "")).asJava)
-    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
-  }
-
-  @Test(expected = classOf[InvalidRequestException])
   def testAlterClientQuotasBadEntityType(): Unit = {
     val entity = new ClientQuotaEntity(Map(("" -> "name")).asJava)
     alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)


### PR DESCRIPTION
*More detailed description of your change,
The client-side passes an empty string "" to the server controller indicating that the quota changes apply to the default entity. However, the server logic fails to convert the empty string to "<default>", which will lead to the query for zk node "/config/" and cause an exception.

Will remove all the warning level log before merge.

*Summary of testing strategy (including rationale)
Tested all the failed commands in the corresponding Jira ticket, except alter the default quota configs for entity type user, as the API hasn't been implemented.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
