### PR TITLE
KAFKA-9944: Added supporting customized HTTP response headers for Kafka Connect.

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -132,7 +132,7 @@
     </module>
     <module name="NPathComplexity">
       <!-- default is 200 -->
-      <property name="max" value="550"/>
+      <property name="max" value="500"/>
     </module>
   </module>
 

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -132,7 +132,7 @@
     </module>
     <module name="NPathComplexity">
       <!-- default is 200 -->
-      <property name="max" value="500"/>
+      <property name="max" value="550"/>
     </module>
   </module>
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -362,6 +362,7 @@
       <allow pkg="org.reflections"/>
       <allow pkg="org.reflections.util"/>
       <allow pkg="javax.crypto"/>
+      <allow pkg="org.eclipse.jetty.util" />
 
       <subpackage name="rest">
         <allow pkg="org.eclipse.jetty" />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -144,6 +144,9 @@
     <suppress checks="MethodLength"
               files="Values.java"/>
 
+    <suppress checks="NPathComplexity"
+              files="RestServer.java"/>
+
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DistributedHerder|KafkaBasedLog)Test.java"/>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -245,6 +245,14 @@ public class WorkerConfig extends AbstractConfig {
     protected static final boolean TOPIC_TRACKING_ALLOW_RESET_DEFAULT = true;
 
     /**
+     * @link "https://www.eclipse.org/jetty/documentation/current/header-filter.html"
+     * @link "https://www.eclipse.org/jetty/javadoc/9.4.28.v20200408/org/eclipse/jetty/servlets/HeaderFilter.html"
+     **/
+    public static final String RESPONSE_HTTP_HEADERS_CONFIG = "response.http.headers.config";
+    public static final String RESPONSE_HTTP_HEADERS_DOC = "Set values for Jetty HTTP response headers";
+    public static final String RESPONSE_HTTP_HEADERS_DEFAULT = "";
+
+    /**
      * Get a basic ConfigDef for a WorkerConfig. This includes all the common settings. Subclasses can use this to
      * bootstrap their own ConfigDef.
      * @return a ConfigDef with all the common options specified
@@ -324,7 +332,9 @@ public class WorkerConfig extends AbstractConfig {
                 .define(TOPIC_TRACKING_ENABLE_CONFIG, Type.BOOLEAN, TOPIC_TRACKING_ENABLE_DEFAULT,
                         Importance.LOW, TOPIC_TRACKING_ENABLE_DOC)
                 .define(TOPIC_TRACKING_ALLOW_RESET_CONFIG, Type.BOOLEAN, TOPIC_TRACKING_ALLOW_RESET_DEFAULT,
-                        Importance.LOW, TOPIC_TRACKING_ALLOW_RESET_DOC);
+                        Importance.LOW, TOPIC_TRACKING_ALLOW_RESET_DOC)
+                .define(RESPONSE_HTTP_HEADERS_CONFIG, Type.STRING, RESPONSE_HTTP_HEADERS_DEFAULT,
+                        Importance.LOW, RESPONSE_HTTP_HEADERS_DOC);
     }
 
     private void logInternalConverterDeprecationWarnings(Map<String, String> props) {
@@ -398,6 +408,52 @@ public class WorkerConfig extends AbstractConfig {
     public WorkerConfig(ConfigDef definition, Map<String, String> props) {
         super(definition, props);
         logInternalConverterDeprecationWarnings(props);
+    }
+
+    public static void validateHttpResponseHeaderConfig(String config) {
+        try {
+            // validate format
+            String[] configTokens = config.trim().split("\\s+", 2);
+            if (configTokens.length != 2) {
+                throw new ConfigException(String.format("Invalid format of header config \"%s\". "
+                        + "Expected: \"[ation] [header name]:[header value]\"", config));
+            }
+
+            // validate action
+            String method = configTokens[0].trim();
+            validateHeaderConfigAction(method);
+
+            // validate header name and header value pair
+            String header = configTokens[1];
+            String[] headerTokens = header.trim().split(":");
+            if (headerTokens.length != 2) {
+                throw new ConfigException(
+                        String.format("Invalid format of header name and header value pair \"%s\". "
+                                + "Expected: \"[header name]:[header value]\"", header));
+            }
+
+            // validate header name
+            String headerName = headerTokens[0].trim();
+            if (headerName.contains(" ")) {
+                throw new ConfigException(String.format("Invalid header name \"%s\". "
+                        + "The \"[header name]\" cannot contain whitespace", headerName));
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new ConfigException(String.format("Invalid header config \"%s\".", config), e);
+        }
+    }
+
+    private static void validateHeaderConfigAction(String action) {
+        /**
+         * The following actions are defined following link.
+         * {@link https://www.eclipse.org/jetty/documentation/current/header-filter.html}
+         **/
+        if (!Arrays.asList("set", "add", "setDate", "addDate")
+                .stream()
+                .anyMatch(action::equalsIgnoreCase)) {
+            throw new ConfigException(String.format("Invalid header config action: \"%s\". "
+                    + "The action need be one of [\"set\", \"add\", \"setDate\", \"addDate\"]", action));
+        }
     }
 
     private static class AdminListenersValidator implements ConfigDef.Validator {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -413,7 +413,7 @@ public class WorkerConfig extends AbstractConfig {
     }
 
     // Visible for testing
-    public static void validateHttpResponseHeaderConfig(String config) {
+    static void validateHttpResponseHeaderConfig(String config) {
         try {
             // validate format
             String[] configTokens = config.trim().split("\\s+", 2);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -412,13 +412,7 @@ public class WorkerConfig extends AbstractConfig {
         logInternalConverterDeprecationWarnings(props);
     }
 
-    @Override
-    public String toString() {
-        return "Comma-separated header rules, where each header rule is of the form "
-                + "'[action] [header name]:[header value]' and optionally surrounded by double quotes "
-                + "if any part of a header rule contains a comma";
-    }
-
+    // Visible for testing
     public static void validateHttpResponseHeaderConfig(String config) {
         try {
             // validate format
@@ -452,7 +446,8 @@ public class WorkerConfig extends AbstractConfig {
         }
     }
 
-    public static void validateHeaderConfigAction(String action) {
+    // Visible for testing
+    static void validateHeaderConfigAction(String action) {
         if (!HEADER_ACTIONS.stream().anyMatch(action::equalsIgnoreCase)) {
             throw new ConfigException(String.format("Invalid header config action: '%s'. "
                     + "Expected one of %s", action, HEADER_ACTIONS));
@@ -496,6 +491,13 @@ public class WorkerConfig extends AbstractConfig {
 
             String[] configs = StringUtil.csvSplit(strValue); // handles and removed surrounding quotes
             Arrays.stream(configs).forEach(WorkerConfig::validateHttpResponseHeaderConfig);
+        }
+
+        @Override
+        public String toString() {
+            return "Comma-separated header rules, where each header rule is of the form "
+                    + "'[action] [header name]:[header value]' and optionally surrounded by double quotes "
+                    + "if any part of a header rule contains a comma";
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -48,7 +48,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.servlets.HeaderFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.util.StringUtil;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -60,7 +59,6 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -475,10 +473,6 @@ public class RestServer {
      */
     protected void configureHttpResponsHeaderFilter(ServletContextHandler context) {
         String headerConfig = config.getString(WorkerConfig.RESPONSE_HTTP_HEADERS_CONFIG);
-        log.debug("headerConfig : " + headerConfig);
-        String[] configs = StringUtil.csvSplit(headerConfig);
-        Arrays.stream(configs)
-                .forEach(WorkerConfig::validateHttpResponseHeaderConfig);
         FilterHolder headerFilterHolder = new FilterHolder(HeaderFilter.class);
         headerFilterHolder.setInitParameter("headerConfig", headerConfig);
         context.addFilter(headerFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));


### PR DESCRIPTION
Added supporting customized  HTTP Response Headers for Kafka Connect REST server.

**[KIP-577](https://cwiki.apache.org/confluence/display/KAFKA/KIP+577%3A+Allow+HTTP+Response+Headers+to+be+Configured+for+Kafka+Connect) HAS BEEN ACCEPTED**