### PR TITLE
kafkatest: Deploy VerifiableClient in constructor to avoid test timeouts

### DIFF
--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -181,8 +181,16 @@ def create_verifiable_client_implementation(context, parent):
 
 class VerifiableClientMixin (object):
     """
-    Verifiable client mixin class
+    Verifiable client mixin class which loads the actual VerifiableClient.. class.
     """
+    def __init__ (self, *args, **kwargs):
+        super(VerifiableClientMixin, self).__init__(*args, **kwargs)
+        if hasattr(self.impl, 'deploy'):
+            # Deploy client on node
+            self.context.logger.debug("Deploying %s on %s" % (self.impl, self.nodes))
+            for node in self.nodes:
+                self.impl.deploy(node)
+
     @property
     def impl (self):
         """
@@ -195,6 +203,13 @@ class VerifiableClientMixin (object):
                 self.context.logger.debug("Using client implementation %s for %s" % (self._impl.__class__.__name__, self.__class__.__name__))
         return self._impl
 
+
+class VerifiableClient (object):
+    """
+    Verifiable client base class
+    """
+    def __init__(self, *args, **kwargs):
+        super(VerifiableClient, self).__init__()
 
     def exec_cmd (self, node):
         """
@@ -218,7 +233,7 @@ class VerifiableClientMixin (object):
         return self.conf.get("kill_signal", signal.SIGTERM)
 
 
-class VerifiableClientJava (VerifiableClientMixin):
+class VerifiableClientJava (VerifiableClient):
     """
     Verifiable Consumer and Producer using the official Java client.
     """
@@ -258,7 +273,7 @@ class VerifiableClientJava (VerifiableClientMixin):
             return []
 
 
-class VerifiableClientDummy (VerifiableClientMixin):
+class VerifiableClientDummy (VerifiableClient):
     """
     Dummy class for testing the pluggable framework
     """
@@ -280,7 +295,7 @@ class VerifiableClientDummy (VerifiableClientMixin):
         return []
 
 
-class VerifiableClientApp (VerifiableClientMixin):
+class VerifiableClientApp (VerifiableClient):
     """
     VerifiableClient using --global settings for exec_cmd, pids and deploy.
     By using this a verifiable client application can be used through simple
@@ -302,9 +317,9 @@ class VerifiableClientApp (VerifiableClientMixin):
             raise SyntaxError("%s requires \"exec_cmd\": .. to be set in --globals %s object" % \
                               (self.__class__.__name__, self.name))
 
+
     def exec_cmd (self, node):
         """ :return: command to execute to start instance """
-        self.deploy(node)
         return self.conf["exec_cmd"]
 
     def pids (self, node):


### PR DESCRIPTION
Previous to this fix a plugged-in verifiable client, such as
confluent-kafka-python, would be deployed on the node in the background
worker thread as the client was started. Since this could be time consuming
(e.g., 10+ seconds) and since the main test thread would continue to
operate, it was common for the current test to time out waiting
for e.g. the verifiable producer to produce messages while it was in fact
still deploying.

The fix here is to deploy the verifiable client on the node when
the verifiable client is instantiated, which is thus a blocking
operation on the main test thread, avoiding any test-based timeouts.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
