### PR TITLE
KAFKA-9996: Upgrade zookeeper to 3.5.8

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -116,7 +116,7 @@ versions += [
   spotlessPlugin: "3.28.1",
   testRetryPlugin: "1.1.5",
   zinc: "1.3.5",
-  zookeeper: "3.5.7",
+  zookeeper: "3.5.8",
   zstd: "1.4.4-7"
 ]
 libs += [


### PR DESCRIPTION
It fixes 30 issues, including third party CVE fixes, several leader-election related fixes and a
compatibility issue with applications built against earlier 3.5 client libraries (by restoring a few
non public APIs).

See ZooKeeper 3.5.8 Release Notes for details: https://zookeeper.apache.org/doc/r3.5.8/releasenotes.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
