### PR TITLE
KAFKA-10022: console-producer supports the setting of client.id

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -38,20 +38,20 @@ object ConsoleProducer {
   def main(args: Array[String]): Unit = {
 
     try {
-      val config = new ProducerConfig(args)
-      val reader = Class.forName(config.readerClass).getDeclaredConstructor().newInstance().asInstanceOf[MessageReader]
-      reader.init(System.in, getReaderProps(config))
+        val config = new ProducerConfig(args)
+        val reader = Class.forName(config.readerClass).getDeclaredConstructor().newInstance().asInstanceOf[MessageReader]
+        reader.init(System.in, getReaderProps(config))
 
-      val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
+        val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps(config))
 
-      Exit.addShutdownHook("producer-shutdown-hook", producer.close)
+    Exit.addShutdownHook("producer-shutdown-hook", producer.close)
 
-      var record: ProducerRecord[Array[Byte], Array[Byte]] = null
-      do {
-        record = reader.readMessage()
-        if (record != null)
-          send(producer, record, config.sync)
-      } while (record != null)
+        var record: ProducerRecord[Array[Byte], Array[Byte]] = null
+        do {
+          record = reader.readMessage()
+          if (record != null)
+            send(producer, record, config.sync)
+        } while (record != null)
     } catch {
       case e: joptsimple.OptionException =>
         System.err.println(e.getMessage)
@@ -64,7 +64,7 @@ object ConsoleProducer {
   }
 
   private def send(producer: KafkaProducer[Array[Byte], Array[Byte]],
-                   record: ProducerRecord[Array[Byte], Array[Byte]], sync: Boolean): Unit = {
+                         record: ProducerRecord[Array[Byte], Array[Byte]], sync: Boolean): Unit = {
     if (sync)
       producer.send(record).get()
     else
@@ -137,10 +137,10 @@ object ConsoleProducer {
       .ofType(classOf[String])
     val syncOpt = parser.accepts("sync", "If set message send requests to the brokers are synchronously, one at a time as they arrive.")
     val compressionCodecOpt = parser.accepts("compression-codec", "The compression codec: either 'none', 'gzip', 'snappy', 'lz4', or 'zstd'." +
-      "If specified without value, then it defaults to 'gzip'")
-      .withOptionalArg()
-      .describedAs("compression-codec")
-      .ofType(classOf[String])
+                                                                  "If specified without value, then it defaults to 'gzip'")
+                                    .withOptionalArg()
+                                    .describedAs("compression-codec")
+                                    .ofType(classOf[String])
     val batchSizeOpt = parser.accepts("batch-size", "Number of messages to send in a single batch if they are not being sent synchronously.")
       .withRequiredArg
       .describedAs("size")
@@ -215,9 +215,9 @@ object ConsoleProducer {
       .describedAs("prop")
       .ofType(classOf[String])
     val producerPropertyOpt = parser.accepts("producer-property", "A mechanism to pass user-defined properties in the form key=value to the producer. ")
-      .withRequiredArg
-      .describedAs("producer_prop")
-      .ofType(classOf[String])
+            .withRequiredArg
+            .describedAs("producer_prop")
+            .ofType(classOf[String])
     val producerConfigOpt = parser.accepts("producer.config", s"Producer config properties file. Note that $producerPropertyOpt takes precedence over this config.")
       .withRequiredArg
       .describedAs("config file")
@@ -240,10 +240,10 @@ object ConsoleProducer {
     val sync = options.has(syncOpt)
     val compressionCodecOptionValue = options.valueOf(compressionCodecOpt)
     val compressionCodec = if (options.has(compressionCodecOpt))
-      if (compressionCodecOptionValue == null || compressionCodecOptionValue.isEmpty)
-        DefaultCompressionCodec.name
-      else compressionCodecOptionValue
-    else NoCompressionCodec.name
+                             if (compressionCodecOptionValue == null || compressionCodecOptionValue.isEmpty)
+                               DefaultCompressionCodec.name
+                             else compressionCodecOptionValue
+                           else NoCompressionCodec.name
     val batchSize = options.valueOf(batchSizeOpt)
     val readerClass = options.valueOf(messageReaderOpt)
     val cmdLineProps = CommandLineUtils.parseKeyValueArgs(options.valuesOf(propertyOpt).asScala)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10022

"console-producer" supports the setting of "client.id", which is a reasonable requirement, and the way "console consumer" and "console producer" handle "client.id" can be unified. "client.id" defaults to "console-producer"


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
