### PR TITLE
MINOR - Increase Trogdor Histogram buckets for latency to 10000ms

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -200,7 +200,7 @@ public class ConsumeBenchWorker implements TaskWorker {
         private final ThreadSafeConsumer consumer;
 
         private ConsumeMessages(ThreadSafeConsumer consumer) {
-            this.latencyHistogram = new Histogram(5000);
+            this.latencyHistogram = new Histogram(10000);
             this.messageSizeHistogram = new Histogram(2 * 1024 * 1024);
             this.clientId = consumer.clientId();
             this.statusUpdaterFuture = executor.scheduleAtFixedRate(

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -195,7 +195,7 @@ public class ProduceBenchWorker implements TaskWorker {
         SendRecords(HashSet<TopicPartition> activePartitions) {
             this.activePartitions = activePartitions;
             this.partitionsIterator = activePartitions.iterator();
-            this.histogram = new Histogram(5000);
+            this.histogram = new Histogram(10000);
 
             this.transactionGenerator = spec.transactionGenerator();
             this.enableTransactions = this.transactionGenerator.isPresent();


### PR DESCRIPTION
The current latency histograms for ProduceBenchWorker and ConsumeBenchWorker are limited to 5000ms, causing the histograms to truncate and report 5000ms on requests that take longer.  This increases the maximum latency the histogram accepts to 10000ms.