### PR TITLE
KAFKA-10030 allow fetching a key from a single partition

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -58,9 +58,21 @@ public class QueryableStoreProvider {
         }
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider storeProvider : storeProviders) {
-            allStores.addAll(storeProvider.stores(storeQueryParameters));
+            final List<T> stores = storeProvider.stores(storeQueryParameters);
+            if (stores != null && !stores.isEmpty()) {
+                allStores.addAll(storeProvider.stores(storeQueryParameters));
+                if (storeQueryParameters.partition() != null) {
+                    break;
+                }
+            }
         }
         if (allStores.isEmpty()) {
+            if (storeQueryParameters.partition() != null) {
+                throw new InvalidStateStoreException(
+                        String.format("The specified partition %d for store %s does not exist.",
+                                storeQueryParameters.partition(),
+                                storeName));
+            }
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
         }
         return queryableStoreType.create(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -59,7 +59,7 @@ public class QueryableStoreProvider {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider storeProvider : storeProviders) {
             final List<T> stores = storeProvider.stores(storeQueryParameters);
-            if (stores != null && !stores.isEmpty()) {
+            if (!stores.isEmpty()) {
                 allStores.addAll(stores);
                 if (storeQueryParameters.partition() != null) {
                     break;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -60,7 +60,7 @@ public class QueryableStoreProvider {
         for (final StreamThreadStateStoreProvider storeProvider : storeProviders) {
             final List<T> stores = storeProvider.stores(storeQueryParameters);
             if (stores != null && !stores.isEmpty()) {
-                allStores.addAll(storeProvider.stores(storeQueryParameters));
+                allStores.addAll(stores);
                 if (storeQueryParameters.partition() != null) {
                     break;
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -61,10 +61,7 @@ public class StreamThreadStateStoreProvider {
             if (keyTaskId != null) {
                 final Task task = tasks.get(keyTaskId);
                 if (task == null) {
-                    throw new InvalidStateStoreException(
-                        String.format("The specified partition %d for store %s does not exist.",
-                            storeQueryParams.partition(),
-                            storeName));
+                    return Collections.emptyList();
                 }
                 final T store = validateAndListStores(task.getStore(storeName), queryableStoreType, storeName, keyTaskId);
                 if (store != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -48,7 +48,9 @@ public class WrappingStoreProvider implements StateStoreProvider {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider provider : storeProviders) {
             final List<T> stores = provider.stores(storeQueryParameters);
-            allStores.addAll(stores);
+            if (stores != null && !stores.isEmpty()) {
+                allStores.addAll(stores);
+            }
         }
         if (allStores.isEmpty()) {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -48,9 +48,7 @@ public class WrappingStoreProvider implements StateStoreProvider {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider provider : storeProviders) {
             final List<T> stores = provider.stores(storeQueryParameters);
-            if (stores != null && !stores.isEmpty()) {
-                allStores.addAll(stores);
-            }
+            allStores.addAll(stores);
         }
         if (allStores.isEmpty()) {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -332,6 +332,7 @@ public class StoreQueryIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);
         return config;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -62,7 +62,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -22,7 +22,12 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.streams.*;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -53,7 +58,10 @@ import java.util.stream.IntStream;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 
 
@@ -315,7 +323,6 @@ public class StoreQueryIntegrationTest {
 
         startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
 
-        assertTrue(numStreamThreads > 1);
         assertTrue(kafkaStreams1.localThreadsMetadata().size() > 1);
         assertTrue(kafkaStreams2.localThreadsMetadata().size() > 1);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.HashMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertNotNull;
 
 public class QueryableStoreProviderTest {
@@ -96,9 +99,16 @@ public class QueryableStoreProviderTest {
         assertNotNull(storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore()).withPartition(numStateStorePartitions - 1)));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionWhenKVStoreWithPartitionDoesntExists() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore()).withPartition(numStateStorePartitions + 1));
+        final int partition = numStateStorePartitions + 1;
+        final InvalidStateStoreException thrown = assertThrows(InvalidStateStoreException.class, () ->
+                storeProvider.getStore(
+                        StoreQueryParameters
+                                .fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore())
+                                .withPartition(partition))
+        );
+        assertThat(thrown.getMessage(), equalTo(String.format("The specified partition %d for store %s does not exist.", partition, keyValueStore)));
     }
 
     @Test
@@ -106,8 +116,15 @@ public class QueryableStoreProviderTest {
         assertNotNull(storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.windowStore()).withPartition(numStateStorePartitions - 1)));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionWhenWindowStoreWithPartitionDoesntExists() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.windowStore()).withPartition(numStateStorePartitions + 1));
+        final int partition = numStateStorePartitions + 1;
+        final InvalidStateStoreException thrown = assertThrows(InvalidStateStoreException.class, () ->
+                storeProvider.getStore(
+                        StoreQueryParameters
+                                .fromNameAndType(windowStore, QueryableStoreTypes.windowStore())
+                                .withPartition(partition))
+        );
+        assertThat(thrown.getMessage(), equalTo(String.format("The specified partition %d for store %s does not exist.", partition, windowStore)));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -98,7 +98,7 @@ public class QueryableStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenKVStoreWithPartitionDoesntExists() {
-        assertNotNull(storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore()).withPartition(numStateStorePartitions + 1)));
+        storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore()).withPartition(numStateStorePartitions + 1));
     }
 
     @Test
@@ -108,6 +108,6 @@ public class QueryableStoreProviderTest {
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowExceptionWhenWindowStoreWithPartitionDoesntExists() {
-        assertNotNull(storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.windowStore()).withPartition(numStateStorePartitions + 1)));
+        storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.windowStore()).withPartition(numStateStorePartitions + 1));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -73,9 +73,7 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 public class StreamThreadStateStoreProviderTest {
 
@@ -323,16 +321,12 @@ public class StreamThreadStateStoreProviderTest {
     }
 
     @Test
-    public void shouldThrowForInvalidPartitions() {
+    public void shouldReturnEmptyListForInvalidPartitions() {
         mockThread(true);
-        final InvalidStateStoreException thrown = assertThrows(
-            InvalidStateStoreException.class,
-            () -> provider.stores(
-                StoreQueryParameters
-                    .fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore())
-                    .withPartition(2))
+        assertEquals(
+                Collections.emptyList(),
+                provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()).withPartition(2))
         );
-        assertThat(thrown.getMessage(), equalTo("The specified partition 2 for store kv-store does not exist."));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -52,8 +52,7 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
             throw new InvalidStateStoreException("store is unavailable");
         }
         if (storeQueryParameters.partition() != null) {
-            final int storePartition = storeQueryParameters.partition() != null ? storeQueryParameters.partition() : defaultStorePartition;
-            final Entry<String, Integer> stateStoreKey = new SimpleEntry<>(storeName, storePartition);
+            final Entry<String, Integer> stateStoreKey = new SimpleEntry<>(storeName, storeQueryParameters.partition());
             if (stores.containsKey(stateStoreKey) && queryableStoreType.accepts(stores.get(stateStoreKey))) {
                 return (List<T>) Collections.singletonList(stores.get(stateStoreKey));
             }

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -26,11 +26,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.AbstractMap;
 
 public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
 
-    private final Map<String, StateStore> stores = new HashMap<>();
+    //<store name : partition> -> state store
+    private final Map<Map.Entry<String, Integer>, StateStore> stores = new HashMap<>();
     private final boolean throwException;
+
+    private final int defaultStorePartition = 0;
 
     public StateStoreProviderStub(final boolean throwException) {
         super(null, null);
@@ -41,19 +45,27 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     @Override
     public <T> List<T> stores(final StoreQueryParameters storeQueryParameters) {
         final String storeName = storeQueryParameters.storeName();
+        final int storePartition = storeQueryParameters.partition() != null ? storeQueryParameters.partition() : 0;
+        final Map.Entry<String, Integer> stateStoreKey = new AbstractMap.SimpleEntry<>(storeName, storePartition);
         final QueryableStoreType<T> queryableStoreType = storeQueryParameters.queryableStoreType();
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
         }
-        if (stores.containsKey(storeName) && queryableStoreType.accepts(stores.get(storeName))) {
-            return (List<T>) Collections.singletonList(stores.get(storeName));
+        if (stores.containsKey(stateStoreKey) && queryableStoreType.accepts(stores.get(stateStoreKey))) {
+            return (List<T>) Collections.singletonList(stores.get(stateStoreKey));
         }
         return Collections.emptyList();
     }
 
     public void addStore(final String storeName,
                          final StateStore store) {
-        stores.put(storeName, store);
+        addStore(storeName, defaultStorePartition, store);
+    }
+
+    public void addStore(final String storeName,
+                         final int partition,
+                         final StateStore store) {
+        stores.put(new AbstractMap.SimpleEntry<>(storeName, partition), store);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -46,7 +46,7 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     @Override
     public <T> List<T> stores(final StoreQueryParameters storeQueryParameters) {
         final String storeName = storeQueryParameters.storeName();
-        final int storePartition = storeQueryParameters.partition() != null ? storeQueryParameters.partition() : 0;
+        final int storePartition = storeQueryParameters.partition() != null ? storeQueryParameters.partition() : defaultStorePartition;
         final Entry<String, Integer> stateStoreKey = new SimpleEntry<>(storeName, storePartition);
         final QueryableStoreType<T> queryableStoreType = storeQueryParameters.queryableStoreType();
         if (throwException) {

--- a/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/StateStoreProviderStub.java
@@ -22,16 +22,17 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.internals.StreamThreadStateStoreProvider;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.AbstractMap;
+import java.util.Map.Entry;
 
 public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
 
     //<store name : partition> -> state store
-    private final Map<Map.Entry<String, Integer>, StateStore> stores = new HashMap<>();
+    private final Map<Entry<String, Integer>, StateStore> stores = new HashMap<>();
     private final boolean throwException;
 
     private final int defaultStorePartition = 0;
@@ -46,7 +47,7 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     public <T> List<T> stores(final StoreQueryParameters storeQueryParameters) {
         final String storeName = storeQueryParameters.storeName();
         final int storePartition = storeQueryParameters.partition() != null ? storeQueryParameters.partition() : 0;
-        final Map.Entry<String, Integer> stateStoreKey = new AbstractMap.SimpleEntry<>(storeName, storePartition);
+        final Entry<String, Integer> stateStoreKey = new SimpleEntry<>(storeName, storePartition);
         final QueryableStoreType<T> queryableStoreType = storeQueryParameters.queryableStoreType();
         if (throwException) {
             throw new InvalidStateStoreException("store is unavailable");
@@ -65,7 +66,6 @@ public class StateStoreProviderStub extends StreamThreadStateStoreProvider {
     public void addStore(final String storeName,
                          final int partition,
                          final StateStore store) {
-        stores.put(new AbstractMap.SimpleEntry<>(storeName, partition), store);
+        stores.put(new SimpleEntry<>(storeName, partition), store);
     }
-
 }


### PR DESCRIPTION
StreamThreadStateStoreProvider#stores throws exception whenever taskId is not found, which is not correct behaviour in multi-threaded env where state store partitions are distributed among several StreamTasks. 

final Task task = tasks.get(keyTaskId);
if (task == null) {
 throw new InvalidStateStoreException(
 String.format("The specified partition %d for store %s does not exist.",
 storeQueryParams.partition(),
 storeName));
}
Reproducible with KStream number of threads more then 1 

StoreQueryIntegrationTest#streamsConfiguration

config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);

 

Suggested solution is to not throw exception if at least one state store is found, which is always true when using StoreQueryParameters.withPartition

https://issues.apache.org/jira/browse/KAFKA-10030?jql=project%20%3D%20KAFKA%20AND%20component%20%3D%20streams

@mjsax @guozhangwang 