### PR TITLE
MINOR: Only add 'Data' suffix for generated request/response/header types

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -54,7 +54,7 @@ public final class MessageDataGenerator {
         schemaGenerator.generateSchemas(message);
         messageFlexibleVersions = message.flexibleVersions();
         generateClass(Optional.of(message),
-            message.name() + "Data",
+            message.generatedClassName(),
             message.struct(),
             message.struct().versions());
         headerGenerator.generate();

--- a/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
@@ -107,6 +107,16 @@ public final class MessageSpec {
     }
 
     public String generatedClassName() {
-        return struct.name() + "Data";
+        switch (type) {
+            case HEADER:
+            case REQUEST:
+            case RESPONSE:
+                // We append the Data suffix to request/response/header classes to avoid
+                // collisions with existing objects. This can go away once the protocols
+                // have all been converted and we begin using the generated types directly.
+                return struct.name() + "Data";
+            default:
+                return struct.name();
+        }
     }
 }

--- a/streams/src/main/resources/common/message/SubscriptionInfoData.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfoData.json
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 {
-  "name": "SubscriptionInfo",
+  "name": "SubscriptionInfoData",
   "validVersions": "1-7",
   "fields": [
     {


### PR DESCRIPTION
Currently we add "Data" to all generated classnames in order to avoid naming collisions with existing Request/Response objects. Generated classes for other persistent schema definitions (such as those used in `GroupCoordinator` and `TransactionCoordinator`) will not necessarily have the same problem, so it would be nice if the generated types could use the name defined in the schema directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
