### PR TITLE
KAFKA-9859 / Add topics generated by KTable FK join to internal topic matching logic

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -649,7 +649,7 @@ public class StreamsResetter {
 
     // visible for testing
     public void doDelete(final List<String> topicsToDelete,
-                          final Admin adminClient) {
+                         final Admin adminClient) {
         boolean hasDeleteErrors = false;
         final DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(topicsToDelete);
         final Map<String, KafkaFuture<Void>> results = deleteTopicsResult.values();
@@ -673,11 +673,17 @@ public class StreamsResetter {
         // Even is this is not expected in general, we need to exclude those topics here
         // and don't consider them as internal topics even if they follow the same naming schema.
         // Cf. https://issues.apache.org/jira/browse/KAFKA-7930
-        return !isInputTopic(topicName) && !isIntermediateTopic(topicName)
-            && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
-            && (topicName.endsWith("-changelog") || topicName.endsWith("-repartition")
-                || topicName.endsWith("-subscription-registration-topic")
-                || topicName.endsWith("-subscription-response-topic"));
+        return !isInputTopic(topicName) && !isIntermediateTopic(topicName) && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
+               && matchesInternalTopicFormat(topicName);
+    }
+
+    // visible for testing
+    public boolean matchesInternalTopicFormat(final String topicName) {
+        return topicName.endsWith("-changelog") || topicName.endsWith("-repartition")
+               || topicName.endsWith("-subscription-registration-topic")
+               || topicName.endsWith("-subscription-response-topic")
+               || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic")
+               || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic");
     }
 
     public static void main(final String[] args) {

--- a/streams/src/test/java/org/apache/kafka/streams/tools/StreamsResetterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tools/StreamsResetterTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class StreamsResetterTest {
@@ -240,6 +241,14 @@ public class StreamsResetterTest {
             streamsResetter.doDelete(Collections.singletonList(TOPIC), adminClient);
             assertEquals(Collections.emptySet(), adminClient.listTopics().names().get());
         }
+    }
+
+    @Test
+    public void shouldDetermineInternalTopicBasedOnTopicName1() {
+        assertTrue(streamsResetter.matchesInternalTopicFormat("appId-named-subscription-response-topic"));
+        assertTrue(streamsResetter.matchesInternalTopicFormat("appId-named-subscription-registration-topic"));
+        assertTrue(streamsResetter.matchesInternalTopicFormat("appId-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-12323232-topic"));
+        assertTrue(streamsResetter.matchesInternalTopicFormat("appId-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-12323232-topic"));
     }
 
     private Cluster createCluster(final int numNodes) {


### PR DESCRIPTION
This PR fixes kafka-streams-application-reset tool. Before, kafka-streams-application-reset tool wasn't taking into account topics generated by KTable foreign key join operation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
