### PR TITLE
MINOR: avoid unnecessary seq iteration in ApiVersion.lastVersion

### DIFF
--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -116,7 +116,7 @@ object ApiVersion {
     versionMap.getOrElse(key, throw new IllegalArgumentException(s"Version `$versionString` is not a valid version"))
   }
 
-  def latestVersion: ApiVersion = allVersions.last
+  val latestVersion: ApiVersion = allVersions.last
 
   /**
    * Return the minimum `ApiVersion` that supports `RecordVersion`.


### PR DESCRIPTION
We unnecessarily iterate the versions seq each time we lookup lastVersion, including in the hotpath Log.appendAsFollower. Given that allVersions is a constant, this is unnecessary.