### PR TITLE
MINOR: Improve security documentation for Kafka Streams

### DIFF
--- a/docs/streams/developer-guide/security.html
+++ b/docs/streams/developer-guide/security.html
@@ -70,6 +70,17 @@
                 the ACL set so that the application has the permissions to create, read and write
                 <a class="reference internal" href="manage-topics.html#streams-developer-guide-topics-internal"><span class="std std-ref">internal topics</span></a>.</p>
 
+                <p>To avoid providing this permission to your application, you can create the required internal topics manually.
+                    If the internal topics exist, Kafka Streams will not try to recreate them.
+                    Note, that the internal repartition and changelog topics must be created with the correct number of partitions&mdash;otherwise, Kafka Streams will fail on startup.
+                The topics must be created with the same number of partitions as your input topic, or if there are multiple topics, the maximum number of partitions across all input topics.
+                    Additionally, changelog topics <emph>must</emph> be created with log compaction enabled&mdash;otherwise, your application might lose data.
+                    For changelog topics for windowed KTables, apply "delete,compact" and set the retention time based on the corresponding store retention time. To avoid premature deletion,
+                    add a delta to the store retention time. By default, Kafka Streams adds 24 hours to the store retention time.
+                    You can find out more about the names of the required internal topics via <code>Topology#describe()</code>.
+                All internal topics follow the naming pattern <code>&lt;application.id&gt;-&lt;operatorName&gt;-&lt;suffix&gt;</code> where the <code>suffix</code> is either <code>repartition</code> or <code>changelog</code>.
+                    Note, that there is no guarantee about this naming pattern in future releases&mdash;it's not part of the public API.</p>
+
             <p>Since all internal topics as well as the embedded consumer group name are prefixed with the <a class="reference internal" href="/{{version}}/documentation/streams/developer-guide/config-streams.html#required-configuration-parameters"><span class="std std-ref">application id</span></a>,
                 it is recommended to use ACLs on prefixed resource pattern
                 to configure control lists to allow client to manage all topics and consumer groups started with this prefix


### PR DESCRIPTION
Migrate content from https://github.com/confluentinc/docs/pull/4655.

Also restore content from https://github.com/apache/kafka/pull/4532, which seems to have been lost along the way. cc @mjsax 