### PR TITLE
KAFKA-9673: Filter and Conditional SMTs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -343,6 +343,18 @@ public final class Utils {
     }
 
     /**
+     * Cast {@code klass} to {@code base} and instantiate it.
+     * @param klass The class to instantiate
+     * @param base A know baseclass of klass.
+     * @param <T> the type of the base class
+     * @throws ClassCastException If {@code klass} is not a subclass of {@code base}.
+     * @return the new instance.
+     */
+    public static <T> T newInstance(Class<?> klass, Class<T> base) {
+        return Utils.newInstance(klass.asSubclass(base));
+    }
+
+    /**
      * Construct a new object using a class name and parameters.
      *
      * @param className                 The full name of the class to construct.

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -35,11 +35,16 @@ public interface Predicate<R extends ConnectRecord<R>> extends Configurable, Aut
 
     /**
      * Configuration specification for this predicate.
+     *
+     * @return the configuration definition for this predicate; never null
      */
     ConfigDef config();
 
     /**
      * Returns whether the given record satisfies this predicate.
+     *
+     * @param record the record to evaluate; may not be null
+     * @return true if the predicate matches, or false otherwise
      */
     boolean test(R record);
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * <p>A predicate on records.
+ * Predicates can be used to conditionally apply a {@link org.apache.kafka.connect.transforms.Transformation}
+ * by configuring the transformation's {@code predicate} (and {@code negate}) configuration parameters.
+ * In particular, the {@code Filter} transformation can be conditionally applied in order to filter
+ * certain records from further processing.
+ *
+ * <p>Implementations of this interface must be public and have a public constructor with no parameters.
+ *
+ * @param <R> The type of record.
+ */
+public interface Predicate<R extends ConnectRecord<R>> extends Configurable, AutoCloseable {
+
+    /**
+     * Configuration specification for this predicate.
+     */
+    ConfigDef config();
+
+    /**
+     * Returns whether the given record satisfies this predicate.
+     */
+    boolean test(R record);
+
+    @Override
+    void close();
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -28,6 +28,9 @@ import org.apache.kafka.connect.runtime.errors.ToleranceType;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -38,6 +41,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,8 +61,11 @@ import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
  * </p>
  */
 public class ConnectorConfig extends AbstractConfig {
+    private static final Logger log = LoggerFactory.getLogger(ConnectorConfig.class);
+
     protected static final String COMMON_GROUP = "Common";
     protected static final String TRANSFORMS_GROUP = "Transforms";
+    protected static final String PREDICATES_GROUP = "Predicates";
     protected static final String ERROR_GROUP = "Error Handling";
 
     public static final String NAME_CONFIG = "name";
@@ -97,6 +104,10 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String TRANSFORMS_CONFIG = "transforms";
     private static final String TRANSFORMS_DOC = "Aliases for the transformations to be applied to records.";
     private static final String TRANSFORMS_DISPLAY = "Transforms";
+
+    public static final String PREDICATES_CONFIG = "predicates";
+    private static final String PREDICATES_DOC = "Aliases for the predicates used by transformations.";
+    private static final String PREDICATES_DISPLAY = "Predicates";
 
     public static final String CONFIG_RELOAD_ACTION_CONFIG = "config.action.reload";
     private static final String CONFIG_RELOAD_ACTION_DOC =
@@ -170,21 +181,8 @@ public class ConnectorConfig extends AbstractConfig {
                 .define(KEY_CONVERTER_CLASS_CONFIG, Type.CLASS, null, Importance.LOW, KEY_CONVERTER_CLASS_DOC, COMMON_GROUP, ++orderInGroup, Width.SHORT, KEY_CONVERTER_CLASS_DISPLAY)
                 .define(VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS, null, Importance.LOW, VALUE_CONVERTER_CLASS_DOC, COMMON_GROUP, ++orderInGroup, Width.SHORT, VALUE_CONVERTER_CLASS_DISPLAY)
                 .define(HEADER_CONVERTER_CLASS_CONFIG, Type.CLASS, HEADER_CONVERTER_CLASS_DEFAULT, Importance.LOW, HEADER_CONVERTER_CLASS_DOC, COMMON_GROUP, ++orderInGroup, Width.SHORT, HEADER_CONVERTER_CLASS_DISPLAY)
-                .define(TRANSFORMS_CONFIG, Type.LIST, Collections.emptyList(), ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.Validator() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public void ensureValid(String name, Object value) {
-                        final List<String> transformAliases = (List<String>) value;
-                        if (transformAliases.size() > new HashSet<>(transformAliases).size()) {
-                            throw new ConfigException(name, value, "Duplicate alias provided.");
-                        }
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "unique transformation aliases";
-                    }
-                }), Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, ++orderInGroup, Width.LONG, TRANSFORMS_DISPLAY)
+                .define(TRANSFORMS_CONFIG, Type.LIST, Collections.emptyList(), aliasValidator("transformation"), Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, ++orderInGroup, Width.LONG, TRANSFORMS_DISPLAY)
+                .define(PREDICATES_CONFIG, Type.LIST, Collections.emptyList(), aliasValidator("predicate"), Importance.LOW, PREDICATES_DOC, PREDICATES_GROUP, ++orderInGroup, Width.LONG, PREDICATES_DISPLAY)
                 .define(CONFIG_RELOAD_ACTION_CONFIG, Type.STRING, CONFIG_RELOAD_ACTION_RESTART,
                         in(CONFIG_RELOAD_ACTION_NONE, CONFIG_RELOAD_ACTION_RESTART), Importance.LOW,
                         CONFIG_RELOAD_ACTION_DOC, COMMON_GROUP, ++orderInGroup, Width.MEDIUM, CONFIG_RELOAD_ACTION_DISPLAY)
@@ -199,6 +197,24 @@ public class ConnectorConfig extends AbstractConfig {
                         ERRORS_LOG_ENABLE_DOC, ERROR_GROUP, ++orderInErrorGroup, Width.SHORT, ERRORS_LOG_ENABLE_DISPLAY)
                 .define(ERRORS_LOG_INCLUDE_MESSAGES_CONFIG, Type.BOOLEAN, ERRORS_LOG_INCLUDE_MESSAGES_DEFAULT, Importance.MEDIUM,
                         ERRORS_LOG_INCLUDE_MESSAGES_DOC, ERROR_GROUP, ++orderInErrorGroup, Width.SHORT, ERRORS_LOG_INCLUDE_MESSAGES_DISPLAY);
+    }
+
+    private static ConfigDef.CompositeValidator aliasValidator(String kind) {
+        return ConfigDef.CompositeValidator.of(new ConfigDef.NonNullValidator(), new ConfigDef.Validator() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public void ensureValid(String name, Object value) {
+                final List<String> aliases = (List<String>) value;
+                if (aliases.size() > new HashSet<>(aliases).size()) {
+                    throw new ConfigException(name, value, "Duplicate alias provided.");
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "unique " + kind + " aliases";
+            }
+        });
     }
 
     public ConnectorConfig(Plugins plugins) {
@@ -257,12 +273,25 @@ public class ConnectorConfig extends AbstractConfig {
         final List<Transformation<R>> transformations = new ArrayList<>(transformAliases.size());
         for (String alias : transformAliases) {
             final String prefix = TRANSFORMS_CONFIG + "." + alias + ".";
+
             try {
                 @SuppressWarnings("unchecked")
                 final Transformation<R> transformation = getClass(prefix + "type").asSubclass(Transformation.class)
                         .getDeclaredConstructor().newInstance();
-                transformation.configure(originalsWithPrefix(prefix));
-                transformations.add(transformation);
+                Map<String, Object> configs = originalsWithPrefix(prefix);
+                Object predicateAlias = configs.remove("predicate");
+                Object negate = configs.remove("negate");
+                transformation.configure(configs);
+                if (predicateAlias != null) {
+                    String predicatePrefix = "predicates." + predicateAlias + ".";
+                    @SuppressWarnings("unchecked")
+                    Predicate<R> predicate = getClass(predicatePrefix + "type").asSubclass(Predicate.class)
+                            .getDeclaredConstructor().newInstance();
+                    predicate.configure(originalsWithPrefix(predicatePrefix));
+                    transformations.add(new PredicatedTransformation<>(predicate, negate == null ? false : Boolean.parseBoolean(negate.toString()), transformation));
+                } else {
+                    transformations.add(transformation);
+                }
             } catch (Exception e) {
                 throw new ConnectException(e);
             }
@@ -276,116 +305,247 @@ public class ConnectorConfig extends AbstractConfig {
      * <p>
      * {@code requireFullConfig} specifies whether required config values that are missing should cause an exception to be thrown.
      */
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static ConfigDef enrich(Plugins plugins, ConfigDef baseConfigDef, Map<String, String> props, boolean requireFullConfig) {
-        Object transformAliases = ConfigDef.parseType(TRANSFORMS_CONFIG, props.get(TRANSFORMS_CONFIG), Type.LIST);
-        if (!(transformAliases instanceof List)) {
-            return baseConfigDef;
-        }
-
         ConfigDef newDef = new ConfigDef(baseConfigDef);
-        LinkedHashSet<?> uniqueTransformAliases = new LinkedHashSet<>((List<?>) transformAliases);
-        for (Object o : uniqueTransformAliases) {
-            if (!(o instanceof String)) {
-                throw new ConfigException("Item in " + TRANSFORMS_CONFIG + " property is not of "
-                        + "type String");
-            }
-            String alias = (String) o;
-            final String prefix = TRANSFORMS_CONFIG + "." + alias + ".";
-            final String group = TRANSFORMS_GROUP + ": " + alias;
-            int orderInGroup = 0;
-
-            final String transformationTypeConfig = prefix + "type";
-            final ConfigDef.Validator typeValidator = new ConfigDef.Validator() {
-                @Override
-                public void ensureValid(String name, Object value) {
-                    getConfigDefFromTransformation(transformationTypeConfig, (Class) value);
-                }
-            };
-            newDef.define(transformationTypeConfig, Type.CLASS, ConfigDef.NO_DEFAULT_VALUE, typeValidator, Importance.HIGH,
-                    "Class for the '" + alias + "' transformation.", group, orderInGroup++, Width.LONG, "Transformation type for " + alias,
-                    Collections.<String>emptyList(), new TransformationClassRecommender(plugins));
-
-            final ConfigDef transformationConfigDef;
-            try {
-                final String className = props.get(transformationTypeConfig);
-                final Class<?> cls = (Class<?>) ConfigDef.parseType(transformationTypeConfig, className, Type.CLASS);
-                transformationConfigDef = getConfigDefFromTransformation(transformationTypeConfig, cls);
-            } catch (ConfigException e) {
-                if (requireFullConfig) {
-                    throw e;
-                } else {
-                    continue;
-                }
+        new EnrichablePlugin<Transformation<?>>("transformation", TRANSFORMS_CONFIG, TRANSFORMS_GROUP, (Class) Transformation.class,
+                props, requireFullConfig) {
+            @SuppressWarnings("rawtypes")
+            @Override
+            protected Set<PluginDesc<Transformation<?>>> plugins() {
+                return (Set) plugins.transformations();
             }
 
-            newDef.embed(prefix, group, orderInGroup, transformationConfigDef);
-        }
 
+            @Override
+            protected ConfigDef initialConfigDef() {
+                // All Transformations get these config parameters implicitly
+                return super.initialConfigDef()
+                        .define("predicate", Type.STRING, "", Importance.MEDIUM,
+                                "The alias of a predicate used to determine whether to apply this transformation.")
+                        .define("negate", Type.BOOLEAN, false, Importance.MEDIUM,
+                                "Whether the configured predicate should be negated.");
+            }
+
+            @Override
+            protected Stream<Map.Entry<String, ConfigDef.ConfigKey>> configDefsForClass(String typeConfig) {
+                return super.configDefsForClass(typeConfig)
+                    .filter(entry -> {
+                        // The implicit parameters mask any from the transformer with the same name
+                        if ("predicate".equals(entry.getValue()) || "negate".equals(entry.getValue())) {
+                            log.warn("Transformer config " + entry.getValue() + " is masked by implicit config of that name");
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    });
+            }
+
+            @Override
+            protected ConfigDef config(Transformation<?> transformation) {
+                return transformation.config();
+            }
+
+            @Override
+            protected void validateProps(String prefix) {
+                if (props.containsKey(prefix + "negate") &&
+                        !props.containsKey(prefix + "predicate")) {
+                    throw new ConfigException("Config '" + prefix + "negate' provided but there is no config '" + prefix + "predicate' to be negated.");
+                }
+            }
+        }.enrich(newDef);
+
+        new EnrichablePlugin<Predicate<?>>("predicate", PREDICATES_CONFIG, PREDICATES_GROUP, (Class) Predicate.class, props, requireFullConfig) {
+            @Override
+            protected Set<PluginDesc<Predicate<?>>> plugins() {
+                return (Set) plugins.predicates();
+            }
+
+            @Override
+            protected ConfigDef config(Predicate<?> predicate) {
+                return predicate.config();
+            }
+        }.enrich(newDef);
         return newDef;
     }
 
     /**
-     * Return {@link ConfigDef} from {@code transformationCls}, which is expected to be a non-null {@code Class<Transformation>},
-     * by instantiating it and invoking {@link Transformation#config()}.
+     * An abstraction over "enrichable plugins" ({@link Transformation}s and {@link Predicate}s) used for computing the
+     * contribution to a Connectors ConfigDef.
+     *
+     * This is not entirely elegant because
+     * although they basically use the same "alias prefix" configuration idiom there are some differences.
+     * The abstract method pattern is used to cope with this.
+     * @param <T> The type of plugin (either {@code Transformation} or {@code Predicate}).
      */
-    static ConfigDef getConfigDefFromTransformation(String key, Class<?> transformationCls) {
-        if (transformationCls == null || !Transformation.class.isAssignableFrom(transformationCls)) {
-            throw new ConfigException(key, String.valueOf(transformationCls), "Not a Transformation");
-        }
-        if (Modifier.isAbstract(transformationCls.getModifiers())) {
-            String childClassNames = Stream.of(transformationCls.getClasses())
-                .filter(transformationCls::isAssignableFrom)
-                .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                .filter(c -> Modifier.isPublic(c.getModifiers()))
-                .map(Class::getName)
-                .collect(Collectors.joining(", "));
-            String message = childClassNames.trim().isEmpty() ?
-                "Transformation is abstract and cannot be created." :
-                "Transformation is abstract and cannot be created. Did you mean " + childClassNames + "?";
-            throw new ConfigException(key, String.valueOf(transformationCls), message);
-        }
-        Transformation transformation;
-        try {
-            transformation = transformationCls.asSubclass(Transformation.class).getConstructor().newInstance();
-        } catch (Exception e) {
-            ConfigException exception = new ConfigException(key, String.valueOf(transformationCls), "Error getting config definition from Transformation: " + e.getMessage());
-            exception.initCause(e);
-            throw exception;
-        }
-        ConfigDef configDef = transformation.config();
-        if (null == configDef) {
-            throw new ConnectException(
-                String.format(
-                    "%s.config() must return a ConfigDef that is not null.",
-                    transformationCls.getName()
-                )
-            );
-        }
-        return configDef;
-    }
+    static abstract class EnrichablePlugin<T> {
 
-    /**
-     * Recommend bundled transformations.
-     */
-    static final class TransformationClassRecommender implements ConfigDef.Recommender {
-        private final Plugins plugins;
+        private final String aliasKind;
+        private final String aliasConfig;
+        private final String aliasGroup;
+        private final Class<T> baseClass;
+        private final Map<String, String> props;
+        private final boolean requireFullConfig;
 
-        TransformationClassRecommender(Plugins plugins) {
-            this.plugins = plugins;
+        public EnrichablePlugin(
+                String aliasKind,
+                String aliasConfig, String aliasGroup, Class<T> baseClass,
+                Map<String, String> props, boolean requireFullConfig) {
+            this.aliasKind = aliasKind;
+            this.aliasConfig = aliasConfig;
+            this.aliasGroup = aliasGroup;
+            this.baseClass = baseClass;
+            this.props = props;
+            this.requireFullConfig = requireFullConfig;
         }
 
-        @Override
-        public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
-            List<Object> transformationPlugins = new ArrayList<>();
-            for (PluginDesc<Transformation> plugin : plugins.transformations()) {
-                transformationPlugins.add(plugin.pluginClass());
+        /** Add the configs for this alias to the given {@code ConfigDef}. */
+        void enrich(ConfigDef newDef) {
+            Object aliases = ConfigDef.parseType(aliasConfig, props.get(aliasConfig), Type.LIST);
+            if (!(aliases instanceof List)) {
+                return;
             }
-            return Collections.unmodifiableList(transformationPlugins);
+
+            LinkedHashSet<?> uniqueAliases = new LinkedHashSet<>((List<?>) aliases);
+            for (Object o : uniqueAliases) {
+                if (!(o instanceof String)) {
+                    throw new ConfigException("Item in " + aliasConfig + " property is not of "
+                            + "type String");
+                }
+                String alias = (String) o;
+                final String prefix = aliasConfig + "." + alias + ".";
+                final String group = aliasGroup + ": " + alias;
+                int orderInGroup = 0;
+
+                final String typeConfig = prefix + "type";
+                final ConfigDef.Validator typeValidator = new ConfigDef.Validator() {
+                    @Override
+                    public void ensureValid(String name, Object value) {
+                        validateProps(prefix);
+                        getConfigDefFromConfigProvidingClass(typeConfig, (Class<?>) value);
+                    }
+                };
+                newDef.define(typeConfig, Type.CLASS, ConfigDef.NO_DEFAULT_VALUE, typeValidator, Importance.HIGH,
+                        "Class for the '" + alias + "' " + aliasKind + ".", group, orderInGroup++, Width.LONG,
+                        baseClass.getSimpleName() + " type for " + alias,
+                        Collections.emptyList(), new ClassRecommender());
+
+                final ConfigDef configDef = populateConfigDef(typeConfig);
+                if (configDef == null) continue;
+                newDef.embed(prefix, group, orderInGroup, configDef);
+            }
         }
 
-        @Override
-        public boolean visible(String name, Map<String, Object> parsedConfig) {
-            return true;
+        /** Subclasses can add extra validation of the {@link #props}. */
+        protected void validateProps(String prefix) { }
+
+        /**
+         * Populates the ConfigDef according to the configs returned from {@code configs()} method of class
+         * named in the {@code ...type} parameter of the {@code props}.
+         */
+        protected ConfigDef populateConfigDef(String typeConfig) {
+            final ConfigDef configDef = initialConfigDef();
+            try {
+                configDefsForClass(typeConfig)
+                        .forEach(entry -> configDef.define(entry.getValue()));
+
+            } catch (ConfigException e) {
+                if (requireFullConfig) {
+                    throw e;
+                } else {
+                    return null;
+                }
+            }
+            return configDef;
+        }
+
+        /**
+         * Return a stream of configs provided by the {@code configs()} method of class
+         * named in the {@code ...type} parameter of the {@code props}.
+         */
+        protected Stream<Map.Entry<String, ConfigDef.ConfigKey>> configDefsForClass(String typeConfig) {
+            final Class<?> cls = (Class<?>) ConfigDef.parseType(typeConfig, props.get(typeConfig), Type.CLASS);
+            return getConfigDefFromConfigProvidingClass(typeConfig, cls)
+                    .configKeys().entrySet().stream();
+        }
+
+        /** Get an initial ConfigDef */
+        protected ConfigDef initialConfigDef() {
+            return new ConfigDef();
+        }
+
+        /**
+         * Return {@link ConfigDef} from {@code cls}, which is expected to be a non-null {@code Class<T>},
+         * by instantiating it and invoking {@link #config(T)}.
+         * @param key
+         * @param cls The subclass of the baseclass.
+         */
+        ConfigDef getConfigDefFromConfigProvidingClass(String key, Class<?> cls) {
+            if (cls == null || !baseClass.isAssignableFrom(cls)) {
+                throw new ConfigException(key, String.valueOf(cls), "Not a " + baseClass.getSimpleName());
+            }
+            if (Modifier.isAbstract(cls.getModifiers())) {
+                String childClassNames = Stream.of(cls.getClasses())
+                        .filter(cls::isAssignableFrom)
+                        .filter(c -> !Modifier.isAbstract(c.getModifiers()))
+                        .filter(c -> Modifier.isPublic(c.getModifiers()))
+                        .map(Class::getName)
+                        .collect(Collectors.joining(", "));
+                String aliasKind = this.aliasKind.substring(0, 1).toUpperCase(Locale.ENGLISH) + this.aliasKind.substring(1);
+                String message = childClassNames.trim().isEmpty() ?
+                        aliasKind + " is abstract and cannot be created." :
+                        aliasKind + " is abstract and cannot be created. Did you mean " + childClassNames + "?";
+                throw new ConfigException(key, String.valueOf(cls), message);
+            }
+            T transformation;
+            try {
+                transformation = cls.asSubclass(baseClass).getConstructor().newInstance();
+            } catch (Exception e) {
+                throw new ConfigException(key, String.valueOf(cls), "Error getting config definition from " + baseClass.getSimpleName() + ": " + e.getMessage());
+            }
+            ConfigDef configDef = config(transformation);
+            if (null == configDef) {
+                throw new ConnectException(
+                    String.format(
+                        "%s.config() must return a ConfigDef that is not null.",
+                        cls.getName()
+                    )
+                );
+            }
+            return configDef;
+        }
+
+        /**
+         * Get the ConfigDef from the given entity.
+         * This is necessary because there's no abstraction across {@link Transformation#config()} and
+         * {@link Predicate#config()}.
+         */
+        protected abstract ConfigDef config(T t);
+
+        /**
+         * The transformation or predicate plugins (as appropriate for T) to be used
+         * for the {@link ClassRecommender}.
+         */
+        protected abstract Set<PluginDesc<T>> plugins();
+
+        /**
+         * Recommend bundled transformations or predicates.
+         */
+        final class ClassRecommender implements ConfigDef.Recommender {
+
+            @Override
+            public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
+                List<Object> result = new ArrayList<>();
+                for (PluginDesc<T> plugin : plugins()) {
+                    result.add(plugin.pluginClass());
+                }
+                return Collections.unmodifiableList(result);
+            }
+
+            @Override
+            public boolean visible(String name, Map<String, Object> parsedConfig) {
+                return true;
+            }
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.errors.ToleranceType;
@@ -276,8 +277,7 @@ public class ConnectorConfig extends AbstractConfig {
 
             try {
                 @SuppressWarnings("unchecked")
-                final Transformation<R> transformation = getClass(prefix + "type").asSubclass(Transformation.class)
-                        .getDeclaredConstructor().newInstance();
+                final Transformation<R> transformation = Utils.newInstance(getClass(prefix + "type"), Transformation.class);
                 Map<String, Object> configs = originalsWithPrefix(prefix);
                 Object predicateAlias = configs.remove("predicate");
                 Object negate = configs.remove("negate");
@@ -285,8 +285,7 @@ public class ConnectorConfig extends AbstractConfig {
                 if (predicateAlias != null) {
                     String predicatePrefix = "predicates." + predicateAlias + ".";
                     @SuppressWarnings("unchecked")
-                    Predicate<R> predicate = getClass(predicatePrefix + "type").asSubclass(Predicate.class)
-                            .getDeclaredConstructor().newInstance();
+                    Predicate<R> predicate = Utils.newInstance(getClass(predicatePrefix + "type"), Predicate.class);
                     predicate.configure(originalsWithPrefix(predicatePrefix));
                     transformations.add(new PredicatedTransformation<>(predicate, negate == null ? false : Boolean.parseBoolean(negate.toString()), transformation));
                 } else {
@@ -499,7 +498,7 @@ public class ConnectorConfig extends AbstractConfig {
             }
             T transformation;
             try {
-                transformation = cls.asSubclass(baseClass).getConstructor().newInstance();
+                transformation = Utils.newInstance(cls, baseClass);
             } catch (Exception e) {
                 throw new ConfigException(key, String.valueOf(cls), "Error getting config definition from " + baseClass.getSimpleName() + ": " + e.getMessage());
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -315,7 +315,6 @@ public class ConnectorConfig extends AbstractConfig {
                 return (Set) plugins.transformations();
             }
 
-
             @Override
             protected ConfigDef initialConfigDef() {
                 // All Transformations get these config parameters implicitly

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
@@ -69,4 +69,13 @@ class PredicatedTransformation<R extends ConnectRecord<R>> implements Transforma
         Utils.closeQuietly(delegate, "predicated");
         Utils.closeQuietly(predicate, "predicate");
     }
+
+    @Override
+    public String toString() {
+        return "PredicatedTransformation{" +
+                "predicate=" + predicate +
+                ", delegate=" + delegate +
+                ", negate=" + negate +
+                '}';
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 
@@ -31,9 +32,11 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
  */
 class PredicatedTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
 
-    /*test*/ final Predicate<R> predicate;
-    /*test*/ final Transformation<R> delegate;
-    /*test*/ final boolean negate;
+    static final String PREDICATE_CONFIG = "predicate";
+    static final String NEGATE_CONFIG = "negate";
+    /*test*/ Predicate<R> predicate;
+    /*test*/ Transformation<R> delegate;
+    /*test*/ boolean negate;
 
     PredicatedTransformation(Predicate<R> predicate, boolean negate, Transformation<R> delegate) {
         this.predicate = predicate;
@@ -43,7 +46,8 @@ class PredicatedTransformation<R extends ConnectRecord<R>> implements Transforma
 
     @Override
     public void configure(Map<String, ?> configs) {
-
+        throw new ConnectException(PredicatedTransformation.class.getName() + ".configure() " +
+                "should never be called directly.");
     }
 
     @Override
@@ -56,7 +60,8 @@ class PredicatedTransformation<R extends ConnectRecord<R>> implements Transforma
 
     @Override
     public ConfigDef config() {
-        return null;
+        throw new ConnectException(PredicatedTransformation.class.getName() + ".config() " +
+                "should never be called directly.");
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+
+/**
+ * Decorator for a {@link Transformation} which applies the delegate only when a
+ * {@link Predicate} is true (or false, according to {@code negate}).
+ * @param <R>
+ */
+class PredicatedTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    /*test*/ final Predicate<R> predicate;
+    /*test*/ final Transformation<R> delegate;
+    /*test*/ final boolean negate;
+
+    PredicatedTransformation(Predicate<R> predicate, boolean negate, Transformation<R> delegate) {
+        this.predicate = predicate;
+        this.negate = negate;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+
+    @Override
+    public R apply(R record) {
+        if (negate ^ predicate.test(record)) {
+            return delegate.apply(record);
+        }
+        return record;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+        Utils.closeQuietly(delegate, "predicated");
+        Utils.closeQuietly(predicate, "predicate");
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/PredicatedTransformation.java
@@ -34,9 +34,9 @@ class PredicatedTransformation<R extends ConnectRecord<R>> implements Transforma
 
     static final String PREDICATE_CONFIG = "predicate";
     static final String NEGATE_CONFIG = "negate";
-    /*test*/ Predicate<R> predicate;
-    /*test*/ Transformation<R> delegate;
-    /*test*/ boolean negate;
+    Predicate<R> predicate;
+    Transformation<R> delegate;
+    boolean negate;
 
     PredicatedTransformation(Predicate<R> predicate, boolean negate, Transformation<R> delegate) {
         this.predicate = predicate;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.reflections.Configuration;
 import org.reflections.Reflections;
 import org.reflections.ReflectionsException;
@@ -72,6 +73,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     private final SortedSet<PluginDesc<Converter>> converters;
     private final SortedSet<PluginDesc<HeaderConverter>> headerConverters;
     private final SortedSet<PluginDesc<Transformation>> transformations;
+    private final SortedSet<PluginDesc<Predicate>> predicates;
     private final SortedSet<PluginDesc<ConfigProvider>> configProviders;
     private final SortedSet<PluginDesc<ConnectRestExtension>> restExtensions;
     private final SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
@@ -92,6 +94,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         this.converters = new TreeSet<>();
         this.headerConverters = new TreeSet<>();
         this.transformations = new TreeSet<>();
+        this.predicates = new TreeSet<>();
         this.configProviders = new TreeSet<>();
         this.restExtensions = new TreeSet<>();
         this.connectorClientConfigPolicies = new TreeSet<>();
@@ -119,6 +122,10 @@ public class DelegatingClassLoader extends URLClassLoader {
 
     public Set<PluginDesc<Transformation>> transformations() {
         return transformations;
+    }
+
+    public Set<PluginDesc<Predicate>> predicates() {
+        return predicates;
     }
 
     public Set<PluginDesc<ConfigProvider>> configProviders() {
@@ -269,6 +276,8 @@ public class DelegatingClassLoader extends URLClassLoader {
             headerConverters.addAll(plugins.headerConverters());
             addPlugins(plugins.transformations(), loader);
             transformations.addAll(plugins.transformations());
+            addPlugins(plugins.predicates(), loader);
+            predicates.addAll(plugins.predicates());
             addPlugins(plugins.configProviders(), loader);
             configProviders.addAll(plugins.configProviders());
             addPlugins(plugins.restExtensions(), loader);
@@ -329,6 +338,7 @@ public class DelegatingClassLoader extends URLClassLoader {
                 getPluginDesc(reflections, Converter.class, loader),
                 getPluginDesc(reflections, HeaderConverter.class, loader),
                 getPluginDesc(reflections, Transformation.class, loader),
+                getPluginDesc(reflections, Predicate.class, loader),
                 getServiceLoaderPluginDesc(ConfigProvider.class, loader),
                 getServiceLoaderPluginDesc(ConnectRestExtension.class, loader),
                 getServiceLoaderPluginDesc(ConnectorClientConfigOverridePolicy.class, loader)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -412,6 +412,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         addAliases(converters);
         addAliases(headerConverters);
         addAliases(transformations);
+        addAliases(predicates);
         addAliases(restExtensions);
         addAliases(connectorClientConfigPolicies);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +34,7 @@ public class PluginScanResult {
     private final Collection<PluginDesc<Converter>> converters;
     private final Collection<PluginDesc<HeaderConverter>> headerConverters;
     private final Collection<PluginDesc<Transformation>> transformations;
+    private final Collection<PluginDesc<Predicate>> predicates;
     private final Collection<PluginDesc<ConfigProvider>> configProviders;
     private final Collection<PluginDesc<ConnectRestExtension>> restExtensions;
     private final Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
@@ -44,6 +46,7 @@ public class PluginScanResult {
             Collection<PluginDesc<Converter>> converters,
             Collection<PluginDesc<HeaderConverter>> headerConverters,
             Collection<PluginDesc<Transformation>> transformations,
+            Collection<PluginDesc<Predicate>> predicates,
             Collection<PluginDesc<ConfigProvider>> configProviders,
             Collection<PluginDesc<ConnectRestExtension>> restExtensions,
             Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies
@@ -52,6 +55,7 @@ public class PluginScanResult {
         this.converters = converters;
         this.headerConverters = headerConverters;
         this.transformations = transformations;
+        this.predicates = predicates;
         this.configProviders = configProviders;
         this.restExtensions = restExtensions;
         this.connectorClientConfigPolicies = connectorClientConfigPolicies;
@@ -74,6 +78,10 @@ public class PluginScanResult {
 
     public Collection<PluginDesc<Transformation>> transformations() {
         return transformations;
+    }
+
+    public Collection<PluginDesc<Predicate>> predicates() {
+        return predicates;
     }
 
     public Collection<PluginDesc<ConfigProvider>> configProviders() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -128,7 +128,7 @@ public class PluginUtils {
     // added to the WHITELIST), then this base interface or class needs to be excluded in the
     // regular expression pattern
     private static final Pattern WHITELIST = Pattern.compile("^org\\.apache\\.kafka\\.(?:connect\\.(?:"
-            + "transforms\\.(?!Transformation$).*"
+            + "transforms\\.(?!Transformation|predicates\\.Predicate$).*"
             + "|json\\..*"
             + "|file\\..*"
             + "|mirror\\..*"

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.storage.ConverterConfig;
 import org.apache.kafka.connect.storage.ConverterType;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,6 +166,10 @@ public class Plugins {
 
     public Set<PluginDesc<Transformation>> transformations() {
         return delegatingLoader.transformations();
+    }
+
+    public Set<PluginDesc<Predicate>> predicates() {
+        return delegatingLoader.predicates();
     }
 
     public Set<PluginDesc<ConfigProvider>> configProviders() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.tools;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.transforms.Cast;
 import org.apache.kafka.connect.transforms.ExtractField;
+import org.apache.kafka.connect.transforms.Filter;
 import org.apache.kafka.connect.transforms.Flatten;
 import org.apache.kafka.connect.transforms.HoistField;
 import org.apache.kafka.connect.transforms.InsertField;
@@ -60,7 +61,8 @@ public class TransformationDoc {
             new DocInfo(RegexRouter.class.getName(), RegexRouter.OVERVIEW_DOC, RegexRouter.CONFIG_DEF),
             new DocInfo(Flatten.class.getName(), Flatten.OVERVIEW_DOC, Flatten.CONFIG_DEF),
             new DocInfo(Cast.class.getName(), Cast.OVERVIEW_DOC, Cast.CONFIG_DEF),
-            new DocInfo(TimestampConverter.class.getName(), TimestampConverter.OVERVIEW_DOC, TimestampConverter.CONFIG_DEF)
+            new DocInfo(TimestampConverter.class.getName(), TimestampConverter.OVERVIEW_DOC, TimestampConverter.CONFIG_DEF),
+            new DocInfo(Filter.class.getName(), Filter.OVERVIEW_DOC, Filter.CONFIG_DEF)
     );
 
     private static void printTransformationHtml(PrintStream out, DocInfo docInfo) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -25,11 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A handle to a connector executing in a Connect cluster.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -16,18 +16,20 @@
  */
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.connect.errors.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A handle to a connector executing in a Connect cluster.
@@ -57,7 +59,19 @@ public class ConnectorHandle {
      * @return a non-null {@link TaskHandle}
      */
     public TaskHandle taskHandle(String taskId) {
-        return taskHandles.computeIfAbsent(taskId, k -> new TaskHandle(this, taskId));
+        return taskHandle(taskId, null);
+    }
+
+    /**
+     * Get or create a task handle for a given task id. The task need not be created when this method is called. If the
+     * handle is called before the task is created, the task will bind to the handle once it starts (or restarts).
+     *
+     * @param taskId the task id
+     * @param consumer A callback invoked when a sink task processes a record.
+     * @return a non-null {@link TaskHandle}
+     */
+    public TaskHandle taskHandle(String taskId, Consumer<SinkRecord> consumer) {
+        return taskHandles.computeIfAbsent(taskId, k -> new TaskHandle(this, taskId, consumer));
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -125,7 +125,7 @@ public class MonitorableSinkConnector extends TestSinkConnector {
         @Override
         public void put(Collection<SinkRecord> records) {
             for (SinkRecord rec : records) {
-                taskHandle.record();
+                taskHandle.record(rec);
                 TopicPartition tp = cachedTopicPartitions
                         .computeIfAbsent(rec.topic(), v -> new HashMap<>())
                         .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.runtime.TestSourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -138,7 +139,9 @@ public class MonitorableSourceConnector extends TestSourceConnector {
                                 Schema.STRING_SCHEMA,
                                 "key-" + taskId + "-" + seqno,
                                 Schema.STRING_SCHEMA,
-                                "value-" + taskId + "-" + seqno))
+                                "value-" + taskId + "-" + seqno,
+                                null,
+                                new ConnectHeaders().addLong("header-" + seqno, seqno)))
                         .collect(Collectors.toList());
             }
             return null;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
@@ -16,16 +16,16 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A handle to an executing task in a worker. Use this class to record progress, for example: number of records seen

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
@@ -52,12 +52,16 @@ public class TaskHandle {
         this.consumer = consumer;
     }
 
+    public void record() {
+        record(null);
+    }
+
     /**
      * Record a message arrival at the task and the connector overall.
      */
-    public void record(SinkRecord rec) {
-        if (consumer != null) {
-            consumer.accept(rec);
+    public void record(SinkRecord record) {
+        if (consumer != null && record != null) {
+            consumer.accept(record);
         }
         if (recordsRemainingLatch != null) {
             recordsRemainingLatch.countDown();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.transforms.Filter;
+import org.apache.kafka.connect.transforms.predicates.HasHeaderKey;
+import org.apache.kafka.connect.transforms.predicates.RecordIsTombstone;
+import org.apache.kafka.connect.transforms.predicates.TopicNameMatches;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static java.util.Collections.singletonMap;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.PREDICATES_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TRANSFORMS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * An integration test for connectors with transformations
+ */
+@Category(IntegrationTest.class)
+public class TransformationIntegrationTest {
+
+    private static final int NUM_RECORDS_PRODUCED = 2000;
+    private static final int NUM_TOPIC_PARTITIONS = 3;
+    private static final long RECORD_TRANSFER_DURATION_MS = TimeUnit.SECONDS.toMillis(30);
+    private static final long OBSERVED_RECORDS_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+    private static final int NUM_TASKS = 3;
+    private static final int NUM_WORKERS = 3;
+    private static final String CONNECTOR_NAME = "simple-conn";
+    private static final String SINK_CONNECTOR_CLASS_NAME = MonitorableSinkConnector.class.getSimpleName();
+    private static final String SOURCE_CONNECTOR_CLASS_NAME = MonitorableSourceConnector.class.getSimpleName();
+
+    private EmbeddedConnectCluster connect;
+    private ConnectorHandle connectorHandle;
+
+    @Before
+    public void setup() {
+        // setup Connect worker properties
+        Map<String, String> exampleWorkerProps = new HashMap<>();
+        exampleWorkerProps.put(OFFSET_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(5_000));
+
+        // setup Kafka broker properties
+        Properties exampleBrokerProps = new Properties();
+        exampleBrokerProps.put("auto.create.topics.enable", "false");
+
+        // build a Connect cluster backed by Kafka and Zk
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("connect-cluster")
+                .numWorkers(NUM_WORKERS)
+                .numBrokers(1)
+                .workerProps(exampleWorkerProps)
+                .brokerProps(exampleBrokerProps)
+                .build();
+
+        // start the clusters
+        connect.start();
+
+        // get a handle to the connector
+        connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+    }
+
+    @After
+    public void close() {
+        // delete connector handle
+        RuntimeHandles.get().deleteConnector(CONNECTOR_NAME);
+
+        // stop all Connect, Kafka and Zk threads.
+        connect.stop();
+    }
+
+    /**
+     * Test the {@link Filter} transformer with a
+     * {@link TopicNameMatches} predicate on a sink connector.
+     */
+    @Test
+    public void testFilterOnTopicNameWithSinkConnector() throws Exception {
+        Map<String, Long> observedRecords = observeRecords();
+
+        // create test topics
+        String fooTopic = "foo-topic";
+        String barTopic = "bar-topic";
+        int numFooRecords = NUM_RECORDS_PRODUCED;
+        int numBarRecords = NUM_RECORDS_PRODUCED;
+        connect.kafka().createTopic(fooTopic, NUM_TOPIC_PARTITIONS);
+        connect.kafka().createTopic(barTopic, NUM_TOPIC_PARTITIONS);
+
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put("name", CONNECTOR_NAME);
+        props.put(CONNECTOR_CLASS_CONFIG, SINK_CONNECTOR_CLASS_NAME);
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put(TOPICS_CONFIG, String.join(",", fooTopic, barTopic));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(TRANSFORMS_CONFIG, "filter");
+        props.put(TRANSFORMS_CONFIG + ".filter.type", Filter.class.getSimpleName());
+        props.put(TRANSFORMS_CONFIG + ".filter.predicate", "barPredicate");
+        props.put(PREDICATES_CONFIG, "barPredicate");
+        props.put(PREDICATES_CONFIG + ".barPredicate.type", TopicNameMatches.class.getSimpleName());
+        props.put(PREDICATES_CONFIG + ".barPredicate.pattern", "bar-.*");
+
+        // expect all records to be consumed by the connector
+        connectorHandle.expectedRecords(numFooRecords);
+
+        // expect all records to be consumed by the connector
+        connectorHandle.expectedCommits(numFooRecords);
+
+        // start a sink connector
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        // produce some messages into source topic partitions
+        for (int i = 0; i < numBarRecords; i++) {
+            connect.kafka().produce(barTopic, i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
+        }
+        for (int i = 0; i < numFooRecords; i++) {
+            connect.kafka().produce(fooTopic, i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
+        }
+
+        // consume all records from the source topic or fail, to ensure that they were correctly produced.
+        assertEquals("Unexpected number of records consumed", numFooRecords,
+                connect.kafka().consume(numFooRecords, RECORD_TRANSFER_DURATION_MS, fooTopic).count());
+        assertEquals("Unexpected number of records consumed", numFooRecords,
+                connect.kafka().consume(numBarRecords, RECORD_TRANSFER_DURATION_MS, barTopic).count());
+
+        // wait for the connector tasks to consume all records.
+        connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
+
+        // wait for the connector tasks to commit all records.
+        connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
+
+        // Assert that we didn't see any baz
+        Map<String, Long> expectedRecordCounts = singletonMap(fooTopic, Long.valueOf(numFooRecords));
+        assertObservedRecords(observedRecords, expectedRecordCounts);
+
+        // delete connector
+        connect.deleteConnector(CONNECTOR_NAME);
+    }
+
+    private void assertObservedRecords(Map<String, Long> observedRecords, Map<String, Long> expectedRecordCounts) throws InterruptedException {
+        waitForCondition(() -> expectedRecordCounts.equals(observedRecords),
+            OBSERVED_RECORDS_DURATION_MS,
+            () -> "The observed records should be " + expectedRecordCounts + " but was " + observedRecords);
+    }
+
+    private Map<String, Long> observeRecords() {
+        Map<String, Long> observedRecords = new HashMap<>();
+        // record all the record we see
+        connectorHandle.taskHandle(CONNECTOR_NAME + "-0",
+            record -> observedRecords.compute(record.topic(),
+                (key, value) -> value == null ? 1 : value + 1));
+        return observedRecords;
+    }
+
+    /**
+     * Test the {@link Filter} transformer with a
+     * {@link RecordIsTombstone} predicate on a sink connector.
+     */
+    @Test
+    public void testFilterOnTombstonesWithSinkConnector() throws Exception {
+        Map<String, Long> observedRecords = observeRecords();
+
+        // create test topics
+        String topic = "foo-topic";
+        int numRecords = NUM_RECORDS_PRODUCED;
+        connect.kafka().createTopic(topic, NUM_TOPIC_PARTITIONS);
+
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put("name", CONNECTOR_NAME);
+        props.put(CONNECTOR_CLASS_CONFIG, SINK_CONNECTOR_CLASS_NAME);
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put(TOPICS_CONFIG, String.join(",", topic));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(TRANSFORMS_CONFIG, "filter");
+        props.put(TRANSFORMS_CONFIG + ".filter.type", Filter.class.getSimpleName());
+        props.put(TRANSFORMS_CONFIG + ".filter.predicate", "barPredicate");
+        props.put(PREDICATES_CONFIG, "barPredicate");
+        props.put(PREDICATES_CONFIG + ".barPredicate.type", RecordIsTombstone.class.getSimpleName());
+
+        // expect only half the records to be consumed by the connector
+        connectorHandle.expectedCommits(numRecords);
+        connectorHandle.expectedRecords(numRecords / 2);
+
+        // start a sink connector
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        // produce some messages into source topic partitions
+        for (int i = 0; i < numRecords; i++) {
+            connect.kafka().produce(topic, i % NUM_TOPIC_PARTITIONS, "key", i % 2 == 0 ? "simple-message-value-" + i : null);
+        }
+
+        // consume all records from the source topic or fail, to ensure that they were correctly produced.
+        assertEquals("Unexpected number of records consumed", numRecords,
+                connect.kafka().consume(numRecords, RECORD_TRANSFER_DURATION_MS, topic).count());
+
+        // wait for the connector tasks to consume all records.
+        connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
+
+        // wait for the connector tasks to commit all records.
+        connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
+
+        Map<String, Long> expectedRecordCounts = singletonMap(topic, Long.valueOf(numRecords / 2));
+        assertObservedRecords(observedRecords, expectedRecordCounts);
+
+        // delete connector
+        connect.deleteConnector(CONNECTOR_NAME);
+    }
+
+    /**
+     * Test the {@link Filter} transformer with a
+     * {@link HasHeaderKey} predicate on a source connector.
+     */
+    @Test
+    public void testFilterOnHasHeaderKeyWithSourceConnector() throws Exception {
+        // create test topic
+        connect.kafka().createTopic("test-topic", NUM_TOPIC_PARTITIONS);
+
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put("name", CONNECTOR_NAME);
+        props.put(CONNECTOR_CLASS_CONFIG, SOURCE_CONNECTOR_CLASS_NAME);
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put("topic", "test-topic");
+        props.put("throughput", String.valueOf(500));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(TRANSFORMS_CONFIG, "filter");
+        props.put(TRANSFORMS_CONFIG + ".filter.type", Filter.class.getSimpleName());
+        props.put(TRANSFORMS_CONFIG + ".filter.predicate", "headerPredicate");
+        props.put(TRANSFORMS_CONFIG + ".filter.negate", "true");
+        props.put(PREDICATES_CONFIG, "headerPredicate");
+        props.put(PREDICATES_CONFIG + ".headerPredicate.type", HasHeaderKey.class.getSimpleName());
+        props.put(PREDICATES_CONFIG + ".headerPredicate.name", "header-8");
+
+        // expect all records to be produced by the connector
+        connectorHandle.expectedRecords(NUM_RECORDS_PRODUCED);
+
+        // expect all records to be produced by the connector
+        connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
+
+        // validate the intended connector configuration, a valid config
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(SOURCE_CONNECTOR_CLASS_NAME, props, 0,
+                "Validating connector configuration produced an unexpected number or errors.");
+
+        // start a source connector
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        // wait for the connector tasks to produce enough records
+        connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
+
+        // wait for the connector tasks to commit enough records
+        connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
+
+        // consume all records from the source topic or fail, to ensure that they were correctly produced
+        for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "test-topic")) {
+            assertNotNull("Expected header to exist",
+                    record.headers().lastHeader("header-8"));
+        }
+
+        // delete connector
+        connect.deleteConnector(CONNECTOR_NAME);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -159,7 +159,7 @@ public class TransformationIntegrationTest {
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals("Unexpected number of records consumed", numFooRecords,
                 connect.kafka().consume(numFooRecords, RECORD_TRANSFER_DURATION_MS, fooTopic).count());
-        assertEquals("Unexpected number of records consumed", numFooRecords,
+        assertEquals("Unexpected number of records consumed", numBarRecords,
                 connect.kafka().consume(numBarRecords, RECORD_TRANSFER_DURATION_MS, barTopic).count());
 
         // wait for the connector tasks to consume all records.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -292,7 +292,7 @@ public class AbstractHerderTest {
         // the config fields for SourceConnectorConfig, but we expect these to change rarely.
         assertEquals(TestSourceConnector.class.getName(), result.name());
         assertEquals(Arrays.asList(ConnectorConfig.COMMON_GROUP, ConnectorConfig.TRANSFORMS_GROUP,
-                ConnectorConfig.ERROR_GROUP, SourceConnectorConfig.TOPIC_CREATION_GROUP), result.groups());
+                ConnectorConfig.PREDICATES_GROUP, ConnectorConfig.ERROR_GROUP, SourceConnectorConfig.TOPIC_CREATION_GROUP), result.groups());
         assertEquals(2, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
@@ -353,6 +353,7 @@ public class AbstractHerderTest {
         List<String> expectedGroups = Arrays.asList(
                 ConnectorConfig.COMMON_GROUP,
                 ConnectorConfig.TRANSFORMS_GROUP,
+                ConnectorConfig.PREDICATES_GROUP,
                 ConnectorConfig.ERROR_GROUP,
                 SourceConnectorConfig.TOPIC_CREATION_GROUP,
                 "Transforms: xformA",
@@ -471,6 +472,7 @@ public class AbstractHerderTest {
         List<String> expectedGroups = Arrays.asList(
             ConnectorConfig.COMMON_GROUP,
             ConnectorConfig.TRANSFORMS_GROUP,
+            ConnectorConfig.PREDICATES_GROUP,
             ConnectorConfig.ERROR_GROUP,
             SourceConnectorConfig.TOPIC_CREATION_GROUP
         );

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -295,7 +296,8 @@ public class AbstractHerderTest {
         assertEquals(2, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
-        assertEquals(16, infos.size());
+        // Base connector config has 14 fields, connector's configs add 2
+        assertEquals(17, infos.size());
         // Missing name should generate an error
         assertEquals(ConnectorConfig.NAME_CONFIG,
                 infos.get(ConnectorConfig.NAME_CONFIG).configValue().name());
@@ -360,7 +362,7 @@ public class AbstractHerderTest {
         assertEquals(2, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
-        assertEquals(19, infos.size());
+        assertEquals(22, infos.size());
         // Should get 2 type fields from the transforms, first adds its own config since it has a valid class
         assertEquals("transforms.xformA.type",
                 infos.get("transforms.xformA.type").configValue().name());
@@ -369,6 +371,78 @@ public class AbstractHerderTest {
                 infos.get("transforms.xformA.subconfig").configValue().name());
         assertEquals("transforms.xformB.type", infos.get("transforms.xformB.type").configValue().name());
         assertFalse(infos.get("transforms.xformB.type").configValue().errors().isEmpty());
+
+        verifyAll();
+    }
+
+    @Test()
+    public void testConfigValidationPredicatesExtendResults() {
+        AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy);
+
+        // 2 transform aliases defined -> 2 plugin lookups
+        Set<PluginDesc<Transformation>> transformations = new HashSet<>();
+        transformations.add(new PluginDesc<Transformation>(SampleTransformation.class, "1.0", classLoader));
+        EasyMock.expect(plugins.transformations()).andReturn(transformations).times(1);
+
+        Set<PluginDesc<Predicate>> predicates = new HashSet<>();
+        predicates.add(new PluginDesc<Predicate>(SamplePredicate.class, "1.0", classLoader));
+        EasyMock.expect(plugins.predicates()).andReturn(predicates).times(2);
+
+        replayAll();
+
+        // Define 2 transformations. One has a class defined and so can get embedded configs, the other is missing
+        // class info that should generate an error.
+        Map<String, String> config = new HashMap<>();
+        config.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, TestSourceConnector.class.getName());
+        config.put(ConnectorConfig.NAME_CONFIG, "connector-name");
+        config.put(ConnectorConfig.TRANSFORMS_CONFIG, "xformA");
+        config.put(ConnectorConfig.TRANSFORMS_CONFIG + ".xformA.type", SampleTransformation.class.getName());
+        config.put(ConnectorConfig.TRANSFORMS_CONFIG + ".xformA.predicate", "predX");
+        config.put(ConnectorConfig.PREDICATES_CONFIG, "predX,predY");
+        config.put(ConnectorConfig.PREDICATES_CONFIG + ".predX.type", SamplePredicate.class.getName());
+        config.put("required", "value"); // connector required config
+        ConfigInfos result = herder.validateConnectorConfig(config);
+        assertEquals(herder.connectorTypeForClass(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG)), ConnectorType.SOURCE);
+
+        // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
+        // the config fields for SourceConnectorConfig, but we expect these to change rarely.
+        assertEquals(TestSourceConnector.class.getName(), result.name());
+        // Each transform also gets its own group
+        List<String> expectedGroups = Arrays.asList(
+                ConnectorConfig.COMMON_GROUP,
+                ConnectorConfig.TRANSFORMS_GROUP,
+                ConnectorConfig.PREDICATES_GROUP,
+                ConnectorConfig.ERROR_GROUP,
+                SourceConnectorConfig.TOPIC_CREATION_GROUP,
+                "Transforms: xformA",
+                "Predicates: predX",
+                "Predicates: predY"
+        );
+        assertEquals(expectedGroups, result.groups());
+        assertEquals(2, result.errorCount());
+        Map<String, ConfigInfo> infos = result.values().stream()
+                .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
+        assertEquals(24, infos.size());
+        // Should get 2 type fields from the transforms, first adds its own config since it has a valid class
+        assertEquals("transforms.xformA.type",
+                infos.get("transforms.xformA.type").configValue().name());
+        assertTrue(infos.get("transforms.xformA.type").configValue().errors().isEmpty());
+        assertEquals("transforms.xformA.subconfig",
+                infos.get("transforms.xformA.subconfig").configValue().name());
+        assertEquals("transforms.xformA.predicate",
+                infos.get("transforms.xformA.predicate").configValue().name());
+        assertTrue(infos.get("transforms.xformA.predicate").configValue().errors().isEmpty());
+        assertEquals("transforms.xformA.negate",
+                infos.get("transforms.xformA.negate").configValue().name());
+        assertTrue(infos.get("transforms.xformA.negate").configValue().errors().isEmpty());
+        assertEquals("predicates.predX.type",
+                infos.get("predicates.predX.type").configValue().name());
+        assertEquals("predicates.predX.predconfig",
+                infos.get("predicates.predX.predconfig").configValue().name());
+        assertEquals("predicates.predY.type",
+                infos.get("predicates.predY.type").configValue().name());
+        assertFalse(
+                infos.get("predicates.predY.type").configValue().errors().isEmpty());
 
         verifyAll();
     }
@@ -402,8 +476,8 @@ public class AbstractHerderTest {
         );
         assertEquals(expectedGroups, result.groups());
         assertEquals(1, result.errorCount());
-        // Base connector config has 13 fields, connector's configs add 2, and 2 producer overrides
-        assertEquals(18, result.values().size());
+        // Base connector config has 14 fields, connector's configs add 2, and 2 producer overrides
+        assertEquals(19, result.values().size());
         assertTrue(result.values().stream().anyMatch(
             configInfo -> ackConfigKey.equals(configInfo.configValue().name()) && !configInfo.configValue().errors().isEmpty()));
         assertTrue(result.values().stream().anyMatch(
@@ -560,6 +634,30 @@ public class AbstractHerderTest {
 
         @Override
         public void close() {
+
+        }
+    }
+
+    public static class SamplePredicate<R extends ConnectRecord<R>> implements Predicate<R> {
+
+        @Override
+        public ConfigDef config() {
+            return new ConfigDef()
+                    .define("predconfig", ConfigDef.Type.STRING, "default", ConfigDef.Importance.LOW, "docs");
+        }
+
+        @Override
+        public boolean test(R record) {
+            return false;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
 
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -363,7 +363,7 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         new ConnectorConfig(MOCK_PLUGINS, props);
     }
 
-    static class TestPredicate<R extends ConnectRecord<R>> implements Predicate<R>  {
+    public static class TestPredicate<R extends ConnectRecord<R>> implements Predicate<R>  {
 
         int param;
 
@@ -391,7 +391,7 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         }
     }
 
-    static abstract class AbstractTestPredicate<R extends ConnectRecord<R>> implements Predicate<R>  {
+    public static abstract class AbstractTestPredicate<R extends ConnectRecord<R>> implements Predicate<R>  {
 
         public AbstractTestPredicate() { }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -16,12 +16,6 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -32,6 +26,12 @@ import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -215,8 +215,6 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
             );
         }
     }
-
-
 
     @Test(expected = ConfigException.class)
     public void wrongPredicateType() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/PredicatedTransformationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/PredicatedTransformationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.junit.Test;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PredicatedTransformationTest {
+
+    private final SourceRecord initial = new SourceRecord(singletonMap("initial", 1), null, null, null, null);
+    private final SourceRecord transformed = new SourceRecord(singletonMap("transformed", 2), null, null, null, null);
+
+    @Test
+    public void apply() {
+        applyAndAssert(true, false, transformed);
+        applyAndAssert(true, true, initial);
+        applyAndAssert(false, false, initial);
+        applyAndAssert(false, true, transformed);
+    }
+
+    private void applyAndAssert(boolean predicateResult, boolean negate,
+                                SourceRecord expectedResult) {
+        class TestTransformation implements Transformation<SourceRecord> {
+
+            private boolean closed = false;
+            private SourceRecord transformedRecord;
+
+            private TestTransformation(SourceRecord transformedRecord) {
+                this.transformedRecord = transformedRecord;
+            }
+
+            @Override
+            public SourceRecord apply(SourceRecord record) {
+                return transformedRecord;
+            }
+
+            @Override
+            public ConfigDef config() {
+                return null;
+            }
+
+            @Override
+            public void close() {
+                closed = true;
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs) {
+
+            }
+
+            private void assertClosed() {
+                assertTrue("Transformer should be closed", closed);
+            }
+        }
+
+        class TestPredicate implements Predicate<SourceRecord> {
+
+            private boolean testResult;
+            private boolean closed = false;
+
+            private TestPredicate(boolean testResult) {
+                this.testResult = testResult;
+            }
+
+            @Override
+            public ConfigDef config() {
+                return null;
+            }
+
+            @Override
+            public boolean test(SourceRecord record) {
+                return testResult;
+            }
+
+            @Override
+            public void close() {
+                closed = true;
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs) {
+
+            }
+
+            private void assertClosed() {
+                assertTrue("Predicate should be closed", closed);
+            }
+        }
+        TestPredicate predicate = new TestPredicate(predicateResult);
+        TestTransformation predicatedTransform = new TestTransformation(transformed);
+        PredicatedTransformation<SourceRecord> pt = new PredicatedTransformation<>(
+                predicate,
+                negate,
+                predicatedTransform);
+
+        assertEquals(expectedResult, pt.apply(initial));
+
+        pt.close();
+        predicate.assertClosed();
+        predicatedTransform.assertClosed();
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -100,6 +100,9 @@ public class PluginUtilsTest {
                 "org.apache.kafka.connect.transforms.Transformation")
         );
         assertFalse(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.transforms.predicates.Predicate")
+        );
+        assertFalse(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.storage.Converter")
         );
         assertFalse(PluginUtils.shouldLoadInIsolation(
@@ -127,6 +130,10 @@ public class PluginUtilsTest {
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.transforms.ExtractField$Key")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation("org.apache.kafka.connect.transforms.predicates."));
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.transforms.predicates.TopicNameMatches")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation("org.apache.kafka.connect.json."));
         assertTrue(PluginUtils.shouldLoadInIsolation(

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * Drops all records, filtering them from subsequent transformations in the chain.
+ * This is intended to be used conditionally to filter out records matching (or not matching)
+ * a particular {@link org.apache.kafka.connect.transforms.predicates.Predicate}.
+ * @param <R> The type of record.
+ */
+public class Filter<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    @Override
+    public R apply(R record) {
+        return null;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
@@ -29,6 +29,11 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  */
 public class Filter<R extends ConnectRecord<R>> implements Transformation<R> {
 
+    public static final String OVERVIEW_DOC = "Drops all records, filtering them from subsequent transformations in the chain. " +
+            "This is intended to be used conditionally to filter out records matching (or not matching) " +
+            "a particular Predicate.";
+    public static final ConfigDef CONFIG_DEF = new ConfigDef();
+
     @Override
     public R apply(R record) {
         return null;
@@ -36,7 +41,7 @@ public class Filter<R extends ConnectRecord<R>> implements Transformation<R> {
 
     @Override
     public ConfigDef config() {
-        return new ConfigDef();
+        return CONFIG_DEF;
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Filter.java
@@ -36,7 +36,7 @@ public class Filter<R extends ConnectRecord<R>> implements Transformation<R> {
 
     @Override
     public ConfigDef config() {
-        return null;
+        return new ConfigDef();
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
@@ -31,7 +31,7 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
 
     private static final String NAME_CONFIG = "name";
-    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(NAME_CONFIG, ConfigDef.Type.STRING, null,
+    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(NAME_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
             new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM,
             "The header name.");
     private String name;

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A predicate which is true for records with at least one header with the configured name.
+ * @param <R> The type of connect record.
+ */
+public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
+
+    private static final String NAME_CONFIG_KEY = "name";
+    private String name;
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef().define(NAME_CONFIG_KEY, ConfigDef.Type.STRING, null,
+                new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM,
+                "The header name.");
+    }
+
+    @Override
+    public boolean test(R record) {
+        return record.headers().allWithName(name).hasNext();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.name = (String) configs.get(NAME_CONFIG_KEY);
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
@@ -56,4 +56,11 @@ public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
     public void configure(Map<String, ?> configs) {
         this.name = new SimpleConfig(config(), configs).getString(NAME_CONFIG);
     }
+
+    @Override
+    public String toString() {
+        return "HasHeaderKey{" +
+                "name='" + name + '\'' +
+                '}';
+    }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
@@ -16,10 +16,13 @@
  */
 package org.apache.kafka.connect.transforms.predicates;
 
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 /**
  * A predicate which is true for records with at least one header with the configured name.
@@ -27,19 +30,21 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  */
 public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
 
-    private static final String NAME_CONFIG_KEY = "name";
+    private static final String NAME_CONFIG = "name";
+    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(NAME_CONFIG, ConfigDef.Type.STRING, null,
+            new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM,
+            "The header name.");
     private String name;
 
     @Override
     public ConfigDef config() {
-        return new ConfigDef().define(NAME_CONFIG_KEY, ConfigDef.Type.STRING, null,
-                new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM,
-                "The header name.");
+        return CONFIG_DEF;
     }
 
     @Override
     public boolean test(R record) {
-        return record.headers().allWithName(name).hasNext();
+        Iterator<Header> headerIterator = record.headers().allWithName(name);
+        return headerIterator != null && headerIterator.hasNext();
     }
 
     @Override
@@ -49,6 +54,6 @@ public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
 
     @Override
     public void configure(Map<String, ?> configs) {
-        this.name = (String) configs.get(NAME_CONFIG_KEY);
+        this.name = new SimpleConfig(config(), configs).getString(NAME_CONFIG);
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKey.java
@@ -31,7 +31,8 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 public class HasHeaderKey<R extends ConnectRecord<R>> implements Predicate<R> {
 
     private static final String NAME_CONFIG = "name";
-    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(NAME_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(NAME_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
             new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM,
             "The header name.");
     private String name;

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
@@ -22,18 +22,21 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 
 /**
- * A predicate which is true for records which are tombstones (i.e. have null key).
+ * A predicate which is true for records which are tombstones (i.e. have null value).
  * @param <R> The type of connect record.
  */
 public class RecordIsTombstone<R extends ConnectRecord<R>> implements Predicate<R> {
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef();
+
     @Override
     public ConfigDef config() {
-        return new ConfigDef();
+        return CONFIG_DEF;
     }
 
     @Override
     public boolean test(R record) {
-        return record.key() == null;
+        return record.value() == null;
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A predicate which is true for records which are tombstones (i.e. have null key).
+ * @param <R> The type of connect record.
+ */
+public class RecordIsTombstone<R extends ConnectRecord<R>> implements Predicate<R> {
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public boolean test(R record) {
+        return record.key() == null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/RecordIsTombstone.java
@@ -48,4 +48,9 @@ public class RecordIsTombstone<R extends ConnectRecord<R>> implements Predicate<
     public void configure(Map<String, ?> configs) {
 
     }
+
+    @Override
+    public String toString() {
+        return "RecordIsTombstone{}";
+    }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+/**
+ * A predicate which is true for records with a topic name that matches the configured regular expression.
+ * @param <R> The type of connect record.
+ */
+public class TopicNameMatches<R extends ConnectRecord<R>> implements Predicate<R> {
+
+    public static final String PATTERN_CONFIG_KEY = "pattern";
+    private Pattern pattern;
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef().define(PATTERN_CONFIG_KEY, ConfigDef.Type.STRING, null,
+                new ConfigDef.Validator() {
+                    @Override
+                    public void ensureValid(String name, Object value) {
+                        if (value != null) {
+                            compile(name, value);
+                        }
+                    }
+                }, ConfigDef.Importance.MEDIUM,
+                "A Java regular expression for matching against the name of a record's topic.");
+    }
+
+    private Pattern compile(String name, Object value) {
+        try {
+            return Pattern.compile((String) value);
+        } catch (PatternSyntaxException e) {
+            throw new ConfigException(name, value, "entry must be a Java-compatible regular expression: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean test(R record) {
+        return record.topic() != null && pattern.matcher(record.topic()).matches();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.pattern = compile(PATTERN_CONFIG_KEY, configs.get(PATTERN_CONFIG_KEY));
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
@@ -33,8 +33,10 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 public class TopicNameMatches<R extends ConnectRecord<R>> implements Predicate<R> {
 
     private static final String PATTERN_CONFIG = "pattern";
-    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(PATTERN_CONFIG, ConfigDef.Type.STRING, ".*",
-            new RegexValidator(), ConfigDef.Importance.MEDIUM,
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(PATTERN_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.CompositeValidator.of(new ConfigDef.NonEmptyString(), new RegexValidator()),
+            ConfigDef.Importance.MEDIUM,
             "A Java regular expression for matching against the name of a record's topic.");
     private Pattern pattern;
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatches.java
@@ -23,6 +23,7 @@ import java.util.regex.PatternSyntaxException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.util.RegexValidator;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 /**
@@ -32,29 +33,14 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 public class TopicNameMatches<R extends ConnectRecord<R>> implements Predicate<R> {
 
     private static final String PATTERN_CONFIG = "pattern";
-    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(PATTERN_CONFIG, ConfigDef.Type.STRING, null,
-            new ConfigDef.Validator() {
-                @Override
-                public void ensureValid(String name, Object value) {
-                    if (value instanceof String) {
-                        compile(name, (String) value);
-                    }
-                }
-            }, ConfigDef.Importance.MEDIUM,
+    private static final ConfigDef CONFIG_DEF = new ConfigDef().define(PATTERN_CONFIG, ConfigDef.Type.STRING, ".*",
+            new RegexValidator(), ConfigDef.Importance.MEDIUM,
             "A Java regular expression for matching against the name of a record's topic.");
     private Pattern pattern;
 
     @Override
     public ConfigDef config() {
         return CONFIG_DEF;
-    }
-
-    private static Pattern compile(String name, String value) {
-        try {
-            return Pattern.compile(value);
-        } catch (PatternSyntaxException e) {
-            throw new ConfigException(name, value, "entry must be a Java-compatible regular expression: " + e.getMessage());
-        }
     }
 
     @Override
@@ -70,6 +56,20 @@ public class TopicNameMatches<R extends ConnectRecord<R>> implements Predicate<R
     @Override
     public void configure(Map<String, ?> configs) {
         SimpleConfig simpleConfig = new SimpleConfig(config(), configs);
-        this.pattern = compile(PATTERN_CONFIG, simpleConfig.getString(PATTERN_CONFIG));
+        Pattern result;
+        String value = simpleConfig.getString(PATTERN_CONFIG);
+        try {
+            result = Pattern.compile(value);
+        } catch (PatternSyntaxException e) {
+            throw new ConfigException(PATTERN_CONFIG, value, "entry must be a Java-compatible regular expression: " + e.getMessage());
+        }
+        this.pattern = result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopicNameMatches{" +
+                "pattern=" + pattern +
+                '}';
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKeyTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKeyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HasHeaderKeyTest {
+
+    @Test
+    public void testConfig() {
+        HasHeaderKey<SourceRecord> predicate = new HasHeaderKey<>();
+        predicate.config().validate(Collections.singletonMap("name", "foo"));
+
+        List<ConfigValue> configs = predicate.config().validate(Collections.singletonMap("name", ""));
+        assertEquals(singletonList("Invalid value  for configuration name: String must be non-empty"), configs.get(0).errorMessages());
+    }
+
+    @Test
+    public void testTest() {
+        HasHeaderKey<SourceRecord> predicate = new HasHeaderKey<>();
+        predicate.configure(Collections.singletonMap("name", "foo"));
+
+        assertTrue(predicate.test(recordWithHeaders("foo")));
+        assertTrue(predicate.test(recordWithHeaders("foo", "bar")));
+        assertTrue(predicate.test(recordWithHeaders("bar", "foo", "bar", "foo")));
+        assertFalse(predicate.test(recordWithHeaders("bar")));
+        assertFalse(predicate.test(recordWithHeaders("bar", "bar")));
+        assertFalse(predicate.test(recordWithHeaders()));
+        assertFalse(predicate.test(new SourceRecord(null, null, null, null, null)));
+
+    }
+
+    private SourceRecord recordWithHeaders(String... headers) {
+        return new SourceRecord(null, null, null, null, null, null, null, null, null,
+                Arrays.stream(headers).map(header -> new TestHeader(header)).collect(Collectors.toList()));
+    }
+
+    private static class TestHeader implements Header {
+
+        private final String key;
+
+        public TestHeader(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        @Override
+        public Schema schema() {
+            return null;
+        }
+
+        @Override
+        public Object value() {
+            return null;
+        }
+
+        @Override
+        public Header with(Schema schema, Object value) {
+            return null;
+        }
+
+        @Override
+        public Header rename(String key) {
+            return null;
+        }
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKeyTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/HasHeaderKeyTest.java
@@ -18,21 +18,41 @@ package org.apache.kafka.connect.transforms.predicates;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
 import org.junit.Test;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class HasHeaderKeyTest {
+
+    @Test
+    public void testNameRequiredInConfig() {
+        Map<String, String> props = new HashMap<>();
+        ConfigException e = assertThrows(ConfigException.class, () -> config(props));
+        assertTrue(e.getMessage().contains("Missing required configuration \"name\""));
+    }
+
+    @Test
+    public void testNameMayNotBeEmptyInConfig() {
+        Map<String, String> props = new HashMap<>();
+        props.put("name", "");
+        ConfigException e = assertThrows(ConfigException.class, () -> config(props));
+        assertTrue(e.getMessage().contains("String must be non-empty"));
+    }
 
     @Test
     public void testConfig() {
@@ -56,6 +76,10 @@ public class HasHeaderKeyTest {
         assertFalse(predicate.test(recordWithHeaders()));
         assertFalse(predicate.test(new SourceRecord(null, null, null, null, null)));
 
+    }
+
+    private SimpleConfig config(Map<String, String> props) {
+        return new SimpleConfig(new HasHeaderKey().config(), props);
     }
 
     private SourceRecord recordWithHeaders(String... headers) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatchesTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatchesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.predicates;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TopicNameMatchesTest {
+
+    @Test
+    public void testConfig() {
+        TopicNameMatches<SourceRecord> predicate = new TopicNameMatches<>();
+        predicate.config().validate(Collections.singletonMap("pattern", "my-prefix-.*"));
+
+        List<ConfigValue> configs = predicate.config().validate(Collections.singletonMap("pattern", "*"));
+        assertEquals(singletonList("Invalid value * for configuration pattern: " +
+                        "entry must be a Java-compatible regular expression: " +
+                        "Dangling meta character '*' near index 0" + System.lineSeparator() +
+                        "*" + System.lineSeparator() +
+                        "^"),
+                configs.get(0).errorMessages());
+    }
+
+    @Test
+    public void testTest() {
+        TopicNameMatches<SourceRecord> predicate = new TopicNameMatches<>();
+        predicate.configure(Collections.singletonMap("pattern", "my-prefix-.*"));
+
+        assertTrue(predicate.test(recordWithTopicName("my-prefix-")));
+        assertTrue(predicate.test(recordWithTopicName("my-prefix-foo")));
+        assertFalse(predicate.test(recordWithTopicName("x-my-prefix-")));
+        assertFalse(predicate.test(recordWithTopicName("x-my-prefix-foo")));
+        assertFalse(predicate.test(recordWithTopicName("your-prefix-")));
+        assertFalse(predicate.test(recordWithTopicName("your-prefix-foo")));
+        assertFalse(predicate.test(new SourceRecord(null, null, null, null, null)));
+
+    }
+
+    private SourceRecord recordWithTopicName(String topicName) {
+        return new SourceRecord(null, null, topicName, null, null);
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatchesTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/predicates/TopicNameMatchesTest.java
@@ -36,12 +36,9 @@ public class TopicNameMatchesTest {
         predicate.config().validate(Collections.singletonMap("pattern", "my-prefix-.*"));
 
         List<ConfigValue> configs = predicate.config().validate(Collections.singletonMap("pattern", "*"));
-        assertEquals(singletonList("Invalid value * for configuration pattern: " +
-                        "entry must be a Java-compatible regular expression: " +
-                        "Dangling meta character '*' near index 0" + System.lineSeparator() +
-                        "*" + System.lineSeparator() +
-                        "^"),
-                configs.get(0).errorMessages());
+        List<String> errorMsgs = configs.get(0).errorMessages();
+        assertEquals(1, errorMsgs.size());
+        assertTrue(errorMsgs.get(0).contains("Invalid regex"));
     }
 
     @Test


### PR DESCRIPTION
* Add Predicate interface
* Add Filter SMT
* Add the predicate implementations defined in the KIP.
* Create abstraction in ConnectorConfig for configuring Transformations and Connectors with the "alias prefix" mechanism
* Add tests and fix existing tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
