### PR TITLE
KAFKA-10002; Improve performances of StopReplicaRequest with large number of partitions to be deleted

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -459,7 +459,12 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  def close(): Unit = {
+  /**
+   * Delete the partition. The underlying logs are deleted by default but one can choose to not
+   * delete them automatically and to delete them manually later one. For instance, we do this
+   * in the handling of the StopReplicaRequest to batch the deletions and checkpoint only once.
+   */
+  def delete(deleteLogs: Boolean = true): Unit = {
     // need to hold the lock to prevent appendMessagesToLeader() from hitting I/O exceptions due to log being deleted
     inWriteLock(leaderIsrUpdateLock) {
       remoteReplicasMap.clear()
@@ -470,6 +475,11 @@ class Partition(val topicPartition: TopicPartition,
       leaderReplicaIdOpt = None
       leaderEpochStartOffsetOpt = None
       Partition.removeMetrics(topicPartition)
+      if (deleteLogs) {
+        logManager.asyncDelete(topicPartition)
+        if (logManager.getLog(topicPartition, isFuture = true).isDefined)
+          logManager.asyncDelete(topicPartition, isFuture = true)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -459,7 +459,7 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  def delete(): Unit = {
+  def close(): Unit = {
     // need to hold the lock to prevent appendMessagesToLeader() from hitting I/O exceptions due to log being deleted
     inWriteLock(leaderIsrUpdateLock) {
       remoteReplicasMap.clear()
@@ -470,9 +470,6 @@ class Partition(val topicPartition: TopicPartition,
       leaderReplicaIdOpt = None
       leaderEpochStartOffsetOpt = None
       Partition.removeMetrics(topicPartition)
-      logManager.asyncDelete(topicPartition)
-      if (logManager.getLog(topicPartition, isFuture = true).isDefined)
-        logManager.asyncDelete(topicPartition, isFuture = true)
     }
   }
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -198,8 +198,8 @@ class LogCleaner(initialConfig: CleanerConfig,
    *  Abort the cleaning of a particular partition, if it's in progress. This call blocks until the cleaning of
    *  the partition is aborted.
    */
-  def abortCleaning(topicPartition: TopicPartition): Unit = {
-    cleanerManager.abortCleaning(topicPartition)
+  def abortCleaning(topicPartition: TopicPartition, partitionDeleted: Boolean): Unit = {
+    cleanerManager.abortCleaning(topicPartition, partitionDeleted)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -198,8 +198,8 @@ class LogCleaner(initialConfig: CleanerConfig,
    *  Abort the cleaning of a particular partition, if it's in progress. This call blocks until the cleaning of
    *  the partition is aborted.
    */
-  def abortCleaning(topicPartition: TopicPartition, partitionDeleted: Boolean): Unit = {
-    cleanerManager.abortCleaning(topicPartition, partitionDeleted)
+  def abortCleaning(topicPartition: TopicPartition): Unit = {
+    cleanerManager.abortCleaning(topicPartition)
   }
 
   /**
@@ -894,7 +894,7 @@ private[log] class Cleaner(val id: Int,
     // Add all the cleanable dirty segments. We must take at least map.slots * load_factor,
     // but we may be able to fit more (if there is lots of duplication in the dirty section of the log)
     var full = false
-    for ( (segment, nextSegmentStartOffset) <- dirty.zip(nextSegmentStartOffsets) if !full) {
+    for ((segment, nextSegmentStartOffset) <- dirty.zip(nextSegmentStartOffsets) if !full) {
       checkDone(log.topicPartition)
 
       full = buildOffsetMapForSegment(log.topicPartition, segment, map, start, nextSegmentStartOffset, log.config.maxMessageSize,

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -255,8 +255,6 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
    */
   def abortCleaning(topicPartition: TopicPartition): Unit = {
     inLock(lock) {
-      // Cleaning is aborted before deleting a partition. In this case, we don't want
-      // to spam the log with useless information.
       abortAndPauseCleaning(topicPartition)
       resumeCleaning(Seq(topicPartition))
     }

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -257,7 +257,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     inLock(lock) {
       // Cleaning is aborted before deleting a partition. In this case, we don't want
       // to spam the log with useless information.
-      abortAndPauseCleaning(topicPartition, logAbortMessage = false)
+      abortAndPauseCleaning(topicPartition)
       resumeCleaning(Seq(topicPartition))
     }
   }
@@ -274,7 +274,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
    *  6. If the partition is already paused, a new call to this function
    *     will increase the paused count by one.
    */
-  def abortAndPauseCleaning(topicPartition: TopicPartition, logAbortMessage: Boolean = true): Unit = {
+  def abortAndPauseCleaning(topicPartition: TopicPartition): Unit = {
     inLock(lock) {
       inProgress.get(topicPartition) match {
         case None =>
@@ -289,8 +289,6 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
       while(!isCleaningInStatePaused(topicPartition))
         pausedCleaningCond.await(100, TimeUnit.MILLISECONDS)
     }
-    if (logAbortMessage)
-      info(s"The cleaning for partition $topicPartition is aborted and paused")
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -334,9 +334,9 @@ class ReplicaManager(val config: KafkaConfig,
       brokerTopicStats.removeMetrics(topic)
   }
 
-  def stopReplica(topicPartition: TopicPartition,
-                  deletePartition: Boolean,
-                  logDirs: mutable.Set[File]): Unit  = {
+  private def stopReplica(topicPartition: TopicPartition,
+                          deletePartition: Boolean,
+                          logDirs: mutable.Set[File]): Unit  = {
     if (deletePartition) {
       val log = logManager.getLog(topicPartition)
       val futureLog = logManager.getLog(topicPartition, isFuture = true)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -396,7 +396,7 @@ class ReplicaManager(val config: KafkaConfig,
                     maybeRemoveTopicMetrics(topicPartition.topic)
                     // Logs are not deleted here. They are deleted in a single batch later on.
                     // This is done to avoid having to checkpoint for every deletions.
-                    partition.delete(deleteLogs = false)
+                    partition.delete()
                     deletedPartitions += topicPartition
                   }
                 }
@@ -449,7 +449,8 @@ class ReplicaManager(val config: KafkaConfig,
             case e =>
               stateChangeLogger.error(s"Ignoring StopReplica request (delete=true) from " +
                 s"controller $controllerId with correlation id $correlationId " +
-                s"epoch $controllerEpoch for partition $topicPartition due to ${e.getMessage}")
+                s"epoch $controllerEpoch for partition $topicPartition due to an unexpected " +
+                s"${e.getClass.getName} exception: ${e.getMessage}")
               responseMap.put(topicPartition, Errors.forException(e))
           }
         })

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -393,7 +393,7 @@ class LogCleanerManagerTest extends Logging {
     // log cleanup starts
     val pausedPartitions = cleanerManager.pauseCleaningForNonCompactedPartitions()
     // Broker processes StopReplicaRequest with delete=true
-    cleanerManager.abortCleaning(log.topicPartition)
+    cleanerManager.abortCleaning(log.topicPartition, true)
     // log cleanup finishes and pausedPartitions are resumed
     cleanerManager.resumeCleaning(pausedPartitions.map(_._1))
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -393,7 +393,7 @@ class LogCleanerManagerTest extends Logging {
     // log cleanup starts
     val pausedPartitions = cleanerManager.pauseCleaningForNonCompactedPartitions()
     // Broker processes StopReplicaRequest with delete=true
-    cleanerManager.abortCleaning(log.topicPartition, true)
+    cleanerManager.abortCleaning(log.topicPartition)
     // log cleanup finishes and pausedPartitions are resumed
     cleanerManager.resumeCleaning(pausedPartitions.map(_._1))
 

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -448,8 +448,8 @@ class LogManagerTest {
       log.flush()
     }
 
-    logManager.checkpointRecoveryOffsetsInDir(this.logDir)
-    logManager.cleanSnapshotsInDir(allLogs.filter(_.dir.getName.contains("test-a")), this.logDir)
+    logManager.checkpointRecoveryOffsetsAndCleanSnapshotsInDir(logDir,
+      allLogs.filter(_.dir.getName.contains("test-a")))
 
     val checkpoints = new OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
 

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -448,7 +448,8 @@ class LogManagerTest {
       log.flush()
     }
 
-    logManager.checkpointRecoveryOffsetsAndCleanSnapshot(this.logDir, allLogs.filter(_.dir.getName.contains("test-a")))
+    logManager.checkpointRecoveryOffsetsInDir(this.logDir)
+    logManager.cleanSnapshotsInDir(allLogs.filter(_.dir.getName.contains("test-a")), this.logDir)
 
     val checkpoints = new OffsetCheckpointFile(new File(logDir, LogManager.RecoveryPointCheckpointFile)).read()
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2098,8 +2098,8 @@ class ReplicaManagerTest {
     partition.log.get.maybeIncrementLogStartOffset(1L, LeaderOffsetIncremented)
     replicaManager.logManager.checkpointLogRecoveryOffsets()
     replicaManager.logManager.checkpointLogStartOffsets()
-    assertTrue(readRecoveryPointCheckpoint().contains(tp0))
-    assertTrue(readLogStartOffsetCheckpoint().contains(tp0))
+    assertEquals(Some(1L), readRecoveryPointCheckpoint().get(tp0))
+    assertEquals(Some(1L), readLogStartOffsetCheckpoint().get(tp0))
 
     if (throwIOException) {
       // Delete the underlying directory to trigger an KafkaStorageException

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -27,6 +27,7 @@ import kafka.api.LeaderAndIsr
 import kafka.api.Request
 import kafka.log.{AppendOrigin, Log, LogConfig, LogManager, ProducerStateManager}
 import kafka.cluster.BrokerEndPoint
+import kafka.log.LeaderOffsetIncremented
 import kafka.server.QuotaFactory.UnboundedQuota
 import kafka.server.checkpoints.LazyOffsetCheckpoints
 import kafka.server.checkpoints.OffsetCheckpointFile
@@ -2094,7 +2095,7 @@ class ReplicaManagerTest {
       new SimpleRecord(11, "k2".getBytes, "v2".getBytes)))
     partition.appendRecordsToLeader(batch, AppendOrigin.Client, requiredAcks = 0)
     partition.log.get.updateHighWatermark(2L)
-    partition.log.get.maybeIncrementLogStartOffset(1L)
+    partition.log.get.maybeIncrementLogStartOffset(1L, LeaderOffsetIncremented)
     replicaManager.logManager.checkpointLogRecoveryOffsets()
     replicaManager.logManager.checkpointLogStartOffsets()
     assertTrue(readRecoveryPointCheckpoint().contains(tp0))

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1303,8 +1303,12 @@ class ReplicaManagerTest {
 
     // We have a fetch in purgatory, now receive a stop replica request and
     // assert that the fetch returns with a NOT_LEADER error
+    replicaManager.stopReplicas(2, 0, 0, brokerEpoch,
+      mutable.Map(tp0 -> new StopReplicaPartitionState()
+        .setPartitionIndex(tp0.partition)
+        .setDeletePartition(true)
+        .setLeaderEpoch(LeaderAndIsr.EpochDuringDelete)))
 
-    replicaManager.stopReplica(tp0, deletePartition = true, mutable.Set.empty[File])
     assertNotNull(fetchResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, fetchResult.get.error)
   }
@@ -1338,7 +1342,12 @@ class ReplicaManagerTest {
 
     Mockito.when(replicaManager.metadataCache.contains(tp0)).thenReturn(true)
 
-    replicaManager.stopReplica(tp0, deletePartition = true, mutable.Set.empty[File])
+    replicaManager.stopReplicas(2, 0, 0, brokerEpoch,
+      mutable.Map(tp0 -> new StopReplicaPartitionState()
+        .setPartitionIndex(tp0.partition)
+        .setDeletePartition(true)
+        .setLeaderEpoch(LeaderAndIsr.EpochDuringDelete)))
+
     assertNotNull(produceResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, produceResult.get.error)
   }


### PR DESCRIPTION
* Update checkpoint files once for all deleted partitions instead of updating them for each deleted partitions. With this, a stop replica requests with 2000 partitions to be deleted takes ~2 secs instead of ~40 secs previously.
* Refactor the checkpointing methods to not compute the `logsByDir` all the time. It is now reused as much as possible.
* Refactor the exception handling. Some checkpointing methods were handling `IOException` but the underlying write process already catches them and throws KafkaStorageException instead.
* Reduce the logging in the log cleaner manager. It does not log anymore when a partition is deleted as it is not a useful information.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
