### PR TITLE
KAFKA-10012 Reducing memory overhead associated with strings in Metri…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1114,9 +1114,10 @@ public class Selector implements Selectable, AutoCloseable {
 
     class SelectorMetrics implements AutoCloseable {
         private final Metrics metrics;
-        private final String metricGrpPrefix;
         private final Map<String, String> metricTags;
         private final boolean metricsPerConnection;
+        private final String metricGrpName;
+        private final String perConnectionMetricGrpName;
 
         public final Sensor connectionClosed;
         public final Sensor connectionCreated;
@@ -1142,10 +1143,10 @@ public class Selector implements Selectable, AutoCloseable {
 
         public SelectorMetrics(Metrics metrics, String metricGrpPrefix, Map<String, String> metricTags, boolean metricsPerConnection) {
             this.metrics = metrics;
-            this.metricGrpPrefix = metricGrpPrefix;
             this.metricTags = metricTags;
             this.metricsPerConnection = metricsPerConnection;
-            String metricGrpName = metricGrpPrefix + "-metrics";
+            this.metricGrpName = metricGrpPrefix + "-metrics";
+            this.perConnectionMetricGrpName = metricGrpPrefix + "-node-metrics";
             StringBuilder tagsSuffix = new StringBuilder();
 
             for (Map.Entry<String, String> tag: metricTags.entrySet()) {
@@ -1256,10 +1257,10 @@ public class Selector implements Selectable, AutoCloseable {
 
         private Meter createMeter(Metrics metrics, String groupName, Map<String, String> metricTags,
                 SampledStat stat, String baseName, String descriptiveName) {
-            MetricName rateMetricName = metrics.metricName(baseName + "-rate", groupName,
-                            String.format("The number of %s per second", descriptiveName), metricTags);
-            MetricName totalMetricName = metrics.metricName(baseName + "-total", groupName,
-                            String.format("The total number of %s", descriptiveName), metricTags);
+            MetricName rateMetricName = metrics.metricName((baseName + "-rate").intern(), groupName,
+                            String.format("The number of %s per second", descriptiveName).intern(), metricTags);
+            MetricName totalMetricName = metrics.metricName((baseName + "-total").intern(), groupName,
+                            String.format("The total number of %s", descriptiveName).intern(), metricTags);
             if (stat == null)
                 return new Meter(rateMetricName, totalMetricName);
             else
@@ -1293,34 +1294,33 @@ public class Selector implements Selectable, AutoCloseable {
                 String nodeRequestName = "node-" + connectionId + ".requests-sent";
                 Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
                 if (nodeRequest == null) {
-                    String metricGrpName = metricGrpPrefix + "-node-metrics";
                     Map<String, String> tags = new LinkedHashMap<>(metricTags);
                     tags.put("node-id", "node-" + connectionId);
 
                     nodeRequest = sensor(nodeRequestName);
-                    nodeRequest.add(createMeter(metrics, metricGrpName, tags, new WindowedCount(), "request", "requests sent"));
-                    MetricName metricName = metrics.metricName("request-size-avg", metricGrpName, "The average size of requests sent.", tags);
+                    nodeRequest.add(createMeter(metrics, perConnectionMetricGrpName, tags, new WindowedCount(), "request", "requests sent"));
+                    MetricName metricName = metrics.metricName("request-size-avg", perConnectionMetricGrpName, "The average size of requests sent.", tags);
                     nodeRequest.add(metricName, new Avg());
-                    metricName = metrics.metricName("request-size-max", metricGrpName, "The maximum size of any request sent.", tags);
+                    metricName = metrics.metricName("request-size-max", perConnectionMetricGrpName, "The maximum size of any request sent.", tags);
                     nodeRequest.add(metricName, new Max());
 
                     String bytesSentName = "node-" + connectionId + ".bytes-sent";
                     Sensor bytesSent = sensor(bytesSentName);
-                    bytesSent.add(createMeter(metrics, metricGrpName, tags, "outgoing-byte", "outgoing bytes"));
+                    bytesSent.add(createMeter(metrics, perConnectionMetricGrpName, tags, "outgoing-byte", "outgoing bytes"));
 
                     String nodeResponseName = "node-" + connectionId + ".responses-received";
                     Sensor nodeResponse = sensor(nodeResponseName);
-                    nodeResponse.add(createMeter(metrics, metricGrpName, tags, new WindowedCount(), "response", "responses received"));
+                    nodeResponse.add(createMeter(metrics, perConnectionMetricGrpName, tags, new WindowedCount(), "response", "responses received"));
 
                     String bytesReceivedName = "node-" + connectionId + ".bytes-received";
                     Sensor bytesReceive = sensor(bytesReceivedName);
-                    bytesReceive.add(createMeter(metrics, metricGrpName, tags, "incoming-byte", "incoming bytes"));
+                    bytesReceive.add(createMeter(metrics, perConnectionMetricGrpName, tags, "incoming-byte", "incoming bytes"));
 
                     String nodeTimeName = "node-" + connectionId + ".latency";
                     Sensor nodeRequestTime = sensor(nodeTimeName);
-                    metricName = metrics.metricName("request-latency-avg", metricGrpName, tags);
+                    metricName = metrics.metricName("request-latency-avg", perConnectionMetricGrpName, tags);
                     nodeRequestTime.add(metricName, new Avg());
-                    metricName = metrics.metricName("request-latency-max", metricGrpName, tags);
+                    metricName = metrics.metricName("request-latency-max", perConnectionMetricGrpName, tags);
                     nodeRequestTime.add(metricName, new Max());
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1257,9 +1257,9 @@ public class Selector implements Selectable, AutoCloseable {
 
         private Meter createMeter(Metrics metrics, String groupName, Map<String, String> metricTags,
                 SampledStat stat, String baseName, String descriptiveName) {
-            MetricName rateMetricName = metrics.metricName((baseName + "-rate"), groupName,
+            MetricName rateMetricName = metrics.metricName(baseName + "-rate", groupName,
                             String.format("The number of %s per second", descriptiveName), metricTags);
-            MetricName totalMetricName = metrics.metricName((baseName + "-total"), groupName,
+            MetricName totalMetricName = metrics.metricName(baseName + "-total", groupName,
                             String.format("The total number of %s", descriptiveName), metricTags);
             if (stat == null)
                 return new Meter(rateMetricName, totalMetricName);

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1257,10 +1257,10 @@ public class Selector implements Selectable, AutoCloseable {
 
         private Meter createMeter(Metrics metrics, String groupName, Map<String, String> metricTags,
                 SampledStat stat, String baseName, String descriptiveName) {
-            MetricName rateMetricName = metrics.metricName((baseName + "-rate").intern(), groupName,
-                            String.format("The number of %s per second", descriptiveName).intern(), metricTags);
-            MetricName totalMetricName = metrics.metricName((baseName + "-total").intern(), groupName,
-                            String.format("The total number of %s", descriptiveName).intern(), metricTags);
+            MetricName rateMetricName = metrics.metricName((baseName + "-rate"), groupName,
+                            String.format("The number of %s per second", descriptiveName), metricTags);
+            MetricName totalMetricName = metrics.metricName((baseName + "-total"), groupName,
+                            String.format("The total number of %s", descriptiveName), metricTags);
             if (stat == null)
                 return new Meter(rateMetricName, totalMetricName);
             else


### PR DESCRIPTION
`SelectorMetrics` has a per-connection metrics, which means the number of `MetricName` objects and the strings associated with it (such as group name and description) grows with the number of connections in the client. This overhead of duplicate string objects is amplified when there are multiple instances of kafka clients within the same JVM. 
This patch address some of the memory overhead by making `metricGrpName` a constant and introducing a new constant `perConnectionMetricGrpName`. Additionally, the strings for metric name and description in `createMeter` have been interned since there are about 8 types of meter metric for every single client.  
