### PR TITLE
KAFKA-9479: Describe consumer group --state --all-groups  show header once

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -165,17 +165,23 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
       val group = this.group + describeType.mkString("")
       addConsumerGroupExecutor(numConsumers = 1, group = group)
     }
-
     val expectedNumLines = describeTypes.length * 2
+    val expectedNumLinesState = describeTypes.length + 1
+
+    def provideExpectedNumLines(describeType:Array[String]):Int = {
+      if(Array(describeType).sameElements(describeTypeState))
+        expectedNumLinesState
+      else
+        expectedNumLines
+    }
 
     for (describeType <- describeTypes) {
       val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--all-groups") ++ describeType
       val service = getConsumerGroupService(cgcArgs)
-
       TestUtils.waitUntilTrue(() => {
         val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroups())
         val numLines = output.trim.split("\n").filterNot(line => line.isEmpty).length
-        (numLines == expectedNumLines) && error.isEmpty
+        (numLines == provideExpectedNumLines(describeType)) && error.isEmpty
       }, s"Expected a data row and no error in describe results with describe type ${describeType.mkString(" ")}.")
     }
   }


### PR DESCRIPTION
Used the  [previous PR ](https://github.com/apache/kafka/pull/8096) made by vetler as a starting point.

Updated the  printState() method in ConsumerGroup command to only print the header once when the following options are set `--describe --state --all-groups`.

Modified testDescribeAllExistingGroups test in DescribeConsumerGroupTest so that we take into account the case where we only print the header once. In this case number of lines is equal to the length of DescribeTypes + 1. 

Tagging @hachikuji @jeffkbkim as they reviewed the previous PR for this ticket.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
