### PR TITLE
MINOR: Correct MirrorMaker2 integration test configs for Connect internal topics

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -85,9 +85,9 @@ public class MirrorConnectorsIntegrationTest {
         mm2Props.put("checkpoints.topic.replication.factor", "1");
         mm2Props.put("heartbeats.topic.replication.factor", "1");
         mm2Props.put("offset-syncs.topic.replication.factor", "1");
-        mm2Props.put("config.storage.topic.replication.factor", "1");
-        mm2Props.put("offset.storage.topic.replication.factor", "1");
-        mm2Props.put("status.storage.topic.replication.factor", "1");
+        mm2Props.put("config.storage.replication.factor", "1");
+        mm2Props.put("offset.storage.replication.factor", "1");
+        mm2Props.put("status.storage.replication.factor", "1");
         mm2Props.put("replication.factor", "1");
         
         mm2Config = new MirrorMakerConfig(mm2Props); 


### PR DESCRIPTION
The replication factor for the Connect workers’ internal topics were incorrectly named and not actually used.

This only affects & fixes tests, and should be backported all the way back to the `2.4` branch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
