### PR TITLE
KAFKA-6145: Add unit tests to verify fix of bug KAFKA-9173

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -58,6 +58,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
@@ -170,7 +171,7 @@ public class HighAvailabilityTaskAssignorTest {
     }
 
     @Test
-    public void shouldAssignActiveStatefulTasksEvenlyOverClientsWithLessClientsThanTasks() {
+    public void shouldAssignActiveStatefulTasksEvenlyOverClientsWithMoreClientsThanTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
         final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, 1);
@@ -195,9 +196,9 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignActiveStatefulTasksEvenlyOverClientsAndStreamThreadsWithMoreStreamThreadsThanTasks() {
         final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, 6);
-        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, 6);
-        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, 6);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), lags, 9);
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), lags, 9);
+        final ClientState clientState3 = new ClientState(emptySet(), emptySet(), lags, 9);
         final Map<UUID, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
         final boolean unstable = new HighAvailabilityTaskAssignor().assign(
             clientStates,
@@ -208,6 +209,61 @@ public class HighAvailabilityTaskAssignorTest {
 
         assertThat(unstable, is(false));
         assertValidAssignment(0, allTaskIds, emptySet(), clientStates, new StringBuilder());
+        assertBalancedActiveAssignment(clientStates, new StringBuilder());
+        assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
+        assertBalancedTasks(clientStates);
+    }
+
+    @Test
+    public void shouldAssignWarmUpTasksIfStatefulActiveTasksBalancedOverStreamThreadsButNotOverClients() {
+        final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
+        final Map<TaskId, Long> lagsForCaughtUpClient = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L));
+        final Map<TaskId, Long> lagsForNotCaughtUpClient =
+            allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
+        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, 5);
+        final ClientState notCaughtUpClientState1 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, 5);
+        final ClientState notCaughtUpClientState2 = new ClientState(emptySet(), emptySet(), lagsForNotCaughtUpClient, 5);
+        final Map<UUID, ClientState> clientStates =
+            getClientStatesMap(caughtUpClientState, notCaughtUpClientState1, notCaughtUpClientState2);
+        final boolean unstable = new HighAvailabilityTaskAssignor().assign(
+            clientStates,
+            allTaskIds,
+            allTaskIds,
+            new AssignmentConfigs(0L, allTaskIds.size() / 3 + 1, 0, 0L)
+        );
+
+        assertThat(unstable, is(true));
+        assertThat(notCaughtUpClientState1.standbyTaskCount(), greaterThanOrEqualTo(allTaskIds.size() / 3));
+        assertThat(notCaughtUpClientState2.standbyTaskCount(), greaterThanOrEqualTo(allTaskIds.size() / 3));
+        assertValidAssignment(0, allTaskIds.size() / 3 + 1, allTaskIds, emptySet(), clientStates, new StringBuilder());
+    }
+
+    @Test
+    public void shouldEvenlyAssignActiveStatefulTasksIfClientsAreWarmedUpToBalanceTaskOverClients() {
+        final Set<TaskId> allTaskIds = mkSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
+        final Set<TaskId> warmedUpTaskIds1 = mkSet(TASK_0_1);
+        final Set<TaskId> warmedUpTaskIds2 = mkSet(TASK_1_0);
+        final Map<TaskId, Long> lagsForCaughtUpClient = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L));
+        final Map<TaskId, Long> lagsForWarmedUpClient1 =
+            allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
+        lagsForWarmedUpClient1.put(TASK_0_1, 0L);
+        final Map<TaskId, Long> lagsForWarmedUpClient2 =
+            allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
+        lagsForWarmedUpClient2.put(TASK_1_0, 0L);
+        final ClientState caughtUpClientState = new ClientState(allTaskIds, emptySet(), lagsForCaughtUpClient, 5);
+        final ClientState warmedUpClientState1 = new ClientState(emptySet(), warmedUpTaskIds1, lagsForWarmedUpClient1, 5);
+        final ClientState warmedUpClientState2 = new ClientState(emptySet(), warmedUpTaskIds2, lagsForWarmedUpClient2, 5);
+        final Map<UUID, ClientState> clientStates =
+            getClientStatesMap(caughtUpClientState, warmedUpClientState1, warmedUpClientState2);
+        final boolean unstable = new HighAvailabilityTaskAssignor().assign(
+            clientStates,
+            allTaskIds,
+            allTaskIds,
+            new AssignmentConfigs(0L, allTaskIds.size() / 3 + 1, 0, 0L)
+        );
+
+        assertThat(unstable, is(false));
+        assertValidAssignment(0, allTaskIds.size() / 3 + 1, allTaskIds, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
         assertBalancedTasks(clientStates);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -263,7 +263,7 @@ public class HighAvailabilityTaskAssignorTest {
         );
 
         assertThat(unstable, is(false));
-        assertValidAssignment(0, allTaskIds.size() / 3 + 1, allTaskIds, emptySet(), clientStates, new StringBuilder());
+        assertValidAssignment(0, allTaskIds, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
         assertBalancedTasks(clientStates);


### PR DESCRIPTION
Unit tests
- `shouldAssignActiveStatefulTasksEvenlyOverClientsAndStreamThreadsWithMoreStreamThreadsThanTasks()`
- `shouldAssignWarmUpTasksIfStatefulActiveTasksBalancedOverStreamThreadsButNotOverClients()`
- `shouldEvenlyAssignActiveStatefulTasksIfClientsAreWarmedUpToBalanceTaskOverClients()`
verify that bug KAFKA-9173 is fixed with the new `HighAvailabilityTaskAssignor`.

`shouldAssignActiveStatefulTasksEvenlyOverClientsAndStreamThreadsWithMoreStreamThreadsThanTasks()`
ensures that tasks are evenly assigned over clients when all overprovisioned clients join
simultaneously.

`shouldAssignWarmUpTasksIfStatefulActiveTasksBalancedOverStreamThreadsButNotOverClients()`
ensures that warm-up tasks are assigned to two new clients that join the group
although the assignment is already balanced over stream threads.

`shouldEvenlyAssignActiveStatefulTasksIfClientsAreWarmedUpToBalanceTaskOverClients()`
ensures that stateful active tasks are balanced over previous and warmed-up client
although it the previous assignment is balanced over stream threads.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
