### PR TITLE
KAFKA-9931: Implement KIP-605 to expand support for Connect worker internal topic configurations

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -139,7 +139,7 @@
               files="Values.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DistributedHerder|RestClient|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask).java"/>
+              files="(DistributedHerder|RestClient|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin).java"/>
 
     <suppress checks="MethodLength"
               files="Values.java"/>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.LambdaValidator;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.util.TopicAdmin;
@@ -429,7 +430,7 @@ public class DistributedConfig extends WorkerConfig {
         if (CONFIG_STORAGE_PREFIX.equals(prefix) && result.containsKey(PARTITIONS_SUFFIX)) {
             log.warn("Ignoring '{}{}={}' setting, since config topic partitions is always 1", prefix, PARTITIONS_SUFFIX, result.get("partitions"));
         }
-        Object removedPolicy = result.remove("cleanup.policy");
+        Object removedPolicy = result.remove(TopicConfig.CLEANUP_POLICY_CONFIG);
         if (removedPolicy != null) {
             log.warn("Ignoring '{}cleanup.policy={}' setting, since compaction is always used", prefix, removedPolicy);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -50,6 +50,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -454,10 +455,9 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
         Map<String, Object> adminProps = new HashMap<>(originals);
 
-        Map<String, Object> topicSettings = null;
-        if (config instanceof DistributedConfig) {
-            topicSettings = ((DistributedConfig) config).configStorageTopicSettings();
-        }
+        Map<String, Object> topicSettings = config instanceof DistributedConfig
+                                            ? ((DistributedConfig) config).configStorageTopicSettings()
+                                            : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(topic)
                 .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
                 .compacted()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -459,7 +459,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                                             ? ((DistributedConfig) config).configStorageTopicSettings()
                                             : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(topic)
-                .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
+                .config(topicSettings) // first so that we override user-supplied settings as needed
                 .compacted()
                 .partitions(1)
                 .replicationFactor(config.getShort(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG))

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -84,7 +84,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
                                             ? ((DistributedConfig) config).offsetStorageTopicSettings()
                                             : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(topic)
-                .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
+                .config(topicSettings) // first so that we override user-supplied settings as needed
                 .compacted()
                 .partitions(config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG))
                 .replicationFactor(config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG))

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -79,10 +80,9 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
 
         Map<String, Object> adminProps = new HashMap<>(originals);
 
-        Map<String, Object> topicSettings = null;
-        if (config instanceof DistributedConfig) {
-            topicSettings = ((DistributedConfig) config).offsetStorageTopicSettings();
-        }
+        Map<String, Object> topicSettings = config instanceof DistributedConfig
+                                            ? ((DistributedConfig) config).offsetStorageTopicSettings()
+                                            : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(topic)
                 .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
                 .compacted()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -164,10 +164,9 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
 
         Map<String, Object> adminProps = new HashMap<>(originals);
 
-        Map<String, Object> topicSettings = null;
-        if (config instanceof DistributedConfig) {
-            topicSettings = ((DistributedConfig) config).statusStorageTopicSettings();
-        }
+        Map<String, Object> topicSettings = config instanceof DistributedConfig
+                                            ? ((DistributedConfig) config).statusStorageTopicSettings()
+                                            : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(statusTopic)
                 .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
                 .compacted()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -168,7 +168,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
                                             ? ((DistributedConfig) config).statusStorageTopicSettings()
                                             : Collections.emptyMap();
         NewTopic topicDescription = TopicAdmin.defineTopic(statusTopic)
