### PR TITLE
KAFKA-9980: Fix bug where alterClientQuotas could not set default client quotas

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -714,16 +714,16 @@ class AdminManager(val config: KafkaConfig,
     new DescribeConfigsResponse.ConfigEntry(name, valueAsString, source, isSensitive, readOnly, synonyms.asJava)
   }
 
-  private def sanitizeEntityName(entityName: String): String = {
-    if (entityName == ConfigEntityName.Default)
-      throw new InvalidRequestException(s"Entity name '${ConfigEntityName.Default}' is reserved")
-    Sanitizer.sanitize(Option(entityName).getOrElse(ConfigEntityName.Default))
-  }
+  private def sanitizeEntityName(entityName: String): String =
+    Option(entityName) match {
+      case None => ConfigEntityName.Default
+      case Some(name) => Sanitizer.sanitize(name)
+    }
 
   private def desanitizeEntityName(sanitizedEntityName: String): String =
-    Sanitizer.desanitize(sanitizedEntityName) match {
+    sanitizedEntityName match {
       case ConfigEntityName.Default => null
-      case name => name
+      case name => Sanitizer.desanitize(name)
     }
 
   private def entityToSanitizedUserClientId(entity: ClientQuotaEntity): (Option[String], Option[String]) = {

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -382,6 +382,20 @@ class ClientQuotasRequestTest extends BaseRequestTest {
     ))
   }
 
+  @Test
+  def testClientQuotasWithDefaultName(): Unit = {
+    // An entity using the name associated with the default entity name. The entity's name should be sanitized so
+    // that it does not conflict with the default entity name.
+    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.CLIENT_ID -> ConfigEntityName.Default)).asJava)
+    alterEntityQuotas(entity, Map((ProducerByteRateProp -> Some(20000.0))), validateOnly = false)
+    verifyDescribeEntityQuotas(entity, Map((ProducerByteRateProp -> 20000.0)))
+
+    // This should not match.
+    val result = describeClientQuotas(
+      ClientQuotaFilter.containsOnly(List(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.CLIENT_ID)).asJava))
+    assert(result.isEmpty)
+  }
+
   private def verifyDescribeEntityQuotas(entity: ClientQuotaEntity, quotas: Map[String, Double]) = {
     val components = entity.entries.asScala.map(e => ClientQuotaFilterComponent.ofEntity(e._1, e._2))
     val describe = describeClientQuotas(ClientQuotaFilter.containsOnly(components.toList.asJava))


### PR DESCRIPTION
Fixes an issue where the default entity name `"<default>"` was erroneously
being sanitized, which prevented proper inheritance of default configs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
