### PR TITLE
MINOR: Remove redundant TOC and introduction in Running Streams Applications

### DIFF
--- a/docs/streams/developer-guide/running-app.html
+++ b/docs/streams/developer-guide/running-app.html
@@ -30,23 +30,6 @@
       </div -->
     </div>
   </div>
-                
-  <div class="section" id="running-streams-applications">
-<span id="streams-developer-guide-execution"></span><h1>Running Streams Applications<a class="headerlink" href="#running-streams-applications" title="Permalink to this headline"></a></h1>
-<p>You can run Java applications that use the Kafka Streams library without any additional configuration or requirements.</p>
-<div class="contents local topic" id="table-of-contents">
-<p class="topic-title first"><b>Table of Contents</b></p>
-<ul class="simple">
-<li><a class="reference internal" href="#starting-a-kafka-streams-application" id="id3">Starting a Kafka Streams application</a></li>
-<li><a class="reference internal" href="#elastic-scaling-of-your-application" id="id4">Elastic scaling of your application</a><ul>
-<li><a class="reference internal" href="#adding-capacity-to-your-application" id="id5">Adding capacity to your application</a></li>
-<li><a class="reference internal" href="#removing-capacity-from-your-application" id="id6">Removing capacity from your application</a></li>
-<li><a class="reference internal" href="#state-restoration-during-workload-rebalance" id="id7">State restoration during workload rebalance</a></li>
-<li><a class="reference internal" href="#determining-how-many-application-instances-to-run" id="id8">Determining how many application instances to run</a></li>
-</ul>
-</li>
-</ul>
-</div>
       <div class="section" id="running-streams-applications">
           <span id="streams-developer-guide-execution"></span><h1>Running Streams Applications<a class="headerlink" href="#running-streams-applications" title="Permalink to this headline"></a></h1>
           <p>You can run Java applications that use the Kafka Streams library without any additional configuration or requirements. Kafka Streams


### PR DESCRIPTION
Remove redundant TOC and introduction in Running Streams Applications
https://kafka.apache.org/25/documentation/streams/developer-guide/running-app

before:
![image](https://user-images.githubusercontent.com/43372967/82212247-d181ec00-9944-11ea-8aac-3612fc17893d.png)

after:
![image](https://user-images.githubusercontent.com/43372967/82212560-510fbb00-9945-11ea-8b0d-7911a2ac13e2.png)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
