### PR TITLE
KAFKA-8120 Getting NegativeArraySizeException when using Kafka Connect

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
@@ -54,6 +54,9 @@ public class FileStreamSourceTask extends SourceTask {
     private int batchSize = FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE;
 
     private Long streamOffset;
+    private boolean needExtendBuffer;
+    private int nread = 0;
+    private static int maxBufferSize = Integer.MAX_VALUE;
 
     @Override
     public String version() {
@@ -130,36 +133,21 @@ public class FileStreamSourceTask extends SourceTask {
 
             ArrayList<SourceRecord> records = null;
 
-            int nread = 0;
-            while (readerCopy.ready()) {
-                nread = readerCopy.read(buffer, offset, buffer.length - offset);
-                log.trace("Read {} bytes from {}", nread, logFilename());
+            String line;
+            do {
+                line = extractLine();
+                if (line != null) {
+                    log.trace("Read a line from {}", logFilename());
+                    if (records == null)
+                        records = new ArrayList<>();
+                    records.add(new SourceRecord(offsetKey(filename), offsetValue(streamOffset), topic, null,
+                            null, null, VALUE_SCHEMA, line, System.currentTimeMillis()));
 
-                if (nread > 0) {
-                    offset += nread;
-                    if (offset == buffer.length) {
-                        char[] newbuf = new char[buffer.length * 2];
-                        System.arraycopy(buffer, 0, newbuf, 0, buffer.length);
-                        buffer = newbuf;
+                    if (records.size() >= batchSize) {
+                        return records;
                     }
-
-                    String line;
-                    do {
-                        line = extractLine();
-                        if (line != null) {
-                            log.trace("Read a line from {}", logFilename());
-                            if (records == null)
-                                records = new ArrayList<>();
-                            records.add(new SourceRecord(offsetKey(filename), offsetValue(streamOffset), topic, null,
-                                    null, null, VALUE_SCHEMA, line, System.currentTimeMillis()));
-
-                            if (records.size() >= batchSize) {
-                                return records;
-                            }
-                        }
-                    } while (line != null);
                 }
-            }
+            } while (line != null);
 
             if (nread <= 0)
                 synchronized (this) {
@@ -174,8 +162,30 @@ public class FileStreamSourceTask extends SourceTask {
         return null;
     }
 
-    private String extractLine() {
+    /**
+     * Extract a line from the character buffer, looking for \n and \r\n for line separator.
+     * If found, shift buffer leftward.
+     * If not found and the buffer is full expand the buffer until next read.
+     */
+    String extractLine() throws IOException {
         int until = -1, newStart = -1;
+
+        if (needExtendBuffer) {
+            expandBuffer();
+            needExtendBuffer = false;
+        }
+
+        nread = 0;
+        if (offset < buffer.length && reader.ready()) {
+
+            nread = reader.read(buffer, offset, buffer.length - offset);
+            log.trace("Read {} bytes from {}", nread, logFilename());
+            if (nread > 0) {
+                offset += nread;
+            }
+        }
+
+        log.trace("offset {}", offset);
         for (int i = 0; i < offset; i++) {
             if (buffer[i] == '\n') {
                 until = i;
@@ -200,8 +210,22 @@ public class FileStreamSourceTask extends SourceTask {
                 streamOffset += newStart;
             return result;
         } else {
+            if (offset == buffer.length &&  buffer.length  < maxBufferSize) {
+                needExtendBuffer = true;
+            }
             return null;
         }
+    }
+
+    /**
+     * Expand the internal character buffer, double the size if less than maximum value, otherwise use the maximum value.
+     */
+    private void expandBuffer()  {
+        int newSize = (buffer.length > maxBufferSize / 2) ? maxBufferSize :  buffer.length * 2;
+        char[] newBuf = new char[newSize];
+        System.arraycopy(buffer, 0, newBuf, 0, buffer.length);
+        buffer = newBuf;
+        log.debug("internal buffer size expanded to {} ", buffer.length);
     }
 
     @Override


### PR DESCRIPTION
Bug fix only, [JIRA]( https://issues.apache.org/jira/browse/KAFKA-8120)
1. The Outer loop Issue, at Original line 134 of FileStreamSourceTask.java 
	while (readerCopy.ready()) {

Since the buffer is used cross multiple poll. This condition missed a case that file has reached EOF, but buffer has un-parsed data. 

To fix it, change the while loop to if statement, and move the file reading logic to extractLine
        if (offset < buffer.length && reader.ready()) {

Test case: FileStreamSourceTaskTest.testSmallFile

2. The Expanding Buffer Issue, at Original line 140 of FileStreamSourceTask.java
    if (offset == buffer.length) {
        char[] newbuf = new char[buffer.length * 2];
        System.arraycopy(buffer, 0, newbuf, 0, buffer.length);
        buffer = newbuf;
    }

For large file, this condition will be always true even expanding buffer is not needed, so every read will trigger expand buffer which will causes Java heap error or NegativeArraySizeException if buffer.length * 2 overflows. 

To fix it, move the expanding buffer logic to the end of extractLine 
   if (offset == buffer.length &&  buffer.length  < maxBufferSize) {
       needExtendBuffer = true;
   }

Test case: FileStreamSourceTaskTest.testLargeFile

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
