### PR TITLE
KAFKA-9981; dedicated mm2 cluster lose the update operation.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1303,6 +1303,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
             if (changed) {
                 List<Map<String, String>> rawTaskProps = reverseTransform(connName, configState, taskProps);
+                // If configBackingStore task is not running on leader node,A POST request could not be send to notify
+                // the leader of the configuration update.However,dedicated mm2 cluster does not have the HTTP server
+                // turned on,so the request will fail to be sent,causing the update operation to be lost.
                 if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1303,7 +1303,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
             if (changed) {
                 List<Map<String, String>> rawTaskProps = reverseTransform(connName, configState, taskProps);
-                if (isLeader()) {
+                if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);
                 } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1306,7 +1306,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // If configBackingStore task is not running on leader node,A POST request could not be send to notify
                 // the leader of the configuration update.However,dedicated mm2 cluster does not have the HTTP server
                 // turned on,so the request will fail to be sent,causing the update operation to be lost.
-                // TODO: This assessment of NOTUSED logic will be delete when the REST API is added back. 
+                // TODO: This assessment of "NOTUSED" logic will be delete when the REST API is added back.
                 if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1306,7 +1306,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // If configBackingStore task is not running on leader node,A POST request could not be send to notify
                 // the leader of the configuration update.However,dedicated mm2 cluster does not have the HTTP server
                 // turned on,so the request will fail to be sent,causing the update operation to be lost.
-                // TODO: This assessment of "NOTUSED" logic will be delete when the REST API is added back.
+                // TODO: This assessment of NOTUSED logic will be delete when the REST API is added back.
                 if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1306,7 +1306,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // If configBackingStore task is not running on leader node,A POST request could not be send to notify
                 // the leader of the configuration update.However,dedicated mm2 cluster does not have the HTTP server
                 // turned on,so the request will fail to be sent,causing the update operation to be lost.
-                // TODO: This assessment of NOTUSED logic will be delete when the REST API is added back.
+                // TODO: This assessment of NOTUSED logic will be delete when the REST API is added back. 
                 if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1306,6 +1306,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // If configBackingStore task is not running on leader node,A POST request could not be send to notify
                 // the leader of the configuration update.However,dedicated mm2 cluster does not have the HTTP server
                 // turned on,so the request will fail to be sent,causing the update operation to be lost.
+                // TODO: This assessment of NOTUSED logic will be delete when the REST API is added back.
                 if (isLeader() || (leaderUrl() != null && leaderUrl().startsWith("NOTUSED"))) {
                     configBackingStore.putTaskConfigs(connName, rawTaskProps);
                     cb.onCompletion(null, null);


### PR DESCRIPTION
Although the configBackingStore task not on the leader node,The configBackingStore directly notifies the mirrormaker task after sensing the configuration update.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
