### PR TITLE
KAFKA-9954: Config command didn't validate the unsupported user config change

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -363,6 +363,8 @@ object ConfigCommand extends Config {
         adminClient.incrementalAlterConfigs(Map(configResource -> alterLogLevelEntries).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
 
       case ConfigType.User =>
+        throw new InvalidConfigurationException(s"Alternating user configs using AdminClient is not supported yet")
+
       case ConfigType.Client =>
         val oldConfig: Map[String, java.lang.Double] = getClientQuotasConfig(adminClient, entityTypes, entityNames)
 

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -70,6 +70,17 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--describe"))
   }
 
+  @Test
+  def shouldExitWithNonZeroStatusOnAlterUserConfigWithAdminClient(): Unit = {
+    assertNonZeroStatusExit(Array(
+      "--bootstrap-server", "localhost:9092",
+      "--entity-name", "1",
+      "--entity-type", "users",
+      "--alter",
+      "--add-config", "a=b,c=d",
+    ))
+  }
+
   private def assertNonZeroStatusExit(args: Array[String]): Unit = {
     var exitStatus: Option[Int] = None
     Exit.setExitProcedure { (status, _) =>


### PR DESCRIPTION
*More detailed description of your change,
Throw an error when users are trying to alter user configs with AdminClient

*Summary of testing strategy
`bin/kafka-configs.sh --bootstrap-server localhost:9092 --alter --add-config producer_byte_rate=44444 --entity-type users --entity-default` 
will return 
> Alternating user configs using AdminClient is not supported yet


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
