### PR TITLE
KAFKA-9965: Incrementing counter cause uneven distribution with RoundRobinPartitioner

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -75,9 +75,7 @@ public class RoundRobinPartitioner implements Partitioner {
 
     @Override
     public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
-        synchronized (topicCounterMap) {
-            topicCounterMap.computeIfPresent(topic, (k, v) -> new AtomicInteger(v.decrementAndGet()));
-        }
+        topicCounterMap.computeIfPresent(topic, (k, v) -> new AtomicInteger(v.decrementAndGet()));
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -77,7 +77,7 @@ public class RoundRobinPartitioner implements Partitioner {
     public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
         synchronized (topicCounterMap) {
             AtomicInteger counter = topicCounterMap.get(topic);
-            topicCounterMap.put(topic, new AtomicInteger(counter.getAndIncrement()));
+            topicCounterMap.put(topic, new AtomicInteger(counter.decrementAndGet()));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -76,8 +76,7 @@ public class RoundRobinPartitioner implements Partitioner {
     @Override
     public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
         synchronized (topicCounterMap) {
-            AtomicInteger counter = topicCounterMap.get(topic);
-            topicCounterMap.put(topic, new AtomicInteger(counter.decrementAndGet()));
+            topicCounterMap.computeIfPresent(topic, (k, v) -> new AtomicInteger(v.decrementAndGet()));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -73,4 +73,12 @@ public class RoundRobinPartitioner implements Partitioner {
 
     public void close() {}
 
+    @Override
+    public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+        synchronized (topicCounterMap) {
+            AtomicInteger counter = topicCounterMap.get(topic);
+            topicCounterMap.put(topic, new AtomicInteger(counter.getAndIncrement()));
+        }
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
@@ -124,5 +124,35 @@ public class RoundRobinPartitionerTest {
         assertEquals(10, partitionCount.get(0).intValue());
         assertEquals(10, partitionCount.get(1).intValue());
         assertEquals(10, partitionCount.get(2).intValue());
-    }    
+    }
+
+    @Test
+    public void testRoundRobinForNewBatch() {
+        final String topicA = "topicA";
+
+        List<PartitionInfo> allPartitions = asList(new PartitionInfo(topicA, 0, NODES[0], NODES, NODES),
+                new PartitionInfo(topicA, 1, NODES[1], NODES, NODES), new PartitionInfo(topicA, 2, NODES[2], NODES, NODES));
+        Cluster testCluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), allPartitions,
+                Collections.<String>emptySet(), Collections.<String>emptySet());
+
+        int part = 0;
+        final Map<Integer, Integer>  newPartitionCount = new HashMap<>();
+        Partitioner partitioner = new RoundRobinPartitioner();
+        for (int i = 0; i < 30; ++i) {
+            part = partitioner.partition(topicA, null, null, null, null, testCluster);
+            Integer count = newPartitionCount.get(part);
+            if (null == count)
+                count = 0;
+            newPartitionCount.put(part, count + 1);
+        }
+
+        assertEquals(10, newPartitionCount.get(0).intValue());
+        assertEquals(10, newPartitionCount.get(1).intValue());
+        assertEquals(10, newPartitionCount.get(2).intValue());
+        partitioner.onNewBatch (topicA, testCluster, part);
+        partitioner.partition("topicA", null, null, null, null, testCluster);
+        assertEquals(10, newPartitionCount.get(0).intValue());
+        assertEquals(10, newPartitionCount.get(1).intValue());
+        assertEquals(10, newPartitionCount.get(2).intValue());
+    }
 }


### PR DESCRIPTION
This code change provides fix for the JIRA ticket KAFKA-9965. 

Added synchronized block to safely decrement the counter on the map when a new batch is created.