### PR TITLE
KAFKA-8120 Getting NegativeArraySizeException when using Kafka Connect

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamBuffer.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamBuffer.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.file;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+  This class handles internal input stream, buffered reader and character buffer for a FileStreamSourceTask
+  @see FileStreamSourceTask
+ */
+class FileStreamBuffer {
+    private static final Logger log = LoggerFactory.getLogger(FileStreamBuffer.class);
+    private boolean needExtendBuffer = false;
+    private String filename;
+    private InputStream stream;
+    private BufferedReader reader = null;
+    private char[] buffer = new char[1024];
+    private int offset = 0;
+    static int maxBufferSize = Integer.MAX_VALUE;
+    Long streamOffset;
+    int nread;
+
+    FileStreamBuffer(){};
+
+    /**
+     * Create the input stream and buffered reader using the file name provided,
+     * if the file does not exist, wait 1 second and return false;
+     * skip to the stored offset if there is one. error out if skip fail.
+     */
+    boolean ensureOpen(FileStreamSourceTask.OffsetStorageReader offsetStorageReader) throws InterruptedException {
+        if (stream == null) {
+            if (filename == null || filename.isEmpty()) {
+                stream = System.in;
+                // Tracking offset for stdin doesn't make sense
+                streamOffset = null;
+                reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            } else {
+                try {
+                    stream = Files.newInputStream(Paths.get(filename));
+                    reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+                    Map<String, Object> offset = offsetStorageReader.getOffset();
+
+                    if (offset != null) {
+                        Object lastRecordedOffset = offset.get(FileStreamSourceTask.POSITION_FIELD);
+                        if (lastRecordedOffset != null && !(lastRecordedOffset instanceof Long))
+                            throw new ConnectException("Offset position is the incorrect type");
+                        if (lastRecordedOffset != null) {
+                            log.debug("Found previous offset, trying to skip to file offset {}", lastRecordedOffset);
+                            long skipLeft = (Long) lastRecordedOffset;
+                            while (skipLeft > 0) {
+                                try {
+                                    long skipped = stream.skip(skipLeft);
+                                    skipLeft -= skipped;
+                                } catch (IOException e) {
+                                    close();
+                                    log.error("Error while trying to seek to previous offset in file {}: ", filename, e);
+                                    throw new ConnectException(e);
+                                }
+                            }
+                            log.debug("Skipped to offset {}", lastRecordedOffset);
+                        }
+                        streamOffset = (lastRecordedOffset != null) ? (Long) lastRecordedOffset : 0L;
+                    } else {
+                        streamOffset = 0L;
+                    }
+                    log.debug("Opened {} for reading", logFilename());
+                } catch (NoSuchFileException e) {
+                    log.warn("Couldn't find file {} for FileStreamSourceTask, sleeping to wait for it to be created", logFilename());
+                    close();
+                    synchronized (this) {
+                        this.wait(1000);
+                    }
+                    return false;
+                } catch (IOException e) {
+                    close();
+                    log.error("Error while trying to open file {}: ", filename, e);
+                    throw new ConnectException(e);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Expand the internal character buffer, double the size if less than maximum value, otherwise use the maximum value.
+     */
+    private void expandBuffer()  {
+        int newSize = (buffer.length > maxBufferSize / 2) ? maxBufferSize :  buffer.length * 2;
+        char[] newBuf = new char[newSize];
+        System.arraycopy(buffer, 0, newBuf, 0, buffer.length);
+        buffer = newBuf;
+        log.debug("internal buffer size expanded to {} ", buffer.length);
+    }
+
+    /**
+     * Extract a line from the character buffer, looking for \n and \r\n for line separator.
+     * If found, shift buffer left ward.
+     * If not found and the buffer is full expand the buffer until next read.
+     */
+    String extractLine() throws IOException {
+        int until = -1, newStart = -1;
+
+        if (needExtendBuffer) {
+            expandBuffer();
+            needExtendBuffer = false;
+        }
+
+        nread = 0;
+        if (offset < buffer.length && reader.ready()) {
+
+            nread = reader.read(buffer, offset, buffer.length - offset);
+            log.trace("Read {} bytes from {}", nread, logFilename());
+            if (nread > 0) {
+                offset += nread;
+            }
+        }
+
+        log.trace("offset {}", offset);
+        for (int i = 0; i < offset; i++) {
+            if (buffer[i] == '\n') {
+                until = i;
+                newStart = i + 1;
+                break;
+            } else if (buffer[i] == '\r') {
+                // We need to check for \r\n, so we must skip this if we can't check the next char
+                if (i + 1 >= offset)
+                    return null;
+
+                until = i;
+                newStart = (buffer[i + 1] == '\n') ? i + 2 : i + 1;
+                break;
+            }
+        }
+
+        if (until != -1) {
+            String result = new String(buffer, 0, until);
+            // shift buffer left ward.
+            System.arraycopy(buffer, newStart, buffer, 0, buffer.length - newStart);
+            offset = offset - newStart;
+            if (streamOffset != null)
+                streamOffset += newStart;
+            return result;
+        } else {
+            if (offset == buffer.length &&  buffer.length  < maxBufferSize) {
+                needExtendBuffer = true;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * close the input stream if the task stopped
+     */
+    void close() {
+        try {
+            if (stream != null && stream != System.in) {
+                stream.close();
+                log.trace("Closed input stream");
+            }
+        } catch (IOException e) {
+            log.error("Failed to close FileStreamSourceTask stream: ", e);
+        } finally {
+            stream = null;
+            reader = null;
+        }
+    }
+
+    void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    private String logFilename() {
+        return filename == null ? "stdin" : filename;
+    }
+
+    // following are created for unit testing purpose
+    FileStreamBuffer(InputStream stream, BufferedReader reader) {
+        this.stream = stream;
+        this.reader = reader;
+    }
+
+    int _bufferSize() {
+        return buffer.length;
+    }
+
+}

--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
@@ -16,21 +16,13 @@
  */
 package org.apache.kafka.connect.file;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
@@ -42,18 +34,22 @@ import org.slf4j.LoggerFactory;
 public class FileStreamSourceTask extends SourceTask {
     private static final Logger log = LoggerFactory.getLogger(FileStreamSourceTask.class);
     public static final String FILENAME_FIELD = "filename";
-    public  static final String POSITION_FIELD = "position";
+    public static final String POSITION_FIELD = "position";
     private static final Schema VALUE_SCHEMA = Schema.STRING_SCHEMA;
 
     private String filename;
-    private InputStream stream;
-    private BufferedReader reader = null;
-    private char[] buffer = new char[1024];
-    private int offset = 0;
     private String topic = null;
     private int batchSize = FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE;
 
-    private Long streamOffset;
+    private final FileStreamBuffer fileStreamBuffer;
+
+    public FileStreamSourceTask() {
+        this.fileStreamBuffer = new FileStreamBuffer();
+    }
+
+    FileStreamSourceTask(FileStreamBuffer fileStreamBuffer) {
+        this.fileStreamBuffer = fileStreamBuffer;
+    }
 
     @Override
     public String version() {
@@ -63,12 +59,7 @@ public class FileStreamSourceTask extends SourceTask {
     @Override
     public void start(Map<String, String> props) {
         filename = props.get(FileStreamSourceConnector.FILE_CONFIG);
-        if (filename == null || filename.isEmpty()) {
-            stream = System.in;
-            // Tracking offset for stdin doesn't make sense
-            streamOffset = null;
-            reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-        }
+        fileStreamBuffer.setFilename(filename);
         // Missing topic or parsing error is not possible because we've parsed the config in the
         // Connector
         topic = props.get(FileStreamSourceConnector.TOPIC_CONFIG);
@@ -77,91 +68,34 @@ public class FileStreamSourceTask extends SourceTask {
 
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
-        if (stream == null) {
-            try {
-                stream = Files.newInputStream(Paths.get(filename));
-                Map<String, Object> offset = context.offsetStorageReader().offset(Collections.singletonMap(FILENAME_FIELD, filename));
-                if (offset != null) {
-                    Object lastRecordedOffset = offset.get(POSITION_FIELD);
-                    if (lastRecordedOffset != null && !(lastRecordedOffset instanceof Long))
-                        throw new ConnectException("Offset position is the incorrect type");
-                    if (lastRecordedOffset != null) {
-                        log.debug("Found previous offset, trying to skip to file offset {}", lastRecordedOffset);
-                        long skipLeft = (Long) lastRecordedOffset;
-                        while (skipLeft > 0) {
-                            try {
-                                long skipped = stream.skip(skipLeft);
-                                skipLeft -= skipped;
-                            } catch (IOException e) {
-                                log.error("Error while trying to seek to previous offset in file {}: ", filename, e);
-                                throw new ConnectException(e);
-                            }
-                        }
-                        log.debug("Skipped to offset {}", lastRecordedOffset);
-                    }
-                    streamOffset = (lastRecordedOffset != null) ? (Long) lastRecordedOffset : 0L;
-                } else {
-                    streamOffset = 0L;
-                }
-                reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-                log.debug("Opened {} for reading", logFilename());
-            } catch (NoSuchFileException e) {
-                log.warn("Couldn't find file {} for FileStreamSourceTask, sleeping to wait for it to be created", logFilename());
-                synchronized (this) {
-                    this.wait(1000);
-                }
-                return null;
-            } catch (IOException e) {
-                log.error("Error while trying to open file {}: ", filename, e);
-                throw new ConnectException(e);
-            }
-        }
+        if (!fileStreamBuffer.ensureOpen(() -> context.offsetStorageReader().offset(Collections.singletonMap(FILENAME_FIELD, filename))))
+            return null;
 
         // Unfortunately we can't just use readLine() because it blocks in an uninterruptible way.
         // Instead we have to manage splitting lines ourselves, using simple backoff when no new data
         // is available.
         try {
-            final BufferedReader readerCopy;
-            synchronized (this) {
-                readerCopy = reader;
-            }
-            if (readerCopy == null)
-                return null;
 
             ArrayList<SourceRecord> records = null;
 
-            int nread = 0;
-            while (readerCopy.ready()) {
-                nread = readerCopy.read(buffer, offset, buffer.length - offset);
-                log.trace("Read {} bytes from {}", nread, logFilename());
+            String line;
+            do {
+                line = fileStreamBuffer.extractLine();
+                if (line != null) {
+                    log.trace("Read a line from {}", logFilename());
+                    if (records == null)
+                        records = new ArrayList<>();
+                    records.add(new SourceRecord(offsetKey(filename), offsetValue(fileStreamBuffer.streamOffset), topic, null,
+                            null, null, VALUE_SCHEMA, line, System.currentTimeMillis()));
 
-                if (nread > 0) {
-                    offset += nread;
-                    if (offset == buffer.length) {
-                        char[] newbuf = new char[buffer.length * 2];
-                        System.arraycopy(buffer, 0, newbuf, 0, buffer.length);
-                        buffer = newbuf;
+                    if (records.size() >= batchSize) {
+                        return records;
                     }
-
-                    String line;
-                    do {
-                        line = extractLine();
-                        if (line != null) {
-                            log.trace("Read a line from {}", logFilename());
-                            if (records == null)
-                                records = new ArrayList<>();
-                            records.add(new SourceRecord(offsetKey(filename), offsetValue(streamOffset), topic, null,
-                                    null, null, VALUE_SCHEMA, line, System.currentTimeMillis()));
-
-                            if (records.size() >= batchSize) {
-                                return records;
-                            }
-                        }
-                    } while (line != null);
                 }
-            }
+            } while (line != null);
 
-            if (nread <= 0)
+            // wait for 1 second if reaching end of file and nothing been read
+            if (fileStreamBuffer.nread <= 0 && records == null)
                 synchronized (this) {
                     this.wait(1000);
                 }
@@ -174,48 +108,11 @@ public class FileStreamSourceTask extends SourceTask {
         return null;
     }
 
-    private String extractLine() {
-        int until = -1, newStart = -1;
-        for (int i = 0; i < offset; i++) {
-            if (buffer[i] == '\n') {
-                until = i;
-                newStart = i + 1;
-                break;
-            } else if (buffer[i] == '\r') {
-                // We need to check for \r\n, so we must skip this if we can't check the next char
-                if (i + 1 >= offset)
-                    return null;
-
-                until = i;
-                newStart = (buffer[i + 1] == '\n') ? i + 2 : i + 1;
-                break;
-            }
-        }
-
-        if (until != -1) {
-            String result = new String(buffer, 0, until);
-            System.arraycopy(buffer, newStart, buffer, 0, buffer.length - newStart);
-            offset = offset - newStart;
-            if (streamOffset != null)
-                streamOffset += newStart;
-            return result;
-        } else {
-            return null;
-        }
-    }
-
     @Override
     public void stop() {
         log.trace("Stopping");
         synchronized (this) {
-            try {
-                if (stream != null && stream != System.in) {
-                    stream.close();
-                    log.trace("Closed input stream");
-                }
-            } catch (IOException e) {
-                log.error("Failed to close FileStreamSourceTask stream: ", e);
-            }
+            fileStreamBuffer.close();
             this.notify();
         }
     }
@@ -231,4 +128,9 @@ public class FileStreamSourceTask extends SourceTask {
     private String logFilename() {
         return filename == null ? "stdin" : filename;
     }
+
+    interface OffsetStorageReader {
+        Map<String, Object> getOffset();
+    }
+
 }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamBufferTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamBufferTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.file;
+
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import static org.junit.Assert.assertEquals;
+
+public class FileStreamBufferTest extends EasyMockSupport {
+
+    /**
+     *  Test buffer expand only once.
+     */
+    @Test
+    public void testBufferExpandOnce() throws IOException, InterruptedException {
+        InputStream stream = createMock(InputStream.class);
+        BufferedReader reader = createMock(BufferedReader.class);
+        FileStreamBuffer fileStreamBuffer = new FileStreamBuffer(stream, reader);
+
+        FileStreamSourceTask task = new FileStreamSourceTask(fileStreamBuffer);
+        EasyMock.expect(reader.ready()).andReturn(true).times(2);
+        EasyMock.expect(reader.read((char[]) EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt())).andReturn(1024).times(2);
+        stream.close();
+        EasyMock.expectLastCall();
+        replayAll();
+
+        task.poll();
+        task.poll();
+        assertEquals(2048, fileStreamBuffer._bufferSize());
+        task.stop();
+
+        verifyAll();
+
+    }
+
+    /**
+     * This test buffer that will expand from 1024->2048->4096->8192->16384 4 times.
+     */
+    @Test
+    public void testBufferExpandMaxout() throws IOException, InterruptedException {
+        FileStreamBuffer.maxBufferSize = 16384;
+        InputStream stream = createMock(InputStream.class);
+        BufferedReader reader = createMock(BufferedReader.class);
+        FileStreamBuffer fileStreamBuffer = new FileStreamBuffer(stream, reader);
+
+        FileStreamSourceTask task = new FileStreamSourceTask(fileStreamBuffer);
+
+        EasyMock.expect(reader.ready()).andReturn(true).times(5);
+        int x = 1024;
+        EasyMock.expect(reader.read((char[]) EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt())).andReturn(x);
+        for (int i = 0; i < 4; i++) {
+            EasyMock.expect(reader.read((char[]) EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt())).andReturn(x);
+            x *= 2;
+        }
+
+        stream.close();
+        EasyMock.expectLastCall();
+        replayAll();
+
+        for (int i = 0; i < 20; i++) {
+            task.poll();
+        }
+
+        assertEquals(FileStreamBuffer.maxBufferSize, fileStreamBuffer._bufferSize());
+        task.stop();
+
+        verifyAll();
+
+    }
+
+
+}


### PR DESCRIPTION
1. Trigger buffer expansion when buffer does not extract a line
2. Limit buffer size to Integer.MAX_VALUE  
3. Using single loop inside FileStreamSourceTask.poll 
4. Close the stream before throw ConnectException
5. Move stream and buffer related function to a separate class FileStreamBuffer
Check the [JIRA](https://issues.apache.org/jira/browse/KAFKA-8120) comment for the steps to verify.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