-                .config(topicSettings) // first so that cleanup policy is overwritten to be compacted
+                .config(topicSettings) // first so that we override user-supplied settings as needed
                 .compacted()
                 .partitions(config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG))
                 .replicationFactor(config.getShort(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG))

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
@@ -48,12 +49,10 @@ public class TopicAdmin implements AutoCloseable {
     public static final int NO_PARTITIONS = -1;
     public static final short NO_REPLICATION_FACTOR = -1;
 
-    private static final String CLEANUP_POLICY_CONFIG = "cleanup.policy";
-    private static final String CLEANUP_POLICY_COMPACT = "compact";
-
-    private static final String MIN_INSYNC_REPLICAS_CONFIG = "min.insync.replicas";
-
-    private static final String UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG = "unclean.leader.election.enable";
+    private static final String CLEANUP_POLICY_CONFIG = TopicConfig.CLEANUP_POLICY_CONFIG;
+    private static final String CLEANUP_POLICY_COMPACT = TopicConfig.CLEANUP_POLICY_COMPACT;
+    private static final String MIN_INSYNC_REPLICAS_CONFIG = TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
+    private static final String UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG = TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 
     /**
      * A builder of {@link NewTopic} instances.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -299,6 +300,10 @@ public class TopicAdmin implements AutoCloseable {
                                     " Falling back to assume topic(s) exist or will be auto-created by the broker.",
                             topicNameList, bootstrapServers);
                     return Collections.emptySet();
+                }
+                if (cause instanceof InvalidConfigurationException) {
+                    throw new ConnectException("Unable to create topic(s) '" + topicNameList + "': " + cause.getMessage(),
+                            cause);
                 }
                 if (cause instanceof TimeoutException) {
                     // Timed out waiting for the operation to complete

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -60,8 +60,8 @@ public class TopicAdmin implements AutoCloseable {
      */
     public static class NewTopicBuilder {
         private String name;
-        private Integer numPartitions = null;
-        private Short replicationFactor = null;
+        private int numPartitions = NO_PARTITIONS;
+        private short replicationFactor = NO_REPLICATION_FACTOR;
         private Map<String, String> configs = new HashMap<>();
 
         NewTopicBuilder(String name) {
@@ -76,9 +76,6 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder partitions(int numPartitions) {
-            if (numPartitions == NO_PARTITIONS) {
-                return defaultPartitions();
-            }
             this.numPartitions = numPartitions;
             return this;
         }
@@ -90,7 +87,7 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder defaultPartitions() {
-            this.numPartitions = null;
+            this.numPartitions = NO_PARTITIONS;
             return this;
         }
 
@@ -102,9 +99,6 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder replicationFactor(short replicationFactor) {
-            if (replicationFactor == NO_REPLICATION_FACTOR) {
-                return defaultReplicationFactor();
-            }
             this.replicationFactor = replicationFactor;
             return this;
         }
@@ -116,7 +110,7 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder defaultReplicationFactor() {
-            this.replicationFactor = null;
+            this.replicationFactor = NO_REPLICATION_FACTOR;
             return this;
         }
 
@@ -179,8 +173,8 @@ public class TopicAdmin implements AutoCloseable {
         public NewTopic build() {
             return new NewTopic(
                     name,
-                    Optional.ofNullable(numPartitions),
-                    Optional.ofNullable(replicationFactor)
+                    Optional.of(numPartitions),
+                    Optional.of(replicationFactor)
             ).configs(configs);
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -38,7 +38,6 @@ public class InternalTopicsIntegrationTest {
 
     private static final Logger log = LoggerFactory.getLogger(InternalTopicsIntegrationTest.class);
 
-    private EmbeddedConnectCluster.Builder connectBuilder;
     private EmbeddedConnectCluster connect;
     Map<String, String> workerProps = new HashMap<>();
     Properties brokerProps = new Properties();
@@ -47,13 +46,6 @@ public class InternalTopicsIntegrationTest {
     public void setup() {
         // setup Kafka broker properties
         brokerProps.put("auto.create.topics.enable", String.valueOf(false));
-
-        // build a Connect cluster backed by Kafka and Zk
-        connectBuilder = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
-                .numWorkers(1)
-                .numBrokers(1)
-                .brokerProps(brokerProps);
     }
 
     @After
@@ -88,9 +80,6 @@ public class InternalTopicsIntegrationTest {
         log.info("Stopping the Connect worker");
         connect.removeWorker();
 
-        // Sleep for a bit
-        Thread.sleep(3000);
-
         // And restart
         log.info("Starting the Connect worker");
         connect.startConnect();
@@ -110,7 +99,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 1;
         int numBrokers = 2;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-2")
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)
@@ -136,7 +125,7 @@ public class InternalTopicsIntegrationTest {
         workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
         int numWorkers = 1;
         int numBrokers = 1;
-        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-3")
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
                                                       .workerProps(workerProps)
                                                       .numWorkers(numWorkers)
                                                       .numBrokers(numBrokers)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for the creation of internal topics.
+ */
+@Category(IntegrationTest.class)
+public class InternalTopicsIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(InternalTopicsIntegrationTest.class);
+
+    private EmbeddedConnectCluster.Builder connectBuilder;
+    private EmbeddedConnectCluster connect;
+    Map<String, String> workerProps = new HashMap<>();
+    Properties brokerProps = new Properties();
+
+    @Before
+    public void setup() {
+        // setup Kafka broker properties
+        brokerProps.put("auto.create.topics.enable", String.valueOf(false));
+
+        // build a Connect cluster backed by Kafka and Zk
+        connectBuilder = new EmbeddedConnectCluster.Builder()
+                .name("connect-cluster")
+                .numWorkers(1)
+                .numBrokers(1)
+                .brokerProps(brokerProps);
+    }
+
+    @After
+    public void close() {
+        // stop all Connect, Kafka and Zk threads.
+        connect.stop();
+    }
+
+    @Test
+    public void testCreateInternalTopicsWithDefaultSettings() throws InterruptedException {
+        int numWorkers = 1;
+        int numBrokers = 3;
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+                                                      .workerProps(workerProps)
+                                                      .numWorkers(numWorkers)
+                                                      .numBrokers(numBrokers)
+                                                      .brokerProps(brokerProps)
+                                                      .build();
+
+        // Start the Connect cluster
+        connect.start();
+        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Brokers did not start in time.");
+        connect.assertions().assertExactlyNumWorkersAreUp(numWorkers, "Worker did not start in time.");
+        log.info("Completed startup of {} Kafka brokers and {} Connect workers", numBrokers, numWorkers);
+
+        // Check the topics
+        log.info("Verifying the internal topics for Connect");
+        connect.assertions().assertTopicsExist(configTopic(), offsetTopic(), statusTopic());
+        assertInternalTopicSettings();
+
+        // Remove the Connect worker
+        log.info("Stopping the Connect worker");
+        connect.removeWorker();
+
+        // Sleep for a bit
+        Thread.sleep(3000);
+
+        // And restart
+        log.info("Starting the Connect worker");
+        connect.startConnect();
+
+        // Check the topics
+        log.info("Verifying the internal topics for Connect");
+        connect.assertions().assertTopicsExist(configTopic(), offsetTopic(), statusTopic());
+        assertInternalTopicSettings();
+
+        connect.stop();
+    }
+
+    @Test
+    public void testCreateInternalTopicsWithFewerReplicasThanBrokers() throws InterruptedException {
+        workerProps.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "2");
+        workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        int numWorkers = 1;
+        int numBrokers = 2;
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-2")
+                                                      .workerProps(workerProps)
+                                                      .numWorkers(numWorkers)
+                                                      .numBrokers(numBrokers)
+                                                      .brokerProps(brokerProps)
+                                                      .build();
+
+        // Start the Connect cluster
+        connect.start();
+        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
+        connect.assertions().assertAtLeastNumWorkersAreUp(numWorkers, "Worker did not start in time.");
+        log.info("Completed startup of {} Kafka brokers and {} Connect workers", numBrokers, numWorkers);
+
+        // Check the topics
+        log.info("Verifying the internal topics for Connect");
+        connect.assertions().assertTopicsExist(configTopic(), offsetTopic(), statusTopic());
+        assertInternalTopicSettings();
+    }
+
+    @Test
+    public void testFailToCreateInternalTopicsWithMoreReplicasThanBrokers() throws InterruptedException {
+        workerProps.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "3");
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "2");
+        workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        int numWorkers = 1;
+        int numBrokers = 1;
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-3")
+                                                      .workerProps(workerProps)
+                                                      .numWorkers(numWorkers)
+                                                      .numBrokers(numBrokers)
+                                                      .brokerProps(brokerProps)
+                                                      .build();
+
+        // Start the brokers and Connect, but Connect should fail to create config and offset topic
+        connect.start();
+        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
+        log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
+
+        // Verify that the offset and config topic don't exist;
+        // the status topic may have been created if timing was right but we don't care
+        log.info("Verifying the internal topics for Connect");
+        connect.assertions().assertTopicsDoNotExist(configTopic(), offsetTopic());
+    }
+
+    protected void assertInternalTopicSettings() {
+        DistributedConfig config = new DistributedConfig(workerProps);
+        connect.assertions().assertTopicSettings(
+                configTopic(),
+                config.getShort(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG),
+                1
+        );
+        connect.assertions().assertTopicSettings(
+                statusTopic(),
+                config.getShort(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG),
+                config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG)
+        );
+        connect.assertions().assertTopicSettings(
+                offsetTopic(),
+                config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG),
+                config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG)
+        );
+    }
+
+    protected String configTopic() {
+        return workerProps.get(DistributedConfig.CONFIG_TOPIC_CONFIG);
+    }
+
+    protected String offsetTopic() {
+        return workerProps.get(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG);
+    }
+
+    protected String statusTopic() {
+        return workerProps.get(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
@@ -105,4 +105,104 @@ public class DistributedConfigTest {
             algorithms.add(algorithms.remove(0));
         }
     }
+
+    @Test
+    public void shouldAllowNegativeOneAndPositiveForPartitions() {
+        Map<String, String> settings = configs();
+        settings.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, "-1");
+        settings.put(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG, "-1");
+        new DistributedConfig(configs());
+        settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+        settings.remove(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG);
+
+        for (int i = 1; i != 100; ++i) {
+            settings.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            new DistributedConfig(settings);
+            settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+
+            settings.put(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            new DistributedConfig(settings);
+        }
+    }
+
+    @Test
+    public void shouldNotAllowZeroPartitions() {
+        Map<String, String> settings = configs();
+        settings.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, "0");
+        assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+        settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+
+        settings.put(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG, "0");
+        assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+    }
+
+    @Test
+    public void shouldNotAllowNegativePartitionsLessThanNegativeOne() {
+        Map<String, String> settings = configs();
+        for (int i = -2; i > -100; --i) {
+            settings.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+            settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+
+            settings.put(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+        }
+    }
+
+    @Test
+    public void shouldAllowNegativeOneAndPositiveForReplicationFactor() {
+        Map<String, String> settings = configs();
+        settings.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "-1");
+        settings.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "-1");
+        settings.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "-1");
+        new DistributedConfig(configs());
+        settings.remove(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG);
+        settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+        settings.remove(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG);
+
+        for (int i = 1; i != 100; ++i) {
+            settings.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, Integer.toString(i));
+            new DistributedConfig(settings);
+            settings.remove(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG);
+
+            settings.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            new DistributedConfig(settings);
+            settings.remove(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG);
+
+            settings.put(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG, Integer.toString(i));
+            new DistributedConfig(settings);
+        }
+    }
+
+    @Test
+    public void shouldNotAllowZeroReplicationFactor() {
+        Map<String, String> settings = configs();
+        settings.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "0");
+        assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+        settings.remove(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG);
+
+        settings.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "0");
+        assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+        settings.remove(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG);
+
+        settings.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "0");
+        assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+    }
+
+    @Test
+    public void shouldNotAllowNegativeReplicationFactorLessThanNegativeOne() {
+        Map<String, String> settings = configs();
+        for (int i = -2; i > -100; --i) {
+            settings.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, Integer.toString(i));
+            assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+            settings.remove(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG);
+
+            settings.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, Integer.toString(i));
+            assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+            settings.remove(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG);
+
+            settings.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, Integer.toString(i));
+            assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
+        }
+    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
@@ -260,8 +260,8 @@ public class DistributedConfigTest {
         topicSettings.put("partitions", "3");
 
         Map<String, String> settings = configs();
-        topicSettings.entrySet().forEach(e -> {
-            settings.put(DistributedConfig.CONFIG_STORAGE_PREFIX + e.getKey(), e.getValue());
+        topicSettings.forEach((k, v) -> {
+            settings.put(DistributedConfig.CONFIG_STORAGE_PREFIX + k, v);
         });
         DistributedConfig config = new DistributedConfig(settings);
         Map<String, Object> actual = config.configStorageTopicSettings();
@@ -279,8 +279,8 @@ public class DistributedConfigTest {
         topicSettings.put("cleanup.policy", "something-else");
 
         Map<String, String> settings = configs();
-        topicSettings.entrySet().forEach(e -> {
-            settings.put(DistributedConfig.OFFSET_STORAGE_PREFIX + e.getKey(), e.getValue());
+        topicSettings.forEach((k, v) -> {
+            settings.put(DistributedConfig.OFFSET_STORAGE_PREFIX + k, v);
         });
         DistributedConfig config = new DistributedConfig(settings);
         Map<String, Object> actual = config.offsetStorageTopicSettings();
@@ -298,8 +298,8 @@ public class DistributedConfigTest {
         topicSettings.put("cleanup.policy", "something-else");
 
         Map<String, String> settings = configs();
-        topicSettings.entrySet().forEach(e -> {
-            settings.put(DistributedConfig.STATUS_STORAGE_PREFIX + e.getKey(), e.getValue());
+        topicSettings.forEach((k, v) -> {
+            settings.put(DistributedConfig.STATUS_STORAGE_PREFIX + k, v);
         });
         DistributedConfig config = new DistributedConfig(settings);
         Map<String, Object> actual = config.statusStorageTopicSettings();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -204,5 +205,105 @@ public class DistributedConfigTest {
             settings.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, Integer.toString(i));
             assertThrows(ConfigException.class, () -> new DistributedConfig(settings));
         }
+    }
+
+    @Test
+    public void shouldAllowSettingConfigTopicSettings() {
+        Map<String, String> topicSettings = new HashMap<>();
+        topicSettings.put("foo", "foo value");
+        topicSettings.put("bar", "bar value");
+        topicSettings.put("baz.bim", "100");
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.CONFIG_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        assertEquals(topicSettings, config.configStorageTopicSettings());
+    }
+
+    @Test
+    public void shouldAllowSettingOffsetTopicSettings() {
+        Map<String, String> topicSettings = new HashMap<>();
+        topicSettings.put("foo", "foo value");
+        topicSettings.put("bar", "bar value");
+        topicSettings.put("baz.bim", "100");
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.OFFSET_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        assertEquals(topicSettings, config.offsetStorageTopicSettings());
+    }
+
+    @Test
+    public void shouldAllowSettingStatusTopicSettings() {
+        Map<String, String> topicSettings = new HashMap<>();
+        topicSettings.put("foo", "foo value");
+        topicSettings.put("bar", "bar value");
+        topicSettings.put("baz.bim", "100");
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.STATUS_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        assertEquals(topicSettings, config.statusStorageTopicSettings());
+    }
+
+    @Test
+    public void shouldRemoveCompactionFromConfigTopicSettings() {
+        Map<String, String> expectedTopicSettings = new HashMap<>();
+        expectedTopicSettings.put("foo", "foo value");
+        expectedTopicSettings.put("bar", "bar value");
+        expectedTopicSettings.put("baz.bim", "100");
+        Map<String, String> topicSettings = new HashMap<>(expectedTopicSettings);
+        topicSettings.put("cleanup.policy", "something-else");
+        topicSettings.put("partitions", "3");
+
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.CONFIG_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        Map<String, Object> actual = config.configStorageTopicSettings();
+        assertEquals(expectedTopicSettings, actual);
+        assertNotEquals(topicSettings, actual);
+    }
+
+    @Test
+    public void shouldRemoveCompactionFromOffsetTopicSettings() {
+        Map<String, String> expectedTopicSettings = new HashMap<>();
+        expectedTopicSettings.put("foo", "foo value");
+        expectedTopicSettings.put("bar", "bar value");
+        expectedTopicSettings.put("baz.bim", "100");
+        Map<String, String> topicSettings = new HashMap<>(expectedTopicSettings);
+        topicSettings.put("cleanup.policy", "something-else");
+
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.OFFSET_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        Map<String, Object> actual = config.offsetStorageTopicSettings();
+        assertEquals(expectedTopicSettings, actual);
+        assertNotEquals(topicSettings, actual);
+    }
+
+    @Test
+    public void shouldRemoveCompactionFromStatusTopicSettings() {
+        Map<String, String> expectedTopicSettings = new HashMap<>();
+        expectedTopicSettings.put("foo", "foo value");
+        expectedTopicSettings.put("bar", "bar value");
+        expectedTopicSettings.put("baz.bim", "100");
+        Map<String, String> topicSettings = new HashMap<>(expectedTopicSettings);
+        topicSettings.put("cleanup.policy", "something-else");
+
+        Map<String, String> settings = configs();
+        topicSettings.entrySet().forEach(e -> {
+            settings.put(DistributedConfig.STATUS_STORAGE_PREFIX + e.getKey(), e.getValue());
+        });
+        DistributedConfig config = new DistributedConfig(settings);
+        Map<String, Object> actual = config.statusStorageTopicSettings();
+        assertEquals(expectedTopicSettings, actual);
+        assertNotEquals(topicSettings, actual);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -160,7 +160,10 @@ public class KafkaConfigBackingStoreTest {
 
         PowerMock.replayAll();
 
-        configStorage.setupAndCreateKafkaBasedLog(TOPIC, DEFAULT_DISTRIBUTED_CONFIG);
+        Map<String, String> settings = new HashMap<>(DEFAULT_CONFIG_STORAGE_PROPS);
+        settings.put("config.storage.min.insync.replicas", "3");
+        settings.put("config.storage.max.message.bytes", "1001");
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, new DistributedConfig(settings));
 
         assertEquals(TOPIC, capturedTopic.getValue());
         assertEquals("org.apache.kafka.common.serialization.StringSerializer", capturedProducerProps.getValue().get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG));
@@ -171,6 +174,8 @@ public class KafkaConfigBackingStoreTest {
         assertEquals(TOPIC, capturedNewTopic.getValue().name());
         assertEquals(1, capturedNewTopic.getValue().numPartitions());
         assertEquals(TOPIC_REPLICATION_FACTOR, capturedNewTopic.getValue().replicationFactor());
+        assertEquals("3", capturedNewTopic.getValue().configs().get("min.insync.replicas"));
+        assertEquals("1001", capturedNewTopic.getValue().configs().get("max.message.bytes"));
         configStorage.start();
         configStorage.stop();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -122,7 +122,10 @@ public class KafkaOffsetBackingStoreTest {
 
         PowerMock.replayAll();
 
-        store.configure(DEFAULT_DISTRIBUTED_CONFIG);
+        Map<String, String> settings = new HashMap<>(DEFAULT_PROPS);
+        settings.put("offset.storage.min.insync.replicas", "3");
+        settings.put("offset.storage.max.message.bytes", "1001");
+        store.configure(new DistributedConfig(settings));
         assertEquals(TOPIC, capturedTopic.getValue());
         assertEquals("org.apache.kafka.common.serialization.ByteArraySerializer", capturedProducerProps.getValue().get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG));
         assertEquals("org.apache.kafka.common.serialization.ByteArraySerializer", capturedProducerProps.getValue().get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -17,9 +17,12 @@
 package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.Cluster;
@@ -34,11 +37,14 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TopicAdminTest {
 
@@ -97,12 +103,65 @@ public class TopicAdminTest {
     }
 
     @Test
-    public void shouldCreateTopicWhenItDoesNotExist() {
-        NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
-        Cluster cluster = createCluster(1);
-        try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
-            assertTrue(admin.createTopic(newTopic));
+    public void shouldCreateTopicWithPartitionsWhenItDoesNotExist() {
+        for (int numBrokers = 1; numBrokers < 10; ++numBrokers) {
+            int expectedReplicas = Math.min(3, numBrokers);
+            int maxDefaultRf = Math.min(numBrokers, 5);
+            for (int numPartitions = 1; numPartitions != 30; ++numPartitions) {
+                NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(numPartitions).compacted().build();
+
+                // Try clusters with no default replication factor or default partitions
+                assertTopicCreation(numBrokers, newTopic, null, null, expectedReplicas, numPartitions);
+
+                // Try clusters with different default partitions
+                for (int defaultPartitions = 1; defaultPartitions != 20; ++defaultPartitions) {
+                    assertTopicCreation(numBrokers, newTopic, defaultPartitions, null, expectedReplicas, numPartitions);
+                }
+
+                // Try clusters with different default replication factors
+                for (int defaultRF = 1; defaultRF != maxDefaultRf; ++defaultRF) {
+                    assertTopicCreation(numBrokers, newTopic, null, defaultRF, defaultRF, numPartitions);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldCreateTopicWithReplicationFactorWhenItDoesNotExist() {
+        for (int numBrokers = 1; numBrokers < 10; ++numBrokers) {
+            int maxRf = Math.min(numBrokers, 5);
+            int maxDefaultRf = Math.min(numBrokers, 5);
+            for (short rf = 1; rf != maxRf; ++rf) {
+                NewTopic newTopic = TopicAdmin.defineTopic("myTopic").replicationFactor(rf).compacted().build();
+
+                // Try clusters with no default replication factor or default partitions
+                assertTopicCreation(numBrokers, newTopic, null, null, rf, 1);
+
+                // Try clusters with different default partitions
+                for (int numPartitions = 1; numPartitions != 30; ++numPartitions) {
+                    assertTopicCreation(numBrokers, newTopic, numPartitions, null, rf, numPartitions);
+                }
+
+                // Try clusters with different default replication factors
+                for (int defaultRF = 1; defaultRF != maxDefaultRf; ++defaultRF) {
+                    assertTopicCreation(numBrokers, newTopic, null, defaultRF, rf, 1);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldCreateTopicWithDefaultPartitionsAndReplicationFactorWhenItDoesNotExist() {
+        NewTopic newTopic = TopicAdmin.defineTopic("my-topic")
+                                      .defaultPartitions()
+                                      .defaultReplicationFactor()
+                                      .compacted()
+                                      .build();
+
+        for (int numBrokers = 1; numBrokers < 10; ++numBrokers) {
+            int expectedReplicas = Math.min(3, numBrokers);
+            assertTopicCreation(numBrokers, newTopic, null, null, expectedReplicas, 1);
+            assertTopicCreation(numBrokers, newTopic, 30, null, expectedReplicas, 30);
         }
     }
 
@@ -162,5 +221,50 @@ public class TopicAdminTest {
                 setErrorMessage(error.message()));
         }
         return new CreateTopicsResponse(response);
+    }
+
+    protected void assertTopicCreation(
+            int brokers,
+            NewTopic newTopic,
+            Integer defaultPartitions,
+            Integer defaultReplicationFactor,
+            int expectedReplicas,
+            int expectedPartitions
+    ) {
+        Cluster cluster = createCluster(brokers);
+        MockAdminClient.Builder clientBuilder = MockAdminClient.create();
+        if (defaultPartitions != null) {
+            clientBuilder.defaultPartitions(defaultPartitions.shortValue());
+        }
+        if (defaultReplicationFactor != null) {
+            clientBuilder.defaultReplicationFactor(defaultReplicationFactor.intValue());
+        }
+        clientBuilder.brokers(cluster.nodes());
+        clientBuilder.controller(0);
+        try (MockAdminClient admin = clientBuilder.build()) {
+            TopicAdmin topicClient = new TopicAdmin(null, admin, false);
+            assertTrue(topicClient.createTopic(newTopic));
+            assertTopic(admin, newTopic.name(), expectedPartitions, expectedReplicas);
+        }
+    }
+
+    protected void assertTopic(MockAdminClient admin, String topicName, int expectedPartitions, int expectedReplicas) {
+        TopicDescription desc = null;
+        try {
+            desc = topicDescription(admin, topicName);
+        } catch (Throwable t) {
+            fail("Failed to find topic description for topic '" + topicName + "'");
+        }
+        assertEquals(expectedPartitions, desc.partitions().size());
+        for (TopicPartitionInfo tp : desc.partitions()) {
+            assertEquals(expectedReplicas, tp.replicas().size());
+        }
+    }
+
+    protected TopicDescription topicDescription(MockAdminClient admin, String topicName)
+            throws ExecutionException, InterruptedException {
+        DescribeTopicsResult result = admin.describeTopics(Collections.singleton(topicName));
+        Map<String, KafkaFuture<TopicDescription>> byName = result.values();
+        return byName.get(topicName).get();
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -107,19 +107,19 @@ public class TopicAdminTest {
         for (int numBrokers = 1; numBrokers < 10; ++numBrokers) {
             int expectedReplicas = Math.min(3, numBrokers);
             int maxDefaultRf = Math.min(numBrokers, 5);
-            for (int numPartitions = 1; numPartitions != 30; ++numPartitions) {
+            for (int numPartitions = 1; numPartitions < 30; ++numPartitions) {
                 NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(numPartitions).compacted().build();
 
                 // Try clusters with no default replication factor or default partitions
                 assertTopicCreation(numBrokers, newTopic, null, null, expectedReplicas, numPartitions);
 
                 // Try clusters with different default partitions
-                for (int defaultPartitions = 1; defaultPartitions != 20; ++defaultPartitions) {
+                for (int defaultPartitions = 1; defaultPartitions < 20; ++defaultPartitions) {
                     assertTopicCreation(numBrokers, newTopic, defaultPartitions, null, expectedReplicas, numPartitions);
                 }
 
                 // Try clusters with different default replication factors
-                for (int defaultRF = 1; defaultRF != maxDefaultRf; ++defaultRF) {
+                for (int defaultRF = 1; defaultRF < maxDefaultRf; ++defaultRF) {
                     assertTopicCreation(numBrokers, newTopic, null, defaultRF, defaultRF, numPartitions);
                 }
             }
@@ -131,19 +131,19 @@ public class TopicAdminTest {
         for (int numBrokers = 1; numBrokers < 10; ++numBrokers) {
             int maxRf = Math.min(numBrokers, 5);
             int maxDefaultRf = Math.min(numBrokers, 5);
-            for (short rf = 1; rf != maxRf; ++rf) {
+            for (short rf = 1; rf < maxRf; ++rf) {
                 NewTopic newTopic = TopicAdmin.defineTopic("myTopic").replicationFactor(rf).compacted().build();
 
                 // Try clusters with no default replication factor or default partitions
                 assertTopicCreation(numBrokers, newTopic, null, null, rf, 1);
 
                 // Try clusters with different default partitions
-                for (int numPartitions = 1; numPartitions != 30; ++numPartitions) {
+                for (int numPartitions = 1; numPartitions < 30; ++numPartitions) {
                     assertTopicCreation(numBrokers, newTopic, numPartitions, null, rf, numPartitions);
                 }
 
                 // Try clusters with different default replication factors
-                for (int defaultRF = 1; defaultRF != maxDefaultRf; ++defaultRF) {
+                for (int defaultRF = 1; defaultRF < maxDefaultRf; ++defaultRF) {
                     assertTopicCreation(numBrokers, newTopic, null, defaultRF, rf, 1);
                 }
             }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -16,7 +16,15 @@
  */
 package org.apache.kafka.connect.util.clusters;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -27,10 +35,15 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertEquals;
 
 /**
  * A set of common assertions that can be applied to a Connect cluster during integration testing
@@ -94,6 +107,109 @@ public class EmbeddedConnectClusterAssertions {
         } catch (Exception e) {
             log.error("Could not check active workers.", e);
             return Optional.empty();
+        }
+    }
+
+    /**
+     * Assert that at least the requested number of workers are up and running.
+     *
+     * @param numBrokers the number of online brokers
+     */
+    public void assertExactlyNumBrokersAreUp(int numBrokers, String detailMessage) throws InterruptedException {
+        try {
+            waitForCondition(
+                    () -> checkBrokersUp(numBrokers, (actual, expected) -> actual == expected).orElse(false),
+                    WORKER_SETUP_DURATION_MS,
+                    "Didn't meet the exact requested number of online brokers: " + numBrokers);
+        } catch (AssertionError e) {
+            throw new AssertionError(detailMessage, e);
+        }
+    }
+
+    /**
+     * Confirm that the requested number of brokers are up and running.
+     *
+     * @param numBrokers the number of online brokers
+     * @return true if at least {@code numBrokers} are up; false otherwise
+     */
+    protected Optional<Boolean> checkBrokersUp(int numBrokers, BiFunction<Integer, Integer, Boolean> comp) {
+        try {
+            int numRunning = connect.kafka().runningBrokers().size();
+            return Optional.of(comp.apply(numRunning, numBrokers));
+        } catch (Exception e) {
+            log.error("Could not check running brokers.", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Assert that the topics with the specified names do not exist.
+     *
+     * @param topicNames the names of the topics that are expected to not exist
+     */
+    public void assertTopicsDoNotExist(String... topicNames) throws InterruptedException {
+        Set<String> topicNameSet = new HashSet<>(Arrays.asList(topicNames));
+        AtomicReference<Set<String>> existingTopics = new AtomicReference<>(topicNameSet);
+        waitForCondition(
+                () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
+                    existingTopics.set(actual);
+                    return actual.isEmpty();
+                }).orElse(false),
+                WORKER_SETUP_DURATION_MS,
+                "Unexpectedly found topics " + existingTopics.get());
+    }
+
+    /**
+     * Assert that the topics with the specified names do exist.
+     *
+     * @param topicNames the names of the topics that are expected to exist
+     */
+    public void assertTopicsExist(String... topicNames) throws InterruptedException {
+        Set<String> topicNameSet = new HashSet<>(Arrays.asList(topicNames));
+        AtomicReference<Set<String>> missingTopics = new AtomicReference<>(topicNameSet);
+        waitForCondition(
+                () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
+                    Set<String> missing = new HashSet<>(expected);
+                    missing.removeAll(actual);
+                    missingTopics.set(missing);
+                    return missing.isEmpty();
+                }).orElse(false),
+                WORKER_SETUP_DURATION_MS,
+                "Didn't find the topics " + missingTopics.get());
+    }
+
+    protected Optional<Boolean> checkTopicsExist(Set<String> topicNames, BiFunction<Set<String>, Set<String>, Boolean> comp) {
+        try {
+            Map<String, Optional<TopicDescription>> topics = connect.kafka().describeTopics(topicNames);
+            Set<String> actualExistingTopics = topics.entrySet()
+                                                     .stream()
+                                                     .filter(e -> e.getValue().isPresent())
+                                                     .map(Map.Entry::getKey)
+                                                     .collect(Collectors.toSet());
+            return Optional.of(comp.apply(actualExistingTopics, topicNames));
+        } catch (Exception e) {
+            log.error("Could not check config validation error count.", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Assert that the named topic is configured to have the specified replication factor and
+     * number of partitions.
+     *
+     * @param topicName  the name of the topic that is expected to exist
+     * @param replicas   the replication factor
+     * @param partitions the number of partitions
+     */
+    public void assertTopicSettings(String topicName, int replicas, int partitions) {
+        Map<String, Object> consumerProps = Collections.singletonMap("group.id", UUID.randomUUID().toString());
+        try (Consumer<byte[], byte[]> verifiableConsumer = connect.kafka().createConsumer(consumerProps);) {
+            List<PartitionInfo> infos = verifiableConsumer.partitionsFor(topicName);
+            assertEquals(partitions, infos.size());
+            for (PartitionInfo info : infos) {
+                assertEquals(topicName, info.topic());
+                assertEquals(replicas, info.replicas().length);
+            }
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -118,9 +118,9 @@ public class EmbeddedConnectClusterAssertions {
     public void assertExactlyNumBrokersAreUp(int numBrokers, String detailMessage) throws InterruptedException {
         try {
             waitForCondition(
-                    () -> checkBrokersUp(numBrokers, (actual, expected) -> actual == expected).orElse(false),
-                    WORKER_SETUP_DURATION_MS,
-                    "Didn't meet the exact requested number of online brokers: " + numBrokers);
+                () -> checkBrokersUp(numBrokers, (actual, expected) -> actual == expected).orElse(false),
+                WORKER_SETUP_DURATION_MS,
+                "Didn't meet the exact requested number of online brokers: " + numBrokers);
         } catch (AssertionError e) {
             throw new AssertionError(detailMessage, e);
         }
@@ -151,12 +151,12 @@ public class EmbeddedConnectClusterAssertions {
         Set<String> topicNameSet = new HashSet<>(Arrays.asList(topicNames));
         AtomicReference<Set<String>> existingTopics = new AtomicReference<>(topicNameSet);
         waitForCondition(
-                () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
-                    existingTopics.set(actual);
-                    return actual.isEmpty();
-                }).orElse(false),
-                WORKER_SETUP_DURATION_MS,
-                "Unexpectedly found topics " + existingTopics.get());
+            () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
+                existingTopics.set(actual);
+                return actual.isEmpty();
+            }).orElse(false),
+            WORKER_SETUP_DURATION_MS,
+            "Unexpectedly found topics " + existingTopics.get());
     }
 
     /**
@@ -168,14 +168,14 @@ public class EmbeddedConnectClusterAssertions {
         Set<String> topicNameSet = new HashSet<>(Arrays.asList(topicNames));
         AtomicReference<Set<String>> missingTopics = new AtomicReference<>(topicNameSet);
         waitForCondition(
-                () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
-                    Set<String> missing = new HashSet<>(expected);
-                    missing.removeAll(actual);
-                    missingTopics.set(missing);
-                    return missing.isEmpty();
-                }).orElse(false),
-                WORKER_SETUP_DURATION_MS,
-                "Didn't find the topics " + missingTopics.get());
+            () -> checkTopicsExist(topicNameSet, (actual, expected) -> {
+                Set<String> missing = new HashSet<>(expected);
+                missing.removeAll(actual);
+                missingTopics.set(missing);
+                return missing.isEmpty();
+            }).orElse(false),
+            WORKER_SETUP_DURATION_MS,
+            "Didn't find the topics " + missingTopics.get());
     }
 
     protected Optional<Boolean> checkTopicsExist(Set<String> topicNames, BiFunction<Set<String>, Set<String>, Boolean> comp) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -16,16 +16,20 @@
  */
 package org.apache.kafka.connect.util.clusters;
 
+import kafka.server.BrokerState;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaConfig$;
 import kafka.server.KafkaServer;
+import kafka.server.RunningAsBroker;
 import kafka.utils.CoreUtils;
 import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -33,10 +37,12 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -52,12 +58,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
@@ -234,6 +244,84 @@ public class EmbeddedKafkaCluster extends ExternalResource {
 
     public String zKConnectString() {
         return "127.0.0.1:" + zookeeper.port();
+    }
+
+    /**
+     * Get the brokers that have a {@link RunningAsBroker} state.
+     *
+     * @return the list of {@link KafkaServer} instances that are running;
+     *         never null but  possibly empty
+     */
+    public Set<KafkaServer> runningBrokers() {
+        return brokersInState(state -> state.currentState() == RunningAsBroker.state());
+    }
+
+    /**
+     * Get the brokers whose state match the given predicate.
+     *
+     * @return the list of {@link KafkaServer} instances with states that match the predicate;
+     *         never null but  possibly empty
+     */
+    public Set<KafkaServer> brokersInState(Predicate<BrokerState> desiredState) {
+        return Arrays.stream(brokers)
+                     .filter(b -> hasState(b, desiredState))
+                     .collect(Collectors.toSet());
+    }
+
+    protected boolean hasState(KafkaServer server, Predicate<BrokerState> desiredState) {
+        try {
+            return desiredState.test(server.brokerState());
+        } catch (Throwable e) {
+            // Broker failed to respond.
+            return false;
+        }
+    }
+
+    /**
+     * Get the topic descriptions of the named topics. The value of the map entry will be empty
+     * if the topic does not exist.
+     *
+     * @param topicNames the names of the topics to describe
+     * @return the map of optional {@link TopicDescription} keyed by the topic name
+     */
+    public Map<String, Optional<TopicDescription>> describeTopics(String... topicNames) {
+        return describeTopics(new HashSet<>(Arrays.asList(topicNames)));
+    }
+
+    /**
+     * Get the topic descriptions of the named topics. The value of the map entry will be empty
+     * if the topic does not exist.
+     *
+     * @param topicNames the names of the topics to describe
+     * @return the map of optional {@link TopicDescription} keyed by the topic name
+     */
+    public Map<String, Optional<TopicDescription>> describeTopics(Set<String> topicNames) {
+        Map<String, Optional<TopicDescription>> results = new HashMap<>();
+        log.info("Describing topics {}", topicNames);
+        try (Admin admin = createAdminClient()) {
+            DescribeTopicsResult result = admin.describeTopics(topicNames);
+            Map<String, KafkaFuture<TopicDescription>> byName = result.values();
+            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : byName.entrySet()) {
+                String topicName = entry.getKey();
+                try {
+                    TopicDescription desc = entry.getValue().get();
+                    results.put(topicName, Optional.of(desc));
+                    log.info("Found topic {} : {}", topicName, desc);
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof UnknownTopicOrPartitionException) {
+                        results.put(topicName, Optional.empty());
+                        log.info("Found non-existant topic {}", topicName);
+                        continue;
+                    }
+                    throw new AssertionError("Could not describe topic(s)" + topicNames, e);
+                }
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Could not describe topic(s) " + topicNames, e);
+        }
+        log.info("Found topics {}", results);
+        return results;
     }
 
     /**


### PR DESCRIPTION
**[KIP-605](https://cwiki.apache.org/confluence/display/KAFKA/KIP-605%3A+Expand+Connect+Worker+Internal+Topic+Settings) has passed.**

Expanded the allowed values for the internal topics’ replication factor and partitions from positive values to also include -1 to signify that the broker defaults should be used.

The Kafka storage classes were already constructing a `NewTopic` object (always with a replication factor and partitions) and sending it to Kafka when required. This change will avoid setting the replication factor and/or number of partitions on this `NewTopic` if the worker configuration uses -1 for the corresponding configuration value.

Quite a few new tests were added to verify that the `TopicAdmin` utility class is correctly using the AdminClient, that the `DistributedConfig` validators for these configurations are correct, and that the `DistributedConfig` is correctly assembling the configuration properties that define the topic settings, which are now accessed by the three Kafka storage objects before they create the topics.

Also added support for additional topic settings used when creating the config, status, and offset internal topics. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
