### PR TITLE
KAFKA-7472: add the HeaderFrom and HeaderTo SMTs

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Validator;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
+
+public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+            "Moves or copies fields in the key/value on a record into that record's headers"
+                    + "<p/>Use the concrete transformation type designed for the record key"
+                    + "(<code>" + InsertField.Key.class.getName() + "</code>) or value "
+                    + "(<code>" + InsertField.Value.class.getName() + "</code>).";
+
+    public static String[] trimAll(String[] array) {
+        return Arrays
+                .stream(array)
+                .map(String::trim)
+                .toArray(String[]::new);
+    }
+
+    private static final String DEFAULT_OPERATION = "copy";
+
+    private static final String PURPOSE = "Header creation from key/value";
+
+    private static final Validator OPERATION_VALIDATOR = (name, value) -> {
+        try {
+            Operation.valueOf(value.toString().toLowerCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new ConfigException(
+                    String.format("Only two operations are supported: copy and move (found: %s)", value.toString())
+            );
+        }
+    };
+
+    private static final Validator LIST_VALIDATOR = (name, value) -> {
+        if (!Pattern.compile("(\\w+)(,\\w+)*").matcher(value.toString().replaceAll("\\s+", "")).matches()) {
+            throw new ConfigException(
+                    String.format(
+                            "Config %s is suppose to be a comma-separated list of fields (found: %s)",
+                            name,
+                            value.toString()
+                    )
+            );
+        }
+    };
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef()
+
+            .define(ConfigName.FIELDS,
+                    ConfigDef.Type.STRING,
+                    "transformation, not, configured",
+                    LIST_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Field names whose values are to be copied/moved to headers.")
+
+            .define(ConfigName.HEADERS,
+                    ConfigDef.Type.STRING,
+                    "transformation, not, configured",
+                    LIST_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Header names, in the same order as the field names listed in the fields configuration property")
+
+            .define(ConfigName.OPERATION,
+                    ConfigDef.Type.STRING,
+                    DEFAULT_OPERATION,
+                    OPERATION_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Operation applied on the filed (can be either move or copy)");
+
+    private static Struct structWithRemovedFields(Struct struct, String[] fieldsToRemove) {
+        List<String> fieldsToRemoveList = Arrays.asList(fieldsToRemove);
+
+        SchemaBuilder newSchema = SchemaBuilder.struct();
+        newSchema.doc(struct.schema().doc());
+
+        struct.schema().fields().forEach(filed -> {
+            if (!fieldsToRemoveList.contains(filed.name())) newSchema.field(filed.name(), filed.schema());
+        });
+
+        Struct newStruct = new Struct(newSchema.build());
+        struct.schema().fields().forEach(filed -> {
+            if (!fieldsToRemoveList.contains(filed.name())) newStruct.put(filed.name(), struct.get(filed));
+        });
+
+        return newStruct;
+    }
+
+    private static Headers addHeaders(Struct struct,
+                                      Schema schema,
+                                      Headers headers,
+                                      List<Map.Entry<String, String>> fieldsHeadersZipped) {
+
+        Headers newHeaders = new ConnectHeaders(headers);
+
+        fieldsHeadersZipped.forEach(pair -> {
+            Object fieldValue = struct.get(pair.getKey());
+            Schema fieldSchema = schema.field(pair.getKey()).schema();
+            newHeaders.add(pair.getValue(), new SchemaAndValue(fieldSchema, fieldValue));
+        });
+
+        return newHeaders;
+    }
+
+    private enum Operation {
+        move,
+        copy
+    }
+
+    private interface ConfigName {
+        String FIELDS = "fields";
+        String HEADERS = "headers";
+        String OPERATION = "operation";
+    }
+
+    protected String[] fields;
+    protected String[] headers;
+    protected Operation operation;
+
+    protected List<Map.Entry<String, String>> fieldsHeadersZipped;
+
+    @Override
+    public R apply(R record) {
+        if (record == null || operatingSchema(record) == null) return record;
+
+        Schema recordSchema = operatingSchema(record);
+        Struct recordStruct = requireStructOrNull(operatingValue(record), PURPOSE);
+
+        Headers newHeaders = addHeaders(recordStruct, recordSchema, record.headers(), fieldsHeadersZipped);
+        R operatedRecord = operation == Operation.move ? removeFields(record) : record;
+
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                operatedRecord.keySchema(),
+                operatedRecord.key(),
+                operatedRecord.valueSchema(),
+                operatedRecord.value(),
+                record.timestamp(),
+                newHeaders
+        );
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+        fields = trimAll(config.getString(ConfigName.FIELDS).split(","));
+        headers = trimAll(config.getString(ConfigName.HEADERS).split(","));
+        operation = Operation.valueOf(config.getString(ConfigName.OPERATION).toLowerCase(Locale.ROOT));
+
+        if (fields.length != headers.length) {
+            throw new ConfigException(
+                    String.format(
+                            "The fields and headers should have the same number of elements. " +
+                                    "Found: %s fields and %s headers",
+                            fields.length,
+                            headers.length
+                    )
+            );
+        }
+
+        fieldsHeadersZipped = IntStream
+                .range(0, fields.length)
+                .mapToObj(i -> new SimpleImmutableEntry<>(fields[i], headers[i]))
+                .collect(Collectors.toList());
+    }
+
+    protected abstract R removeFields(R record);
+
+    protected abstract Schema operatingSchema(R record);
+
+    protected abstract Object operatingValue(R record);
+
+    public static class Key<R extends ConnectRecord<R>> extends HeaderFrom<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.keySchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.key();
+        }
+
+        @Override
+        protected R removeFields(R record) {
+            Struct oldKey = requireStructOrNull(operatingValue(record), PURPOSE);
+            Struct newKey = structWithRemovedFields(oldKey, fields);
+
+            return record.newRecord(
+                    record.topic(),
+                    record.kafkaPartition(),
+                    newKey.schema(),
+                    newKey,
+                    record.valueSchema(),
+                    record.value(),
+                    record.timestamp(),
+                    record.headers()
+            );
+        }
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends HeaderFrom<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.valueSchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.value();
+        }
+
+        @Override
+        protected R removeFields(R record) {
+            Struct oldValue = requireStructOrNull(operatingValue(record), PURPOSE);
+            Struct newValue = structWithRemovedFields(oldValue, fields);
+
+            return record.newRecord(
+                    record.topic(),
+                    record.kafkaPartition(),
+                    record.keySchema(),
+                    record.key(),
+                    newValue.schema(),
+                    newValue,
+                    record.timestamp(),
+                    record.headers()
+            );
+        }
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderTo.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderTo.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
+
+public abstract class HeaderTo<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+            "Moves or copies headers on a record into fields in on that record's key/value"
+                    + "<p/>Use the concrete transformation type designed for the record key"
+                    + "(<code>" + InsertField.Key.class.getName() + "</code>) or value "
+                    + "(<code>" + InsertField.Value.class.getName() + "</code>).";
+
+    private static final String DEFAULT_OPERATION = "copy";
+
+    private static final String PURPOSE = "Key/value field creation from headers";
+
+    private static final ConfigDef.Validator OPERATION_VALIDATOR = (name, value) -> {
+        try {
+            Operation.valueOf(value.toString().toLowerCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new ConfigException("Only two operations are supported: copy and move");
+        }
+    };
+
+    private static final ConfigDef.Validator LIST_VALIDATOR = (name, value) -> {
+        if (!Pattern.compile("(\\w+)(,\\w+)*").matcher(value.toString().replaceAll("\\s+", "")).matches()) {
+            throw new ConfigException(
+                    String.format("Config %s is suppose to be a comma-separated list of fields", name)
+            );
+        }
+    };
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef()
+
+            .define(ConfigName.FIELDS,
+                    ConfigDef.Type.STRING,
+                    "transformation, not, configured",
+                    LIST_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Field names, in the same order as the header names listed in the headers configuration property")
+
+            .define(ConfigName.HEADERS,
+                    ConfigDef.Type.STRING,
+                    "transformation, not, configured",
+                    LIST_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Header names whose latest values are to be copied/moved to key or value.")
+
+            .define(ConfigName.OPERATION,
+                    ConfigDef.Type.STRING,
+                    DEFAULT_OPERATION,
+                    OPERATION_VALIDATOR,
+                    ConfigDef.Importance.HIGH,
+                    "Operation applied on the header (can be either move or copy)");
+
+    private static Struct structWithAddedFields(Struct struct,
+                                                Headers headers,
+                                                List<Map.Entry<String, String>> headerFieldPairs) {
+
+        SchemaBuilder newSchema = SchemaBuilder.struct();
+        newSchema.doc(struct.schema().doc());
+
+        struct.schema().fields().forEach(filed -> newSchema.field(filed.name(), filed.schema()));
+        headerFieldPairs.forEach(pair ->
+                newSchema.field(pair.getValue(), headers.lastWithName(pair.getKey()).schema())
+        );
+
+        Struct newStruct = new Struct(newSchema.build());
+        struct.schema().fields().forEach(filed -> newStruct.put(filed.name(), struct.get(filed)));
+        headerFieldPairs.forEach(pair ->
+                newStruct.put(pair.getValue(), headers.lastWithName(pair.getKey()).value())
+        );
+
+        return newStruct;
+    }
+
+    private enum Operation {
+        move,
+        copy
+    }
+
+    private interface ConfigName {
+        String FIELDS = "fields";
+        String HEADERS = "headers";
+        String OPERATION = "operation";
+    }
+
+    protected String[] fields;
+    protected String[] headers;
+    protected Operation operation;
+
+    protected List<Map.Entry<String, String>> headersFieldsZipped;
+
+    @Override
+    public R apply(R record) {
+        if (record == null || operatingSchema(record) == null) return record;
+
+        R newRecord = addFields(record);
+
+        if (operation == Operation.move) {
+            Arrays.stream(headers).forEach(header -> newRecord.headers().remove(header));
+        }
+        return newRecord;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+        fields = HeaderFrom.trimAll(config.getString(ConfigName.FIELDS).split(","));
+        headers = HeaderFrom.trimAll(config.getString(ConfigName.HEADERS).split(","));
+        operation = Operation.valueOf(config.getString(ConfigName.OPERATION).toLowerCase(Locale.ROOT));
+
+        if (fields.length != headers.length) {
+            throw new ConfigException(
+                    String.format(
+                            "The fields and headers should have the same number of elements. " +
+                                    "Found: %s fields and %s headers",
+                            fields.length,
+                            headers.length
+                    )
+            );
+        }
+
+        headersFieldsZipped = IntStream
+                .range(0, headers.length)
+                .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>(headers[i], fields[i]))
+                .collect(Collectors.toList());
+    }
+
+    protected abstract Schema operatingSchema(R record);
+
+    protected abstract Object operatingValue(R record);
+
+    protected abstract R addFields(R record);
+
+    public static class Key<R extends ConnectRecord<R>> extends HeaderTo<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.keySchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.key();
+        }
+
+        @Override
+        protected R addFields(R record) {
+            Struct oldKey = requireStructOrNull(operatingValue(record), PURPOSE);
+            Struct newKey = structWithAddedFields(oldKey, record.headers(), headersFieldsZipped);
+
+            return record.newRecord(
+                    record.topic(),
+                    record.kafkaPartition(),
+                    newKey.schema(),
+                    newKey,
+                    record.valueSchema(),
+                    record.value(),
+                    record.timestamp(),
+                    record.headers()
+            );
+        }
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends HeaderTo<R> {
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.valueSchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.value();
+        }
+
+        @Override
+        protected R addFields(R record) {
+            Struct oldValue = requireStructOrNull(operatingValue(record), PURPOSE);
+            Struct newValue = structWithAddedFields(oldValue, record.headers(), headersFieldsZipped);
+
+            return record.newRecord(
+                    record.topic(),
+                    record.kafkaPartition(),
+                    record.keySchema(),
+                    record.key(),
+                    newValue.schema(),
+                    newValue,
+                    record.timestamp(),
+                    record.headers()
+            );
+        }
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HeaderFromTest {
+
+    private HeaderFrom<SourceRecord> fromKey = new HeaderFrom.Key<>();
+    private HeaderFrom<SourceRecord> fromValue = new HeaderFrom.Value<>();
+
+    private static final Schema VALUE_SCHEMA = SchemaBuilder
+            .struct()
+            .name("HeaderFromTestValue")
+            .version(1)
+            .field("value_field1", Schema.STRING_SCHEMA)
+            .field("value_field2", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    private static final Schema KEY_SCHEMA = SchemaBuilder
+            .struct()
+            .name("HeaderFromTestKey")
+            .version(1)
+            .field("key_field1", Schema.INT64_SCHEMA)
+            .field("key_field2", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .build();
+
+    private Struct testStruct(Object struct) {
+        return requireStructOrNull(struct, "test purpose");
+    }
+
+    private SourceRecord testRecord(Long keyField1, String valueField1, Map<String, String> headerMap) {
+        Struct key = new Struct(KEY_SCHEMA);
+        Struct value = new Struct(VALUE_SCHEMA);
+        key.put("key_field1", keyField1);
+        value.put("value_field1", valueField1);
+
+        ConnectHeaders headers = new ConnectHeaders();
+        headerMap.forEach((headerKey, headerValue) ->
+                headers.add(headerKey, new SchemaAndValue(Schema.STRING_SCHEMA, headerValue))
+        );
+
+        return new SourceRecord(
+                null, null, "test-topic", 0, KEY_SCHEMA, key, VALUE_SCHEMA, value, 0L, headers
+        );
+    }
+
+    private static Stream<Header> allHeadersAsStream(Headers headers, String headerName) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(headers.allWithName(headerName), 0), false);
+    }
+
+    @Before
+    public void setUp() {
+        fromKey = new HeaderFrom.Key<>();
+        fromValue = new HeaderFrom.Value<>();
+    }
+
+    @After
+    public void tearDown() {
+        fromKey.close();
+        fromValue.close();
+    }
+
+    @Test
+    public void createHeadersFromValueFieldTest() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1");
+        configMap.put("headers", "new_header");
+
+        fromValue.configure(configMap);
+        SourceRecord record = testRecord(-1L, "test-value", Collections.singletonMap("old_header", "mutmut"));
+
+        SourceRecord resultRecord = fromValue.apply(record);
+
+        Assert.assertEquals("Expected an additional header", 2, resultRecord.headers().size());
+
+        Assert.assertEquals(
+                "Expected the additional header to have a specific value",
+                "test-value", resultRecord.headers().lastWithName("new_header").value()
+        );
+        Assert.assertEquals(
+                "Default operation being copy, value_field1 was still expected in the value",
+                "test-value", testStruct(resultRecord.value()).get("value_field1").toString()
+        );
+    }
+
+    @Test
+    public void createHeadersFromKeyFieldTest() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "key_field1");
+        configMap.put("headers", "new_header");
+
+        fromKey.configure(configMap);
+        SourceRecord record = testRecord(42L, "test-value", Collections.singletonMap("old_header", "mutmut"));
+
+        SourceRecord resultRecord = fromKey.apply(record);
+
+        Assert.assertEquals(
+                "Expected the additional header to have a specific value",
+                42L, resultRecord.headers().lastWithName("new_header").value()
+        );
+    }
+
+    @Test(expected = DataException.class)
+    public void createHeadersWithMoveOperation() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1");
+        configMap.put("headers", "new_header");
+        configMap.put("operation", "move");
+
+        fromValue.configure(configMap);
+        SourceRecord record = testRecord(0L, "test-bladibla", Collections.singletonMap("old_header", "mutmut"));
+
+        SourceRecord resultRecord = fromValue.apply(record);
+
+        testStruct(resultRecord.value()).get("value_field1");
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createHeadersFromImbalancedSourceFields() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1");
+        configMap.put("headers", "header1, header2, header3, header4");
+
+        fromValue.configure(configMap);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createHeadersFromAnInvalidOperation() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1");
+        configMap.put("headers", "new_header1");
+        configMap.put("operation", "weirdCopyPaste");
+
+        fromValue.configure(configMap);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createHeadersFromAnInvalidConfigList() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "field1/field2/field3/field4");
+        configMap.put("headers", "header1/header2/header3/header4");
+
+        fromValue.configure(configMap);
+    }
+
+    @Test
+    public void hasAWellSpecifiedConfigurationDefTest() {
+        assertThat(
+                Arrays.asList("fields", "headers", "operation").toArray(),
+                IsEqual.equalTo(fromValue.config().configKeys().keySet().toArray())
+
+        );
+    }
+
+    @Test
+    public void createHeadersWithMultipleFieldsFromKeyAndValueTest() {
+        final Map<String, Object> keyConfigMap = new HashMap<>();
+        keyConfigMap.put("fields", "key_field1, key_field2, key_field1");
+        keyConfigMap.put("headers", "old_header, new_header1, other_header");
+
+        fromKey.configure(keyConfigMap);
+
+        final Map<String, Object> valueConfigMap = new HashMap<>();
+        valueConfigMap.put("fields", "value_field1, value_field2, value_field1");
+        valueConfigMap.put("headers", "old_header, new_header2, other_header");
+
+        fromValue.configure(valueConfigMap);
+
+        SourceRecord record = testRecord(-1L, "test-value", Collections.singletonMap("old_header", "mutmut"));
+
+        SourceRecord resultRecord = fromValue.apply(fromKey.apply(record));
+
+        assertThat(
+                allHeadersAsStream(resultRecord.headers(), "old_header").map(Header::value).toArray(),
+                IsEqual.equalTo(Stream.of("mutmut", -1L, "test-value").toArray())
+        );
+
+        assertThat(
+                allHeadersAsStream(resultRecord.headers(), "new_header1").map(Header::value).toArray(),
+                IsEqual.equalTo(Stream.of((Object) null).toArray())
+        );
+
+        assertThat(
+                allHeadersAsStream(resultRecord.headers(), "new_header2").map(Header::value).toArray(),
+                IsEqual.equalTo(Stream.of((Object) null).toArray())
+        );
+
+        assertThat(
+                allHeadersAsStream(resultRecord.headers(), "other_header").map(Header::value).toArray(),
+                IsEqual.equalTo(Stream.of(-1L, "test-value").toArray())
+        );
+    }
+
+    @Test
+    public void performNoModificationWithOutSchemaTest() {
+        final Map<String, Object> keyConfigMap = new HashMap<>();
+        keyConfigMap.put("fields", "key_field1, key_field2, key_field1");
+        keyConfigMap.put("headers", "old_header, new_header1, other_header");
+
+        fromKey.configure(keyConfigMap);
+
+        final Map<String, Object> valueConfigMap = new HashMap<>();
+        valueConfigMap.put("fields", "value_field1");
+        valueConfigMap.put("headers", "new_header");
+
+        fromValue.configure(valueConfigMap);
+
+        SourceRecord record = new SourceRecord(null, null, "test-topic", null, emptyMap(), null, emptyMap());
+
+        SourceRecord result = fromValue.apply(fromKey.apply(record));
+
+        Assert.assertEquals(record, result);
+    }
+
+    @Test
+    public void performNoModificationOnNullRecordsTest() {
+        final Map<String, Object> keyConfigMap = new HashMap<>();
+        keyConfigMap.put("fields", "key_field1, key_field2, key_field1");
+        keyConfigMap.put("headers", "old_header, new_header1, other_header");
+
+        fromKey.configure(keyConfigMap);
+
+        final Map<String, Object> valueConfigMap = new HashMap<>();
+        valueConfigMap.put("fields", "value_field1");
+        valueConfigMap.put("headers", "new_header");
+
+        fromValue.configure(valueConfigMap);
+
+        SourceRecord record = null;
+
+        SourceRecord result = fromValue.apply(fromKey.apply(record));
+
+        Assert.assertNull(result);
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderToTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderToTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HeaderToTest {
+
+    private HeaderTo<SinkRecord> toKey = new HeaderTo.Key<>();
+    private HeaderTo<SinkRecord> toValue = new HeaderTo.Value<>();
+
+    private static final Schema VALUE_SCHEMA = SchemaBuilder
+            .struct()
+            .name("HeaderToTestValue")
+            .version(1)
+            .field("value_field1", Schema.STRING_SCHEMA)
+            .field("value_field2", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .build();
+
+    private static final Schema KEY_SCHEMA = SchemaBuilder
+            .struct()
+            .name("HeaderToTestKey")
+            .version(1)
+            .field("key_field1", Schema.STRING_SCHEMA)
+            .field("key_field2", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .build();
+
+    private Struct testStruct(Object struct) {
+        return requireStructOrNull(struct, "test purpose");
+    }
+
+    private SinkRecord testRecord(String valueField1, String keyField1, Map<String, String> headerMap) {
+        Struct key = new Struct(KEY_SCHEMA);
+        Struct value = new Struct(VALUE_SCHEMA);
+        key.put("key_field1", keyField1);
+        value.put("value_field1", valueField1);
+
+        ConnectHeaders headers = new ConnectHeaders();
+        headerMap.forEach((headerKey, headerValue) ->
+                headers.add(headerKey, new SchemaAndValue(Schema.STRING_SCHEMA, headerValue))
+        );
+
+        return new SinkRecord(
+                "test-topic", 0, KEY_SCHEMA, key, VALUE_SCHEMA, value, 0L, 0L, NO_TIMESTAMP_TYPE, headers
+        );
+    }
+
+    @Before
+    public void setUp() {
+        toKey = new HeaderTo.Key<>();
+        toValue = new HeaderTo.Value<>();
+    }
+
+    @After
+    public void tearDown() {
+        toKey.close();
+        toValue.close();
+    }
+
+    @Test
+    public void createValueFieldsFromHeadersTest() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("headers", "header1");
+        configMap.put("fields", "new_field1");
+
+        toValue.configure(configMap);
+        SinkRecord record = testRecord("test-key", "test-value", Collections.singletonMap("header1", "data"));
+
+        SinkRecord result = toValue.apply(record);
+
+        Assert.assertEquals("Expected an additional value field", 3, result.valueSchema().fields().size());
+        Assert.assertEquals(
+                "Expected the additional value field to have a specific data type",
+                Schema.STRING_SCHEMA, requireStructOrNull(result.value(), "test").schema().field("new_field1").schema()
+        );
+        Assert.assertEquals(
+                "Expected the additional value field to have a specific value",
+                "data", testStruct(result.value()).get("new_field1").toString()
+        );
+        Assert.assertEquals(
+                "Default operation being copy, header1 was still expected in the headers",
+                "data", result.headers().lastWithName("header1").value().toString()
+        );
+    }
+
+    @Test
+    public void createKeyFieldsFromHeadersTest() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("headers", "header2");
+        configMap.put("fields", "new_field2");
+
+        toKey.configure(configMap);
+        SinkRecord record = testRecord("test-key", "test-value", Collections.singletonMap("header2", "bladibla"));
+
+        SinkRecord result = toKey.apply(record);
+
+        Assert.assertEquals(
+                "Expected the additional value field to have a specific value",
+                "bladibla", testStruct(result.key()).get("new_field2").toString()
+        );
+    }
+
+    @Test
+    public void createFieldsWithTheMoveOperator() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("headers", "header1");
+        configMap.put("fields", "new_field1");
+        configMap.put("operation", "move");
+
+        toValue.configure(configMap);
+        SinkRecord record = testRecord("test-key", "test-value", Collections.singletonMap("header1", "data"));
+
+        SinkRecord result = toValue.apply(record);
+
+        Assert.assertNull(result.headers().lastWithName("header1"));
+
+        Assert.assertEquals(
+                "Expected the additional value field to have a specific value",
+                "data", testStruct(result.value()).get("new_field1").toString()
+        );
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createValuesFromImbalancedSourceHeaders() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1, value_field2, value_field3");
+        configMap.put("headers", "header1");
+
+        toValue.configure(configMap);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createValuesFromAnInvalidOperation() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "value_field1");
+        configMap.put("headers", "new_header1");
+        configMap.put("operation", "weirdCopyPaste");
+
+        toValue.configure(configMap);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void createValuesFromAnInvalidConfigList() {
+        final Map<String, Object> configMap = new HashMap<>();
+        configMap.put("fields", "field1;field2;field3;field4");
+        configMap.put("headers", "header1;header2;header3;header4");
+
+        toKey.configure(configMap);
+    }
+
+    @Test
+    public void hasAWellSpecifiedConfigurationDefTest() {
+        assertThat(
+                Arrays.asList("fields", "headers", "operation").toArray(),
+                IsEqual.equalTo(toValue.config().configKeys().keySet().toArray())
+
+        );
+    }
+
+    @Test
+    public void performNoModificationWithOutSchemaTest() {
+        final Map<String, Object> keyConfigMap = new HashMap<>();
+        keyConfigMap.put("fields", "key_field1, key_field2, key_field1");
+        keyConfigMap.put("headers", "header1, header2, header3");
+
+        toKey.configure(keyConfigMap);
+
+        final Map<String, Object> valueConfigMap = new HashMap<>();
+        valueConfigMap.put("fields", "value_field1");
+        valueConfigMap.put("headers", "new_header");
+
+        toValue.configure(valueConfigMap);
+
+        SinkRecord record = new SinkRecord("test-topic", 0, null, emptyMap(), null, emptyMap(), 0L);
+
+        SinkRecord result = toValue.apply(toKey.apply(record));
+
+        Assert.assertEquals(record, result);
+    }
+
+    @Test
+    public void performNoModificationOnNullRecordsTest() {
+        final Map<String, Object> keyConfigMap = new HashMap<>();
+        keyConfigMap.put("fields", "key_field1, key_field2, key_field1");
+        keyConfigMap.put("headers", "header1, header2, header3");
+
+        toKey.configure(keyConfigMap);
+
+        final Map<String, Object> valueConfigMap = new HashMap<>();
+        valueConfigMap.put("fields", "value_field1");
+        valueConfigMap.put("headers", "header5");
+
+        toValue.configure(valueConfigMap);
+
+        SinkRecord record = null;
+
+        SinkRecord result = toValue.apply(toKey.apply(record));
+
+        Assert.assertNull(result);
+    }
+}


### PR DESCRIPTION
This change brings the `HeaderFrom` and `HeaderTo` SMTs to complete [KIP-145](https://cwiki.apache.org/confluence/display/KAFKA/KIP-145+-+Expose+Record+Headers+in+Kafka+Connect) (as requested in [KAFKA-7472](https://issues.apache.org/jira/browse/KAFKA-7472))

The tests cover for the creation of key/value fields, of headers and their suppression. They also specify the behaviour of the SMTs in case of miss-configuration.  

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
