### PR TITLE
MINOR: Increase gradle daemon’s heap size to 2g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ group=org.apache.kafka
 version=2.6.0-SNAPSHOT
 scalaVersion=2.13.2
 task=build
-org.gradle.jvmargs=-Xmx1024m -Xss2m
+org.gradle.jvmargs=-Xmx2g -Xss2m


### PR DESCRIPTION
We have seen out of memory error in builds. This PR is to increase the gradle heap memory to 2g.
 
```
[Error] : Error while emitting kafka/log/LogTest
[2020-05-20T11:33:15.133Z] GC overhead limit exceeded
[2020-05-20T11:33:15.133Z] one error found     
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
