### PR TITLE
KAFKA-9904:Use ThreadLocalConcurrent to Replace Random

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -61,7 +61,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -85,8 +85,6 @@ public class NetworkClient implements KafkaClient {
     private final Selectable selector;
 
     private final MetadataUpdater metadataUpdater;
-
-    private final Random randOffset;
 
     /* the state of each node's connection */
     private final ClusterConnectionStates connectionStates;
@@ -262,7 +260,6 @@ public class NetworkClient implements KafkaClient {
         this.socketSendBuffer = socketSendBuffer;
         this.socketReceiveBuffer = socketReceiveBuffer;
         this.correlation = 0;
-        this.randOffset = new Random();
         this.defaultRequestTimeoutMs = defaultRequestTimeoutMs;
         this.reconnectBackoffMs = reconnectBackoffMs;
         this.time = time;
@@ -666,7 +663,7 @@ public class NetworkClient implements KafkaClient {
         Node foundCanConnect = null;
         Node foundReady = null;
 
-        int offset = this.randOffset.nextInt(nodes.size());
+        int offset = ThreadLocalRandom.current().nextInt(nodes.size());
         for (int i = 0; i < nodes.size(); i++) {
             int idx = (offset + i) % nodes.size();
             Node node = nodes.get(idx);

--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -17,7 +17,7 @@
 
 package kafka.admin
 
-import java.util.Random
+import java.util.concurrent.ThreadLocalRandom
 
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplicationFactorException}
@@ -25,7 +25,6 @@ import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplic
 import collection.{Map, mutable, _}
 
 object AdminUtils extends Logging {
-  val rand = new Random
   val AdminClientId = "__admin_client"
 
   /**
@@ -129,9 +128,9 @@ object AdminUtils extends Logging {
                                                  startPartitionId: Int): Map[Int, Seq[Int]] = {
     val ret = mutable.Map[Int, Seq[Int]]()
     val brokerArray = brokerList.toArray
-    val startIndex = if (fixedStartIndex >= 0) fixedStartIndex else rand.nextInt(brokerArray.length)
+    val startIndex = if (fixedStartIndex >= 0) fixedStartIndex else ThreadLocalRandom.current().nextInt(brokerArray.length)
     var currentPartitionId = math.max(0, startPartitionId)
-    var nextReplicaShift = if (fixedStartIndex >= 0) fixedStartIndex else rand.nextInt(brokerArray.length)
+    var nextReplicaShift = if (fixedStartIndex >= 0) fixedStartIndex else ThreadLocalRandom.current().nextInt(brokerArray.length)
     for (_ <- 0 until nPartitions) {
       if (currentPartitionId > 0 && (currentPartitionId % brokerArray.length == 0))
         nextReplicaShift += 1
@@ -157,9 +156,9 @@ object AdminUtils extends Logging {
     val arrangedBrokerList = getRackAlternatedBrokerList(brokerRackMap)
     val numBrokers = arrangedBrokerList.size
     val ret = mutable.Map[Int, Seq[Int]]()
-    val startIndex = if (fixedStartIndex >= 0) fixedStartIndex else rand.nextInt(arrangedBrokerList.size)
+    val startIndex = if (fixedStartIndex >= 0) fixedStartIndex else ThreadLocalRandom.current().nextInt(arrangedBrokerList.size)
     var currentPartitionId = math.max(0, startPartitionId)
-    var nextReplicaShift = if (fixedStartIndex >= 0) fixedStartIndex else rand.nextInt(arrangedBrokerList.size)
+    var nextReplicaShift = if (fixedStartIndex >= 0) fixedStartIndex else ThreadLocalRandom.current().nextInt(arrangedBrokerList.size)
     for (_ <- 0 until nPartitions) {
       if (currentPartitionId > 0 && (currentPartitionId % arrangedBrokerList.size == 0))
         nextReplicaShift += 1

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -21,7 +21,7 @@ import kafka.metrics.KafkaMetricsGroup
 import org.apache.kafka.common.utils.Time
 
 import java.util.concurrent.TimeUnit
-import java.util.Random
+import java.util.concurrent.ThreadLocalRandom
 
 import scala.math._
 
@@ -84,13 +84,12 @@ class Throttler(desiredRatePerSec: Double,
 object Throttler {
   
   def main(args: Array[String]): Unit = {
-    val rand = new Random()
     val throttler = new Throttler(100000, 100, true, time = Time.SYSTEM)
     val interval = 30000
     var start = System.currentTimeMillis
     var total = 0
     while(true) {
-      val value = rand.nextInt(1000)
+      val value = ThreadLocalRandom.current().nextInt(1000)
       Thread.sleep(1)
       throttler.maybeThrottle(value)
       total += value

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -45,9 +45,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static java.util.Collections.singleton;
 import static net.sourceforge.argparse4j.impl.Arguments.store;
@@ -335,7 +335,6 @@ public class TransactionalMessageCopier {
 
         final boolean useGroupMetadata = parsedArgs.getBoolean("useGroupMetadata");
         try {
-            Random random = new Random();
             while (remainingMessages.get() > 0) {
                 System.out.println(statusAsJson(totalMessageProcessed.get(),
                     numMessagesProcessedSinceLastRebalance.get(), remainingMessages.get(), transactionalId, "ProcessLoop"));
@@ -359,7 +358,7 @@ public class TransactionalMessageCopier {
                             producer.sendOffsetsToTransaction(consumerPositions(consumer), consumerGroup);
                         }
 
-                        if (enableRandomAborts && random.nextInt() % 3 == 0) {
+                        if (enableRandomAborts && ThreadLocalRandom.current().nextInt() % 3 == 0) {
                             throw new KafkaException("Aborting transaction");
                         } else {
                             producer.commitTransaction();

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/SustainedConnectionWorker.java
@@ -48,7 +48,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -56,6 +55,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 public class SustainedConnectionWorker implements TaskWorker {
@@ -308,7 +308,6 @@ public class SustainedConnectionWorker implements TaskWorker {
         private KafkaConsumer<byte[], byte[]> consumer;
         private TopicPartition activePartition;
         private final String topicName;
-        private final Random rand;
         private final Properties props;
 
         ConsumerSustainedConnection() {
@@ -316,7 +315,6 @@ public class SustainedConnectionWorker implements TaskWorker {
             this.topicName = SustainedConnectionWorker.this.spec.topicName();
             this.consumer = null;
             this.activePartition = null;
-            this.rand = new Random();
             this.refreshRate = SustainedConnectionWorker.this.spec.refreshRateMs();
 
             // This variable is used to maintain the connection properties.
@@ -345,7 +343,7 @@ public class SustainedConnectionWorker implements TaskWorker {
                             .collect(Collectors.toList());
 
                     // Select a random partition and assign it.
-                    this.activePartition = partitions.get(this.rand.nextInt(partitions.size()));
+                    this.activePartition = partitions.get(ThreadLocalRandom.current().nextInt(partitions.size()));
                     this.consumer.assign(Collections.singletonList(this.activePartition));
                 }
 


### PR DESCRIPTION
When applicable, use of ThreadLocalRandom rather
than shared Random objects in concurrent programs
will typically encounter much less overhead and
contention.

Change-Id: Idf56adc8cbb4c611e327e639a49d90827a23d947
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
