### PR TITLE
MINOR: updated MacOS compatibility statement for RocksDB

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -60,7 +60,7 @@
         For Kafka Streams 0.10.0, broker version 0.10.0 or higher is required.
     </p>
 
-    <p>Since 2.2.0 release, Kafka Streams depends on a RocksDBs version that requires MacOS 10.13 or higher.</p>
+    <p>Since 2.6.0 release, Kafka Streams depends on a RocksDBs version that requires MacOS 10.15 or higher.</p>
 
     <p>
         Another important thing to keep in mind: in deprecated <code>KStreamBuilder</code> class, when a <code>KTable</code> is created from a source topic via <code>KStreamBuilder.table()</code>, its materialized state store


### PR DESCRIPTION
With https://issues.apache.org/jira/browse/KAFKA-9225 Kafka Streams 2.6.0 requires MacOS 10.15.