### PR TITLE
KAFKA-9716: Clarify meaning of compression rate metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -84,7 +84,7 @@ public class SenderMetricsRegistry {
         this.batchSizeMax = createMetricName("batch-size-max",
                 "The max number of bytes sent per partition per-request.");
         this.compressionRateAvg = createMetricName("compression-rate-avg",
-                "The average compression rate of record batches.");
+                "The average compressed-to-uncompressed size ratio of record batches.");
         this.recordQueueTimeAvg = createMetricName("record-queue-time-avg",
                 "The average time in ms record batches spent in the send buffer.");
         this.recordQueueTimeMax = createMetricName("record-queue-time-max",
@@ -139,7 +139,7 @@ public class SenderMetricsRegistry {
         this.topicByteTotal = createTopicTemplate("byte-total", 
                 "The total number of bytes sent for a topic.");
         this.topicCompressionRate = createTopicTemplate("compression-rate",
-                "The average compression rate of record batches for a topic.");
+                "The average compressed-to-uncompressed size ratio of record batches for a topic.");
         this.topicRecordRetryRate = createTopicTemplate("record-retry-rate",
                 "The average per-second number of retried record sends for a topic");
         this.topicRecordRetryTotal = createTopicTemplate("record-retry-total",

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -84,7 +84,8 @@ public class SenderMetricsRegistry {
         this.batchSizeMax = createMetricName("batch-size-max",
                 "The max number of bytes sent per partition per-request.");
         this.compressionRateAvg = createMetricName("compression-rate-avg",
-                "The average compressed-to-uncompressed size ratio of record batches.");
+                "The average compression rate of record batches, defined as the average ratio of the " +
+                        "compressed batch size over the uncompressed size.");
         this.recordQueueTimeAvg = createMetricName("record-queue-time-avg",
                 "The average time in ms record batches spent in the send buffer.");
         this.recordQueueTimeMax = createMetricName("record-queue-time-max",
@@ -139,7 +140,8 @@ public class SenderMetricsRegistry {
         this.topicByteTotal = createTopicTemplate("byte-total", 
                 "The total number of bytes sent for a topic.");
         this.topicCompressionRate = createTopicTemplate("compression-rate",
-                "The average compressed-to-uncompressed size ratio of record batches for a topic.");
+                "The average compression rate of record batches for a topic, defined as the average ratio " +
+                        "of the compressed batch size over the uncompressed size.");
         this.topicRecordRetryRate = createTopicTemplate("record-retry-rate",
                 "The average per-second number of retried record sends for a topic");
         this.topicRecordRetryTotal = createTopicTemplate("record-retry-total",


### PR DESCRIPTION
There is some confusion over the compression rate metrics, as the meaning of the value isn't clearly stated in the metric description. In this case, it was assumed that a higher compression rate value meant better compression. This PR clarifies the meaning of the value, to prevent misunderstandings.

Alternative approaches that were considered were to either change the name of the metric or its implementation, but this would have a negative impact on those who are already making use of this metric.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
